### PR TITLE
fix: use pre-pull commit as baseline for manifest/field comparison

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1131,7 +1131,7 @@ def pull_environment(
         )
 
     _trace("pull_environment(%s): git pull started", branch_name)
-    changed_files = pull_repo(
+    old_head, changed_files = pull_repo(
         repo_path, branch_name, cred_file=team.git_credentials_file()
     )
 
@@ -1163,7 +1163,9 @@ def pull_environment(
                 repo_name,
                 branch,
             )
-            extra_files = pull_extra_worktree(team, repo_name, branch, wt_path)
+            _extra_old, extra_files = pull_extra_worktree(
+                team, repo_name, branch, wt_path
+            )
             extra_changed_files.extend(extra_files)
             if extra_files:
                 _trace(
@@ -1185,7 +1187,7 @@ def pull_environment(
         all_changed,
     )
 
-    analysis = classify_changes(all_changed, repo_path)
+    analysis = classify_changes(all_changed, repo_path, base_ref=old_head)
     action = analysis["action"]
     _trace("pull_environment(%s): classify result action=%s", branch_name, action)
 

--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -417,11 +417,12 @@ def remove_worktree(team: TeamSettings, repo_name: str, target_path: str) -> Non
 
 def pull_extra_worktree(
     team: TeamSettings, repo_name: str, branch: str, worktree_path: str
-) -> list[str]:
+) -> tuple[str, list[str]]:
     """Fetch the bare repo and reset the worktree to the branch tip.
 
-    Returns a list of changed file paths (relative to worktree root),
-    or an empty list if already up to date.
+    Returns ``(old_head, changed_files)`` where *old_head* is the
+    commit hash before the pull and *changed_files* are paths relative
+    to the worktree root.  Returns ``("", [])`` if already up to date.
     """
     fetch_extra_repo(team, repo_name)
 
@@ -453,7 +454,7 @@ def pull_extra_worktree(
     ).stdout.strip()
 
     if old_head == new_head:
-        return []
+        return "", []
 
     result = subprocess.run(
         ["git", "-C", worktree_path, "diff", "--name-only", f"{old_head}..{new_head}"],
@@ -469,7 +470,7 @@ def pull_extra_worktree(
         branch,
         len(changed),
     )
-    return changed
+    return old_head, changed
 
 
 def generate_odoo_conf(

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -10,6 +10,7 @@ from oduflow import settings
 
 logger = logging.getLogger("oduflow")
 
+
 def _trace(msg: str, *args: object) -> None:
     if settings.TRACE:
         logger.info("[TRACE] " + msg, *args)
@@ -61,7 +62,9 @@ def _extract_field_lines(source: str) -> set[str]:
     return lines
 
 
-def _check_field_changes(py_rel_path: str, repo_path: str) -> bool:
+def _check_field_changes(
+    py_rel_path: str, repo_path: str, base_ref: str = "HEAD~1"
+) -> bool:
     """Return True if any ``fields.`` definition was added, removed or modified."""
     abs_path = os.path.join(repo_path, py_rel_path)
 
@@ -72,7 +75,7 @@ def _check_field_changes(py_rel_path: str, repo_path: str) -> bool:
 
     try:
         old_source = subprocess.run(
-            ["git", "-C", repo_path, "show", f"HEAD~1:{py_rel_path}"],
+            ["git", "-C", repo_path, "show", f"{base_ref}:{py_rel_path}"],
             check=True,
             capture_output=True,
             text=True,
@@ -100,7 +103,9 @@ def _is_data_path(file_path: str) -> bool:
     return "/data/" in f"/{file_path}/" or file_path.startswith("data/")
 
 
-def classify_changes(changed_files: list[str], repo_path: str) -> dict:
+def classify_changes(
+    changed_files: list[str], repo_path: str, base_ref: str = "HEAD~1"
+) -> dict:
     """
     Classify changed files and determine required Odoo actions.
 
@@ -141,7 +146,7 @@ def classify_changes(changed_files: list[str], repo_path: str) -> dict:
         module = _get_module_name(f, repo_path)
 
         if os.path.basename(f) == "__manifest__.py" and module:
-            manifest_action = _check_manifest_changes(f, module, repo_path)
+            manifest_action = _check_manifest_changes(f, module, repo_path, base_ref)
             _trace(
                 "  file=%s ext=manifest module=%s -> manifest_action=%s",
                 f,
@@ -158,7 +163,7 @@ def classify_changes(changed_files: list[str], repo_path: str) -> dict:
             py_changed = True
             field_changed = False
             if module and module not in modules_to_install:
-                field_changed = _check_field_changes(f, repo_path)
+                field_changed = _check_field_changes(f, repo_path, base_ref)
                 if field_changed:
                     modules_to_upgrade.add(module)
             _trace(
@@ -235,11 +240,11 @@ def classify_changes(changed_files: list[str], repo_path: str) -> dict:
 
 
 def _check_manifest_changes(
-    manifest_rel_path: str, module: str, repo_path: str
+    manifest_rel_path: str, module: str, repo_path: str, base_ref: str = "HEAD~1"
 ) -> str | None:
     """
     Check if __manifest__.py changes require a module install or upgrade.
-    Uses git to compare old vs new manifest content.
+    Uses git to compare *base_ref* vs current manifest content.
     Returns ``"install"`` for a new module, ``"upgrade"`` for significant
     changes to an existing module, or ``None`` if no action is needed.
     """
@@ -257,7 +262,7 @@ def _check_manifest_changes(
 
     try:
         old_content = subprocess.run(
-            ["git", "-C", repo_path, "show", f"HEAD~1:{manifest_rel_path}"],
+            ["git", "-C", repo_path, "show", f"{base_ref}:{manifest_rel_path}"],
             check=True,
             capture_output=True,
             text=True,

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -247,8 +247,15 @@ def delete_credential(host: str, username: str, cred_file: str) -> bool:
     return removed
 
 
-def pull_repo(repo_path: str, branch: str, cred_file: str = "") -> list[str]:
-    """Pull latest changes and return list of changed file paths."""
+def pull_repo(
+    repo_path: str, branch: str, cred_file: str = ""
+) -> tuple[str, list[str]]:
+    """Pull latest changes and return ``(old_head, changed_files)``.
+
+    *old_head* is the commit hash before the pull — callers can pass it
+    as ``base_ref`` to :func:`git_analysis.classify_changes` so that
+    manifest / field comparisons cover the full range of pulled commits.
+    """
     env = git_env_for_team(cred_file) if cred_file else _GIT_BASE_ENV
 
     old_head = subprocess.run(
@@ -297,7 +304,7 @@ def pull_repo(repo_path: str, branch: str, cred_file: str = "") -> list[str]:
     ).stdout.strip()
 
     if old_head == new_head:
-        return []
+        return old_head, []
 
     result = subprocess.run(
         [
@@ -313,7 +320,7 @@ def pull_repo(repo_path: str, branch: str, cred_file: str = "") -> list[str]:
         text=True,
         env=env,
     )
-    return [f for f in result.stdout.strip().splitlines() if f]
+    return old_head, [f for f in result.stdout.strip().splitlines() if f]
 
 
 def parse_manifest(manifest_path: str) -> dict:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -926,7 +926,7 @@ def pull_and_apply(branch_name: str, ctx: Context = None) -> str:
     Analyzes changed files and automatically:
     - Upgrades modules if __manifest__.py version/data/assets changed, or security XML changed
     - Restarts the container if Python files changed
-    - Does nothing if only XML/JS changed (--dev=xml handles hot reload)
+    - Does nothing if only XML/JS changed (--dev=xml hot-reloads XML; JS assets are reloaded on browser refresh)
 
     Args:
         branch_name: The name of the branch/environment to pull updates for.

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -198,7 +198,7 @@ When you call `pull_and_apply`, Oduflow analyzes every changed file:
 | `*.py` with `fields.*` changes | **Upgrade** the module |
 | `security/*.xml` | **Upgrade** the module |
 | `*.py` without field changes | **Restart** the container |
-| `*.xml` (views, data) / `*.js` | **Nothing** — hot-reloaded via `--dev=xml` |
+| `*.xml` (views) / `*.js` / `*.css` / `*.scss` | **Nothing** — hot-reloaded via `--dev=xml` (refresh browser) |
 
 Priority: install > upgrade > restart > refresh (no action).
 

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -320,6 +320,42 @@ class TestClassifyChanges:
             assert result["action"] == "upgrade"
             assert "sale" in result["modules_to_upgrade"]
 
+    def test_manifest_assets_change_with_base_ref(self, tmp_path):
+        """Manifest change is detected when base_ref points to a commit
+        several steps back (multi-commit pull scenario)."""
+        module_dir = tmp_path / "web_ext"
+        module_dir.mkdir()
+
+        old_manifest = "{'name': 'Web Ext', 'version': '17.0.1.0.0', 'assets': {}}"
+        new_manifest = (
+            "{'name': 'Web Ext', 'version': '17.0.1.0.0', "
+            "'assets': {'web.assets_backend': ['web_ext/static/src/js/app.js']}}"
+        )
+        (module_dir / "__manifest__.py").write_text(new_manifest)
+
+        from unittest.mock import patch
+
+        fake_base_ref = "abc123"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"stdout": old_manifest})()
+
+            files = [
+                "web_ext/__manifest__.py",
+                "web_ext/static/src/js/app.js",
+            ]
+            result = classify_changes(files, str(tmp_path), base_ref=fake_base_ref)
+            assert result["action"] == "upgrade"
+            assert "web_ext" in result["modules_to_upgrade"]
+
+            # Verify git show used base_ref, not HEAD~1
+            git_show_calls = [
+                c
+                for c in mock_run.call_args_list
+                if any(f"{fake_base_ref}:" in str(a) for a in c[0][0])
+            ]
+            assert len(git_show_calls) == 1
+
     def test_py_no_field_change_stays_restart(self, tmp_path):
         module_dir = tmp_path / "sale" / "models"
         module_dir.mkdir(parents=True)


### PR DESCRIPTION
_check_manifest_changes and _check_field_changes used HEAD~1 to get
the old file version, but pull_repo can pull multiple commits at once.
When a manifest change (e.g. adding a JS file to assets) was in an
earlier commit of the batch, HEAD~1 already had the new manifest so
the comparison found no diff and missed the required module upgrade.

Now pull_repo and pull_extra_worktree return (old_head, changed_files)
and the pre-pull commit hash is passed as base_ref through
classify_changes to the comparison functions.

https://claude.ai/code/session_01WTGJZLJ5a8CRxXaz4LxBAV