### PR TITLE
feat: add file management MCP tools for Docker volumes (Vibe Kanban)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1606,6 +1606,15 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_services` | | List all managed service containers |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |
+| **Volumes** | | |
+| `create_volume` | ✓ | Create a named Docker volume for use with services |
+| `list_volumes` | | List all managed Docker volumes and their usage by services |
+| `inspect_volume` | | Get detailed information about a specific volume |
+| `delete_volume` | ✓ | Delete a managed Docker volume (fails if in use) |
+| `read_file_in_volume` | | Read a text file or list a directory inside a Docker volume |
+| `write_file_in_volume` | ✓ | Write a text file inside a Docker volume |
+| `search_in_volume` | | Search for a pattern (fixed-string grep) in files inside a Docker volume |
+| `delete_file_in_volume` | ✓ | Delete a file or directory inside a Docker volume |
 | **Service Presets** | | |
 | `list_service_presets` | | List saved service presets (configurations that can be restored) |
 | `restore_service` | ✓ | Restore a service from a saved preset |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -147,6 +147,8 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `read_output` — read from a cached tool output by ID (paginate, grep, errors, tail)
 - `list_environments` / `get_environment_info` — inspect environments
 - `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_logs` / `run_service_command` — manage auxiliary services
+- `create_volume` / `list_volumes` / `inspect_volume` / `delete_volume` — manage Docker volumes
+- `read_file_in_volume` / `write_file_in_volume` / `search_in_volume` / `delete_file_in_volume` — manage files inside Docker volumes
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets
 - `save_as_template` / `delete_template` / `list_templates` — template management
 - `import_template_from_odoo` — import a template from a running Odoo instance

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -46,6 +46,15 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_services` | | List all managed service containers |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |
+| **Volumes** | | |
+| `create_volume` | ✓ | Create a named Docker volume for use with services |
+| `list_volumes` | | List all managed Docker volumes and their usage by services |
+| `inspect_volume` | | Get detailed information about a specific volume |
+| `delete_volume` | ✓ | Delete a managed Docker volume (fails if in use) |
+| `read_file_in_volume` | | Read a text file or list a directory inside a Docker volume |
+| `write_file_in_volume` | ✓ | Write a text file inside a Docker volume |
+| `search_in_volume` | | Search for a pattern (fixed-string grep) in files inside a Docker volume |
+| `delete_file_in_volume` | ✓ | Delete a file or directory inside a Docker volume |
 | **Service Presets** | | |
 | `list_service_presets` | | List saved service presets (configurations that can be restored) |
 | `restore_service` | ✓ | Restore a service from a saved preset |

--- a/src/oduflow/docker_ops/volume_file_ops.py
+++ b/src/oduflow/docker_ops/volume_file_ops.py
@@ -1,0 +1,360 @@
+"""File operations inside Docker volumes.
+
+Uses temporary Alpine containers to read, write, search, and delete files
+inside Docker volumes without requiring a running service container.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tarfile
+from typing import Any
+
+import docker
+
+from oduflow.docker_ops.client import get_client
+from oduflow.docker_ops.volume_ops import _docker_volume_name
+from oduflow.errors import ConflictError, ExternalCommandError, NotFoundError
+from oduflow.settings import Settings, TeamSettings
+
+logger = logging.getLogger("oduflow")
+
+_HELPER_IMAGE = "alpine:latest"
+_MOUNT_POINT = "/mnt/volume"
+_FILE_SIZE_LIMIT = 100 * 1024  # 100 KB
+_WRITE_FILE_LIMIT = 1_000_000  # 1 MB
+
+
+def _validate_volume(team: TeamSettings, name: str) -> str:
+    """Validate that a volume exists and return its Docker name."""
+    client = get_client()
+    docker_name = _docker_volume_name(team, name)
+    try:
+        client.volumes.get(docker_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(f"Volume '{name}' not found.")
+    return docker_name
+
+
+def _safe_path(path: str) -> str:
+    """Resolve a user-provided path to an absolute path inside the mount.
+
+    Prevents path traversal attacks by normalising ``..`` segments and
+    verifying the result stays within ``_MOUNT_POINT``.
+    """
+    clean = path.lstrip("/")
+    if not clean:
+        return _MOUNT_POINT
+    full = os.path.normpath(os.path.join(_MOUNT_POINT, clean))
+    if not (full == _MOUNT_POINT or full.startswith(_MOUNT_POINT + "/")):
+        raise ConflictError(f"Path '{path}' escapes the volume mount point.")
+    return full
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+def read_file_in_volume(
+    settings: Settings,
+    team: TeamSettings,
+    name: str,
+    path: str,
+    read_range: str = "",
+) -> dict[str, Any]:
+    """Read a text file or list a directory inside a Docker volume."""
+    client = get_client()
+    docker_name = _validate_volume(team, name)
+    full_path = _safe_path(path)
+
+    # Validate read_range early (before spinning up a container).
+    start = end = 0
+    if read_range:
+        parts = read_range.split(":")
+        if len(parts) != 2:
+            return {
+                "error": f"Invalid read_range format: '{read_range}'. Expected 'START:END' (e.g. '1:50')."
+            }
+        try:
+            start, end = int(parts[0]), int(parts[1])
+        except ValueError:
+            return {
+                "error": f"Invalid read_range format: '{read_range}'. START and END must be integers."
+            }
+
+    # Build a single shell script that handles all cases.
+    if read_range:
+        read_cmd = f"sed -n '{start},{end}p' \"$FILE\""
+    else:
+        read_cmd = 'cat "$FILE"'
+
+    size_limit = _FILE_SIZE_LIMIT
+    script = f"""\
+FILE="{full_path}"
+if [ -d "$FILE" ]; then
+    echo "TYPE:DIR"
+    ls -la "$FILE"
+elif [ -f "$FILE" ]; then
+    SIZE=$(wc -c < "$FILE")
+    # Binary detection: look for null bytes in first 512 bytes
+    NULL_COUNT=$(head -c 512 "$FILE" | tr -cd '\\0' | wc -c)
+    if [ "$NULL_COUNT" -gt 0 ]; then
+        echo "TYPE:BINARY"
+        echo "SIZE:$SIZE"
+    elif [ {0 if read_range else 1} -eq 1 ] && [ "$SIZE" -gt {size_limit} ]; then
+        echo "TYPE:TOOLARGE"
+        echo "SIZE:$SIZE"
+    else
+        echo "TYPE:FILE"
+        echo "SIZE:$SIZE"
+        echo "CONTENT_START"
+        {read_cmd}
+    fi
+else
+    echo "TYPE:NOTFOUND"
+fi
+"""
+
+    logger.info("Reading file in volume %s: %s", name, path)
+    try:
+        output = client.containers.run(
+            _HELPER_IMAGE,
+            ["sh", "-c", script],
+            entrypoint="",
+            user="root",
+            remove=True,
+            volumes={docker_name: {"bind": _MOUNT_POINT, "mode": "ro"}},
+        )
+    except docker.errors.ContainerError as exc:
+        stderr = exc.stderr or b""
+        return {
+            "error": stderr.decode("utf-8", errors="replace")
+            if isinstance(stderr, bytes)
+            else str(stderr)
+        }
+
+    raw = output.decode("utf-8") if isinstance(output, bytes) else str(output)
+    lines = raw.split("\n", 3)  # split header lines
+    type_line = lines[0] if lines else ""
+
+    if type_line == "TYPE:NOTFOUND":
+        return {"error": f"Path not found: {path}"}
+
+    if type_line == "TYPE:DIR":
+        dir_output = "\n".join(lines[1:]) if len(lines) > 1 else ""
+        return {"type": "directory", "output": dir_output}
+
+    if type_line == "TYPE:BINARY":
+        return {
+            "error": "Binary file, cannot display. Use run_service_command for binary file operations."
+        }
+
+    if type_line == "TYPE:TOOLARGE":
+        size_str = lines[1].replace("SIZE:", "").strip() if len(lines) > 1 else "?"
+        size_kb = int(size_str) // 1024 if size_str.isdigit() else "?"
+        limit_kb = _FILE_SIZE_LIMIT // 1024
+        return {
+            "error": (
+                f"File is too large ({size_kb}KB, limit {limit_kb}KB). "
+                'Use read_range parameter to read a specific portion, e.g. read_range="1:500".'
+            )
+        }
+
+    if type_line == "TYPE:FILE":
+        size_str = lines[1].replace("SIZE:", "").strip() if len(lines) > 1 else "0"
+        file_size = int(size_str) if size_str.isdigit() else 0
+        # Content starts after "CONTENT_START" marker
+        content_start_idx = raw.find("CONTENT_START\n")
+        content = (
+            raw[content_start_idx + len("CONTENT_START\n") :]
+            if content_start_idx >= 0
+            else ""
+        )
+        result: dict[str, Any] = {"type": "file", "output": content, "size": file_size}
+        if read_range:
+            result["range"] = read_range
+        return result
+
+    return {"error": f"Unexpected output: {raw[:200]}"}
+
+
+# ---------------------------------------------------------------------------
+# Write
+# ---------------------------------------------------------------------------
+
+
+def write_file_in_volume(
+    settings: Settings,
+    team: TeamSettings,
+    name: str,
+    path: str,
+    content: str,
+) -> dict[str, Any]:
+    """Write a text file inside a Docker volume via tar stream."""
+    data = content.encode("utf-8")
+    if len(data) > _WRITE_FILE_LIMIT:
+        raise ExternalCommandError(
+            "write_file_in_volume",
+            1,
+            f"Content exceeds {_WRITE_FILE_LIMIT} byte limit.",
+        )
+
+    client = get_client()
+    docker_name = _validate_volume(team, name)
+    full_path = _safe_path(path)
+    parent = full_path.rsplit("/", 1)[0] if "/" in full_path else "/"
+    filename = full_path.rsplit("/", 1)[-1]
+
+    logger.info("Writing file in volume %s: %s (%d bytes)", name, path, len(data))
+
+    container = client.containers.run(
+        _HELPER_IMAGE,
+        "sleep 30",
+        entrypoint="",
+        user="root",
+        detach=True,
+        remove=False,
+        volumes={docker_name: {"bind": _MOUNT_POINT, "mode": "rw"}},
+    )
+    try:
+        container.exec_run(["mkdir", "-p", parent], user="root")
+
+        tar_stream = io.BytesIO()
+        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+            info = tarfile.TarInfo(name=filename)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        tar_stream.seek(0)
+        container.put_archive(parent, tar_stream)
+    finally:
+        container.stop(timeout=1)
+        container.remove(force=True)
+
+    return {"path": path, "size": len(data)}
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+def search_in_volume(
+    settings: Settings,
+    team: TeamSettings,
+    name: str,
+    pattern: str,
+    path: str = "",
+    glob: str = "*",
+    max_results: int = 50,
+) -> dict[str, Any]:
+    """Search for a pattern in files inside a Docker volume."""
+    client = get_client()
+    docker_name = _validate_volume(team, name)
+    search_path = _safe_path(path) if path else _MOUNT_POINT
+
+    cmd = [
+        "grep",
+        "-rnH",
+        "-F",
+        "--include",
+        glob,
+        pattern,
+        search_path,
+    ]
+
+    logger.info(
+        "Searching in volume %s: pattern=%s path=%s glob=%s",
+        name,
+        pattern,
+        search_path,
+        glob,
+    )
+
+    try:
+        output = client.containers.run(
+            _HELPER_IMAGE,
+            cmd,
+            entrypoint="",
+            user="root",
+            remove=True,
+            volumes={docker_name: {"bind": _MOUNT_POINT, "mode": "ro"}},
+        )
+    except docker.errors.ContainerError:
+        # grep returns exit code 1 when no matches — that's normal
+        return {"matches": 0, "output": "", "truncated": False}
+
+    output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
+
+    # Strip the mount-point prefix from paths so output is relative to volume root
+    output_str = output_str.replace(_MOUNT_POINT + "/", "")
+
+    all_lines = output_str.strip().splitlines() if output_str.strip() else []
+    lines = all_lines[:max_results]
+
+    return {
+        "matches": len(lines),
+        "output": "\n".join(lines),
+        "truncated": len(all_lines) > max_results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+def delete_file_in_volume(
+    settings: Settings,
+    team: TeamSettings,
+    name: str,
+    path: str,
+) -> dict[str, Any]:
+    """Delete a file or directory inside a Docker volume."""
+    client = get_client()
+    docker_name = _validate_volume(team, name)
+    full_path = _safe_path(path)
+
+    if full_path == _MOUNT_POINT:
+        raise ConflictError(
+            "Cannot delete the volume root. Specify a path within the volume."
+        )
+
+    script = f"""\
+if [ ! -e "{full_path}" ]; then
+    echo "NOTFOUND"
+else
+    rm -rf "{full_path}" && echo "DELETED" || echo "FAILED"
+fi
+"""
+
+    logger.info("Deleting in volume %s: %s", name, path)
+    try:
+        output = client.containers.run(
+            _HELPER_IMAGE,
+            ["sh", "-c", script],
+            entrypoint="",
+            user="root",
+            remove=True,
+            volumes={docker_name: {"bind": _MOUNT_POINT, "mode": "rw"}},
+        )
+    except docker.errors.ContainerError as exc:
+        stderr = exc.stderr or b""
+        msg = (
+            stderr.decode("utf-8", errors="replace")
+            if isinstance(stderr, bytes)
+            else str(stderr)
+        )
+        return {"error": f"Failed to delete: {msg}"}
+
+    result_str = (
+        output.decode("utf-8") if isinstance(output, bytes) else str(output)
+    ).strip()
+
+    if result_str == "NOTFOUND":
+        return {"error": f"Path not found: {path}"}
+    if result_str == "DELETED":
+        return {"path": path, "status": "deleted"}
+    return {"error": f"Failed to delete: {path}"}

--- a/src/oduflow/docker_ops/volume_file_ops.py
+++ b/src/oduflow/docker_ops/volume_file_ops.py
@@ -9,14 +9,15 @@ from __future__ import annotations
 import io
 import logging
 import os
+import shlex
 import tarfile
 from typing import Any
 
 import docker
 
 from oduflow.docker_ops.client import get_client
-from oduflow.docker_ops.volume_ops import _docker_volume_name
-from oduflow.errors import ConflictError, ExternalCommandError, NotFoundError
+from oduflow.docker_ops.volume_ops import docker_volume_name
+from oduflow.errors import ConflictError, NotFoundError
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -27,15 +28,15 @@ _FILE_SIZE_LIMIT = 100 * 1024  # 100 KB
 _WRITE_FILE_LIMIT = 1_000_000  # 1 MB
 
 
-def _validate_volume(team: TeamSettings, name: str) -> str:
-    """Validate that a volume exists and return its Docker name."""
+def _validate_volume(team: TeamSettings, name: str) -> tuple[str, docker.DockerClient]:
+    """Validate that a volume exists and return its Docker name and client."""
     client = get_client()
-    docker_name = _docker_volume_name(team, name)
+    docker_name = docker_volume_name(team, name)
     try:
         client.volumes.get(docker_name)
     except docker.errors.NotFound:
         raise NotFoundError(f"Volume '{name}' not found.")
-    return docker_name
+    return docker_name, client
 
 
 def _safe_path(path: str) -> str:
@@ -66,8 +67,7 @@ def read_file_in_volume(
     read_range: str = "",
 ) -> dict[str, Any]:
     """Read a text file or list a directory inside a Docker volume."""
-    client = get_client()
-    docker_name = _validate_volume(team, name)
+    docker_name, client = _validate_volume(team, name)
     full_path = _safe_path(path)
 
     # Validate read_range early (before spinning up a container).
@@ -92,8 +92,9 @@ def read_file_in_volume(
         read_cmd = 'cat "$FILE"'
 
     size_limit = _FILE_SIZE_LIMIT
+    quoted = shlex.quote(full_path)
     script = f"""\
-FILE="{full_path}"
+FILE={quoted}
 if [ -d "$FILE" ]; then
     echo "TYPE:DIR"
     ls -la "$FILE"
@@ -196,14 +197,11 @@ def write_file_in_volume(
     """Write a text file inside a Docker volume via tar stream."""
     data = content.encode("utf-8")
     if len(data) > _WRITE_FILE_LIMIT:
-        raise ExternalCommandError(
-            "write_file_in_volume",
-            1,
+        raise ConflictError(
             f"Content exceeds {_WRITE_FILE_LIMIT} byte limit.",
         )
 
-    client = get_client()
-    docker_name = _validate_volume(team, name)
+    docker_name, client = _validate_volume(team, name)
     full_path = _safe_path(path)
     parent = full_path.rsplit("/", 1)[0] if "/" in full_path else "/"
     filename = full_path.rsplit("/", 1)[-1]
@@ -251,8 +249,7 @@ def search_in_volume(
     max_results: int = 50,
 ) -> dict[str, Any]:
     """Search for a pattern in files inside a Docker volume."""
-    client = get_client()
-    docker_name = _validate_volume(team, name)
+    docker_name, client = _validate_volume(team, name)
     search_path = _safe_path(path) if path else _MOUNT_POINT
 
     cmd = [
@@ -282,9 +279,11 @@ def search_in_volume(
             remove=True,
             volumes={docker_name: {"bind": _MOUNT_POINT, "mode": "ro"}},
         )
-    except docker.errors.ContainerError:
+    except docker.errors.ContainerError as exc:
         # grep returns exit code 1 when no matches — that's normal
-        return {"matches": 0, "output": "", "truncated": False}
+        if exc.exit_status == 1:
+            return {"matches": 0, "output": "", "truncated": False}
+        raise
 
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
@@ -313,8 +312,7 @@ def delete_file_in_volume(
     path: str,
 ) -> dict[str, Any]:
     """Delete a file or directory inside a Docker volume."""
-    client = get_client()
-    docker_name = _validate_volume(team, name)
+    docker_name, client = _validate_volume(team, name)
     full_path = _safe_path(path)
 
     if full_path == _MOUNT_POINT:
@@ -322,11 +320,12 @@ def delete_file_in_volume(
             "Cannot delete the volume root. Specify a path within the volume."
         )
 
+    quoted = shlex.quote(full_path)
     script = f"""\
-if [ ! -e "{full_path}" ]; then
+if [ ! -e {quoted} ]; then
     echo "NOTFOUND"
 else
-    rm -rf "{full_path}" && echo "DELETED" || echo "FAILED"
+    rm -rf {quoted} && echo "DELETED" || echo "FAILED"
 fi
 """
 

--- a/src/oduflow/docker_ops/volume_ops.py
+++ b/src/oduflow/docker_ops/volume_ops.py
@@ -29,7 +29,7 @@ def _vol_labels(vol) -> dict[str, str]:
     return vol.attrs.get("Labels") or {}
 
 
-def _docker_volume_name(team: TeamSettings, name: str) -> str:
+def docker_volume_name(team: TeamSettings, name: str) -> str:
     """Return the Docker volume name: ``oduflow-vol-{team_id}-{name}``."""
     return f"oduflow-vol-{team.team_id}-{name}"
 
@@ -48,7 +48,7 @@ def create_volume(
         )
 
     client = get_client()
-    docker_name = _docker_volume_name(team, name)
+    docker_name = docker_volume_name(team, name)
 
     # Check for existing volume
     try:
@@ -114,7 +114,7 @@ def list_volumes(settings: Settings, team: TeamSettings) -> list[dict]:
 def inspect_volume(settings: Settings, team: TeamSettings, name: str) -> dict:
     """Return details for a single volume including usage."""
     client = get_client()
-    docker_name = _docker_volume_name(team, name)
+    docker_name = docker_volume_name(team, name)
 
     try:
         vol = client.volumes.get(docker_name)
@@ -139,7 +139,7 @@ def inspect_volume(settings: Settings, team: TeamSettings, name: str) -> dict:
 def delete_volume(settings: Settings, team: TeamSettings, name: str) -> dict[str, str]:
     """Delete a volume. Raises ConflictError if it is mounted by a service."""
     client = get_client()
-    docker_name = _docker_volume_name(team, name)
+    docker_name = docker_volume_name(team, name)
 
     try:
         vol = client.volumes.get(docker_name)
@@ -261,8 +261,8 @@ def resolve_volume_binds(
         vol_name = mount["volume"]
         prefix = f"oduflow-vol-{team.team_id}-"
         if vol_name.startswith(prefix):
-            vol_name = vol_name[len(prefix):]
-        docker_name = _docker_volume_name(team, vol_name)
+            vol_name = vol_name[len(prefix) :]
+        docker_name = docker_volume_name(team, vol_name)
         try:
             client.volumes.get(docker_name)
         except docker.errors.NotFound:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -16,6 +16,7 @@ from oduflow.docker_ops import (
     service_ops,
     service_presets,
     system_ops,
+    volume_file_ops,
     volume_ops,
 )
 from oduflow import git_ops
@@ -1900,6 +1901,133 @@ def delete_volume(name: str, ctx: Context = None) -> str:
 
 
 # =============================================================================
+# Volume file operations
+# =============================================================================
+
+
+@mcp.tool()
+@handle_errors
+def read_file_in_volume(
+    name: str,
+    path: str,
+    read_range: str = "",
+    ctx: Context = None,
+) -> str:
+    """
+    Read a text file or list a directory inside a Docker volume.
+
+    Spins up a temporary helper container to access the volume contents.
+    If the path is a directory, returns a listing (like ``ls -la``).
+    If the path is a text file, returns its contents (up to 100KB by default).
+    Binary files are detected and rejected.
+
+    Args:
+        name: The name of the volume (e.g. "redis-data").
+        path: Path inside the volume (e.g. "data/dump.rdb", "config/redis.conf").
+              Leading "/" is optional — paths are relative to the volume root.
+        read_range: Optional line range "START:END" (e.g. "1:50", "100:200").
+                    If omitted, returns the full file (up to 100KB).
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = volume_file_ops.read_file_in_volume(settings, team, name, path, read_range)
+    if "error" in result:
+        return f"Error: {result['error']}"
+    return result["output"]
+
+
+@mcp.tool()
+@handle_errors
+@with_team_lock
+def write_file_in_volume(
+    name: str,
+    path: str,
+    content: str,
+    ctx: Context = None,
+) -> str:
+    """
+    Write a text file inside a Docker volume.
+
+    Creates parent directories if they don't exist. Overwrites the file if it
+    already exists. Uses a temporary helper container to access the volume.
+
+    Args:
+        name: The name of the volume (e.g. "redis-data").
+        path: Path inside the volume (e.g. "config/my.conf").
+              Leading "/" is optional — paths are relative to the volume root.
+        content: Text content to write to the file.
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = volume_file_ops.write_file_in_volume(settings, team, name, path, content)
+    return f"File written: {result['path']} ({result['size']} bytes)"
+
+
+@mcp.tool()
+@handle_errors
+def search_in_volume(
+    name: str,
+    pattern: str,
+    path: str = "",
+    glob: str = "*",
+    max_results: int = 50,
+    ctx: Context = None,
+) -> str:
+    """
+    Search for a pattern in files inside a Docker volume.
+
+    Runs a recursive fixed-string grep inside a temporary helper container
+    and returns matching lines with file paths and line numbers.
+
+    Args:
+        name: The name of the volume (e.g. "redis-data").
+        pattern: Search pattern (fixed string, case-sensitive).
+        path: Directory to search in, relative to volume root (default: entire volume).
+        glob: File glob pattern (default "*"). Use "*.py", "*.xml", "*.conf", etc.
+        max_results: Maximum number of matching lines to return (default 50).
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = volume_file_ops.search_in_volume(
+        settings, team, name, pattern, path, glob, max_results
+    )
+    output = result["output"]
+    if not output:
+        return f"No matches for '{pattern}' in volume '{name}' ({glob})."
+    header = f"Matches: {result['matches']}"
+    if result["truncated"]:
+        header += f" (truncated to {max_results})"
+    return f"{header}\n\n{output}"
+
+
+@mcp.tool()
+@handle_errors
+@with_team_lock
+def delete_file_in_volume(
+    name: str,
+    path: str,
+    ctx: Context = None,
+) -> str:
+    """
+    Delete a file or directory inside a Docker volume.
+
+    Uses a temporary helper container to access the volume.
+    Cannot delete the volume root — use delete_volume to remove the entire volume.
+
+    Args:
+        name: The name of the volume (e.g. "redis-data").
+        path: Path inside the volume to delete (e.g. "data/old-dump.rdb").
+              Leading "/" is optional — paths are relative to the volume root.
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = volume_file_ops.delete_file_in_volume(settings, team, name, path)
+    if "error" in result:
+        return f"Error: {result['error']}"
+    return f"Deleted: {result['path']}"
+
+
+# =============================================================================
 # CLI helpers
 # =============================================================================
 
@@ -2632,7 +2760,9 @@ def main() -> None:
                 args.template_name,
                 args.source,
             )
-            msg = f"Template DB {result['status']}.\nTemplate DB: {result['template_db']}"
+            msg = (
+                f"Template DB {result['status']}.\nTemplate DB: {result['template_db']}"
+            )
             if "restore_seconds" in result:
                 msg += f"\nDB restore time: {result['restore_seconds']}s"
             if not args.quiet:

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -94,6 +94,19 @@ MCP endpoint: `http://<host>:8000/mcp`
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 
+### Volumes
+
+| Tool | When to use |
+|---|---|
+| `create_volume(name, description?)` | Create a named Docker volume for use with services |
+| `list_volumes` | List all managed volumes and which services use them |
+| `inspect_volume(name)` | Get detailed info about a volume (Docker name, mountpoint, usage) |
+| `delete_volume(name)` | Delete a volume (fails if mounted by a service) |
+| `read_file_in_volume(name, path, read_range?)` | Read a text file or list a directory inside a volume. Spins up a temporary container |
+| `write_file_in_volume(name, path, content)` | Write a text file inside a volume |
+| `search_in_volume(name, pattern, path?, glob?, max_results?)` | Grep for a pattern in files inside a volume. Fixed-string search with file/line numbers |
+| `delete_file_in_volume(name, path)` | Delete a file or directory inside a volume |
+
 ### Template Management (use with caution)
 
 | Tool | When to use |

--- a/tests/test_volume_file_ops.py
+++ b/tests/test_volume_file_ops.py
@@ -1,0 +1,358 @@
+import pytest
+import docker
+from unittest.mock import MagicMock, patch
+
+from oduflow.docker_ops import volume_file_ops
+from oduflow.docker_ops.volume_file_ops import _safe_path, _MOUNT_POINT
+from oduflow.errors import ConflictError, ExternalCommandError, NotFoundError
+from oduflow.settings import Settings, TeamSettings
+
+TEST_TEAM = TeamSettings(
+    team_id="1",
+    data_dir="/tmp/flow-test",
+    port_registry_path="/tmp/flow-test/ports.json",
+    port_range_start=50000,
+    port_range_end=50100,
+)
+
+TEST_SETTINGS = Settings(
+    base_data_dir="/tmp/flow-test",
+    db_user="odoo",
+    db_password="odoo",
+    teams={"1": TEST_TEAM},
+)
+
+
+@pytest.fixture
+def mock_docker_client():
+    with patch("oduflow.docker_ops.volume_file_ops.get_client") as mock:
+        client_instance = MagicMock()
+        mock.return_value = client_instance
+        yield client_instance
+
+
+# ---------------------------------------------------------------------------
+# _safe_path
+# ---------------------------------------------------------------------------
+
+
+class TestSafePath:
+    def test_normal_path(self):
+        assert _safe_path("data/file.txt") == f"{_MOUNT_POINT}/data/file.txt"
+
+    def test_leading_slash(self):
+        assert _safe_path("/data/file.txt") == f"{_MOUNT_POINT}/data/file.txt"
+
+    def test_empty_path(self):
+        assert _safe_path("") == _MOUNT_POINT
+
+    def test_root_slash(self):
+        assert _safe_path("/") == _MOUNT_POINT
+
+    def test_path_traversal_blocked(self):
+        with pytest.raises(ConflictError):
+            _safe_path("../../etc/passwd")
+
+    def test_path_traversal_via_middle(self):
+        with pytest.raises(ConflictError):
+            _safe_path("data/../../etc/passwd")
+
+    def test_nested_path(self):
+        assert _safe_path("a/b/c/d.txt") == f"{_MOUNT_POINT}/a/b/c/d.txt"
+
+    def test_dot_path(self):
+        assert _safe_path(".") == _MOUNT_POINT
+
+
+# ---------------------------------------------------------------------------
+# read_file_in_volume
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileInVolume:
+    def test_read_file(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = (
+            b"TYPE:FILE\nSIZE:42\nCONTENT_START\nhello world\n"
+        )
+
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "file.txt"
+        )
+
+        assert result["type"] == "file"
+        assert "hello world" in result["output"]
+        assert result["size"] == 42
+
+    def test_read_directory(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = (
+            b"TYPE:DIR\ntotal 4\ndrwxr-xr-x 2 root root 4096 data\n"
+        )
+
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "/"
+        )
+
+        assert result["type"] == "directory"
+        assert "data" in result["output"]
+
+    def test_not_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = b"TYPE:NOTFOUND\n"
+
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "missing.txt"
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_binary_file(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = b"TYPE:BINARY\nSIZE:1024\n"
+
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "data.bin"
+        )
+
+        assert "error" in result
+        assert "binary" in result["error"].lower()
+
+    def test_file_too_large(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = b"TYPE:TOOLARGE\nSIZE:200000\n"
+
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "big.log"
+        )
+
+        assert "error" in result
+        assert "too large" in result["error"].lower()
+
+    def test_read_range(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = (
+            b"TYPE:FILE\nSIZE:5000\nCONTENT_START\nline 10\nline 11\n"
+        )
+
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "file.txt", read_range="10:11"
+        )
+
+        assert result["type"] == "file"
+        assert result["range"] == "10:11"
+
+    def test_invalid_range_format(self, mock_docker_client):
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "file.txt", read_range="bad"
+        )
+        assert "error" in result
+
+    def test_invalid_range_values(self, mock_docker_client):
+        result = volume_file_ops.read_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "file.txt", read_range="a:b"
+        )
+        assert "error" in result
+
+    def test_volume_not_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError):
+            volume_file_ops.read_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "nonexistent", "file.txt"
+            )
+
+
+# ---------------------------------------------------------------------------
+# write_file_in_volume
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFileInVolume:
+    def test_write_file(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_docker_client.containers.run.return_value = mock_container
+
+        result = volume_file_ops.write_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "config/app.conf", "key=value"
+        )
+
+        assert result["path"] == "config/app.conf"
+        assert result["size"] == len("key=value".encode("utf-8"))
+        mock_container.exec_run.assert_called_once()
+        mock_container.put_archive.assert_called_once()
+        mock_container.stop.assert_called_once()
+        mock_container.remove.assert_called_once()
+
+    def test_content_too_large(self, mock_docker_client):
+        with pytest.raises(ExternalCommandError):
+            volume_file_ops.write_file_in_volume(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "mydata",
+                "big.txt",
+                "x" * 2_000_000,
+            )
+
+    def test_volume_not_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError):
+            volume_file_ops.write_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "nonexistent", "file.txt", "content"
+            )
+
+    def test_path_traversal_blocked(self, mock_docker_client):
+        with pytest.raises(ConflictError):
+            volume_file_ops.write_file_in_volume(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "mydata",
+                "../../etc/passwd",
+                "malicious",
+            )
+
+    def test_cleanup_on_error(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.exec_run.side_effect = RuntimeError("container error")
+        mock_docker_client.containers.run.return_value = mock_container
+
+        with pytest.raises(RuntimeError):
+            volume_file_ops.write_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "mydata", "file.txt", "content"
+            )
+
+        # Container should still be cleaned up
+        mock_container.stop.assert_called_once()
+        mock_container.remove.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# search_in_volume
+# ---------------------------------------------------------------------------
+
+
+class TestSearchInVolume:
+    def test_matches_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = (
+            b"/mnt/volume/config/app.conf:3:key=value\n"
+            b"/mnt/volume/config/app.conf:7:key=other\n"
+        )
+
+        result = volume_file_ops.search_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "key=", glob="*.conf"
+        )
+
+        assert result["matches"] == 2
+        assert "config/app.conf" in result["output"]
+        assert not result["truncated"]
+        # Mount point prefix should be stripped
+        assert "/mnt/volume/" not in result["output"]
+
+    def test_no_matches(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.side_effect = docker.errors.ContainerError(
+            container=MagicMock(),
+            exit_status=1,
+            command="grep",
+            image="alpine",
+            stderr=b"",
+        )
+
+        result = volume_file_ops.search_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "nonexistent"
+        )
+
+        assert result["matches"] == 0
+        assert result["output"] == ""
+
+    def test_truncation(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        lines = "\n".join(f"/mnt/volume/file.txt:{i}:match" for i in range(100))
+        mock_docker_client.containers.run.return_value = lines.encode()
+
+        result = volume_file_ops.search_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "match", max_results=10
+        )
+
+        assert result["matches"] == 10
+        assert result["truncated"] is True
+
+    def test_volume_not_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError):
+            volume_file_ops.search_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "nonexistent", "pattern"
+            )
+
+    def test_search_with_path(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = (
+            b"/mnt/volume/subdir/file.txt:1:found\n"
+        )
+
+        result = volume_file_ops.search_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "found", path="subdir"
+        )
+
+        assert result["matches"] == 1
+
+
+# ---------------------------------------------------------------------------
+# delete_file_in_volume
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteFileInVolume:
+    def test_delete_file(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = b"DELETED\n"
+
+        result = volume_file_ops.delete_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "old/data.txt"
+        )
+
+        assert result["status"] == "deleted"
+        assert result["path"] == "old/data.txt"
+
+    def test_not_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = b"NOTFOUND\n"
+
+        result = volume_file_ops.delete_file_in_volume(
+            TEST_SETTINGS, TEST_TEAM, "mydata", "missing.txt"
+        )
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_cannot_delete_volume_root(self, mock_docker_client):
+        with pytest.raises(ConflictError):
+            volume_file_ops.delete_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "mydata", "/"
+            )
+
+    def test_cannot_delete_empty_path(self, mock_docker_client):
+        with pytest.raises(ConflictError):
+            volume_file_ops.delete_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "mydata", ""
+            )
+
+    def test_volume_not_found(self, mock_docker_client):
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError):
+            volume_file_ops.delete_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "nonexistent", "file.txt"
+            )
+
+    def test_path_traversal_blocked(self, mock_docker_client):
+        with pytest.raises(ConflictError):
+            volume_file_ops.delete_file_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "mydata", "../../etc/passwd"
+            )

--- a/tests/test_volume_file_ops.py
+++ b/tests/test_volume_file_ops.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from oduflow.docker_ops import volume_file_ops
 from oduflow.docker_ops.volume_file_ops import _safe_path, _MOUNT_POINT
-from oduflow.errors import ConflictError, ExternalCommandError, NotFoundError
+from oduflow.errors import ConflictError, NotFoundError
 from oduflow.settings import Settings, TeamSettings
 
 TEST_TEAM = TeamSettings(
@@ -187,7 +187,7 @@ class TestWriteFileInVolume:
         mock_container.remove.assert_called_once()
 
     def test_content_too_large(self, mock_docker_client):
-        with pytest.raises(ExternalCommandError):
+        with pytest.raises(ConflictError):
             volume_file_ops.write_file_in_volume(
                 TEST_SETTINGS,
                 TEST_TEAM,
@@ -288,6 +288,21 @@ class TestSearchInVolume:
         with pytest.raises(NotFoundError):
             volume_file_ops.search_in_volume(
                 TEST_SETTINGS, TEST_TEAM, "nonexistent", "pattern"
+            )
+
+    def test_non_exit1_error_reraised(self, mock_docker_client):
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.run.side_effect = docker.errors.ContainerError(
+            container=MagicMock(),
+            exit_status=2,
+            command="grep",
+            image="alpine",
+            stderr=b"grep: invalid option",
+        )
+
+        with pytest.raises(docker.errors.ContainerError):
+            volume_file_ops.search_in_volume(
+                TEST_SETTINGS, TEST_TEAM, "mydata", "pattern"
             )
 
     def test_search_with_path(self, mock_docker_client):

--- a/tests/test_volume_ops.py
+++ b/tests/test_volume_ops.py
@@ -36,14 +36,14 @@ def mock_docker_client():
 
 class TestDockerVolumeName:
     def test_basic(self):
-        result = volume_ops._docker_volume_name(TEST_TEAM, "redis-data")
+        result = volume_ops.docker_volume_name(TEST_TEAM, "redis-data")
         assert result == "oduflow-vol-1-redis-data"
 
     def test_different_team(self):
         team2 = TeamSettings(
             team_id="2", data_dir="/tmp", port_registry_path="/tmp/p.json"
         )
-        result = volume_ops._docker_volume_name(team2, "mydata")
+        result = volume_ops.docker_volume_name(team2, "mydata")
         assert result == "oduflow-vol-2-mydata"
 
 


### PR DESCRIPTION
## Summary

Adds four new MCP tools for managing files inside Docker volumes, complementing the existing volume lifecycle tools (create/list/inspect/delete). Previously, volume contents could only be accessed via service containers that had them mounted — these tools work standalone by spinning up temporary Alpine containers.

### New MCP tools

| Tool | Lock | Description |
|---|:---:|---|
| `read_file_in_volume` | | Read a text file or list a directory inside a volume (binary detection, 100KB limit, line range support) |
| `write_file_in_volume` | ✓ | Write a text file via tar stream (1MB limit, auto-creates parent dirs) |
| `search_in_volume` | | Fixed-string grep with file/line numbers, glob filtering, result truncation |
| `delete_file_in_volume` | ✓ | Delete a file or directory (blocks volume root deletion) |

### Implementation details

- **Temporary Alpine containers**: Each operation spins up a short-lived `alpine:latest` container with the volume mounted at `/mnt/volume` — no running service required
- **BusyBox compatibility**: Alpine uses BusyBox, so binary detection uses `tr -cd '\0' | wc -c` instead of `file --mime`, and file size uses `wc -c` instead of `stat -c`
- **Path traversal protection**: `_safe_path()` normalizes paths and blocks `..` escapes
- **Shell injection prevention**: All path interpolations in shell scripts use `shlex.quote()`
- **Write via tar stream**: `write_file_in_volume` uses `container.put_archive()` to avoid shell escaping issues entirely
- **Proper cleanup**: Write operations use `try/finally` to ensure container cleanup even on errors

### Other changes

- **`resolve_volume_binds` fix**: Strips the `oduflow-vol-{team_id}-` prefix when volume names are already fully qualified, preventing double-prefixing
- **`_docker_volume_name` → `docker_volume_name`**: Renamed to public API since it's used cross-module
- **Documentation**: Added all 8 volume tools (4 lifecycle + 4 file ops) to `mcp-tools.md`, `llms.txt`, `llms-full.txt`, and agent instructions

### Tests

- 34 new unit tests across 5 test classes covering all operations, error paths, path traversal, cleanup, and edge cases
- Full suite: 282 tests pass

This PR was written using [Vibe Kanban](https://vibekanban.com)