### PR TITLE
feat: add created_at timestamp, editable notes, and preset-based service updates

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import json
 import logging
 import os
@@ -485,6 +486,7 @@ def create_environment(
         settings.image_label: odoo_image,
         "oduflow.template": template_name if template_name is not None else "none",
         "oduflow.git_branch": branch,
+        "oduflow.created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
 
     if extra_addons:
@@ -862,6 +864,17 @@ def is_protected(settings: Settings, team: TeamSettings, env_name: str) -> bool:
     return os.path.exists(os.path.join(workspace_path, ".protected"))
 
 
+def _get_note_text(env_name: str, workspaces_dir: str) -> str:
+    note_path = os.path.join(get_workspace_path(env_name, workspaces_dir), ".note")
+    if os.path.exists(note_path):
+        try:
+            with open(note_path) as f:
+                return f.read().strip()
+        except OSError:
+            return ""
+    return ""
+
+
 def protect_environment(
     settings: Settings, team: TeamSettings, env_name: str
 ) -> dict[str, Any]:
@@ -895,6 +908,32 @@ def unprotect_environment(
         os.remove(marker)
     logger.info("Environment unprotected", extra={"env_name": env_name})
     return {"env_name": env_name, "protected": False}
+
+
+def get_note(settings: Settings, team: TeamSettings, env_name: str) -> str:
+    return _get_note_text(env_name, team.workspaces_dir)
+
+
+def set_note(
+    settings: Settings, team: TeamSettings, env_name: str, note: str
+) -> dict[str, Any]:
+    """Set or clear a note for an environment."""
+    client = get_client()
+    container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    try:
+        client.containers.get(container_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(f"Environment '{env_name}' does not exist.")
+    workspace_path = get_workspace_path(env_name, team.workspaces_dir)
+    note_path = os.path.join(workspace_path, ".note")
+    note = note.strip()
+    if note:
+        with open(note_path, "w") as f:
+            f.write(note)
+    elif os.path.exists(note_path):
+        os.remove(note_path)
+    logger.info("Environment note updated", extra={"env_name": env_name, "note": note})
+    return {"env_name": env_name, "note": note}
 
 
 def delete_environment(
@@ -999,6 +1038,9 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                 "auto_install_modules": container.labels.get(
                     "oduflow.auto_install_modules", ""
                 ),
+                "created_at": container.labels.get("oduflow.created_at", "")
+                or container.attrs.get("Created", ""),
+                "note": _get_note_text(env_name, team.workspaces_dir),
             }
 
         try:
@@ -1164,6 +1206,10 @@ def get_environment_info(
             json.loads(labels.get("oduflow.extra_addons", "{}")),
         )
         result["auto_install_modules"] = labels.get("oduflow.auto_install_modules", "")
+        result["created_at"] = labels.get("oduflow.created_at", "") or odoo_container.attrs.get(
+            "Created", ""
+        )
+        result["note"] = _get_note_text(env_name, team.workspaces_dir)
 
         if settings.routing_mode == "traefik":
             result["url"] = (

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -339,80 +339,92 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
             "The container has no image tag or Config.Image."
         )
 
-    # Capture current environment variables (filtering system keys)
-    raw_env = container.attrs.get("Config", {}).get("Env", [])
-    env_vars: dict[str, str] = {}
-    for entry in raw_env:
-        if "=" in entry:
-            key, value = entry.split("=", 1)
-            if key not in _SYSTEM_ENV_KEYS:
-                env_vars[key] = value
+    # Read service options from saved preset (authoritative source).
+    # Fall back to container inspection for legacy services without a preset.
+    preset = None
+    try:
+        preset = service_presets.get_preset(team, name)
+    except Exception:
+        pass
 
-    # Detect host mode
-    is_host_mode = container.labels.get("oduflow.host_mode") == "true"
-
-    # Capture port and hostname depending on routing mode
-    port: int | None = None
-    hostname: str | None = None
-
-    if settings.routing_mode == "traefik":
-        rule_label = f"traefik.http.routers.{container_name}.rule"
-
-        rule_value = container.labels.get(rule_label, "")
-        match = re.search(r"Host\(`([^`]+)`\)", rule_value)
-        if match:
-            hostname = match.group(1)
-
-        if is_host_mode:
-            url_label = (
-                f"traefik.http.services.{container_name}.loadbalancer.server.url"
-            )
-            url_value = container.labels.get(url_label, "")
-            port_match = re.search(r":(\d+)$", url_value)
-            if port_match:
-                port = int(port_match.group(1))
-        else:
-            port_label = (
-                f"traefik.http.services.{container_name}.loadbalancer.server.port"
-            )
-            label_port = container.labels.get(port_label)
-            if label_port:
-                port = int(label_port)
+    if preset:
+        port = preset.get("port")
+        hostname = preset.get("hostname") or None
+        env_vars = preset.get("env_vars") or None
+        is_host_mode = preset.get("host_mode", False)
+        old_volumes = preset.get("volumes") or None
     else:
-        if is_host_mode:
-            try:
-                preset = service_presets.get_preset(team, name)
-                port = preset.get("port")
-            except Exception:
-                pass
+        # Legacy fallback: extract from running container
+        raw_env = container.attrs.get("Config", {}).get("Env", [])
+        env_vars: dict[str, str] = {}
+        for entry in raw_env:
+            if "=" in entry:
+                key, value = entry.split("=", 1)
+                if key not in _SYSTEM_ENV_KEYS:
+                    env_vars[key] = value
+
+        is_host_mode = container.labels.get("oduflow.host_mode") == "true"
+
+        port: int | None = None
+        hostname: str | None = None
+
+        if settings.routing_mode == "traefik":
+            rule_label = f"traefik.http.routers.{container_name}.rule"
+            rule_value = container.labels.get(rule_label, "")
+            match = re.search(r"Host\(`([^`]+)`\)", rule_value)
+            if match:
+                hostname = match.group(1)
+
+            if is_host_mode:
+                url_label = (
+                    f"traefik.http.services.{container_name}.loadbalancer.server.url"
+                )
+                url_value = container.labels.get(url_label, "")
+                port_match = re.search(r":(\d+)$", url_value)
+                if port_match:
+                    port = int(port_match.group(1))
+            else:
+                port_label = (
+                    f"traefik.http.services.{container_name}.loadbalancer.server.port"
+                )
+                label_port = container.labels.get(port_label)
+                if label_port:
+                    port = int(label_port)
         else:
-            ports_dict = container.attrs.get("NetworkSettings", {}).get("Ports", {})
-            if ports_dict:
-                for port_key in ports_dict:
-                    port_match = re.match(r"(\d+)/", port_key)
-                    if port_match:
-                        port = int(port_match.group(1))
-                        break
+            if is_host_mode:
+                pass  # Cannot determine port without preset in host mode
+            else:
+                ports_dict = container.attrs.get("NetworkSettings", {}).get("Ports", {})
+                if ports_dict:
+                    for port_key in ports_dict:
+                        port_match = re.match(r"(\d+)/", port_key)
+                        if port_match:
+                            port = int(port_match.group(1))
+                            break
+
+        old_volumes = None
+        mounts_data = container.attrs.get("Mounts", [])
+        vols: list[dict[str, str]] = []
+        for mount in mounts_data:
+            if mount.get("Type") == "volume":
+                vol_docker_name = mount.get("Name", "")
+                prefix = f"oduflow-vol-{team.team_id}-"
+                if vol_docker_name.startswith(prefix):
+                    short_name = vol_docker_name[len(prefix):]
+                    vols.append(
+                        {
+                            "volume": short_name,
+                            "mount_path": mount.get("Destination", ""),
+                            "mode": "ro" if not mount.get("RW", True) else "rw",
+                        }
+                    )
+        if vols:
+            old_volumes = vols
+
+        env_vars = env_vars or None
 
     if port is None:
         raise NotFoundError(f"Cannot determine port for service '{name}'.")
-
-    # Capture volume mounts from old container
-    old_volumes: list[dict[str, str]] = []
-    mounts = container.attrs.get("Mounts", [])
-    for mount in mounts:
-        if mount.get("Type") == "volume":
-            vol_docker_name = mount.get("Name", "")
-            prefix = f"oduflow-vol-{team.team_id}-"
-            if vol_docker_name.startswith(prefix):
-                short_name = vol_docker_name[len(prefix) :]
-                old_volumes.append(
-                    {
-                        "volume": short_name,
-                        "mount_path": mount.get("Destination", ""),
-                        "mode": "ro" if not mount.get("RW", True) else "rw",
-                    }
-                )
 
     # Capture old image digest
     old_digest = container.image.id  # e.g. sha256:abc...

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -98,6 +98,17 @@
     margin-bottom: 10px;
   }
   .env-meta strong { color: var(--text); font-weight: 500; }
+  .env-note {
+    font-size: 12px;
+    color: var(--text-dim);
+    margin-bottom: 10px;
+    padding: 4px 8px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    border-radius: 4px;
+  }
+  .env-note:hover { border-color: var(--border); }
+  .env-note-empty { font-style: italic; opacity: 0.5; }
   .containers {
     font-size: 12px;
     color: var(--text-dim);
@@ -921,6 +932,7 @@ function renderEnvironments(envs) {
           (env.template_name && env.template_name !== 'none' ? '<span>Template: <strong>' + esc(env.template_name) + '</strong></span>' : '') +
           (env.odoo_image ? '<span>Image: <strong>' + esc(env.odoo_image) + '</strong></span>' : '') +
           (env.repo_url ? '<span>Repo: <strong>' + esc(env.repo_url) + '</strong></span>' : '') +
+          (env.created_at ? '<span>Created: <strong>' + formatDate(env.created_at) + '</strong></span>' : '') +
         '</div>'
       : '';
 
@@ -967,6 +979,11 @@ function renderEnvironments(envs) {
       urlHtml +
       metaHtml +
       extraHtml +
+      '<div class="env-note' + (!env.note ? ' env-note-empty' : '') + '" ' +
+        'onclick="editNote(\'' + escAttr(env.branch) + '\')" ' +
+        'title="Click to edit note">' +
+        (env.note ? esc(env.note) : 'Add a note...') +
+      '</div>' +
       '<div class="containers">' + containerHtml + '</div>' +
     '</div>';
   }).join('');
@@ -980,6 +997,30 @@ function esc(s) {
 
 function escAttr(s) {
   return (s || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleString(); }
+  catch(e) { return esc(iso); }
+}
+
+async function editNote(branch) {
+  var el = document.querySelector('.env-card[data-branch="' + branch + '"] .env-note');
+  var current = el && el.classList.contains('env-note-empty') ? '' : (el ? el.textContent : '');
+  var note = prompt('Note for "' + branch + '":', current);
+  if (note === null) return;
+  try {
+    var r = await fetch(API + '/' + encodeURIComponent(branch) + '/note', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({note: note})
+    });
+    var data = await r.json();
+    if (data.ok) { showToast('Note updated'); }
+    else { showToast(data.error || 'Failed to update note', true); }
+  } catch(e) { showToast('Connection error: ' + e.message, true); }
+  await loadEnvironments();
 }
 
 async function loadEnvironments() {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -977,6 +977,20 @@ def _build_routes(
             logger.exception("Unexpected error in api_unprotect")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
+    async def api_set_note(request: Request) -> JSONResponse:
+        branch = request.path_params["branch"]
+        try:
+            team = _get_ui_team(request)
+            body = await request.json()
+            note = body.get("note", "")
+            result = env_ops.set_note(get_settings(), team, branch, note)
+            return JSONResponse({"ok": True, "result": result})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_set_note")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
     async def ws_terminal(websocket: WebSocket) -> None:
         branch = websocket.path_params["branch"]
         await websocket.accept()
@@ -1209,6 +1223,7 @@ def _build_routes(
         Route(
             "/api/environments/{branch:path}/unprotect", api_unprotect, methods=["POST"]
         ),
+        Route("/api/environments/{branch:path}/note", api_set_note, methods=["POST"]),
         Route("/api/environments/{branch:path}/rebuild", api_rebuild, methods=["POST"]),
         Route(
             "/api/environments/{branch:path}/recreate", api_recreate, methods=["POST"]

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -339,54 +339,20 @@ class TestListServices:
 
 
 class TestUpdateService:
-    def test_update_port_mode(self, mock_docker_client):
-        """Update pulls the image, removes old container, and re-creates with same settings."""
+    def _make_container(self, image_tags, labels, attrs):
         container = MagicMock()
-        container.image.tags = ["redis:7"]
-        container.labels = {"oduflow.managed": "true", "oduflow.service": "redis"}
-        container.attrs = {
-            "NetworkSettings": {
-                "Ports": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]}
-            },
-            "Config": {"Env": ["REDIS_PASSWORD=secret", "PATH=/usr/bin", "HOME=/root"]},
-        }
+        container.image.tags = image_tags
+        container.labels = labels
+        container.attrs = attrs
+        return container
 
-        # First get() returns the existing container, second get() (inside create_service)
-        # raises NotFound (container was removed)
-        mock_docker_client.containers.get.side_effect = [
-            container,  # update_service lookup
-            docker.errors.NotFound("nf"),  # create_service conflict check
-        ]
-        mock_docker_client.networks.get.return_value = MagicMock()
-        mock_docker_client.containers.run.return_value = MagicMock()
-
-        result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
-
-        assert result["name"] == "redis"
-        assert result["image"] == "redis:7"
-        assert result["url"] == "http://localhost:6379"
-
-        # Verify pull was called
-        mock_docker_client.images.pull.assert_called_once_with("redis:7")
-
-        # Verify old container was stopped and removed
-        container.stop.assert_called_once()
-        container.remove.assert_called_once_with(v=True)
-
-        # Verify re-creation with same env vars (only non-system)
-        run_kwargs = mock_docker_client.containers.run.call_args
-        assert run_kwargs[1]["environment"] == {"REDIS_PASSWORD": "secret"}
-
-    def test_update_traefik_mode(self, mock_docker_client):
-        container = MagicMock()
-        container.image.tags = ["getmeili/meilisearch:v1.6"]
-        container.labels = {
-            "oduflow.managed": "true",
-            "oduflow.service": "meili",
-            "traefik.http.routers.oduflow-svc-meili.rule": "Host(`meili.example.com`)",
-            "traefik.http.services.oduflow-svc-meili.loadbalancer.server.port": "7700",
-        }
-        container.attrs = {"Config": {"Env": ["MEILI_MASTER_KEY=abc"]}}
+    def test_update_uses_preset(self, mock_docker_client):
+        """When a preset exists, update_service reads options from it (not the container)."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
 
         mock_docker_client.containers.get.side_effect = [
             container,
@@ -395,14 +361,149 @@ class TestUpdateService:
         mock_docker_client.networks.get.return_value = MagicMock()
         mock_docker_client.containers.run.return_value = MagicMock()
 
-        result = service_ops.update_service(TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili")
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {"REDIS_PASSWORD": "secret"},
+            "volumes": [
+                {"volume": "oduflow-traefik-acme", "mount_path": "/acme", "mode": "ro"}
+            ],
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+
+        assert result["name"] == "redis"
+        assert result["image"] == "redis:7"
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["environment"] == {"REDIS_PASSWORD": "secret"}
+
+    def test_update_preset_preserves_volumes(self, mock_docker_client):
+        """Volumes from the preset (including external) are preserved through update."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        volumes = [
+            {"volume": "oduflow-traefik-acme", "mount_path": "/acme", "mode": "ro"},
+            {"volume": "data", "mount_path": "/data", "mode": "rw"},
+        ]
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+            "volumes": volumes,
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ), patch(
+            "oduflow.docker_ops.service_ops.volume_ops.resolve_volume_binds",
+            return_value={"vol1": {"bind": "/acme", "mode": "ro"}},
+        ) as mock_resolve:
+            service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+            mock_resolve.assert_called_once_with(TEST_TEAM, volumes)
+
+    def test_update_port_mode_legacy_no_preset(self, mock_docker_client):
+        """Legacy fallback: extract settings from container when no preset exists."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={
+                "NetworkSettings": {
+                    "Ports": {
+                        "6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]
+                    }
+                },
+                "Config": {
+                    "Env": ["REDIS_PASSWORD=secret", "PATH=/usr/bin", "HOME=/root"]
+                },
+                "Mounts": [],
+            },
+        )
+
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=NotFoundError("not found"),
+        ):
+            result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+
+        assert result["name"] == "redis"
+        assert result["image"] == "redis:7"
+        assert result["url"] == "http://localhost:6379"
+
+        mock_docker_client.images.pull.assert_called_once_with("redis:7")
+        container.stop.assert_called_once()
+        container.remove.assert_called_once_with(v=True)
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["environment"] == {"REDIS_PASSWORD": "secret"}
+
+    def test_update_traefik_mode(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["getmeili/meilisearch:v1.6"],
+            labels={
+                "oduflow.managed": "true",
+                "oduflow.service": "meili",
+                "traefik.http.routers.oduflow-svc-meili.rule": "Host(`meili.example.com`)",
+                "traefik.http.services.oduflow-svc-meili.loadbalancer.server.port": "7700",
+            },
+            attrs={"Config": {"Env": ["MEILI_MASTER_KEY=abc"]}},
+        )
+
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "meili",
+            "image": "getmeili/meilisearch:v1.6",
+            "port": 7700,
+            "hostname": "meili",
+            "env_vars": {"MEILI_MASTER_KEY": "abc"},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili"
+            )
 
         assert result["url"] == "https://meili.example.com"
         mock_docker_client.images.pull.assert_called_once_with(
             "getmeili/meilisearch:v1.6"
         )
 
-        # Verify traefik labels are restored
         run_kwargs = mock_docker_client.containers.run.call_args
         labels = run_kwargs[1]["labels"]
         assert (
@@ -411,16 +512,12 @@ class TestUpdateService:
         )
 
     def test_update_no_env_vars(self, mock_docker_client):
-        """When the container has no custom env vars, env_vars=None is passed to create."""
-        container = MagicMock()
-        container.image.tags = ["redis:7"]
-        container.labels = {"oduflow.managed": "true", "oduflow.service": "redis"}
-        container.attrs = {
-            "NetworkSettings": {
-                "Ports": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]}
-            },
-            "Config": {"Env": ["PATH=/usr/bin", "HOME=/root"]},
-        }
+        """When the preset has no custom env vars, env_vars=None is passed to create."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
 
         mock_docker_client.containers.get.side_effect = [
             container,
@@ -429,7 +526,19 @@ class TestUpdateService:
         mock_docker_client.networks.get.return_value = MagicMock()
         mock_docker_client.containers.run.return_value = MagicMock()
 
-        service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
 
         run_kwargs = mock_docker_client.containers.run.call_args
         assert "environment" not in run_kwargs[1]
@@ -442,15 +551,11 @@ class TestUpdateService:
 
     def test_update_image_fallback_to_config(self, mock_docker_client):
         """When image.tags is empty, fall back to Config.Image."""
-        container = MagicMock()
-        container.image.tags = []
-        container.labels = {"oduflow.managed": "true", "oduflow.service": "redis"}
-        container.attrs = {
-            "NetworkSettings": {
-                "Ports": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]}
-            },
-            "Config": {"Image": "redis:7-alpine", "Env": []},
-        }
+        container = self._make_container(
+            image_tags=[],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Image": "redis:7-alpine", "Env": []}},
+        )
 
         mock_docker_client.containers.get.side_effect = [
             container,
@@ -459,7 +564,19 @@ class TestUpdateService:
         mock_docker_client.networks.get.return_value = MagicMock()
         mock_docker_client.containers.run.return_value = MagicMock()
 
-        result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+        preset = {
+            "name": "redis",
+            "image": "redis:7-alpine",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
 
         assert result["image"] == "redis:7-alpine"
         mock_docker_client.images.pull.assert_called_once_with("redis:7-alpine")

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -375,6 +375,9 @@ class TestUpdateService:
         with patch(
             "oduflow.docker_ops.service_ops.service_presets.get_preset",
             return_value=preset,
+        ), patch(
+            "oduflow.docker_ops.service_ops.volume_ops.resolve_volume_binds",
+            return_value={"vol1": {"bind": "/acme", "mode": "ro"}},
         ):
             result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
 


### PR DESCRIPTION
## Summary

- **Environment creation timestamp**: Adds `oduflow.created_at` Docker label set at creation time, surfaced in `list_environments` and `get_environment_info`. Falls back to Docker's container creation time for legacy environments. Displayed in the dashboard metadata row.
- **Editable environment notes**: Stores notes in a `.note` file in the workspace directory (survives rebuild/recreate). New REST endpoint `POST /api/environments/{branch}/note` and clickable note field on environment cards in the dashboard UI.
- **Preset-based service updates**: `update_service` now reads port, hostname, env_vars, volumes, and host_mode from the saved preset (authoritative source) instead of reverse-engineering them from container labels/attributes. Falls back to container inspection for legacy services without a preset.

## Test plan
- [ ] Verify `ruff check` and `ruff format` pass
- [ ] Run `pytest tests/test_service_ops.py -v` — updated tests cover preset-based and legacy fallback paths
- [ ] Create an environment and confirm `created_at` appears in list/info API responses and on the dashboard
- [ ] Click "Add a note..." on an environment card, set a note, verify it persists across page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)