### PR TITLE
feat: read repo-level odoo.conf from .oduflow/ directory

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 
 ### Features
 
+- **Move repo-level `odoo.conf` to `.oduflow/odoo.conf`** — per-repo Odoo config is now read from `<repo>/.oduflow/odoo.conf` instead of the repo root
 - **Auto-initialize on startup** — `oduflow` automatically runs initialization (system setup, Docker check) on first start, removing the need for a separate `oduflow init` step ([34e42fa](https://github.com/oduist/oduflow/commit/34e42fa), [f33dfe6](https://github.com/oduist/oduflow/commit/f33dfe6))
 - **MCP tools refinement** — output cache for long-running tool results, 7 new MCP tools, 3 enhanced tools; renamed `exec_in_odoo` to `run_odoo_command` ([44810aa](https://github.com/oduist/oduflow/commit/44810aa))
 - **Include odoo.conf in upgrade** — module upgrades now apply odoo.conf changes, skipping files that haven't changed ([f69bc2f](https://github.com/oduist/oduflow/commit/f69bc2f))

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -24,7 +24,7 @@ When creating an environment, Oduflow:
 3. **Mounts the filestore overlay** — fuse-overlayfs with the template as lower layer
 4. **Detects UID/GID** — runs `id` in the Odoo image to set correct file ownership
 5. **Installs dependencies** — auto-installs from `apt_packages.txt` and `requirements.txt` if present in the repo
-6. **Configures Odoo** — uses repo's `odoo.conf` if available, otherwise the default template
+6. **Configures Odoo** — uses repo's `.oduflow/odoo.conf` if available, otherwise the default template
 7. **Starts the container** — with `--dev=xml` for hot-reloading XML/QWeb changes
 8. **Initializes base** — when `template=none`, runs `odoo -i base --stop-after-init`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 ### Smart Automation
 - **Smart pull** — `pull_and_apply` analyzes changed files (manifest, Python fields, security XML, JS) and automatically decides whether to install, upgrade, restart, or do nothing
 - **Auto-install dependencies** — `requirements.txt` (pip) and `apt_packages.txt` (apt) in the repository root are automatically installed when creating an environment
-- **Custom odoo.conf** — if the repository contains an `odoo.conf` at its root, it is used instead of the default template
+- **Custom odoo.conf** — if the repository contains an `odoo.conf` in its `.oduflow/` directory, it is used instead of the default template
 - **Field change detection** — Python files are analyzed for `fields.*` definition changes, triggering module upgrades only when necessary
 
 ### Infrastructure

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -206,7 +206,7 @@ On startup, Oduflow copies the bundled `postgresql.conf` and `odoo.conf` to the 
   traefik/                ← Traefik dynamic configuration (auto-generated)
 ```
 
-If a repository contains an `odoo.conf` at its root, it takes priority over both the bundled and system-level versions for that specific environment.
+If a repository contains an `odoo.conf` in its `.oduflow/` directory (`<repo>/.oduflow/odoo.conf`), it takes priority over both the bundled and system-level versions for that specific environment.
 
 ## Telemetry
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -222,7 +222,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 ### Smart Automation
 - **Smart pull** — `pull_and_apply` analyzes changed files (manifest, Python fields, security XML, JS) and automatically decides whether to install, upgrade, restart, or do nothing
 - **Auto-install dependencies** — `requirements.txt` (pip) and `apt_packages.txt` (apt) in the repository root are automatically installed when creating an environment
-- **Custom odoo.conf** — if the repository contains an `odoo.conf` at its root, it is used instead of the default template
+- **Custom odoo.conf** — if the repository contains an `odoo.conf` in its `.oduflow/` directory, it is used instead of the default template
 - **Field change detection** — Python files are analyzed for `fields.*` definition changes, triggering module upgrades only when necessary
 
 ### Infrastructure
@@ -459,7 +459,7 @@ When `oduflow init` runs, it copies the bundled `postgresql.conf` and `odoo.conf
   traefik/                ← Traefik dynamic configuration (auto-generated)
 ```
 
-If a repository contains an `odoo.conf` at its root, it takes priority over both the bundled and system-level versions for that specific environment.
+If a repository contains an `odoo.conf` in its `.oduflow/` directory (`<repo>/.oduflow/odoo.conf`), it takes priority over both the bundled and system-level versions for that specific environment.
 
 ## Auto-start with systemd
 
@@ -950,7 +950,7 @@ When creating an environment, Oduflow:
 3. **Mounts the filestore overlay** — fuse-overlayfs with the template as lower layer
 4. **Detects UID/GID** — runs `id` in the Odoo image to set correct file ownership
 5. **Installs dependencies** — auto-installs from `apt_packages.txt` and `requirements.txt` if present in the repo
-6. **Configures Odoo** — uses repo's `odoo.conf` if available, otherwise the default template
+6. **Configures Odoo** — uses repo's `.oduflow/odoo.conf` if available, otherwise the default template
 7. **Starts the container** — with `--dev=xml` for hot-reloading XML/QWeb changes
 8. **Initializes base** — when `template=none`, runs `odoo -i base --stop-after-init`
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -667,7 +667,7 @@ def create_environment(
     for host_path, container_path in extra_mount_paths:
         odoo_volumes[host_path] = {"bind": container_path, "mode": "ro"}
 
-    repo_odoo_conf = os.path.join(repo_path, "odoo.conf")
+    repo_odoo_conf = os.path.join(repo_path, ".oduflow", "odoo.conf")
     if os.path.isfile(repo_odoo_conf):
         base_conf_path = repo_odoo_conf
         logger.info("Using odoo.conf from repository")
@@ -1580,7 +1580,7 @@ def rebuild_environment(
     # Copy odoo.conf into the container (same resolution logic as create)
     repo_path = get_repo_path(env_name, team.workspaces_dir)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
-    repo_odoo_conf = os.path.join(repo_path, "odoo.conf")
+    repo_odoo_conf = os.path.join(repo_path, ".oduflow", "odoo.conf")
     if os.path.isfile(repo_odoo_conf):
         base_conf_path: str | None = repo_odoo_conf
     elif _resolve_instance_conf("odoo.conf", team.data_dir).exists():


### PR DESCRIPTION
## Summary
- Per-repo Odoo config is now loaded from `<repo>/.oduflow/odoo.conf` instead of the repo root — keeps the root clean and colocates Oduflow-specific files under `.oduflow/`.
- Applies to both `create_environment` and `rebuild_environment` resolution paths; instance-level and bundled fallbacks are unchanged.
- Docs (`installation.md`, `index.md`, `environments.md`, `llms-full.txt`) and `changelog.md` updated to reflect the new location.

## Test plan
- [x] `pytest -m "not integration and not heavyweight"` — 278 passed
- [ ] In a repo with `odoo.conf` at root → create env → confirm the file is no longer picked up (no `Using odoo.conf from repository` log)
- [ ] Move the file to `<repo>/.oduflow/odoo.conf` → create env → confirm log appears and `/etc/odoo/odoo.conf` in the container matches
- [ ] `rebuild_environment` resolves the new path identically