### PR TITLE
fix: skip submodule recursion in git fetch

### DIFF
--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -282,7 +282,7 @@ def fetch_extra_repo(team: TeamSettings, name: str) -> dict:
 
     try:
         subprocess.run(
-            ["git", "-C", path, "fetch", "--all", "--prune"],
+            ["git", "-C", path, "fetch", "--all", "--prune", "--recurse-submodules=no"],
             check=True,
             capture_output=True,
             text=True,

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -273,6 +273,7 @@ def pull_repo(
                 "-C",
                 repo_path,
                 "fetch",
+                "--recurse-submodules=no",
                 "origin",
                 f"+refs/heads/{branch}:refs/remotes/origin/{branch}",
             ],


### PR DESCRIPTION
## Summary
- `pull_and_apply` failed for repos referencing a private/unreachable submodule (e.g. `connect_addons_ng` → `tests_suite`) because git's default `fetch.recurseSubmodules=on-demand` tries to fetch submodule commits.
- Pass `--recurse-submodules=no` to `git fetch` in `git_ops.pull_repo()` and `extra_addons.fetch_extra_repo()`; oduflow never uses submodules, so skipping them is the correct behaviour.

## Test plan
- [ ] Re-run `pull_and_apply` against an environment whose repo references an inaccessible submodule; fetch should succeed.
- [ ] `ruff check src/oduflow tests`, `mypy src/oduflow`, `pytest -m "not integration and not heavyweight"`.