### PR TITLE
feat: privileged and NET_ADMIN capability options for services

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,6 +133,9 @@ oduflow call create_service redis redis:7 6379
 # Call a tool with JSON-encoded arguments
 oduflow call create_environment '{"branch":"dev","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:17.0","template_name":"myproject"}'
 
+# Service with NET_ADMIN capability (VPN / tun / iptables)
+oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
+
 # Type coercion is automatic: int, bool, and float parameters are cast from strings
 oduflow call get_environment_logs dev 500
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1280,6 +1280,9 @@ oduflow call create_service meilisearch getmeili/meilisearch:v1.6 7700 "" "MEILI
 
 # Elasticsearch
 oduflow call create_service elasticsearch docker.elastic.co/elasticsearch/elasticsearch:8.11.0 9200 "" "discovery.type=single-node,ES_JAVA_OPTS=-Xms512m -Xmx512m"
+
+# WireGuard VPN — needs NET_ADMIN to manage tun/iptables
+oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
 ```
 
 Services are:
@@ -1288,6 +1291,15 @@ Services are:
 - Given an `unless-stopped` restart policy
 - Automatically routed through Traefik with HTTPS when in traefik mode
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
+
+### Linux Capabilities
+
+Two optional flags grant additional container privileges:
+
+- `net_admin` — adds the `NET_ADMIN` Linux capability. Required for VPN / WireGuard, `tun`/`tap` devices, and `iptables` manipulation inside the container.
+- `privileged` — runs the container in privileged mode (full host access, all capabilities). Use with care — only when a service genuinely needs it (e.g. Docker-in-Docker, hardware passthrough).
+
+Both can be enabled at the same time; on the Docker side, `privileged` implies all capabilities so `net_admin` is then redundant — but it is still recorded in the preset so disabling `privileged` later keeps `NET_ADMIN` active.
 
 ## Managing Services
 
@@ -1309,14 +1321,14 @@ oduflow call delete_service redis
 
 The `update_service` operation:
 
-1. Captures the current image name, environment variables, port, and hostname
+1. Captures the current image name, environment variables, port, hostname, volumes, and capabilities (`cap_add`, `privileged`)
 2. Pulls the latest version of the image
 3. Compares image digests — if unchanged, reports "already up-to-date"
 4. If the image changed: stops the old container, removes it, and creates a new one with identical settings
 
 ## Service Presets
 
-Every time a service is created, its configuration (image, port, hostname, environment variables) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
+Every time a service is created, its configuration (image, port, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
 
 ```bash
 # List saved presets
@@ -1501,7 +1513,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/services` | List all managed services |
-| `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`) |
+| `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
 | `POST` | `/api/services/{name}/update` | Update (pull latest image & recreate) |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
@@ -1512,7 +1524,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/service-presets` | List saved service presets |
-| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`) |
+| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
 | `POST` | `/api/service-presets/{name}/delete` | Delete a saved service preset |
 
 ### System
@@ -1599,7 +1611,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch) |
+| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
 | `update_service` | ✓ | Pull latest image and recreate the service |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -39,7 +39,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch) |
+| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
 | `update_service` | ✓ | Pull latest image and recreate the service |

--- a/docs/services.md
+++ b/docs/services.md
@@ -17,6 +17,9 @@ oduflow call create_service meilisearch getmeili/meilisearch:v1.6 7700 "" "MEILI
 
 # Elasticsearch
 oduflow call create_service elasticsearch docker.elastic.co/elasticsearch/elasticsearch:8.11.0 9200 "" "discovery.type=single-node,ES_JAVA_OPTS=-Xms512m -Xmx512m"
+
+# WireGuard VPN — needs NET_ADMIN to manage tun/iptables
+oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
 ```
 
 Services are:
@@ -25,6 +28,15 @@ Services are:
 - Given an `unless-stopped` restart policy
 - Automatically routed through Traefik with HTTPS when in traefik mode
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
+
+### Linux Capabilities
+
+Two optional flags grant additional container privileges:
+
+- `net_admin` — adds the `NET_ADMIN` Linux capability. Required for VPN / WireGuard, `tun`/`tap` devices, and `iptables` manipulation inside the container.
+- `privileged` — runs the container in privileged mode (full host access, all capabilities). Use with care — only when a service genuinely needs it (e.g. Docker-in-Docker, hardware passthrough).
+
+Both can be enabled at the same time; on the Docker side, `privileged` implies all capabilities so `net_admin` is then redundant — but it is still recorded in the preset so disabling `privileged` later keeps `NET_ADMIN` active.
 
 ## Managing Services
 
@@ -52,14 +64,14 @@ oduflow call run_service_command redis "redis-cli ping"
 
 The `update_service` operation:
 
-1. Captures the current image name, environment variables, port, and hostname
+1. Captures the current image name, environment variables, port, hostname, volumes, and capabilities (`cap_add`, `privileged`)
 2. Pulls the latest version of the image
 3. Compares image digests — if unchanged, reports "already up-to-date"
 4. If the image changed: stops the old container, removes it, and creates a new one with identical settings
 
 ## Service Presets
 
-Every time a service is created, its configuration (image, port, hostname, environment variables) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
+Every time a service is created, its configuration (image, port, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
 
 ```bash
 # List saved presets

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -47,7 +47,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/services` | List all managed services |
-| `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`) |
+| `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
 | `POST` | `/api/services/{name}/update` | Update (pull latest image & recreate) |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
@@ -58,7 +58,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/service-presets` | List saved service presets |
-| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`) |
+| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
 | `POST` | `/api/service-presets/{name}/delete` | Delete a saved service preset |
 
 ### System

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -58,6 +58,8 @@ def create_service(
     env_vars: dict[str, str] | None = None,
     host_mode: bool = False,
     volumes: list[dict[str, str]] | None = None,
+    cap_add: list[str] | None = None,
+    privileged: bool = False,
 ) -> dict[str, str]:
     client = get_client()
     container_name = f"oduflow-svc-{name}"
@@ -133,6 +135,11 @@ def create_service(
         if vol_binds:
             run_kwargs["volumes"] = vol_binds
 
+    if privileged:
+        run_kwargs["privileged"] = True
+    elif cap_add:
+        run_kwargs["cap_add"] = list(cap_add)
+
     client.containers.run(**run_kwargs)
     logger.info("Created service container %s from image %s", container_name, image)
 
@@ -148,6 +155,8 @@ def create_service(
             base_hostname=team.hostname,
             host_mode=host_mode,
             volumes=volumes,
+            cap_add=cap_add,
+            privileged=privileged,
         )
     except Exception:
         logger.warning("Failed to save service preset for %s", name, exc_info=True)
@@ -301,6 +310,10 @@ def list_services(settings: Settings, team: TeamSettings) -> list[dict]:
                     }
                 )
 
+        host_config = container.attrs.get("HostConfig", {}) or {}
+        svc_cap_add = list(host_config.get("CapAdd") or [])
+        svc_privileged = bool(host_config.get("Privileged", False))
+
         result.append(
             {
                 "name": svc_name,
@@ -312,6 +325,8 @@ def list_services(settings: Settings, team: TeamSettings) -> list[dict]:
                 "env_vars": env_vars,
                 "host_mode": is_host_mode,
                 "volumes": svc_volumes,
+                "cap_add": svc_cap_add,
+                "privileged": svc_privileged,
             }
         )
 
@@ -353,6 +368,8 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
         env_vars = preset.get("env_vars") or None
         is_host_mode = preset.get("host_mode", False)
         old_volumes = preset.get("volumes") or None
+        cap_add = preset.get("cap_add") or None
+        privileged = preset.get("privileged", False)
     else:
         # Legacy fallback: extract from running container
         raw_env = container.attrs.get("Config", {}).get("Env", [])
@@ -364,6 +381,10 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
                     env_vars[key] = value
 
         is_host_mode = container.labels.get("oduflow.host_mode") == "true"
+
+        host_config = container.attrs.get("HostConfig", {}) or {}
+        cap_add = list(host_config.get("CapAdd") or []) or None
+        privileged = bool(host_config.get("Privileged", False))
 
         port: int | None = None
         hostname: str | None = None
@@ -466,6 +487,8 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
         env_vars=env_vars or None,
         host_mode=is_host_mode,
         volumes=old_volumes or None,
+        cap_add=cap_add,
+        privileged=privileged,
     )
 
     result["image_updated"] = True

--- a/src/oduflow/docker_ops/service_presets.py
+++ b/src/oduflow/docker_ops/service_presets.py
@@ -54,6 +54,8 @@ def save_preset(
     base_hostname: str = "",
     host_mode: bool = False,
     volumes: list[dict[str, str]] | None = None,
+    cap_add: list[str] | None = None,
+    privileged: bool = False,
 ) -> dict:
     """Save (or overwrite) a single service preset and return it."""
     short_hostname = hostname or ""
@@ -71,6 +73,10 @@ def save_preset(
         preset["host_mode"] = True
     if volumes:
         preset["volumes"] = volumes
+    if cap_add:
+        preset["cap_add"] = list(cap_add)
+    if privileged:
+        preset["privileged"] = True
     data = _load_presets(team)
     data[name] = preset
     _save_presets(team, data)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1558,6 +1558,8 @@ def create_service(
     env_vars: str = "",
     host_mode: bool = False,
     volumes: str = "",
+    privileged: bool = False,
+    net_admin: bool = False,
     ctx: Context = None,
 ) -> str:
     """
@@ -1571,6 +1573,8 @@ def create_service(
         env_vars: Comma-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production").
         host_mode: Run the container in host network mode instead of the shared Docker network. Use when the service needs direct host network access. Traefik routing still works.
         volumes: Comma-separated volume mounts (e.g. "mydata:/data,config:/etc/app:ro"). Each entry is volume_name:/container/path[:ro|rw]. Volumes must be created first via create_volume.
+        privileged: Run the container in privileged mode (full host access). Use with care — implies all Linux capabilities. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
+        net_admin: Add the NET_ADMIN Linux capability. Required for VPN/WireGuard, tun/tap devices, and iptables manipulation inside the container.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -1580,6 +1584,7 @@ def create_service(
             item.split("=", 1) for item in env_vars.split(",") if "=" in item
         )
     parsed_volumes = volume_ops.parse_volume_mounts(volumes) if volumes else None
+    cap_add = ["NET_ADMIN"] if net_admin else None
     result = service_ops.create_service(
         settings,
         team,
@@ -1590,6 +1595,8 @@ def create_service(
         env_vars=parsed_env,
         host_mode=host_mode,
         volumes=parsed_volumes,
+        cap_add=cap_add,
+        privileged=privileged,
     )
     vol_info = ""
     if parsed_volumes:

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -90,7 +90,7 @@ MCP endpoint: `http://<host>:8000/mcp`
 
 | Tool | When to use |
 |---|---|
-| `create_service(name, image, port, hostname?, env_vars?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}` |
+| `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -676,6 +676,17 @@
         <label for="svc-volumes">Volumes (optional)</label>
         <textarea id="svc-volumes" rows="3" placeholder="volume_name:/container/path&#10;volume_name:/container/path:ro"></textarea>
       </div>
+      <div class="form-group">
+        <label>Capabilities</label>
+        <div style="display:flex;align-items:center;gap:8px;margin-top:4px;">
+          <input type="checkbox" id="svc-privileged">
+          <label for="svc-privileged" style="margin-bottom:0;cursor:pointer;">Privileged <span style="color:var(--muted);font-weight:normal;">— full host access (use with care)</span></label>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;margin-top:6px;">
+          <input type="checkbox" id="svc-net-admin">
+          <label for="svc-net-admin" style="margin-bottom:0;cursor:pointer;">NET_ADMIN <span style="color:var(--muted);font-weight:normal;">— VPN / tun / iptables</span></label>
+        </div>
+      </div>
       <div class="form-actions">
         <button class="btn" onclick="closeCreateServiceModal()">Cancel</button>
         <button class="btn-create" id="svc-submit" onclick="submitCreateService()">Create</button>
@@ -724,6 +735,17 @@
       <div class="form-group">
         <label for="restore-svc-volumes">Volumes (optional)</label>
         <textarea id="restore-svc-volumes" rows="3" placeholder="volume_name:/container/path&#10;volume_name:/container/path:ro"></textarea>
+      </div>
+      <div class="form-group">
+        <label>Capabilities</label>
+        <div style="display:flex;align-items:center;gap:8px;margin-top:4px;">
+          <input type="checkbox" id="restore-svc-privileged">
+          <label for="restore-svc-privileged" style="margin-bottom:0;cursor:pointer;">Privileged <span style="color:var(--muted);font-weight:normal;">— full host access (use with care)</span></label>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;margin-top:6px;">
+          <input type="checkbox" id="restore-svc-net-admin">
+          <label for="restore-svc-net-admin" style="margin-bottom:0;cursor:pointer;">NET_ADMIN <span style="color:var(--muted);font-weight:normal;">— VPN / tun / iptables</span></label>
+        </div>
       </div>
       <div class="form-actions">
         <button class="btn" onclick="closeRestoreServiceModal()">Cancel</button>
@@ -1628,11 +1650,18 @@ function renderServices(services) {
       var volStr = svc.volumes.map(function(v) { return esc(v.volume) + ':' + esc(v.mount_path) + (v.mode === 'ro' ? ':ro' : ''); }).join(', ');
       volHtml = '<div class="svc-meta"><span>Volumes: <strong>' + volStr + '</strong></span></div>';
     }
+    var capBadges = '';
+    if (svc.privileged) {
+      capBadges += '<span class="badge" style="background:#7a1f1f;color:#fff;margin-left:6px;" title="Privileged container (full host access)">privileged</span>';
+    } else if (svc.cap_add && svc.cap_add.indexOf('NET_ADMIN') !== -1) {
+      capBadges += '<span class="badge" style="background:#1f4f7a;color:#fff;margin-left:6px;" title="NET_ADMIN capability granted">NET_ADMIN</span>';
+    }
     return '<div class="svc-card" data-svc="' + esc(svc.name) + '">' +
       '<div class="svc-header">' +
         '<div class="left">' +
           '<span class="svc-name">' + esc(svc.name) + '</span>' +
           '<span class="badge ' + badgeClass(svc.status) + '">' + esc(svc.status) + '</span>' +
+          capBadges +
         '</div>' +
         '<div class="svc-actions">' +
           '<button class="btn btn-update" onclick="doUpdateService(\'' + escAttr(svc.name) + '\')">Update</button>' +
@@ -1736,6 +1765,8 @@ function openCreateServiceModal() {
    document.getElementById('svc-envvars').value = '';
    document.getElementById('svc-host-mode').checked = false;
    document.getElementById('svc-volumes').value = '';
+   document.getElementById('svc-privileged').checked = false;
+   document.getElementById('svc-net-admin').checked = false;
    var errEl = document.getElementById('create-svc-error');
   errEl.style.display = 'none';
   errEl.textContent = '';
@@ -1771,7 +1802,9 @@ async function submitCreateService() {
   try {
     var hostMode = document.getElementById('svc-host-mode').checked;
     var svcVolumes = document.getElementById('svc-volumes').value.trim();
-    var payload = { name: name, image: image, port: parseInt(port, 10), host_mode: hostMode };
+    var privileged = document.getElementById('svc-privileged').checked;
+    var netAdmin = document.getElementById('svc-net-admin').checked;
+    var payload = { name: name, image: image, port: parseInt(port, 10), host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
     if (hostname) payload.hostname = hostname;
     if (envvars) payload.env_vars = envvars;
     if (svcVolumes) payload.volumes = svcVolumes;
@@ -1884,6 +1917,8 @@ function _fillRestoreFields(p) {
      volStr = p.volumes.map(function(v) { return v.volume + ':' + v.mount_path + (v.mode === 'ro' ? ':ro' : ''); }).join('\n');
    }
    document.getElementById('restore-svc-volumes').value = volStr;
+   document.getElementById('restore-svc-privileged').checked = !!p.privileged;
+   document.getElementById('restore-svc-net-admin').checked = !!(p.cap_add && p.cap_add.indexOf('NET_ADMIN') !== -1);
 }
 
 function openRestoreServiceModal(preselect) {
@@ -1898,6 +1933,8 @@ function openRestoreServiceModal(preselect) {
    document.getElementById('restore-svc-envvars').value = '';
    document.getElementById('restore-svc-host-mode').checked = false;
    document.getElementById('restore-svc-volumes').value = '';
+   document.getElementById('restore-svc-privileged').checked = false;
+   document.getElementById('restore-svc-net-admin').checked = false;
 
   sel.innerHTML = '<option value="">Loading...</option>';
   document.getElementById('restore-svc-modal').classList.add('show');
@@ -1953,7 +1990,9 @@ async function submitRestoreService() {
   try {
     var hostMode = document.getElementById('restore-svc-host-mode').checked;
     var restoreVolumes = document.getElementById('restore-svc-volumes').value.trim();
-    var payload = { name: name, image: image, port: parseInt(port, 10), host_mode: hostMode };
+    var privileged = document.getElementById('restore-svc-privileged').checked;
+    var netAdmin = document.getElementById('restore-svc-net-admin').checked;
+    var payload = { name: name, image: image, port: parseInt(port, 10), host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
     if (hostname) payload.hostname = hostname;
     if (envvars) payload.env_vars = envvars;
     if (restoreVolumes) payload.volumes = restoreVolumes;

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -477,6 +477,9 @@ def _build_routes(
             parsed_volumes = (
                 volume_ops.parse_volume_mounts(volumes_raw) if volumes_raw else None
             )
+            privileged = bool(body.get("privileged", False))
+            net_admin = bool(body.get("net_admin", False))
+            cap_add = ["NET_ADMIN"] if net_admin else None
             result = service_ops.create_service(
                 get_settings(),
                 team,
@@ -487,6 +490,8 @@ def _build_routes(
                 env_vars=env_vars,
                 host_mode=host_mode,
                 volumes=parsed_volumes,
+                cap_add=cap_add,
+                privileged=privileged,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -601,6 +606,9 @@ def _build_routes(
             parsed_volumes = (
                 volume_ops.parse_volume_mounts(volumes_raw) if volumes_raw else None
             )
+            privileged = bool(body.get("privileged", False))
+            net_admin = bool(body.get("net_admin", False))
+            cap_add = ["NET_ADMIN"] if net_admin else None
             result = service_ops.create_service(
                 get_settings(),
                 team,
@@ -611,6 +619,8 @@ def _build_routes(
                 env_vars=env_vars,
                 host_mode=host_mode,
                 volumes=parsed_volumes,
+                cap_add=cap_add,
+                privileged=privileged,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:


### PR DESCRIPTION
## Summary

- Add two optional flags to the `create_service` MCP tool, REST API (`/api/services/create`, `/api/service-presets/restore`), and dashboard modals: `privileged` (runs the container in privileged mode) and `net_admin` (adds the `NET_ADMIN` Linux capability — for VPN/WireGuard, tun/tap, iptables).
- Persist capabilities in service presets so `update_service` and Restore preserve them; `list_services` returns `cap_add`/`privileged` and the dashboard shows them as badges.
- Sync documentation (`services.md`, `mcp-tools.md`, `cli.md`, `web-api.md`, `llms-full.txt`, agent instructions template).

## Test plan

- [x] \`ruff check\` and \`pytest -m \"not integration and not heavyweight\"\` (278 passed)
- [ ] Smoke test: \`create_service\` with \`net_admin=true\` → \`docker inspect ... HostConfig.CapAdd\` returns \`[NET_ADMIN]\`
- [ ] \`update_service\` preserves the capability after recreate
- [ ] Dashboard: Create Service modal toggles work independently and survive Restore flow