### PR TITLE
fix: raise NotFoundError when deleting a non-existent environment

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -946,6 +946,17 @@ def delete_environment(
     client = get_client()
     odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
     env_db = get_db_name(env_name, team.team_id)
+    workspace_path = get_workspace_path(env_name, team.workspaces_dir)
+
+    container_exists = True
+    try:
+        client.containers.get(odoo_container_name)
+    except docker.errors.NotFound:
+        container_exists = False
+
+    if not container_exists and not os.path.exists(workspace_path):
+        raise NotFoundError(f"Environment '{env_name}' does not exist.")
+
     warnings: list[str] = []
 
     logger.info("Deleting environment", extra={"env_name": env_name})
@@ -953,12 +964,13 @@ def delete_environment(
     if settings.routing_mode == "port":
         release_port(team.port_registry_path, env_name)
 
-    try:
-        container = client.containers.get(odoo_container_name)
-        container.stop()
-        container.remove(v=True)
-    except docker.errors.NotFound:
-        pass
+    if container_exists:
+        try:
+            container = client.containers.get(odoo_container_name)
+            container.stop()
+            container.remove(v=True)
+        except docker.errors.NotFound:
+            pass
 
     try:
         _exec_sql(
@@ -981,7 +993,6 @@ def delete_environment(
         logger.warning(msg, extra={"env_name": env_name})
         warnings.append(msg)
 
-    workspace_path = get_workspace_path(env_name, team.workspaces_dir)
     if os.path.exists(workspace_path):
         _unmount_filestore(env_name, team)
         extra_dir = os.path.join(workspace_path, "extra")

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -327,6 +327,24 @@ class TestDeleteEnvironment:
             TEST_TEAM.port_registry_path, "feature/payments"
         )
 
+    @patch("oduflow.docker_ops.env_ops.release_port")
+    @patch("oduflow.docker_ops.env_ops._exec_sql")
+    @patch("oduflow.docker_ops.env_ops.os.path.exists", return_value=False)
+    def test_delete_missing_raises_not_found(
+        self,
+        mock_exists,
+        mock_sql,
+        mock_release,
+        mock_docker_client,
+    ):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError, match="does not exist"):
+            env_ops.delete_environment(TEST_SETTINGS, TEST_TEAM, "ghost")
+
+        mock_release.assert_not_called()
+        mock_sql.assert_not_called()
+
 
 class TestRestartEnvironment:
     def test_restart(self, mock_docker_client):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -90,6 +90,16 @@ class TestDeleteEnvironmentTool:
         assert "Warnings:" in result
         assert "Failed to drop database" in result
 
+    @patch("oduflow.docker_ops.env_ops.delete_environment")
+    def test_delete_missing_raises(self, mock_delete):
+        from oduflow.errors import NotFoundError
+
+        mock_delete.side_effect = NotFoundError(
+            "Environment 'firewall' does not exist."
+        )
+        with pytest.raises(ToolError, match="does not exist"):
+            _call_tool("delete_environment", env_name="firewall")
+
 
 class TestListEnvironmentsTool:
     @patch("oduflow.docker_ops.env_ops.list_environments")


### PR DESCRIPTION
## Summary
- `delete_environment` silently returned success (\"Environment 'X' has been torn down.\") when the target environment did not exist; now it raises `NotFoundError` matching the behavior of `restart_environment`, `start_environment`, `stop_environment`, and `pull_environment`.
- Existence is determined by the Docker container OR the workspace directory, so half-created/orphan environments can still be cleaned up.
- Added unit tests at the tool layer (`tests/test_server.py`) and the `env_ops` layer (`tests/test_odoo_manager.py`).

## Test plan
- [x] `pytest -m "not integration and not heavyweight"` — 280 passed
- [x] `ruff check` on changed files — clean
- [ ] Manual: call `delete_environment` with a non-existent name via MCP and verify it returns a NotFound error instead of "torn down"