### PR TITLE
feat: self-hosted OAuth Authorization Server for MCP clients

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -22,62 +22,56 @@ auth_token = "secret-token-team-2"
 
 The token is used to both authenticate and identify the team. This is implemented via FastMCP's `StaticTokenVerifier`.
 
-## GitHub OAuth (for Claude.ai and other MCP clients)
+## Self-hosted OAuth (for Claude.ai and other MCP clients)
 
-Oduflow supports GitHub OAuth 2.1 for MCP clients that use OAuth authorization (e.g. Claude.ai Remote MCP, MCP Inspector). This allows users to authenticate via their GitHub account instead of static tokens.
+Oduflow can act as its own OAuth 2.1 Authorization Server, so MCP clients that require an OAuth flow (e.g. Claude.ai Remote MCP, MCP Inspector) can connect without any external identity provider.
+
+When the OAuth flow completes, the issued `access_token` is exactly the team's `auth_token` from `oduflow.toml` — so the same value works as a plain Bearer token for CLI clients.
 
 ### Setup
 
-1. Create a [GitHub OAuth App](https://github.com/settings/developers):
-    - **Authorization callback URL**: `https://your-server.com/auth/callback`
-    - Note the **Client ID** and **Client Secret**
-
-2. Configure `oduflow.toml`:
+In `oduflow.toml`, set the public URL of this instance and an `auth_token` per team:
 
 ```toml
-[server]
-oauth_client_id = "Ov23li..."
-oauth_client_secret = "your-github-client-secret"
+[oauth]
 oauth_base_url = "https://your-server.com"
-```
 
-3. (Optional) Restrict access to specific GitHub users per team:
-
-```toml
 [team.1]
-github_users = ["octocat", "dev1"]
-
-[team.2]
-github_users = ["admin2"]
+auth_token = "secret-token-team-1"
 ```
 
-If `github_users` is not set in any team and there is only one team, all authenticated GitHub users get access. If `github_users` is set, only listed users can access the MCP server — others get **403 Access Denied**.
+That's it. Oduflow now exposes:
+
+- `GET /.well-known/oauth-authorization-server` — discovery metadata
+- `GET /authorize` — authorization endpoint (Authorization Code + PKCE)
+- `POST /token` — token endpoint
+
+Dynamic Client Registration (`/register`) is **disabled** — clients must use the preregistered credentials.
 
 ### Connecting from Claude.ai
 
-1. Go to Claude.ai Settings → Integrations → Add Remote MCP Server
-2. Enter your oduflow URL: `https://your-server.com/mcp`
-3. In **Advanced Settings**, enter the GitHub OAuth App **Client ID** and **Client Secret**
-4. Claude will redirect you to GitHub for login, then connect to oduflow
+1. Go to Claude.ai Settings → Connectors → Add custom MCP
+2. Enter your Oduflow URL: `https://your-server.com/mcp`
+3. In the OAuth fields enter the team's `auth_token` as **both** `Client ID` **and** `Client Secret`:
 
-### Combined mode (static tokens + OAuth)
+   ```
+   Client ID     = secret-token-team-1
+   Client Secret = secret-token-team-1
+   ```
 
-Both auth methods can work simultaneously. Static Bearer tokens are checked first; if no match, the OAuth flow is used:
+4. Claude.ai performs the OAuth flow against your Oduflow instance, receives an access token, and connects.
 
-```toml
-[server]
-oauth_client_id = "Ov23li..."
-oauth_client_secret = "abc..."
-oauth_base_url = "https://your-server.com"
+The team is identified by the `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
 
-[team.1]
-auth_token = "secret-token"         # for CLI / automation
-github_users = ["octocat", "dev1"]  # for Claude.ai / browser-based clients
+### Bearer-only mode (CLI / automation)
+
+For curl, IDE clients, or anything that doesn't need OAuth, simply send the `auth_token` as a Bearer header:
+
+```
+Authorization: Bearer secret-token-team-1
 ```
 
-### GitHub username in MCP context
-
-When a user authenticates via GitHub OAuth, their GitHub login is available in the MCP tool context. This can be used for audit trails and environment metadata (e.g. "created by octocat").
+This works whether or not `oauth_base_url` is configured.
 
 ## Web Dashboard Auth
 
@@ -100,6 +94,8 @@ Warnings are logged on startup for each team:
 ```
 INFO  [team.1] http://localhost:8000/ (MCP token OFF, OAuth OFF, UI auth OFF)
 ```
+
+When OAuth is enabled the status reads `OAuth ON (self-hosted)`.
 
 ## Git Credentials
 

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -1,0 +1,150 @@
+"""Self-hosted OAuth 2.1 Authorization Server for Oduflow.
+
+Each team's ``auth_token`` is preregistered as an OAuth client where
+``client_id == client_secret == auth_token``. After a successful
+Authorization Code + PKCE flow the issued ``access_token`` is the same
+``auth_token``, so the existing Bearer-token path in ``_resolve_team()``
+keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    RefreshToken,
+)
+from mcp.shared.auth import (
+    InvalidRedirectUriError,
+    OAuthClientInformationFull,
+    OAuthToken,
+)
+from pydantic import AnyUrl
+
+from oduflow.settings import Settings
+
+logger = logging.getLogger("oduflow")
+
+
+class _FlexibleClient(OAuthClientInformationFull):
+    """Client info that accepts any redirect_uri at /authorize time.
+
+    Preregistered clients have ``client_id == client_secret == auth_token``;
+    the secret-bearing /token exchange already proves identity, so we let
+    MCP clients (claude.ai, IDEs, etc.) bring whatever callback URL they use.
+    """
+
+    def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
+        if redirect_uri is not None:
+            return redirect_uri
+        if self.redirect_uris:
+            return self.redirect_uris[0]
+        raise InvalidRedirectUriError("redirect_uri must be specified")
+
+
+class OduflowOAuthProvider(InMemoryOAuthProvider):
+    """OAuth Authorization Server backed by ``team.auth_token`` values."""
+
+    def __init__(self, settings: Settings) -> None:
+        if not settings.oauth_base_url:
+            raise ValueError("oauth_base_url is required for self-hosted OAuth")
+        super().__init__(base_url=settings.oauth_base_url)
+
+        self._token_to_team: dict[str, str] = {}
+        placeholder_redirect = AnyUrl("https://claude.ai/")
+
+        for team in settings.teams.values():
+            token = team.auth_token
+            if not token:
+                continue
+            client = _FlexibleClient(
+                client_id=token,
+                client_secret=token,
+                redirect_uris=[placeholder_redirect],
+                grant_types=["authorization_code", "refresh_token"],
+                response_types=["code"],
+                token_endpoint_auth_method="client_secret_post",
+                scope=None,
+            )
+            self.clients[token] = client
+            self._token_to_team[token] = team.team_id
+            # Preseed the access token so direct Bearer-token calls also work
+            # (curl/CLI clients that skip the OAuth dance entirely).
+            self.access_tokens[token] = AccessToken(
+                token=token,
+                client_id=team.team_id,
+                scopes=[],
+                expires_at=None,
+            )
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        raise ValueError(
+            "Dynamic client registration is disabled. "
+            "Set client_id = client_secret = team.<id>.auth_token from oduflow.toml."
+        )
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        # Single-use code.
+        self.auth_codes.pop(authorization_code.code, None)
+
+        if client.client_id is None or client.client_id not in self._token_to_team:
+            from mcp.server.auth.provider import TokenError
+
+            raise TokenError("invalid_client", "Unknown client.")
+
+        token = client.client_id
+        scope = (
+            " ".join(authorization_code.scopes) if authorization_code.scopes else None
+        )
+        return OAuthToken(
+            access_token=token,
+            token_type="Bearer",
+            expires_in=None,
+            refresh_token=token,
+            scope=scope,
+        )
+
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        if (
+            client.client_id is not None
+            and refresh_token == client.client_id
+            and refresh_token in self._token_to_team
+        ):
+            return RefreshToken(
+                token=refresh_token,
+                client_id=client.client_id,
+                scopes=[],
+                expires_at=None,
+            )
+        return None
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        token = refresh_token.token
+        return OAuthToken(
+            access_token=token,
+            token_type="Bearer",
+            expires_in=None,
+            refresh_token=token,
+            scope=" ".join(scopes) if scopes else None,
+        )
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        # Tokens are tied to oduflow.toml; runtime revocation would just
+        # break the next request. Operator should rotate auth_token instead.
+        return None

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -54,25 +54,14 @@ def _get_settings() -> Settings:
 def _resolve_team(ctx: Context | None) -> TeamSettings:
     """Resolve the team from MCP Context.
 
-    Priority: static token → GitHub user → Host header → single-team → team "1".
+    Priority: token/OAuth client_id → Host header → single-team → team "1".
     """
     settings = _get_settings()
-    # 1. Token-based: client_id set by auth provider (static tokens map to team_id)
+    # 1. Token-based: client_id set by auth provider maps to team_id
     team_id = ctx.client_id if ctx and ctx.client_id else None
     if team_id and team_id in settings.teams:
         return settings.teams[team_id]
-    # 2. GitHub OAuth: resolve by GitHub login from access token claims
-    if settings.oauth_enabled and ctx:
-        github_login = _get_github_user(ctx)
-        if github_login:
-            team = settings.get_team_by_github_user(github_login)
-            if team:
-                return team
-            # No github_users configured anywhere → single-team fallback
-            if not settings.any_team_has_github_users:
-                if len(settings.teams) == 1:
-                    return next(iter(settings.teams.values()))
-    # 3. Hostname-based: match Host header against team hostnames
+    # 2. Hostname-based: match Host header against team hostnames
     if ctx:
         try:
             from fastmcp.server.dependencies import get_http_request
@@ -84,28 +73,10 @@ def _resolve_team(ctx: Context | None) -> TeamSettings:
                 return team
         except Exception:
             pass
-    # 4. Fallback: single team or default team "1"
+    # 3. Fallback: single team or default team "1"
     if len(settings.teams) == 1:
         return next(iter(settings.teams.values()))
     return settings.get_team("1")
-
-
-def _get_github_user(ctx: Context | None) -> str:
-    """Extract GitHub login from MCP Context access token claims.
-
-    Returns empty string if not available (e.g. static token auth).
-    """
-    if not ctx:
-        return ""
-    try:
-        from fastmcp.server.dependencies import get_access_token
-
-        token = get_access_token()
-        if token and hasattr(token, "claims") and token.claims:
-            return str(token.claims.get("login", ""))
-    except Exception:
-        pass
-    return ""
 
 
 # -- Output cache helpers --
@@ -2860,7 +2831,9 @@ def _start_http() -> None:
         else:
             url = f"http://{host}:{port}/"
         mcp_status = "MCP token ON" if team.auth_token else "MCP token OFF"
-        oauth_status = "OAuth ON" if settings.oauth_enabled else "OAuth OFF"
+        oauth_status = (
+            "OAuth ON (self-hosted)" if settings.oauth_enabled else "OAuth OFF"
+        )
         ui_status = "UI auth ON" if team.ui_password else "UI auth OFF"
         logger.info(
             "[team.%s] %s (%s, %s, %s)", tid, url, mcp_status, oauth_status, ui_status
@@ -2874,93 +2847,38 @@ def _start_http() -> None:
 def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
     """Build the auth provider from settings.
 
-    Supports three modes (auto-detected):
-    - Static tokens only (auth_token in team sections)
-    - GitHub OAuth only (oauth_* in server/oauth section)
-    - Both combined: static tokens checked first, GitHub OAuth fallback
+    Two modes (auto-detected by ``oauth_base_url``):
+    - Self-hosted OAuth Authorization Server (when oauth_base_url is set):
+      Oduflow exposes /authorize, /token, /.well-known/oauth-authorization-server.
+      Each team's auth_token doubles as client_id, client_secret, and the
+      issued access token. Suitable for claude.ai and other MCP clients that
+      require an OAuth flow.
+    - Static Bearer tokens (default when oauth_base_url is empty):
+      auth_token is consumed directly from the Authorization header.
+      Suitable for curl, CLI clients, and IDEs that don't need OAuth.
     """
-    # Collect static tokens
     tokens: dict[str, dict[str, object]] = {}
     for team_id, team in settings.teams.items():
         if team.auth_token:
             tokens[team.auth_token] = {"client_id": team_id, "scopes": []}
 
-    has_tokens = bool(tokens)
-    has_oauth = settings.oauth_enabled
+    if settings.oauth_enabled:
+        if not tokens:
+            logger.warning(
+                "oauth_base_url is set but no team has auth_token; OAuth disabled"
+            )
+            return None
+        from oduflow.oauth_provider import OduflowOAuthProvider
 
-    if has_oauth and has_tokens:
-        # Both: GitHub OAuth provider with composite verifier
-        return _build_github_auth(settings, static_tokens=tokens)
+        return OduflowOAuthProvider(settings)
 
-    if has_oauth:
-        # GitHub OAuth only
-        return _build_github_auth(settings)
-
-    if has_tokens:
-        # Static tokens only (current behavior)
+    if tokens:
         from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 
         return StaticTokenVerifier(tokens=tokens)
 
-    logger.warning("HTTP auth DISABLED (no auth_token or OAuth configured)")
+    logger.warning("HTTP auth DISABLED (no auth_token or oauth_base_url set)")
     return None
-
-
-def _build_github_auth(
-    settings: Settings,
-    static_tokens: dict[str, dict[str, object]] | None = None,
-) -> object:
-    """Build GitHubProvider with optional static token fallback."""
-    from fastmcp.server.auth.providers.github import (
-        GitHubProvider,
-        GitHubTokenVerifier,
-    )
-
-    if static_tokens:
-        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
-
-        static_verifier = StaticTokenVerifier(tokens=static_tokens)
-        github_verifier = GitHubTokenVerifier()
-        token_verifier = _CompositeTokenVerifier(static_verifier, github_verifier)
-
-        from fastmcp.server.auth.oauth_proxy import OAuthProxy
-
-        return OAuthProxy(
-            upstream_authorization_endpoint="https://github.com/login/oauth/authorize",
-            upstream_token_endpoint="https://github.com/login/oauth/access_token",
-            upstream_client_id=settings.oauth_client_id,
-            upstream_client_secret=settings.oauth_client_secret,
-            token_verifier=token_verifier,
-            base_url=settings.oauth_base_url,
-            require_authorization_consent=False,
-        )
-
-    return GitHubProvider(
-        client_id=settings.oauth_client_id,
-        client_secret=settings.oauth_client_secret,
-        base_url=settings.oauth_base_url,
-        require_authorization_consent=False,
-    )
-
-
-class _CompositeTokenVerifier:
-    """Token verifier that tries static tokens first, then GitHub API.
-
-    Implements the TokenVerifier protocol (verify_token + required_scopes)
-    without inheriting from it to avoid pulling in pydantic BaseModel.
-    """
-
-    required_scopes: list[str] | None = None
-
-    def __init__(self, *verifiers: object) -> None:
-        self.verifiers = verifiers
-
-    async def verify_token(self, token: str):  # type: ignore[no-untyped-def]
-        for verifier in self.verifiers:
-            result = await verifier.verify_token(token)  # type: ignore[union-attr]
-            if result is not None:
-                return result
-        return None
 
 
 if __name__ == "__main__":

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -25,7 +25,6 @@ class TeamSettings:
     hostname: str = "localhost"
     auth_token: str = ""
     ui_password: str = ""
-    github_users: tuple[str, ...] = ()
     port_range_start: int = 50000
     port_range_end: int = 50100
     data_dir: str = ""
@@ -111,9 +110,11 @@ class Settings:
     repo_label: str = "oduflow.repo"
     image_label: str = "oduflow.image"
 
-    # OAuth (GitHub)
-    oauth_client_id: str = ""
-    oauth_client_secret: str = ""
+    # OAuth (self-hosted Authorization Server). Public base URL of this server,
+    # used as the OAuth issuer and to advertise authorize/token endpoints.
+    # When set, Oduflow exposes /.well-known/oauth-authorization-server,
+    # /authorize, and /token, and each team's auth_token doubles as
+    # client_id, client_secret, and the issued access token.
     oauth_base_url: str = ""
 
     # Config location
@@ -145,21 +146,9 @@ class Settings:
                 return team
         return None
 
-    def get_team_by_github_user(self, login: str) -> TeamSettings | None:
-        if not login:
-            return None
-        for team in self.teams.values():
-            if login in team.github_users:
-                return team
-        return None
-
     @property
     def oauth_enabled(self) -> bool:
-        return bool(self.oauth_client_id)
-
-    @property
-    def any_team_has_github_users(self) -> bool:
-        return any(t.github_users for t in self.teams.values())
+        return bool(self.oauth_base_url)
 
     def get_team_by_ui_password(self, password: str) -> TeamSettings | None:
         if not password:
@@ -206,38 +195,14 @@ class Settings:
         if len(passwords) != len(set(passwords)):
             raise ValueError("Duplicate ui_password values across teams.")
 
-        # Validate OAuth settings: all-or-nothing
-        oauth_fields = [
-            self.oauth_client_id,
-            self.oauth_client_secret,
-            self.oauth_base_url,
-        ]
-        has_any = any(oauth_fields)
-        has_all = all(oauth_fields)
-        if has_any and not has_all:
-            missing = []
-            if not self.oauth_client_id:
-                missing.append("oauth_client_id")
-            if not self.oauth_client_secret:
-                missing.append("oauth_client_secret")
-            if not self.oauth_base_url:
-                missing.append("oauth_base_url")
+        # Validate OAuth: when oauth_base_url is set, at least one team must
+        # have a non-empty auth_token (it doubles as OAuth client credentials).
+        if self.oauth_base_url and not any(t.auth_token for t in self.teams.values()):
             raise ValueError(
-                f"Incomplete OAuth configuration: missing {', '.join(missing)}. "
-                "Set all three (oauth_client_id, oauth_client_secret, oauth_base_url) "
-                "or remove them entirely."
+                "oauth_base_url is set but no team has an auth_token. "
+                "Self-hosted OAuth requires at least one [team.*] section "
+                "with a non-empty auth_token."
             )
-
-        # Validate github_users: no duplicates across teams
-        if self.oauth_client_id:
-            all_gh_users: list[str] = []
-            for team in self.teams.values():
-                for user in team.github_users:
-                    if user in all_gh_users:
-                        raise ValueError(
-                            f"Duplicate github_users entry '{user}' across teams."
-                        )
-                    all_gh_users.append(user)
 
     @staticmethod
     def from_toml(path: str) -> Settings:
@@ -277,15 +242,11 @@ class Settings:
             )
             hostname = re.sub(r"^https?://", "", raw_hostname).strip()
 
-            raw_gh_users = team_cfg.get("github_users", [])
-            github_users = tuple(str(u) for u in raw_gh_users)
-
             teams[team_id] = TeamSettings(
                 team_id=team_id,
                 hostname=hostname,
                 auth_token=str(team_cfg.get("auth_token", "")),
                 ui_password=str(team_cfg.get("ui_password", "")),
-                github_users=github_users,
                 port_range_start=port_start,
                 port_range_end=port_end,
                 data_dir=team_data_dir,
@@ -309,8 +270,6 @@ class Settings:
             postgres_image=str(database.get("image", "postgres:15")),
             base_data_dir=base_data_dir,
             overlay_threshold_mb=int(storage.get("overlay_threshold_mb", 50)),
-            oauth_client_id=str(oauth.get("oauth_client_id", "")).strip(),
-            oauth_client_secret=str(oauth.get("oauth_client_secret", "")).strip(),
             oauth_base_url=str(oauth.get("oauth_base_url", "")).strip(),
             etc_dir=etc_dir,
             toml_path=path,
@@ -355,7 +314,9 @@ def _resolve_etc_dir() -> str:
         _cached_etc_dir = default
     else:
         _cached_etc_dir = os.path.join(os.path.expanduser("~"), ".oduflow", "conf")
-        logger.debug("Default %s is not writable, falling back to %s", default, _cached_etc_dir)
+        logger.debug(
+            "Default %s is not writable, falling back to %s", default, _cached_etc_dir
+        )
     return _cached_etc_dir
 
 
@@ -377,5 +338,7 @@ def _resolve_data_dir(explicit: str) -> str:
         _cached_data_dir = default
     else:
         _cached_data_dir = os.path.join(os.path.expanduser("~"), ".oduflow", "data")
-        logger.debug("Default %s is not writable, falling back to %s", default, _cached_data_dir)
+        logger.debug(
+            "Default %s is not writable, falling back to %s", default, _cached_data_dir
+        )
     return _cached_data_dir

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -20,12 +20,27 @@ image = "postgres:15"
 # data_dir = "/srv/oduflow"       # default: /srv/oduflow or ~/.oduflow/data
 overlay_threshold_mb = 50         # filestore size limit for overlay vs copy
 
+# ── OAuth (optional) ──────────────────────────────────
+# Set oauth_base_url to the public URL of this Oduflow instance to enable
+# the self-hosted OAuth Authorization Server. Endpoints exposed:
+#   /.well-known/oauth-authorization-server
+#   /authorize
+#   /token
+# For each team, claude.ai (and any OAuth-based MCP client) should be
+# configured with:
+#   client_id     = team.<id>.auth_token
+#   client_secret = team.<id>.auth_token   (same value)
+# After the OAuth flow the issued access_token is also auth_token, so plain
+# Bearer-token clients keep working. Leave empty to use Bearer-only auth.
+# [oauth]
+# oauth_base_url = "https://oduflow.example.com"
+
 # ── Teams ─────────────────────────────────────────────
 # Each team gets isolated workspaces, templates, credentials and services.
 # At least one [team.*] section is required.
 
 [team.1]
 hostname = "localhost"            # port: http://{hostname}:{port}, traefik: https://{slug}.{hostname}
-auth_token = ""                   # MCP bearer token (empty = auth disabled)
+auth_token = ""                   # MCP bearer token / OAuth client_id+secret (empty = auth disabled)
 ui_password = ""                  # Web UI password (empty = UI open)
 port_range = [50000, 50100]       # port range for Odoo containers

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -1,0 +1,152 @@
+"""Unit tests for the self-hosted OAuth Authorization Server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from oduflow.oauth_provider import OduflowOAuthProvider
+from oduflow.settings import Settings, TeamSettings
+
+
+def _settings(**overrides):
+    teams = overrides.pop(
+        "teams",
+        {
+            "1": TeamSettings(
+                team_id="1",
+                auth_token="tok-a",
+                port_range_start=50000,
+                port_range_end=50100,
+            ),
+            "2": TeamSettings(
+                team_id="2",
+                auth_token="tok-b",
+                port_range_start=50100,
+                port_range_end=50200,
+            ),
+        },
+    )
+    return Settings(
+        oauth_base_url=overrides.pop("oauth_base_url", "https://oduflow.example.com"),
+        teams=teams,
+        **overrides,
+    )
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class TestOduflowOAuthProvider:
+    def test_requires_oauth_base_url(self):
+        s = Settings(
+            teams={
+                "1": TeamSettings(
+                    team_id="1",
+                    auth_token="tok",
+                    port_range_start=50000,
+                    port_range_end=50100,
+                )
+            }
+        )
+        with pytest.raises(ValueError, match="oauth_base_url"):
+            OduflowOAuthProvider(s)
+
+    def test_preregistered_clients(self):
+        provider = OduflowOAuthProvider(_settings())
+        client_a = _run(provider.get_client("tok-a"))
+        assert client_a is not None
+        assert client_a.client_id == "tok-a"
+        assert client_a.client_secret == "tok-a"
+
+        client_b = _run(provider.get_client("tok-b"))
+        assert client_b is not None
+        assert client_b.client_secret == "tok-b"
+
+        assert _run(provider.get_client("unknown")) is None
+
+    def test_register_client_disabled(self):
+        from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
+
+        provider = OduflowOAuthProvider(_settings())
+        new_client = OAuthClientInformationFull(
+            client_id="new",
+            client_secret="new",
+            redirect_uris=[AnyUrl("https://example.com/cb")],
+        )
+        with pytest.raises(ValueError, match="Dynamic client registration"):
+            _run(provider.register_client(new_client))
+
+    def test_verify_token(self):
+        provider = OduflowOAuthProvider(_settings())
+        access = _run(provider.verify_token("tok-a"))
+        assert access is not None
+        assert access.token == "tok-a"
+        assert access.client_id == "1"
+        assert access.expires_at is None
+
+        access_b = _run(provider.verify_token("tok-b"))
+        assert access_b is not None
+        assert access_b.client_id == "2"
+
+        assert _run(provider.verify_token("nope")) is None
+
+    def test_exchange_authorization_code_returns_auth_token(self):
+        from mcp.server.auth.provider import AuthorizationCode
+        from pydantic import AnyUrl
+
+        provider = OduflowOAuthProvider(_settings())
+        client = _run(provider.get_client("tok-a"))
+        assert client is not None
+        code = AuthorizationCode(
+            code="dummy",
+            client_id="tok-a",
+            redirect_uri=AnyUrl("https://claude.ai/cb"),
+            redirect_uri_provided_explicitly=True,
+            scopes=["mcp"],
+            expires_at=9999999999,
+            code_challenge="abc",
+        )
+        token = _run(provider.exchange_authorization_code(client, code))
+        assert token.access_token == "tok-a"
+        assert token.refresh_token == "tok-a"
+        assert token.token_type == "Bearer"
+
+    def test_flexible_redirect_uri(self):
+        from pydantic import AnyUrl
+
+        provider = OduflowOAuthProvider(_settings())
+        client = _run(provider.get_client("tok-a"))
+        assert client is not None
+        # Any redirect_uri the client sends must be accepted, since the
+        # /token exchange is gated by client_secret.
+        result = client.validate_redirect_uri(AnyUrl("https://claude.ai/some/cb"))
+        assert str(result) == "https://claude.ai/some/cb"
+
+    def test_well_known_route_exposed(self):
+        provider = OduflowOAuthProvider(_settings())
+        routes = provider.get_routes("/mcp")
+        paths = [getattr(r, "path", "") for r in routes]
+        assert "/.well-known/oauth-authorization-server" in paths
+        assert "/authorize" in paths
+        assert "/token" in paths
+
+    def test_metadata_via_test_client(self):
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        provider = OduflowOAuthProvider(_settings())
+        app = Starlette(routes=provider.get_routes("/mcp"))
+        client = TestClient(app)
+        resp = client.get("/.well-known/oauth-authorization-server")
+        assert resp.status_code == 200
+        meta = json.loads(resp.text)
+        assert meta["issuer"].rstrip("/") == "https://oduflow.example.com"
+        assert "authorization_endpoint" in meta
+        assert "token_endpoint" in meta
+        # DCR is disabled — endpoint must not be advertised.
+        assert "registration_endpoint" not in meta

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -65,80 +65,24 @@ class TestOAuthSettings:
 
     def test_oauth_defaults(self):
         s = Settings()
-        assert s.oauth_client_id == ""
-        assert s.oauth_client_secret == ""
         assert s.oauth_base_url == ""
         assert not s.oauth_enabled
 
     def test_oauth_enabled(self):
         s = Settings(
-            oauth_client_id="id",
-            oauth_client_secret="secret",
             oauth_base_url="https://example.com",
-            teams={"1": self._team()},
+            teams={"1": self._team(auth_token="tok-a")},
         )
         s.validate()
         assert s.oauth_enabled
 
-    def test_oauth_incomplete_raises(self):
+    def test_oauth_without_auth_token_raises(self):
         s = Settings(
-            oauth_client_id="id",
-            oauth_client_secret="",
-            oauth_base_url="",
+            oauth_base_url="https://example.com",
             teams={"1": self._team()},
         )
-        with pytest.raises(ValueError, match="Incomplete OAuth"):
+        with pytest.raises(ValueError, match="auth_token"):
             s.validate()
-
-    def test_github_users_in_team(self):
-        t = TeamSettings(
-            team_id="1",
-            github_users=("octocat", "dev1"),
-            port_range_start=50000,
-            port_range_end=50100,
-        )
-        assert t.github_users == ("octocat", "dev1")
-
-    def test_github_users_default_empty(self):
-        t = TeamSettings(team_id="1")
-        assert t.github_users == ()
-
-    def test_get_team_by_github_user(self):
-        t1 = self._team(team_id="1", github_users=("octocat",))
-        t2 = self._team(team_id="2", github_users=("dev1",))
-        s = Settings(
-            oauth_client_id="id",
-            oauth_client_secret="secret",
-            oauth_base_url="https://example.com",
-            teams={"1": t1, "2": t2},
-        )
-        assert s.get_team_by_github_user("octocat") is t1
-        assert s.get_team_by_github_user("dev1") is t2
-        assert s.get_team_by_github_user("unknown") is None
-        assert s.get_team_by_github_user("") is None
-
-    def test_duplicate_github_users_raises(self):
-        t1 = self._team(team_id="1", github_users=("octocat",))
-        t2 = self._team(team_id="2", github_users=("octocat",))
-        s = Settings(
-            oauth_client_id="id",
-            oauth_client_secret="secret",
-            oauth_base_url="https://example.com",
-            teams={"1": t1, "2": t2},
-        )
-        with pytest.raises(ValueError, match="Duplicate github_users.*octocat"):
-            s.validate()
-
-    def test_any_team_has_github_users(self):
-        t1 = self._team(team_id="1", github_users=("octocat",))
-        t2 = self._team(team_id="2")
-        s = Settings(teams={"1": t1, "2": t2})
-        assert s.any_team_has_github_users
-
-    def test_no_team_has_github_users(self):
-        t1 = self._team(team_id="1")
-        s = Settings(teams={"1": t1})
-        assert not s.any_team_has_github_users
 
 
 class TestTeamSettings:


### PR DESCRIPTION
## Summary

- Replace the GitHub OAuth proxy with a built-in OAuth 2.1 Authorization Server (`OduflowOAuthProvider`) so claude.ai and other MCP clients can authenticate without any external IdP.
- Each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token — plain Bearer-token usage is unchanged.
- Breaking: `oauth_client_id`, `oauth_client_secret`, and per-team `github_users` removed from `oduflow.toml`; configure `oauth_base_url` and use `team.<id>.auth_token` as the OAuth credentials in connected clients.

## Test plan

- [x] `pytest tests/` — 287 passed
- [ ] End-to-end: configure `oauth_base_url`, add a custom MCP connector in claude.ai with `client_id = client_secret = auth_token`, verify the OAuth flow and tool calls