### PR TITLE
fix: surface and restore host_mode/privileged/cap_add/volumes in service presets

### DIFF
--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1661,6 +1661,18 @@ def list_service_presets(ctx: Context = None) -> str:
             output += f", hostname={p['hostname']}"
         if env_str:
             output += f", env=[{env_str}]"
+        if p.get("host_mode"):
+            output += ", host_mode=true"
+        if p.get("privileged"):
+            output += ", privileged=true"
+        if p.get("cap_add"):
+            output += f", cap_add=[{','.join(p['cap_add'])}]"
+        if p.get("volumes"):
+            vol_str = ",".join(
+                f"{v['volume']}:{v['mount_path']}:{v.get('mode', 'rw')}"
+                for v in p["volumes"]
+            )
+            output += f", volumes=[{vol_str}]"
         output += "\n"
     return output
 
@@ -1679,6 +1691,8 @@ def restore_service(name: str, ctx: Context = None) -> str:
     team = _resolve_team(ctx)
     preset = service_presets.get_preset(team, name)
     preset_volumes = preset.get("volumes") or None
+    preset_cap_add = preset.get("cap_add") or None
+    preset_privileged = preset.get("privileged", False)
     result = service_ops.create_service(
         settings,
         team,
@@ -1689,20 +1703,26 @@ def restore_service(name: str, ctx: Context = None) -> str:
         env_vars=preset.get("env_vars") or None,
         host_mode=preset.get("host_mode", False),
         volumes=preset_volumes,
+        cap_add=preset_cap_add,
+        privileged=preset_privileged,
     )
-    vol_info = ""
+    extra = ""
     if preset_volumes:
-        vol_info = "\nVolumes: " + ", ".join(
+        extra += "\nVolumes: " + ", ".join(
             f"{v['volume']}:{v['mount_path']}:{v.get('mode', 'rw')}"
             for v in preset_volumes
         )
+    if preset_privileged:
+        extra += "\nPrivileged: true"
+    elif preset_cap_add:
+        extra += f"\nCapabilities: {','.join(preset_cap_add)}"
     return (
         f"Service restored from preset!\n"
         f"Name: {result['name']}\n"
         f"Container: {result['container_name']}\n"
         f"Image: {result['image']}\n"
         f"URL: {result['url']}"
-        f"{vol_info}"
+        f"{extra}"
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -365,3 +365,137 @@ class TestEnvLock:
                 )
         finally:
             _locks.release_env("main")
+
+
+class TestListServicePresetsTool:
+    @patch("oduflow.docker_ops.service_presets.list_presets")
+    def test_list_shows_all_fields(self, mock_list):
+        mock_list.return_value = [
+            {
+                "name": "wg",
+                "image": "linuxserver/wireguard:latest",
+                "port": 51820,
+                "hostname": "wg",
+                "env_vars": {"PUID": "1000"},
+                "host_mode": True,
+                "privileged": True,
+                "cap_add": ["NET_ADMIN", "SYS_MODULE"],
+                "volumes": [
+                    {"volume": "wg-data", "mount_path": "/config", "mode": "rw"},
+                ],
+            }
+        ]
+        result = _call_tool("list_service_presets")
+        assert "wg" in result
+        assert "image=linuxserver/wireguard:latest" in result
+        assert "port=51820" in result
+        assert "hostname=wg" in result
+        assert "env=[PUID=1000]" in result
+        assert "host_mode=true" in result
+        assert "privileged=true" in result
+        assert "cap_add=[NET_ADMIN,SYS_MODULE]" in result
+        assert "volumes=[wg-data:/config:rw]" in result
+
+    @patch("oduflow.docker_ops.service_presets.list_presets")
+    def test_list_omits_absent_fields(self, mock_list):
+        mock_list.return_value = [
+            {
+                "name": "redis",
+                "image": "redis:7",
+                "port": 6379,
+                "hostname": "",
+                "env_vars": {},
+            }
+        ]
+        result = _call_tool("list_service_presets")
+        assert "redis" in result
+        assert "host_mode" not in result
+        assert "privileged" not in result
+        assert "cap_add" not in result
+        assert "volumes" not in result
+
+
+class TestRestoreServiceTool:
+    @patch("oduflow.docker_ops.service_ops.create_service")
+    @patch("oduflow.docker_ops.service_presets.get_preset")
+    def test_restore_propagates_capabilities(self, mock_get, mock_create):
+        mock_get.return_value = {
+            "name": "wg",
+            "image": "linuxserver/wireguard:latest",
+            "port": 51820,
+            "hostname": "wg",
+            "env_vars": {"PUID": "1000"},
+            "host_mode": True,
+            "privileged": False,
+            "cap_add": ["NET_ADMIN"],
+            "volumes": [
+                {"volume": "wg-data", "mount_path": "/config", "mode": "rw"},
+            ],
+        }
+        mock_create.return_value = {
+            "name": "wg",
+            "container_name": "oduflow-svc-wg",
+            "image": "linuxserver/wireguard:latest",
+            "url": "http://localhost:51820",
+        }
+        result = _get_tool_fn("restore_service")(name="wg")
+
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["cap_add"] == ["NET_ADMIN"]
+        assert kwargs["privileged"] is False
+        assert kwargs["host_mode"] is True
+        assert kwargs["volumes"] == [
+            {"volume": "wg-data", "mount_path": "/config", "mode": "rw"},
+        ]
+        assert kwargs["env_vars"] == {"PUID": "1000"}
+        assert "Service restored from preset!" in result
+        assert "Capabilities: NET_ADMIN" in result
+        assert "Volumes: wg-data:/config:rw" in result
+
+    @patch("oduflow.docker_ops.service_ops.create_service")
+    @patch("oduflow.docker_ops.service_presets.get_preset")
+    def test_restore_propagates_privileged(self, mock_get, mock_create):
+        mock_get.return_value = {
+            "name": "dind",
+            "image": "docker:dind",
+            "port": 2375,
+            "hostname": "",
+            "env_vars": {},
+            "privileged": True,
+        }
+        mock_create.return_value = {
+            "name": "dind",
+            "container_name": "oduflow-svc-dind",
+            "image": "docker:dind",
+            "url": "http://localhost:2375",
+        }
+        result = _get_tool_fn("restore_service")(name="dind")
+
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["privileged"] is True
+        assert kwargs["cap_add"] is None
+        assert "Privileged: true" in result
+
+    @patch("oduflow.docker_ops.service_ops.create_service")
+    @patch("oduflow.docker_ops.service_presets.get_preset")
+    def test_restore_minimal_preset(self, mock_get, mock_create):
+        mock_get.return_value = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+        mock_create.return_value = {
+            "name": "redis",
+            "container_name": "oduflow-svc-redis",
+            "image": "redis:7",
+            "url": "http://localhost:6379",
+        }
+        _get_tool_fn("restore_service")(name="redis")
+
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["cap_add"] is None
+        assert kwargs["privileged"] is False
+        assert kwargs["host_mode"] is False
+        assert kwargs["volumes"] is None


### PR DESCRIPTION
## Summary
- `list_service_presets` теперь печатает `host_mode`, `privileged`, `cap_add` и `volumes`, если они присутствуют в preset; до этого они были скрыты, хотя `save_preset` их сохраняет.
- `restore_service` пробрасывает `cap_add` и `privileged` в `service_ops.create_service` — раньше эти поля терялись, и восстановление сервиса с NET_ADMIN/privileged молча давало сломанный контейнер (VPN, WireGuard, iptables и т.п.).
- Финальное сообщение `restore_service` теперь упоминает `Privileged:` или `Capabilities:` — по аналогии с уже выводимым `Volumes:`.

Сам слой `service_presets.save_preset` и `service_ops.create_service` уже корректно поддерживали эти поля начиная с #17 — баг был только на верхнем MCP-слое в `server.py`.

## Test plan
- [x] `pytest tests/test_server.py::TestListServicePresetsTool tests/test_server.py::TestRestoreServiceTool -v` — 5 новых тестов проходят.
- [x] `pytest -m "not integration and not heavyweight"` — 287 passed.
- [x] `ruff check src/oduflow/server.py tests/test_server.py` и `ruff format --check` — чисто.
- [ ] Вручную через MCP: `create_service name=wg image=linuxserver/wireguard:latest port=51820 net_admin=true` → `list_service_presets` (видим `cap_add=[NET_ADMIN]`) → `delete_service` → `restore_service name=wg` → `docker inspect oduflow-svc-wg --format '{{.HostConfig.CapAdd}}'` показывает `[NET_ADMIN]`.
- [ ] Аналогично с `privileged=true` и `volumes=...`.