### PR TITLE
fix: update_service url KeyError, fresh pull on create, add get_service_info

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -44,6 +44,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `restart_service` | | Restart a service container |
 | `update_service` | ✓ | Pull latest image and recreate the service |
 | `list_services` | | List all managed service containers |
+| `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |
 | **Volumes** | | |

--- a/docs/services.md
+++ b/docs/services.md
@@ -28,6 +28,7 @@ Services are:
 - Given an `unless-stopped` restart policy
 - Automatically routed through Traefik with HTTPS when in traefik mode
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
+- Always created from a freshly pulled image — `create_service` and `restore_service` explicitly pull before running, so mutable tags like `:latest` get the current published version instead of a stale local cache
 
 ### Linux Capabilities
 
@@ -44,6 +45,10 @@ Both can be enabled at the same time; on the Docker side, `privileged` implies a
 # List all services with status, ports, URLs, and env vars
 oduflow call list_services
 
+# Full state of a single service — image + digest, port, hostname, host_mode,
+# volumes, env vars, capabilities, restart count, started_at, has_preset
+oduflow call get_service_info redis
+
 # View service logs
 oduflow call get_service_logs redis 200
 
@@ -59,6 +64,12 @@ oduflow call delete_service redis
 # Execute a command inside a service container
 oduflow call run_service_command redis "redis-cli ping"
 ```
+
+### Inspecting a Service Before Recreating It
+
+When you need to delete and recreate a service (e.g. to change the image tag or a single env var), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
+
+For a plain image refresh prefer `update_service`, which captures and preserves every setting automatically.
 
 ## Service Update Flow
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -140,6 +140,9 @@ def create_service(
     elif cap_add:
         run_kwargs["cap_add"] = list(cap_add)
 
+    logger.info("Pulling image %s for service %s", image, name)
+    client.images.pull(image)
+
     client.containers.run(**run_kwargs)
     logger.info("Created service container %s from image %s", container_name, image)
 
@@ -206,6 +209,115 @@ def delete_service(settings: Settings, name: str) -> dict[str, str]:
     }
 
 
+def _describe_service_container(
+    settings: Settings, team: TeamSettings, container
+) -> dict:
+    """Extract a normalized state dict for a managed service container.
+
+    Used by both ``list_services`` and ``get_service_info``.
+    """
+    svc_name = container.labels.get("oduflow.service")
+    container_name = container.name
+    image = container.image.tags[0] if container.image.tags else "unknown"
+    status = container.status
+
+    raw_env = container.attrs.get("Config", {}).get("Env", [])
+    env_vars: dict[str, str] = {}
+    for entry in raw_env:
+        if "=" in entry:
+            key, value = entry.split("=", 1)
+            if key not in _SYSTEM_ENV_KEYS:
+                env_vars[key] = value
+
+    port_num: int | None = None
+    url: str | None = None
+    hostname: str | None = None
+    is_host_mode = container.labels.get("oduflow.host_mode") == "true"
+
+    if settings.routing_mode == "traefik":
+        rule_label = f"traefik.http.routers.oduflow-svc-{svc_name}.rule"
+        rule_value = container.labels.get(rule_label, "")
+        match = re.search(r"Host\(`([^`]+)`\)", rule_value)
+        if match:
+            hostname = match.group(1)
+            url = f"https://{hostname}"
+
+        if is_host_mode:
+            url_label = f"traefik.http.services.oduflow-svc-{svc_name}.loadbalancer.server.url"
+            url_value = container.labels.get(url_label, "")
+            port_match = re.search(r":(\d+)$", url_value)
+            if port_match:
+                port_num = int(port_match.group(1))
+        else:
+            port_label = f"traefik.http.services.oduflow-svc-{svc_name}.loadbalancer.server.port"
+            label_port = container.labels.get(port_label)
+            if label_port:
+                port_num = int(label_port)
+    else:
+        if is_host_mode:
+            # In host mode without traefik, port is not mapped via Docker.
+            # Try to get it from the preset.
+            try:
+                preset = service_presets.get_preset(team, svc_name)
+                port_num = preset.get("port")
+            except Exception:
+                pass
+            if port_num:
+                url = f"http://{team.hostname}:{port_num}"
+        else:
+            ports_dict = container.attrs.get("NetworkSettings", {}).get("Ports", {})
+            if ports_dict:
+                for port_key, mappings in ports_dict.items():
+                    port_match = re.match(r"(\d+)/", port_key)
+                    if port_match:
+                        port_num = int(port_match.group(1))
+                    if mappings:
+                        for mapping in mappings:
+                            host_port = mapping.get("HostPort")
+                            if host_port:
+                                url = f"http://{team.hostname}:{host_port}"
+                                break
+                    break  # only process first port entry
+
+    svc_volumes: list[dict[str, str]] = []
+    mounts = container.attrs.get("Mounts", [])
+    for mount in mounts:
+        if mount.get("Type") == "volume":
+            vol_docker_name = mount.get("Name", "")
+            prefix = f"oduflow-vol-{team.team_id}-"
+            short_name = (
+                vol_docker_name[len(prefix) :]
+                if vol_docker_name.startswith(prefix)
+                else vol_docker_name
+            )
+            svc_volumes.append(
+                {
+                    "volume": short_name,
+                    "mount_path": mount.get("Destination", ""),
+                    "mode": "ro" if not mount.get("RW", True) else "rw",
+                }
+            )
+
+    host_config = container.attrs.get("HostConfig", {}) or {}
+    svc_cap_add = list(host_config.get("CapAdd") or [])
+    svc_privileged = bool(host_config.get("Privileged", False))
+
+    return {
+        "name": svc_name,
+        "container_name": container_name,
+        "image": image,
+        "status": status,
+        "port": port_num,
+        "hostname": hostname,
+        "url": url,
+        "env_vars": env_vars,
+        "host_mode": is_host_mode,
+        "volumes": svc_volumes,
+        "cap_add": svc_cap_add,
+        "privileged": svc_privileged,
+    }
+
+
 def list_services(settings: Settings, team: TeamSettings) -> list[dict]:
     client = get_client()
     containers = client.containers.list(
@@ -220,117 +332,50 @@ def list_services(settings: Settings, team: TeamSettings) -> list[dict]:
 
     result = []
     for container in containers:
-        svc_name = container.labels.get("oduflow.service")
-        if not svc_name:
+        if not container.labels.get("oduflow.service"):
             continue
-
-        container_name = container.name
-        image = container.image.tags[0] if container.image.tags else "unknown"
-        status = container.status
-
-        # Parse environment variables, filtering out system keys
-        raw_env = container.attrs.get("Config", {}).get("Env", [])
-        env_vars = {}
-        for entry in raw_env:
-            if "=" in entry:
-                key, value = entry.split("=", 1)
-                if key not in _SYSTEM_ENV_KEYS:
-                    env_vars[key] = value
-
-        # Extract port and URL
-        port_num = None
-        url = None
-        is_host_mode = container.labels.get("oduflow.host_mode") == "true"
-
-        if settings.routing_mode == "traefik":
-            rule_label = f"traefik.http.routers.oduflow-svc-{svc_name}.rule"
-
-            rule_value = container.labels.get(rule_label, "")
-            match = re.search(r"Host\(`([^`]+)`\)", rule_value)
-            if match:
-                traefik_hostname = match.group(1)
-                url = f"https://{traefik_hostname}"
-
-            if is_host_mode:
-                url_label = f"traefik.http.services.oduflow-svc-{svc_name}.loadbalancer.server.url"
-                url_value = container.labels.get(url_label, "")
-                port_match = re.search(r":(\d+)$", url_value)
-                if port_match:
-                    port_num = int(port_match.group(1))
-            else:
-                port_label = f"traefik.http.services.oduflow-svc-{svc_name}.loadbalancer.server.port"
-                label_port = container.labels.get(port_label)
-                if label_port:
-                    port_num = int(label_port)
-        else:
-            if is_host_mode:
-                # In host mode without traefik, port is not mapped via Docker
-                # Try to get it from the preset
-                try:
-                    preset = service_presets.get_preset(team, svc_name)
-                    port_num = preset.get("port")
-                except Exception:
-                    pass
-                if port_num:
-                    url = f"http://{team.hostname}:{port_num}"
-            else:
-                ports_dict = container.attrs.get("NetworkSettings", {}).get("Ports", {})
-                if ports_dict:
-                    for port_key, mappings in ports_dict.items():
-                        # Extract port number from key like "6379/tcp"
-                        port_match = re.match(r"(\d+)/", port_key)
-                        if port_match:
-                            port_num = int(port_match.group(1))
-                        if mappings:
-                            for mapping in mappings:
-                                host_port = mapping.get("HostPort")
-                                if host_port:
-                                    url = f"http://{team.hostname}:{host_port}"
-                                    break
-                        break  # only process first port entry
-
-        # Extract volume mounts
-        svc_volumes: list[dict[str, str]] = []
-        mounts = container.attrs.get("Mounts", [])
-        for mount in mounts:
-            if mount.get("Type") == "volume":
-                vol_docker_name = mount.get("Name", "")
-                # Extract short name from oduflow-vol-{team}-{name}
-                prefix = f"oduflow-vol-{team.team_id}-"
-                short_name = (
-                    vol_docker_name[len(prefix) :]
-                    if vol_docker_name.startswith(prefix)
-                    else vol_docker_name
-                )
-                svc_volumes.append(
-                    {
-                        "volume": short_name,
-                        "mount_path": mount.get("Destination", ""),
-                        "mode": "ro" if not mount.get("RW", True) else "rw",
-                    }
-                )
-
-        host_config = container.attrs.get("HostConfig", {}) or {}
-        svc_cap_add = list(host_config.get("CapAdd") or [])
-        svc_privileged = bool(host_config.get("Privileged", False))
-
-        result.append(
-            {
-                "name": svc_name,
-                "container_name": container_name,
-                "image": image,
-                "status": status,
-                "port": port_num,
-                "url": url,
-                "env_vars": env_vars,
-                "host_mode": is_host_mode,
-                "volumes": svc_volumes,
-                "cap_add": svc_cap_add,
-                "privileged": svc_privileged,
-            }
-        )
+        result.append(_describe_service_container(settings, team, container))
 
     return result
+
+
+def get_service_info(settings: Settings, team: TeamSettings, name: str) -> dict:
+    """Return full state and configuration of a single managed service.
+
+    Combines live container state (image, digest, ports, volumes, env, caps,
+    runtime status) with preset presence flag. Raises :class:`NotFoundError`
+    if the service container is missing.
+    """
+    client = get_client()
+    container_name = f"oduflow-svc-{name}"
+
+    try:
+        container = client.containers.get(container_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(f"Service '{name}' not found")
+
+    if not container.labels.get("oduflow.service"):
+        raise NotFoundError(f"Service '{name}' not found")
+
+    info = _describe_service_container(settings, team, container)
+
+    info["image_digest"] = container.image.id
+
+    state = container.attrs.get("State", {}) or {}
+    info["started_at"] = state.get("StartedAt")
+    info["restart_count"] = int(container.attrs.get("RestartCount", 0) or 0)
+
+    has_preset = False
+    try:
+        service_presets.get_preset(team, name)
+        has_preset = True
+    except NotFoundError:
+        pass
+    except Exception:
+        logger.warning("Failed to check preset for service %s", name, exc_info=True)
+    info["has_preset"] = has_preset
+
+    return info
 
 
 def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[str, str]:
@@ -458,10 +503,19 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
 
     if not image_updated:
         logger.info("Image unchanged for service %s: %s", name, new_digest[:19])
+        if settings.routing_mode == "traefik":
+            if not hostname:
+                hostname = f"{name}.{team.hostname}"
+            elif "." not in hostname:
+                hostname = f"{hostname}.{team.hostname}"
+            url = f"https://{hostname}"
+        else:
+            url = f"http://{team.hostname}:{port}"
         return {
             "name": name,
             "container_name": container_name,
             "image": old_image,
+            "url": url,
             "image_updated": False,
             "old_digest": old_digest,
             "new_digest": new_digest,

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1643,6 +1643,61 @@ def restart_service(name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
+def get_service_info(name: str, ctx: Context = None) -> str:
+    """
+    Get full state and configuration of a managed auxiliary service.
+
+    Returns image (with digest), runtime status, port, hostname, URL, host_mode,
+    volumes, environment variables, capabilities, privileged flag, restart count,
+    started_at, and whether a saved preset exists. Use this before recreating or
+    updating a service so all current options (volumes, host_mode, cap_add, env)
+    are preserved.
+
+    Args:
+        name: The name of the service to inspect (e.g. "redis", "fs").
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    info = service_ops.get_service_info(settings, team, name)
+
+    digest = (info.get("image_digest") or "")
+    digest_short = digest[:19] if digest else ""
+
+    lines = [f"Service '{info['name']}': {info['status']}"]
+    lines.append(f"Container: {info['container_name']}")
+    lines.append(f"Image: {info['image']}")
+    if digest_short:
+        lines.append(f"Digest: {digest_short}")
+    if info.get("port") is not None:
+        lines.append(f"Port: {info['port']}")
+    if info.get("hostname"):
+        lines.append(f"Hostname: {info['hostname']}")
+    if info.get("url"):
+        lines.append(f"URL: {info['url']}")
+    lines.append(f"Host mode: {'true' if info.get('host_mode') else 'false'}")
+    if info.get("privileged"):
+        lines.append("Privileged: true")
+    if info.get("cap_add"):
+        lines.append(f"Capabilities: {','.join(info['cap_add'])}")
+    if info.get("volumes"):
+        vol_str = ", ".join(
+            f"{v['volume']}:{v['mount_path']}:{v.get('mode', 'rw')}"
+            for v in info["volumes"]
+        )
+        lines.append(f"Volumes: {vol_str}")
+    if info.get("env_vars"):
+        env_str = ", ".join(f"{k}={v}" for k, v in info["env_vars"].items())
+        lines.append(f"Env: {env_str}")
+    if info.get("started_at"):
+        lines.append(
+            f"Started: {info['started_at']} (restart_count={info.get('restart_count', 0)})"
+        )
+    lines.append(f"Preset: {'yes' if info.get('has_preset') else 'no'}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+@handle_errors
 def list_service_presets(ctx: Context = None) -> str:
     """List saved service presets (configurations that can be restored)."""
     team = _resolve_team(ctx)

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -90,9 +90,14 @@ MCP endpoint: `http://<host>:8000/mcp`
 
 | Tool | When to use |
 |---|---|
-| `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access |
+| `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access. The image is always pulled fresh, so mutable tags like `:latest` get the current version |
+| `get_service_info(name)` | **Use this before recreating a service.** Returns full live state: image + digest, port, hostname, URL, `host_mode`, `volumes`, env vars, `cap_add`, `privileged`, restart count, started_at, whether a preset exists |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
+| `update_service(name)` | Pull the latest image and recreate the container with the same settings. Reports "already up-to-date" if the digest is unchanged |
+| `restore_service(name)` | Recreate a service from its saved preset after deletion (volumes, host_mode, cap_add, env are all preserved) |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
+
+> **Recreating a service:** if you are about to `delete_service` and then `create_service` for the same service (e.g. to change the image or a single parameter), **call `get_service_info(name)` first** and reuse its `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged` in the new `create_service` call. Otherwise you will silently drop volumes, env vars, capabilities, or host_mode and the recreated service will be broken. For a plain image refresh prefer `update_service`, which preserves everything automatically.
 
 ### Volumes
 

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -77,6 +77,8 @@ class TestCreateService:
         assert run_kwargs[1]["labels"]["oduflow.managed"] == "true"
         assert run_kwargs[1]["labels"]["oduflow.service"] == "redis"
 
+        mock_docker_client.images.pull.assert_called_once_with("redis:7")
+
     def test_create_traefik_mode(self, mock_docker_client):
         mock_docker_client.networks.get.return_value = MagicMock()
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
@@ -460,7 +462,7 @@ class TestUpdateService:
         assert result["image"] == "redis:7"
         assert result["url"] == "http://localhost:6379"
 
-        mock_docker_client.images.pull.assert_called_once_with("redis:7")
+        mock_docker_client.images.pull.assert_any_call("redis:7")
         container.stop.assert_called_once()
         container.remove.assert_called_once_with(v=True)
 
@@ -503,9 +505,7 @@ class TestUpdateService:
             )
 
         assert result["url"] == "https://meili.example.com"
-        mock_docker_client.images.pull.assert_called_once_with(
-            "getmeili/meilisearch:v1.6"
-        )
+        mock_docker_client.images.pull.assert_any_call("getmeili/meilisearch:v1.6")
 
         run_kwargs = mock_docker_client.containers.run.call_args
         labels = run_kwargs[1]["labels"]
@@ -546,6 +546,80 @@ class TestUpdateService:
         run_kwargs = mock_docker_client.containers.run.call_args
         assert "environment" not in run_kwargs[1]
 
+    def test_update_image_unchanged_returns_url_port_mode(self, mock_docker_client):
+        """When image digest is unchanged, return early with a valid URL (port mode)."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        container.image.id = "sha256:same"
+
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.networks.get.return_value = MagicMock()
+        pulled = MagicMock()
+        pulled.id = "sha256:same"
+        mock_docker_client.images.pull.return_value = pulled
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+
+        assert result["image_updated"] is False
+        assert result["url"] == "http://localhost:6379"
+        assert result["name"] == "redis"
+        assert result["image"] == "redis:7"
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
+
+    def test_update_image_unchanged_returns_url_traefik(self, mock_docker_client):
+        """When image digest is unchanged in traefik mode, URL is built from hostname."""
+        container = self._make_container(
+            image_tags=["getmeili/meilisearch:v1.6"],
+            labels={"oduflow.managed": "true", "oduflow.service": "meili"},
+            attrs={"Config": {"Env": []}},
+        )
+        container.image.id = "sha256:same"
+
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.networks.get.return_value = MagicMock()
+        pulled = MagicMock()
+        pulled.id = "sha256:same"
+        mock_docker_client.images.pull.return_value = pulled
+
+        preset = {
+            "name": "meili",
+            "image": "getmeili/meilisearch:v1.6",
+            "port": 7700,
+            "hostname": "meili",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili"
+            )
+
+        assert result["image_updated"] is False
+        assert result["url"] == "https://meili.example.com"
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
+
     def test_update_not_found(self, mock_docker_client):
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
@@ -582,7 +656,137 @@ class TestUpdateService:
             result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
 
         assert result["image"] == "redis:7-alpine"
-        mock_docker_client.images.pull.assert_called_once_with("redis:7-alpine")
+        mock_docker_client.images.pull.assert_any_call("redis:7-alpine")
+
+
+class TestGetServiceInfo:
+    def _make_container(self, image_tags, image_id, labels, attrs, status="running"):
+        container = MagicMock()
+        container.name = labels.get("__name") or "oduflow-svc-redis"
+        container.image.tags = image_tags
+        container.image.id = image_id
+        container.labels = {k: v for k, v in labels.items() if k != "__name"}
+        container.attrs = attrs
+        container.status = status
+        return container
+
+    def test_get_service_info_port_mode(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["redis:7"],
+            image_id="sha256:abc123def456",
+            labels={
+                "__name": "oduflow-svc-redis",
+                "oduflow.managed": "true",
+                "oduflow.service": "redis",
+            },
+            attrs={
+                "Config": {
+                    "Env": [
+                        "REDIS_PASSWORD=secret",
+                        "PATH=/usr/bin",
+                    ]
+                },
+                "NetworkSettings": {
+                    "Ports": {
+                        "6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]
+                    }
+                },
+                "Mounts": [
+                    {
+                        "Type": "volume",
+                        "Name": "oduflow-vol-1-data",
+                        "Destination": "/data",
+                        "RW": True,
+                    }
+                ],
+                "HostConfig": {"CapAdd": ["NET_ADMIN"], "Privileged": False},
+                "State": {"StartedAt": "2026-05-26T13:00:00Z"},
+                "RestartCount": 2,
+            },
+        )
+        mock_docker_client.containers.get.return_value = container
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value={"name": "redis"},
+        ):
+            info = service_ops.get_service_info(TEST_SETTINGS, TEST_TEAM, "redis")
+
+        assert info["name"] == "redis"
+        assert info["container_name"] == "oduflow-svc-redis"
+        assert info["image"] == "redis:7"
+        assert info["image_digest"] == "sha256:abc123def456"
+        assert info["status"] == "running"
+        assert info["port"] == 6379
+        assert info["url"] == "http://localhost:6379"
+        assert info["env_vars"] == {"REDIS_PASSWORD": "secret"}
+        assert info["host_mode"] is False
+        assert info["volumes"] == [
+            {"volume": "data", "mount_path": "/data", "mode": "rw"}
+        ]
+        assert info["cap_add"] == ["NET_ADMIN"]
+        assert info["privileged"] is False
+        assert info["restart_count"] == 2
+        assert info["started_at"] == "2026-05-26T13:00:00Z"
+        assert info["has_preset"] is True
+
+    def test_get_service_info_traefik_mode(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["getmeili/meilisearch:v1.6"],
+            image_id="sha256:meili123",
+            labels={
+                "__name": "oduflow-svc-meili",
+                "oduflow.managed": "true",
+                "oduflow.service": "meili",
+                "traefik.http.routers.oduflow-svc-meili.rule": "Host(`meili.example.com`)",
+                "traefik.http.services.oduflow-svc-meili.loadbalancer.server.port": "7700",
+            },
+            attrs={
+                "Config": {"Env": ["MEILI_MASTER_KEY=abc"]},
+                "Mounts": [],
+                "HostConfig": {"CapAdd": [], "Privileged": False},
+                "State": {"StartedAt": "2026-05-26T13:00:00Z"},
+                "RestartCount": 0,
+            },
+        )
+        mock_docker_client.containers.get.return_value = container
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=NotFoundError("no preset"),
+        ):
+            info = service_ops.get_service_info(
+                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili"
+            )
+
+        assert info["hostname"] == "meili.example.com"
+        assert info["url"] == "https://meili.example.com"
+        assert info["port"] == 7700
+        assert info["has_preset"] is False
+
+    def test_get_service_info_not_found(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError, match="Service 'redis' not found"):
+            service_ops.get_service_info(TEST_SETTINGS, TEST_TEAM, "redis")
+
+    def test_get_service_info_not_managed(self, mock_docker_client):
+        """A container with name oduflow-svc-X but no oduflow.service label is rejected."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            image_id="sha256:abc",
+            labels={"some_other_label": "foo"},
+            attrs={
+                "Config": {"Env": []},
+                "Mounts": [],
+                "HostConfig": {},
+                "State": {},
+            },
+        )
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(NotFoundError, match="Service 'redis' not found"):
+            service_ops.get_service_info(TEST_SETTINGS, TEST_TEAM, "redis")
 
 
 class TestGetServiceLogs:


### PR DESCRIPTION
## Summary

- **Fix** `KeyError: 'url'` in MCP `update_service` when the image is already up-to-date — the early-return path now builds the URL with the same rules as `create_service`.
- **Fix** stale `:latest` caching: `create_service` now explicitly pulls the image before `containers.run`, so `restore_service` / `create_service` / UI restore no longer reuse old cached layers.
- **Feature** new MCP tool `get_service_info(name)` symmetric with `get_environment_info` — returns full live state (image + digest, port, hostname, url, host_mode, volumes, env, cap_add, privileged, restart_count, started_at, has_preset) so agents can recreate a service without losing options.

## Test plan

- [x] `pytest -m "not integration and not heavyweight"` — 293 passed
- [x] `ruff check` on changed files — clean
- [ ] Manually call MCP `update_service` on a service whose image is already current — should no longer raise `KeyError`
- [ ] Manually call MCP `restore_service` with a `:latest` tag — service should come up on the actual latest image
- [ ] Call MCP `get_service_info <name>` — verify all fields are populated