### PR TITLE
fix: run_odoo_tests crashes on port 8069 — add --no-http --workers 0

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -198,7 +198,10 @@ oduflow call upgrade_odoo_modules feature-login sale,crm
 oduflow call run_odoo_tests feature-login sale,crm
 ```
 
-This runs `odoo --test-enable --stop-after-init -i <modules>` inside the container.
+This runs `odoo --test-enable --stop-after-init --no-http --workers 0 -i <modules>` inside the
+container. The `--no-http` flag prevents the test process from starting a second HTTP server on
+the already-bound port 8069, and `--workers 0` makes the test run deterministic (Odoo recommends
+single-worker mode for unit tests).
 
 ## Smart Pull — Intelligent Change Detection
 

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -32,7 +32,7 @@ def run_environment_tests(
         env_name, team.workspaces_dir, settings.db_user, settings.db_password
     )
     cmd = (
-        f"odoo --test-enable --stop-after-init -i {modules} "
+        f"odoo --test-enable --stop-after-init --no-http --workers 0 -i {modules} "
         f"--db_host={settings.shared_db_container} "
         f"-r {creds['pg_user']} -w {creds['pg_password']} "
         f"--database={env_db}"

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -478,6 +478,11 @@ class TestRunEnvironmentTests:
         assert "--db_host=oduflow-db" in args
         assert "--database=oduflow_1_main" in args
         assert "-r u_1_main" in args
+        # Tests run via `docker exec` inside the already-running odoo container,
+        # which already holds port 8069 — the test process must not start its own
+        # HTTP server, otherwise it crashes on bind.
+        assert "--no-http" in args
+        assert "--workers 0" in args
 
 
 class TestGetLogs:


### PR DESCRIPTION
`run_environment_tests` built the Odoo test command without `--no-http`, so the test process — launched via `docker exec` inside the already-running odoo container that already binds port 8069 — tried to start a second HTTP server and crashed on bind. All sibling commands (`install`/`upgrade`/`shell`) already pass `--no-http`; the test command was the only outlier. This adds `--no-http` (fixes the port conflict) and `--workers 0` (silences Odoo's "Unit testing in workers mode could fail" warning and makes runs deterministic). The change is in `src/oduflow/docker_ops/odoo_ops.py`, with regression assertions in `tests/test_odoo_manager.py` and the command description synced in `docs/environments.md`.