### PR TITLE
fix: run_odoo_tests — override test ports and use -u so tests run

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -198,10 +198,13 @@ oduflow call upgrade_odoo_modules feature-login sale,crm
 oduflow call run_odoo_tests feature-login sale,crm
 ```
 
-This runs `odoo --test-enable --stop-after-init --no-http --workers 0 -i <modules>` inside the
-container. The `--no-http` flag prevents the test process from starting a second HTTP server on
-the already-bound port 8069, and `--workers 0` makes the test run deterministic (Odoo recommends
-single-worker mode for unit tests).
+This runs `odoo --test-enable --stop-after-init --workers 0 --http-port 8089 --gevent-port 8090 -u
+<modules>` inside the container. The module must already be installed — tests run via an upgrade
+(`-u`); `-i` on an already-installed module is a no-op that never enters the test phase ("0 of 0
+tests"). Because `--no-http` has no effect under `--test-enable` (tests require a live HTTP
+server), the test server's HTTP and gevent ports are moved off the defaults (8069/8072) — already
+held by the running Odoo container — to avoid a port conflict. `--workers 0` makes the run
+deterministic (Odoo recommends single-worker mode for unit tests).
 
 ## Smart Pull — Intelligent Change Detection
 

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -31,13 +31,20 @@ def run_environment_tests(
     creds = load_credentials(
         env_name, team.workspaces_dir, settings.db_user, settings.db_password
     )
+    # Use -u (upgrade), not -i (install): the module is already installed in the
+    # template, and -i on an installed module is a no-op that never enters the test
+    # phase (→ "0 of 0 tests"). -u re-runs the module's tests on the existing DB.
+    #
+    # --no-http has no effect under --test-enable (tests need a live HTTP server),
+    # so instead of disabling HTTP we move the test server's HTTP and gevent ports
+    # off the defaults (8069/8072) already held by the running Odoo container.
     cmd = (
-        f"odoo --test-enable --stop-after-init --no-http --workers 0 -i {modules} "
+        f"odoo --test-enable --stop-after-init --workers 0 "
+        f"--http-port 8089 --gevent-port 8090 -u {modules} "
         f"--db_host={settings.shared_db_container} "
         f"-r {creds['pg_user']} -w {creds['pg_password']} "
         f"--database={env_db}"
     )
-
     logger.info(
         "Running tests",
         extra={"env_name": env_name, "modules": modules},

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -758,9 +758,13 @@ def run_odoo_tests(env_name: str, modules: str, ctx: Context = None) -> str:
     """
     Run Odoo tests for specific modules in an environment.
 
+    The module must already be installed in the environment (it runs the tests via
+    an upgrade, `-u`). Install it first with install_odoo_modules or pull_and_apply
+    if it is not present; testing an uninstalled module yields "0 of 0 tests".
+
     Args:
         env_name: The name of the environment.
-        modules: Comma-separated list of modules to test.
+        modules: Comma-separated list of already-installed modules to test.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -478,10 +478,15 @@ class TestRunEnvironmentTests:
         assert "--db_host=oduflow-db" in args
         assert "--database=oduflow_1_main" in args
         assert "-r u_1_main" in args
+        # Use -u (upgrade), not -i: the module is already installed, and -i would be
+        # a no-op that never runs the test phase ("0 of 0 tests").
+        assert "-u base" in args
         # Tests run via `docker exec` inside the already-running odoo container,
-        # which already holds port 8069 — the test process must not start its own
-        # HTTP server, otherwise it crashes on bind.
-        assert "--no-http" in args
+        # which already holds 8069/8072. --no-http is ignored under --test-enable
+        # (tests need a live HTTP server), so the test server's ports are moved off
+        # the defaults to avoid the bind conflict.
+        assert "--http-port 8089" in args
+        assert "--gevent-port 8090" in args
         assert "--workers 0" in args
 
 


### PR DESCRIPTION
Follow-up to #22, which shipped `--no-http --workers 0` but didn't fully fix the test runner. Two issues remained: `--no-http` has no effect under `--test-enable` (Odoo tests require a live HTTP server), so the test process still tried to bind the busy 8069/8072 ports held by the running container; and `-i` on an already-installed module is a no-op that never enters the test phase, yielding "0 of 0 tests". This runs the test server on `--http-port 8089 --gevent-port 8090` and switches `-i` to `-u` (upgrade) so the module's tests re-run on the existing DB. The `run_odoo_tests` docstring now documents that the module must be installed first, and the regression assertions and docs are updated to match.