### PR TITLE
Dashboard copy-DB-on-click, .oduflow/ dependency files, docs auto-deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Allow pushing the built site to the gh-pages branch.
+permissions:
+  contents: write
+
+# Never run two deploys at once; a newer commit supersedes an in-flight one.
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,9 @@ to assume the python venv.
 
 ## Publishing Documentation
 
-After committing and pushing changes to `docs/` or `mkdocs.yml`, always publish the documentation to GitHub Pages automatically — do not ask the user:
+Documentation is published to GitHub Pages **automatically by a GitHub Action when changes are merged into `main`**. Do NOT run `mkdocs gh-deploy --force` (or otherwise deploy docs) from a working/feature branch — publishing a not-yet-merged branch would make the live site reflect unmerged content.
 
-```bash
-pip install -r requirements-docs.txt
-source .venv/bin/activate && mkdocs gh-deploy --force
-```
-
-Documentation dependencies are listed in `requirements-docs.txt`.
+Just commit the `docs/`/`mkdocs.yml` changes as part of your branch; the site updates on merge. Documentation build dependencies (for local preview only) are listed in `requirements-docs.txt`.
 
 The site is hosted at: https://oduist.github.io/oduflow/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,11 @@ to assume the python venv.
 
 ## Publishing Documentation
 
-Documentation is published to GitHub Pages **automatically by a GitHub Action when changes are merged into `main`**. Do NOT run `mkdocs gh-deploy --force` (or otherwise deploy docs) from a working/feature branch — publishing a not-yet-merged branch would make the live site reflect unmerged content.
+Documentation is published to GitHub Pages **automatically** by `.github/workflows/docs.yml`: on every push to `main` touching `docs/`, `mkdocs.yml`, or `requirements-docs.txt`, it installs `requirements-docs.txt` and runs `mkdocs gh-deploy --force` to update the `gh-pages` branch, which GitHub's `pages-build-deployment` then publishes live.
 
-Just commit the `docs/`/`mkdocs.yml` changes as part of your branch; the site updates on merge. Documentation build dependencies (for local preview only) are listed in `requirements-docs.txt`.
+Do NOT run `mkdocs gh-deploy` (or otherwise deploy docs) from a working/feature branch — that would push unmerged content live. Just commit the `docs/`/`mkdocs.yml` changes as part of your branch; the site updates once they merge to `main`. A manual redeploy is available via the workflow's `workflow_dispatch` trigger.
 
-The site is hosted at: https://oduist.github.io/oduflow/
+The site is hosted at: https://docs.oduflow.dev/
 
 ## Publishing Docker Image
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,11 @@ MCP Clients (Cursor, Claude, etc.)
 
 ## Documentation
 
-Documentation is published to GitHub Pages **automatically by a GitHub Action when changes land on `main`**. Do NOT run `mkdocs gh-deploy --force` (or otherwise deploy docs) from a working/feature branch — that would push an unmerged branch's docs to the live site. Just commit the `docs/`/`mkdocs.yml` changes; publishing happens on merge.
+Documentation is published to GitHub Pages **automatically**. `.github/workflows/docs.yml` runs `mkdocs gh-deploy --force` on every push to `main` that touches `docs/`, `mkdocs.yml`, or `requirements-docs.txt`; that updates the `gh-pages` branch, which GitHub's built-in `pages-build-deployment` then mirrors to the live site.
 
-Site: https://oduist.github.io/oduflow/
+Do NOT run `mkdocs gh-deploy --force` manually from a working/feature branch — just commit the `docs/`/`mkdocs.yml` changes; publishing happens once they land on `main`. (A manual redeploy is available via the workflow's `workflow_dispatch` trigger.)
+
+Site: https://docs.oduflow.dev/
 
 ## Agent workflow
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,10 +93,8 @@ MCP Clients (Cursor, Claude, etc.)
 
 ## Documentation
 
-After committing changes to `docs/` or `mkdocs.yml`, auto-publish to GitHub Pages:
-```bash
-source .venv/bin/activate && mkdocs gh-deploy --force
-```
+Documentation is published to GitHub Pages **automatically by a GitHub Action when changes land on `main`**. Do NOT run `mkdocs gh-deploy --force` (or otherwise deploy docs) from a working/feature branch — that would push an unmerged branch's docs to the live site. Just commit the `docs/`/`mkdocs.yml` changes; publishing happens on merge.
+
 Site: https://oduist.github.io/oduflow/
 
 ## Agent workflow

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -23,7 +23,7 @@ When creating an environment, Oduflow:
 2. **Creates the database** — `CREATE DATABASE ... TEMPLATE oduflow_template_{team_id}_{name}` for instant copy, or empty DB when `template=none`
 3. **Mounts the filestore overlay** — fuse-overlayfs with the template as lower layer
 4. **Detects UID/GID** — runs `id` in the Odoo image to set correct file ownership
-5. **Installs dependencies** — auto-installs from `apt_packages.txt` and `requirements.txt` if present in the repo
+5. **Installs dependencies** — auto-installs from `.oduflow/apt_packages.txt` and `.oduflow/requirements.txt` (the latter falls back to the repo root) if present
 6. **Configures Odoo** — uses repo's `.oduflow/odoo.conf` if available, otherwise the default template
 7. **Starts the container** — with `--dev=xml` for hot-reloading XML/QWeb changes
 8. **Initializes base** — when `template=none`, runs `odoo -i base --stop-after-init`
@@ -40,9 +40,11 @@ Credentials are stored in the git credential store. Subsequent `create_environme
 
 ### Auto-dependency installation
 
-Place these files in your repository root for automatic installation during environment creation:
+Place these files in your repository for automatic installation during environment creation:
 
-**`requirements.txt`** — Python packages installed via pip:
+**`.oduflow/requirements.txt`** — Python packages installed via pip. Oduflow looks in
+`.oduflow/` first and falls back to a `requirements.txt` in the repository root (for
+compatibility with conventions used elsewhere, e.g. odoo.sh):
 
 ```
 phonenumbers==8.13.0
@@ -50,7 +52,8 @@ python-barcode==0.15.1
 xlsxwriter>=3.0
 ```
 
-**`apt_packages.txt`** — System packages installed via apt:
+**`.oduflow/apt_packages.txt`** — System packages installed via apt. This is an
+Oduflow-specific convention and is read **only** from `.oduflow/` (no repo-root fallback):
 
 ```
 # Dependencies for wkhtmltopdf

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 
 ### Smart Automation
 - **Smart pull** — `pull_and_apply` analyzes changed files (manifest, Python fields, security XML, JS) and automatically decides whether to install, upgrade, restart, or do nothing
-- **Auto-install dependencies** — `requirements.txt` (pip) and `apt_packages.txt` (apt) in the repository root are automatically installed when creating an environment
+- **Auto-install dependencies** — `.oduflow/requirements.txt` (pip, falls back to the repo root) and `.oduflow/apt_packages.txt` (apt) are automatically installed when creating an environment
 - **Custom odoo.conf** — if the repository contains an `odoo.conf` in its `.oduflow/` directory, it is used instead of the default template
 - **Field change detection** — Python files are analyzed for `fields.*` definition changes, triggering module upgrades only when necessary
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -221,7 +221,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 
 ### Smart Automation
 - **Smart pull** — `pull_and_apply` analyzes changed files (manifest, Python fields, security XML, JS) and automatically decides whether to install, upgrade, restart, or do nothing
-- **Auto-install dependencies** — `requirements.txt` (pip) and `apt_packages.txt` (apt) in the repository root are automatically installed when creating an environment
+- **Auto-install dependencies** — `.oduflow/requirements.txt` (pip, falls back to the repo root) and `.oduflow/apt_packages.txt` (apt) are automatically installed when creating an environment
 - **Custom odoo.conf** — if the repository contains an `odoo.conf` in its `.oduflow/` directory, it is used instead of the default template
 - **Field change detection** — Python files are analyzed for `fields.*` definition changes, triggering module upgrades only when necessary
 
@@ -949,7 +949,7 @@ When creating an environment, Oduflow:
 2. **Creates the database** — `CREATE DATABASE ... TEMPLATE oduflow_template_{team_id}_{name}` for instant copy, or empty DB when `template=none`
 3. **Mounts the filestore overlay** — fuse-overlayfs with the template as lower layer
 4. **Detects UID/GID** — runs `id` in the Odoo image to set correct file ownership
-5. **Installs dependencies** — auto-installs from `apt_packages.txt` and `requirements.txt` if present in the repo
+5. **Installs dependencies** — auto-installs from `.oduflow/apt_packages.txt` and `.oduflow/requirements.txt` (the latter falls back to the repo root) if present
 6. **Configures Odoo** — uses repo's `.oduflow/odoo.conf` if available, otherwise the default template
 7. **Starts the container** — with `--dev=xml` for hot-reloading XML/QWeb changes
 8. **Initializes base** — when `template=none`, runs `odoo -i base --stop-after-init`
@@ -966,9 +966,11 @@ Credentials are stored in the git credential store. Subsequent `create_environme
 
 ### Auto-dependency installation
 
-Place these files in your repository root for automatic installation during environment creation:
+Place these files in your repository for automatic installation during environment creation:
 
-**`requirements.txt`** — Python packages installed via pip:
+**`.oduflow/requirements.txt`** — Python packages installed via pip. Oduflow looks in
+`.oduflow/` first and falls back to a `requirements.txt` in the repository root (for
+compatibility with conventions used elsewhere, e.g. odoo.sh):
 
 ```
 phonenumbers==8.13.0
@@ -976,7 +978,8 @@ python-barcode==0.15.1
 xlsxwriter>=3.0
 ```
 
-**`apt_packages.txt`** — System packages installed via apt:
+**`.oduflow/apt_packages.txt`** — System packages installed via apt. This is an
+Oduflow-specific convention and is read **only** from `.oduflow/` (no repo-root fallback):
 
 ```
 # Dependencies for wkhtmltopdf

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -287,9 +287,9 @@ def _unmount_filestore(env_name: str, team: TeamSettings) -> None:
 
 def _install_apt_packages(container, repo_path: str) -> str:
     """Install apt packages. Returns a human-readable log of what happened."""
-    apt_file = os.path.join(repo_path, "apt_packages.txt")
+    apt_file = os.path.join(repo_path, ".oduflow", "apt_packages.txt")
     if not os.path.isfile(apt_file):
-        logger.debug("No apt_packages.txt in repo, skipping apt install")
+        logger.debug("No .oduflow/apt_packages.txt in repo, skipping apt install")
         return ""
 
     with open(apt_file) as f:
@@ -345,21 +345,28 @@ def _install_pip_requirements(
     When *restart* is False the caller is responsible for restarting the
     container after all setup steps are done.
     """
-    req_file = os.path.join(repo_path, "requirements.txt")
-    if not os.path.isfile(req_file):
+    # Prefer .oduflow/requirements.txt; fall back to the repo root for
+    # compatibility with conventions used elsewhere (e.g. odoo.sh).
+    oduflow_req = os.path.join(repo_path, ".oduflow", "requirements.txt")
+    root_req = os.path.join(repo_path, "requirements.txt")
+    if os.path.isfile(oduflow_req):
+        container_req = "/mnt/extra-addons/.oduflow/requirements.txt"
+    elif os.path.isfile(root_req):
+        container_req = "/mnt/extra-addons/requirements.txt"
+    else:
         logger.debug("No requirements.txt in repo, skipping pip install")
         return False, ""
 
     # Ensure the odoo user can write to its local site-packages
     _ensure_user_site_packages(container)
 
-    cmd = "pip3 install --user --break-system-packages -r /mnt/extra-addons/requirements.txt"
-    logger.info("Installing pip requirements from requirements.txt")
+    cmd = f"pip3 install --user --break-system-packages -r {container_req}"
+    logger.info("Installing pip requirements from %s", container_req)
     exit_code, output = container.exec_run(cmd, user="odoo")
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
     if exit_code != 0 and "no such option" in output_str.lower():
         logger.info("--break-system-packages not supported, retrying without it")
-        cmd = "pip3 install --user -r /mnt/extra-addons/requirements.txt"
+        cmd = f"pip3 install --user -r {container_req}"
         exit_code, output = container.exec_run(cmd, user="odoo")
         output_str = (
             output.decode("utf-8") if isinstance(output, bytes) else str(output)

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -124,6 +124,12 @@
   }
   .env-note:hover { border-color: var(--border); }
   .env-note-empty { font-style: italic; opacity: 0.5; }
+  .copy-db {
+    cursor: pointer;
+    border-bottom: 1px dashed transparent;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .copy-db:hover { border-bottom-color: var(--accent); color: var(--accent); }
   .containers {
     font-size: 12px;
     color: var(--text-dim);
@@ -872,6 +878,27 @@ function showToast(msg, isError) {
   t._tid = setTimeout(() => t.className = 'toast', 3000);
 }
 
+function copyToClipboard(text) {
+  const onErr = () => showToast('Copy failed', true);
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(text)
+      .then(() => showToast('Copied: ' + text))
+      .catch(onErr);
+    return;
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    ok ? showToast('Copied: ' + text) : onErr();
+  } catch (e) { onErr(); }
+}
+
 function closeSyncResult(event) {
   if (event && event.target !== event.currentTarget) return;
   document.getElementById('sync-result-modal').classList.remove('show');
@@ -965,7 +992,7 @@ function renderEnvironments(envs) {
 
     const metaHtml = (env.odoo_image || env.repo_url || env.db_name || env.template_name)
       ? '<div class="env-meta">' +
-          (env.db_name ? '<span>DB: <strong>' + esc(env.db_name) + '</strong></span>' : '') +
+          (env.db_name ? '<span>DB: <strong class="copy-db" title="Click to copy" onclick="copyToClipboard(\'' + esc(env.db_name).replace(/'/g, "\\'") + '\')">' + esc(env.db_name) + '</strong></span>' : '') +
           (env.template_name && env.template_name !== 'none' ? '<span>Template: <strong>' + esc(env.template_name) + '</strong></span>' : '') +
           (env.odoo_image ? '<span>Image: <strong>' + esc(env.odoo_image) + '</strong></span>' : '') +
           (env.repo_url ? '<span>Repo: <strong>' + esc(env.repo_url) + '</strong>' +

--- a/tests/test_dependency_install.py
+++ b/tests/test_dependency_install.py
@@ -1,0 +1,107 @@
+"""Unit tests for dependency-file resolution in env_ops.
+
+Covers the `.oduflow/`-first lookup for ``apt_packages.txt`` (no repo-root
+fallback) and ``requirements.txt`` (falls back to the repo root).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+from oduflow.docker_ops import env_ops
+
+
+def _write(path: str, content: str = "# pkg\n") -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _mock_container():
+    container = MagicMock()
+    container.exec_run.return_value = (0, b"ok")
+    return container
+
+
+def _pip_cmd(container) -> str | None:
+    """Return the ``pip3 install`` command passed to exec_run, if any."""
+    for call in container.exec_run.call_args_list:
+        cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+        if "pip3 install" in cmd:
+            return cmd
+    return None
+
+
+class TestInstallAptPackages:
+    def test_reads_from_oduflow_dir(self, tmp_path):
+        repo = str(tmp_path)
+        _write(os.path.join(repo, ".oduflow", "apt_packages.txt"), "libfoo\nlibbar\n")
+        container = _mock_container()
+
+        result = env_ops._install_apt_packages(container, repo)
+
+        assert "[APT] Installed" in result
+        assert "libfoo" in result and "libbar" in result
+
+    def test_repo_root_is_ignored(self, tmp_path):
+        # apt_packages.txt at the repo root must NOT be picked up anymore.
+        repo = str(tmp_path)
+        _write(os.path.join(repo, "apt_packages.txt"), "libfoo\n")
+        container = _mock_container()
+
+        result = env_ops._install_apt_packages(container, repo)
+
+        assert result == ""
+        container.exec_run.assert_not_called()
+
+    def test_missing_returns_empty(self, tmp_path):
+        container = _mock_container()
+        result = env_ops._install_apt_packages(container, str(tmp_path))
+        assert result == ""
+        container.exec_run.assert_not_called()
+
+
+class TestInstallPipRequirements:
+    def test_prefers_oduflow_dir(self, tmp_path):
+        repo = str(tmp_path)
+        _write(os.path.join(repo, ".oduflow", "requirements.txt"), "phonenumbers\n")
+        container = _mock_container()
+
+        installed, _ = env_ops._install_pip_requirements(container, repo, restart=False)
+
+        assert installed is True
+        assert _pip_cmd(container) is not None
+        assert "/mnt/extra-addons/.oduflow/requirements.txt" in _pip_cmd(container)
+
+    def test_falls_back_to_repo_root(self, tmp_path):
+        repo = str(tmp_path)
+        _write(os.path.join(repo, "requirements.txt"), "phonenumbers\n")
+        container = _mock_container()
+
+        installed, _ = env_ops._install_pip_requirements(container, repo, restart=False)
+
+        assert installed is True
+        cmd = _pip_cmd(container)
+        assert cmd is not None
+        assert cmd.endswith("/mnt/extra-addons/requirements.txt")
+        assert ".oduflow" not in cmd
+
+    def test_oduflow_wins_over_root(self, tmp_path):
+        repo = str(tmp_path)
+        _write(os.path.join(repo, ".oduflow", "requirements.txt"), "phonenumbers\n")
+        _write(os.path.join(repo, "requirements.txt"), "other\n")
+        container = _mock_container()
+
+        env_ops._install_pip_requirements(container, repo, restart=False)
+
+        assert "/mnt/extra-addons/.oduflow/requirements.txt" in _pip_cmd(container)
+
+    def test_missing_returns_false(self, tmp_path):
+        container = _mock_container()
+        installed, log = env_ops._install_pip_requirements(
+            container, str(tmp_path), restart=False
+        )
+        assert installed is False
+        assert log == ""
+        assert _pip_cmd(container) is None


### PR DESCRIPTION
This branch bundles three independent improvements (all committed, no uncommitted changes):

- **Dashboard:** clicking a database name in the environments list now copies it to the clipboard, using `navigator.clipboard` with a hidden-`textarea` fallback for non-secure/HTTP contexts and a `Copied: <name>` toast.
- **Dependency files under `.oduflow/`:** `apt_packages.txt` is now read only from `.oduflow/` (Oduflow-specific, no repo-root fallback) and `requirements.txt` prefers `.oduflow/requirements.txt` with a repo-root fallback for odoo.sh compatibility, mirroring the existing `.oduflow/odoo.conf` resolution — with docs and new unit tests.
- **Docs auto-deploy:** new `.github/workflows/docs.yml` runs `mkdocs gh-deploy --force` on pushes to `main` that touch docs (so GitHub Pages publishes automatically), and `CLAUDE.md`/`AGENTS.md` are updated to describe the real publish chain.