### PR TITLE
feat: update_service can change env/image/port/hostname/host_mode/volumes

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1316,6 +1316,12 @@ oduflow call get_service_logs redis 200
 # Update a service (pull latest image, recreate container with same settings)
 oduflow call update_service meilisearch
 
+# Change environment variables on a running service (fully replaces existing env_vars)
+oduflow call update_service meilisearch --env_vars "MEILI_MASTER_KEY=newkey,MEILI_ENV=production"
+
+# Change the image (tag) of a running service
+oduflow call update_service meilisearch --image getmeili/meilisearch:v1.8
+
 # Delete a service
 oduflow call delete_service redis
 ```
@@ -1324,10 +1330,15 @@ oduflow call delete_service redis
 
 The `update_service` operation:
 
-1. Captures the current image name, environment variables, port, hostname, volumes, and capabilities (`cap_add`, `privileged`)
-2. Pulls the latest version of the image
-3. Compares image digests — if unchanged, reports "already up-to-date"
-4. If the image changed: stops the old container, removes it, and creates a new one with identical settings
+1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
+2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`) — each override **fully replaces** the current value
+3. Pulls the target image (the override, or the current one)
+4. Decides whether to recreate:
+    - If neither the image digest nor any setting changed → reports "already up-to-date"
+    - If the image digest changed or any setting was overridden → stops the old container, removes it, and creates a new one with the merged settings
+5. Updates the saved preset so subsequent `restore_service` calls use the new configuration
+
+Overrides are optional: calling `update_service` with only `name` preserves the previous behaviour (pull and recreate only on digest change).
 
 ## Service Presets
 
@@ -1617,7 +1628,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Pull latest image and recreate the service |
+| `update_service` | ✓ | Pull latest image and/or change service settings (env vars, image, port, hostname, host_mode, volumes); recreates the container when anything changes |
 | `list_services` | | List all managed service containers |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -42,7 +42,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Pull latest image and recreate the service |
+| `update_service` | ✓ | Pull latest image and/or change service settings (env vars, image, port, hostname, host_mode, volumes); recreates the container when anything changes |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |

--- a/docs/services.md
+++ b/docs/services.md
@@ -58,6 +58,12 @@ oduflow call restart_service redis
 # Update a service (pull latest image, recreate container with same settings)
 oduflow call update_service meilisearch
 
+# Change environment variables on a running service (fully replaces existing env_vars)
+oduflow call update_service meilisearch --env_vars "MEILI_MASTER_KEY=newkey,MEILI_ENV=production"
+
+# Change the image (tag) of a running service
+oduflow call update_service meilisearch --image getmeili/meilisearch:v1.8
+
 # Delete a service
 oduflow call delete_service redis
 
@@ -75,10 +81,15 @@ For a plain image refresh prefer `update_service`, which captures and preserves 
 
 The `update_service` operation:
 
-1. Captures the current image name, environment variables, port, hostname, volumes, and capabilities (`cap_add`, `privileged`)
-2. Pulls the latest version of the image
-3. Compares image digests — if unchanged, reports "already up-to-date"
-4. If the image changed: stops the old container, removes it, and creates a new one with identical settings
+1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
+2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`) — each override **fully replaces** the current value
+3. Pulls the target image (the override, or the current one)
+4. Decides whether to recreate:
+    - If neither the image digest nor any setting changed → reports "already up-to-date"
+    - If the image digest changed or any setting was overridden → stops the old container, removes it, and creates a new one with the merged settings
+5. Updates the saved preset so subsequent `restore_service` calls use the new configuration
+
+Overrides are optional: calling `update_service` with only `name` preserves the previous behaviour (pull and recreate only on digest change).
 
 ## Service Presets
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -378,8 +378,24 @@ def get_service_info(settings: Settings, team: TeamSettings, name: str) -> dict:
     return info
 
 
-def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[str, str]:
-    """Pull the latest image for a service and re-create it with the same settings."""
+def update_service(
+    settings: Settings,
+    team: TeamSettings,
+    name: str,
+    *,
+    env_override: dict[str, str] | None = None,
+    image_override: str | None = None,
+    port_override: int | None = None,
+    hostname_override: str | None = None,
+    host_mode_override: bool | None = None,
+    volume_override: list[dict[str, str]] | None = None,
+) -> dict[str, str]:
+    """Pull the latest image for a service and re-create it with the same settings.
+
+    Optional overrides replace the corresponding setting from the saved preset.
+    When any override differs from the current config the container is recreated
+    even if the image digest has not changed.
+    """
     client = get_client()
     container_name = f"oduflow-svc-{name}"
 
@@ -492,37 +508,66 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
     if port is None:
         raise NotFoundError(f"Cannot determine port for service '{name}'.")
 
+    # Apply overrides and track whether config changed
+    config_changed = False
+    if env_override is not None and env_override != (env_vars or {}):
+        env_vars = env_override or None
+        config_changed = True
+    if port_override is not None and port_override != port:
+        port = port_override
+        config_changed = True
+    if hostname_override is not None and hostname_override != hostname:
+        hostname = hostname_override or None
+        config_changed = True
+    if host_mode_override is not None and host_mode_override != is_host_mode:
+        is_host_mode = host_mode_override
+        config_changed = True
+    if volume_override is not None and volume_override != (old_volumes or []):
+        old_volumes = volume_override or None
+        config_changed = True
+
+    # Determine the image to pull (override or current)
+    target_image = image_override if image_override else old_image
+    if image_override and image_override != old_image:
+        config_changed = True
+
     # Capture old image digest
     old_digest = container.image.id  # e.g. sha256:abc...
 
     # Pull the latest image
-    logger.info("Pulling latest image %s for service %s", old_image, name)
-    new_image_obj = client.images.pull(old_image)
+    logger.info("Pulling latest image %s for service %s", target_image, name)
+    new_image_obj = client.images.pull(target_image)
     new_digest = new_image_obj.id
     image_updated = old_digest != new_digest
 
-    if not image_updated:
-        logger.info("Image unchanged for service %s: %s", name, new_digest[:19])
+    needs_recreate = image_updated or config_changed
+
+    if not needs_recreate:
+        logger.info("No changes for service %s: %s", name, new_digest[:19])
+        # Compute URL for return
         if settings.routing_mode == "traefik":
-            if not hostname:
-                hostname = f"{name}.{team.hostname}"
-            elif "." not in hostname:
-                hostname = f"{hostname}.{team.hostname}"
-            url = f"https://{hostname}"
+            h = hostname or f"{name}.{team.hostname}"
+            if "." not in h:
+                h = f"{h}.{team.hostname}"
+            url = f"https://{h}"
         else:
             url = f"http://{team.hostname}:{port}"
         return {
             "name": name,
             "container_name": container_name,
-            "image": old_image,
+            "image": target_image,
             "url": url,
             "image_updated": False,
+            "config_updated": False,
             "old_digest": old_digest,
             "new_digest": new_digest,
         }
 
     logger.info(
-        "Image changed for service %s: %s -> %s", name, old_digest[:19], new_digest[:19]
+        "Recreating service %s (image_updated=%s, config_changed=%s)",
+        name,
+        image_updated,
+        config_changed,
     )
 
     # Stop and remove the old container
@@ -530,12 +575,12 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
     container.remove(v=True)
     logger.info("Removed old container %s for update", container_name)
 
-    # Re-create with the same settings
+    # Re-create with the (possibly overridden) settings
     result = create_service(
         settings,
         team,
         name=name,
-        image=old_image,
+        image=target_image,
         port=port,
         hostname=hostname,
         env_vars=env_vars or None,
@@ -545,11 +590,12 @@ def update_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
         privileged=privileged,
     )
 
-    result["image_updated"] = True
+    result["image_updated"] = image_updated
+    result["config_updated"] = config_changed
     result["old_digest"] = old_digest
     result["new_digest"] = new_digest
 
-    logger.info("Service %s updated with image %s", name, old_image)
+    logger.info("Service %s updated with image %s", name, target_image)
     return result
 
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -505,7 +505,7 @@ def update_service(
 
         env_vars = env_vars or None
 
-    if port is None:
+    if port is None and port_override is None:
         raise NotFoundError(f"Cannot determine port for service '{name}'.")
 
     # Apply overrides and track whether config changed

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1591,21 +1591,63 @@ def create_service(
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def update_service(name: str, ctx: Context = None) -> str:
+def update_service(
+    name: str,
+    env_vars: str = "",
+    image: str = "",
+    port: int = 0,
+    hostname: str = "",
+    host_mode: bool | None = None,
+    volumes: str = "",
+    ctx: Context = None,
+) -> str:
     """
-    Update a managed auxiliary service container by pulling the latest image and re-creating the container with the same settings.
+    Update a managed auxiliary service container. Pulls the latest image and
+    optionally changes settings (env vars, image, port, hostname, host_mode,
+    volumes). The container is recreated when the image or any setting changes.
 
     Args:
         name: The name of the service to update (e.g. "redis", "meilisearch").
+        env_vars: Comma-separated KEY=VALUE pairs that fully replace existing env vars (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Leave empty to keep current env vars.
+        image: New Docker image with tag (e.g. "redis:8"). Leave empty to keep current image.
+        port: New container port. Pass 0 to keep current port.
+        hostname: New hostname for traefik routing. Leave empty to keep current hostname.
+        host_mode: Run in host network mode. Leave unset (null) to keep current mode.
+        volumes: Comma-separated volume mounts that fully replace existing volumes (e.g. "mydata:/data,config:/etc/app:ro"). Leave empty to keep current volumes.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
-    result = service_ops.update_service(settings, team, name)
-    status = (
-        "Image updated (new image pulled, container recreated)"
-        if result.get("image_updated")
-        else "Already up-to-date (no changes)"
+
+    # Parse optional overrides
+    parsed_env = None
+    if env_vars:
+        parsed_env = dict(
+            item.split("=", 1) for item in env_vars.split(",") if "=" in item
+        )
+
+    parsed_volumes = None
+    if volumes:
+        parsed_volumes = volume_ops.parse_volume_mounts(volumes)
+
+    result = service_ops.update_service(
+        settings,
+        team,
+        name,
+        env_override=parsed_env,
+        image_override=image or None,
+        port_override=port or None,
+        hostname_override=hostname or None,
+        host_mode_override=host_mode,
+        volume_override=parsed_volumes,
     )
+
+    if result.get("image_updated"):
+        status = "Image updated (new image pulled, container recreated)"
+    elif result.get("config_updated"):
+        status = "Config updated (container recreated)"
+    else:
+        status = "Already up-to-date (no changes)"
+
     digest_short = (result.get("new_digest") or "")[:19]
     return (
         f"Service updated successfully!\n"

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -92,8 +92,8 @@ MCP endpoint: `http://<host>:8000/mcp`
 |---|---|
 | `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access. The image is always pulled fresh, so mutable tags like `:latest` get the current version |
 | `get_service_info(name)` | **Use this before recreating a service.** Returns full live state: image + digest, port, hostname, URL, `host_mode`, `volumes`, env vars, `cap_add`, `privileged`, restart count, started_at, whether a preset exists |
+| `update_service(name, env_vars?, image?, port?, hostname?, host_mode?, volumes?)` | Change settings on a running service. Without overrides, pulls the latest image. With any override, fully replaces that setting and recreates the container. `env_vars` is a full replacement, not a merge |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
-| `update_service(name)` | Pull the latest image and recreate the container with the same settings. Reports "already up-to-date" if the digest is unchanged |
 | `restore_service(name)` | Recreate a service from its saved preset after deletion (volumes, host_mode, cap_add, env are all preserved) |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -502,7 +502,7 @@ def _build_routes(
         finally:
             locks.release_team(team.team_id)
 
-    def api_service_update(request: Request) -> JSONResponse:
+    async def api_service_update(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         team = _get_ui_team(request)
         try:
@@ -510,7 +510,51 @@ def _build_routes(
         except BusyError as e:
             return _error_response(e)
         try:
-            result = service_ops.update_service(get_settings(), team, name)
+            # Body is optional; if missing or not JSON, treat as no overrides
+            try:
+                body = await request.json()
+            except Exception:
+                body = {}
+
+            env_override = None
+            env_vars_raw = (body.get("env_vars") or "").strip() if body else ""
+            if env_vars_raw:
+                import re
+
+                env_override = dict(
+                    item.split("=", 1)
+                    for item in re.split(r"[\n,]+", env_vars_raw)
+                    if "=" in item
+                )
+
+            volumes_raw = (body.get("volumes") or "").strip() if body else ""
+            volume_override = (
+                volume_ops.parse_volume_mounts(volumes_raw) if volumes_raw else None
+            )
+
+            image_override = (body.get("image") or "").strip() or None if body else None
+            hostname_override = (
+                (body.get("hostname") or "").strip() or None if body else None
+            )
+            port_raw = body.get("port") if body else None
+            port_override = int(port_raw) if port_raw else None
+            host_mode_override = (
+                bool(body["host_mode"])
+                if body and "host_mode" in body and body["host_mode"] is not None
+                else None
+            )
+
+            result = service_ops.update_service(
+                get_settings(),
+                team,
+                name,
+                env_override=env_override,
+                image_override=image_override,
+                port_override=port_override,
+                hostname_override=hostname_override,
+                host_mode_override=host_mode_override,
+                volume_override=volume_override,
+            )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -242,7 +242,17 @@ class TestUpdateServiceTool:
         assert "Service updated successfully!" in result
         assert "redis" in result
         assert "oduflow-svc-redis" in result
-        mock_update.assert_called_once_with(TEST_SETTINGS, TEST_TEAM, "redis")
+        mock_update.assert_called_once_with(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "redis",
+            env_override=None,
+            image_override=None,
+            port_override=None,
+            hostname_override=None,
+            host_mode_override=None,
+            volume_override=None,
+        )
 
     @patch("oduflow.docker_ops.service_ops.update_service")
     def test_update_not_found(self, mock_update):

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -658,6 +658,156 @@ class TestUpdateService:
         assert result["image"] == "redis:7-alpine"
         mock_docker_client.images.pull.assert_any_call("redis:7-alpine")
 
+    def test_update_env_override_replaces_env_vars(self, mock_docker_client):
+        """env_override fully replaces preset env_vars and forces recreation."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        # Force same digest so only config change triggers recreate
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {"OLD_KEY": "old", "KEEP_ME": "1"},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "redis",
+                env_override={"NEW_KEY": "new"},
+            )
+
+        assert result["config_updated"] is True
+        assert result["image_updated"] is False
+        container.stop.assert_called_once()
+        container.remove.assert_called_once_with(v=True)
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        # Full replace: only NEW_KEY remains
+        assert run_kwargs[1]["environment"] == {"NEW_KEY": "new"}
+
+    def test_update_no_changes_no_recreate(self, mock_docker_client):
+        """When image digest and all overrides match, no recreation happens."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.return_value = container
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {"A": "1"},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+
+        assert result["image_updated"] is False
+        assert result["config_updated"] is False
+        assert result["url"] == "http://localhost:6379"
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+
+    def test_update_image_override(self, mock_docker_client):
+        """image_override pulls a new image tag and recreates."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "redis", image_override="redis:8"
+            )
+
+        assert result["image"] == "redis:8"
+        assert result["config_updated"] is True
+        mock_docker_client.images.pull.assert_any_call("redis:8")
+
+    def test_update_port_override(self, mock_docker_client):
+        """port_override changes port and recreates even if image digest unchanged."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "redis", port_override=6380
+            )
+
+        assert result["config_updated"] is True
+        assert result["image_updated"] is False
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["ports"] == {"6380/tcp": 6380}
+
 
 class TestGetServiceInfo:
     def _make_container(self, image_tags, image_id, labels, attrs, status="running"):

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -808,6 +808,45 @@ class TestUpdateService:
         run_kwargs = mock_docker_client.containers.run.call_args
         assert run_kwargs[1]["ports"] == {"6380/tcp": 6380}
 
+    def test_update_port_override_repairs_legacy_host_mode(self, mock_docker_client):
+        """port_override repairs a legacy host-mode service whose port cannot be inferred.
+
+        In non-traefik host mode without a preset the port is unknowable, so the
+        guard would normally raise. Supplying port_override must bypass the guard
+        and let the service be recreated with the given port.
+        """
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={
+                "oduflow.managed": "true",
+                "oduflow.service": "redis",
+                "oduflow.host_mode": "true",
+            },
+            attrs={"Config": {"Env": []}, "HostConfig": {}, "Mounts": []},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=NotFoundError("no preset"),
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "redis", port_override=7700
+            )
+
+        assert result["config_updated"] is True
+        assert result["url"] == "http://localhost:7700"
+        container.stop.assert_called_once()
+        container.remove.assert_called_once_with(v=True)
+
 
 class TestGetServiceInfo:
     def _make_container(self, image_tags, image_id, labels, attrs, status="running"):


### PR DESCRIPTION
## What

Extends `update_service` so it can change a running auxiliary service's settings, not just pull a fresh image. New optional overrides (also exposed through the MCP tool and the dashboard REST endpoint):

- `env_vars` (full replacement, not a merge)
- `image`, `port`, `hostname`, `host_mode`, `volumes`

When any override differs from the current config the container is recreated and the saved preset is updated, so a later `restore_service` uses the new configuration. Calling with only `name` preserves the previous behaviour (pull + recreate only on digest change).

## Commits

- `feat:` add the override parameters across `service_ops.update_service`, the `update_service` MCP tool, and `POST /api/services/{name}/update`; docs + agent instructions updated.
- `fix:` apply `port_override` before the "Cannot determine port" guard. A legacy host-mode service without a saved preset has an un-inferable port, so the guard fired before the override was applied — blocking exactly the services that `port_override` was meant to repair. The guard now only raises when neither the preset/container nor an override supplies a port. (Addresses review feedback.)

## Tests

`tests/test_service_ops.py` — added coverage for `env_override` (full replace), `image_override`, `port_override`, the no-change path, and the legacy host-mode repair case. Full suite: 298 passed.