### PR TITLE
feat: non-destructive template update for fuse-overlayfs envs (#2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ mkdocs gh-deploy --force
 MCP Clients (Cursor, Claude, etc.)
         │ MCP (Streamable HTTP)
         ▼
-   server.py ── FastMCP + CLI entry point (42 tools)
+   server.py ── FastMCP + CLI entry point (43 tools)
         │         ├── @handle_errors decorator → ToolError
         │         └── LockManager (per-branch / per-team / system) → BusyError
         ├── web_ui.py ── Starlette dashboard + REST API + Basic auth

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,8 +45,14 @@ All template commands accept `--team` to specify the team ID (default: `1`).
 # Generate a clean template from a Docker image
 oduflow init-template --odoo-image odoo:17.0 --template-name myproject [--modules base,web,sale] [--force] [--team 1]
 
-# Save a branch environment as the new template
-oduflow template-from-env <branch> --template-name myproject [--team 1]
+# Save a branch environment as the new template.
+# Other environments on this template keep their filestore changes by default;
+# pass --reset-env-changes to discard them and reset to the new baseline.
+oduflow template-from-env <branch> --template-name myproject [--reset-env-changes] [--team 1]
+
+# Re-apply a template's current filestore to live overlay environments
+# (non-destructive by default; --reset-env-changes discards env deltas)
+oduflow refresh-template <template_name> [--reset-env-changes] [--team 1]
 
 # Reload template DB from a dump file
 oduflow reload-template <template_name> [--dump-path /path/to/new.dump] [--team 1]
@@ -64,6 +70,8 @@ oduflow delete-template <template_name> [--team 1]
 # Import a template from a running Odoo instance
 oduflow import-template <odoo_url> <master_pwd> --template-name myproject [--db-name <db>] [--team 1]
 ```
+
+`template-from-env`, `refresh-template`, `import-template`, and `reload-template --source` are **non-destructive** for live overlay environments: each is unmounted and remounted against the new template filestore while keeping its `upper` changes. Use `--reset-env-changes` (on `template-from-env`/`refresh-template`) to reset environments to the clean baseline instead.
 
 ## Service Commands
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -12,7 +12,7 @@
                      │  MCP (stdio or Streamable HTTP)
 ┌────────────────────▼─────────────────────────────┐
 │  server.py — FastMCP transport layer             │
-│  • MCP tool definitions (42 tools)               │
+│  • MCP tool definitions (43 tools)               │
 │  • Per-branch / per-team / system locking        │
 │  • Unified error handler (FlowError → ToolError) │
 │  • Web UI mount (Starlette)                      │

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -70,13 +70,35 @@ This operation:
 1. Dumps the branch database to a new template dump file
 2. Reloads the template database from the new dump
 3. Snapshots the branch's merged filestore
-4. Unmounts all overlay filesystems across active environments
+4. Unmounts the overlay filesystems of other active environments on this template (keeping their `upper` deltas)
 5. Replaces the template filestore with the snapshot
-6. Remounts overlays for all active environments (clearing their upper dirs)
-7. Restarts all active containers
+6. Remounts those overlays against the new baseline, **preserving each environment's filestore changes** by default
+7. Restarts the affected containers
 
-!!! warning
-    **Destructive operation**: All other environments lose their filestore deltas and are reset to the new baseline.
+The **source environment** is always reset to the new baseline (its data just became the template). **Other environments keep their filestore changes** (the overlay `upper` layer) — this is non-destructive by default. Their existing files shadow the new template (env-local edits win); files they deleted stay deleted; new template files show through.
+
+To instead discard other environments' changes and reset them to the clean new baseline:
+
+```bash
+oduflow template-from-env my-branch --template-name default --reset-env-changes
+```
+
+!!! note
+    `--reset-env-changes` is **destructive**: other environments lose their filestore deltas. Without it, their changes are preserved.
+
+!!! info "Copy-mode templates"
+    Environments created from a small (copy-mode, `use_overlay=false`) template have an independent filestore copy, not an overlay. They are not affected by template filestore updates and are left untouched.
+
+## Refreshing Template Overlays
+
+Re-apply a template's current on-disk filestore to all live overlay environments without re-importing or re-saving — non-destructive by default (each environment keeps its `upper` deltas):
+
+```bash
+oduflow refresh-template default
+oduflow refresh-template default --reset-env-changes   # discard env deltas (destructive)
+```
+
+Use this after changing the template filestore on disk, or to re-sync an environment that was busy/skipped during an import or save.
 
 ## Reloading a Template
 
@@ -103,6 +125,9 @@ oduflow reload-template default --source s3://mybucket/prod/ --quiet
 ```
 
 The source directory should contain `dump.pgdump` (or `dump.sql`) and optionally `filestore/`. Files are synced using `aws s3 sync` (S3) or `rsync` (local), then the template DB is reloaded.
+
+!!! info "Non-destructive for live environments"
+    When `--source` replaces the template filestore, live overlay environments on that template are automatically unmounted and remounted against the new lower layer, **keeping their filestore changes**. The same applies to `import-template` re-imports.
 
 ## Listing and Dropping Templates
 
@@ -146,6 +171,8 @@ The `use_overlay` flag determines whether new environments use fuse-overlayfs (f
 | Need to install modules or configure the template | Create an env, configure it, then `oduflow template-from-env my-branch --template-name default` |
 | Update the template from a newer production dump | `oduflow reload-template default --dump-path /path/to/new.dump` |
 | Sync template from S3 and reload | `oduflow reload-template default --source s3://bucket/prod/` |
-| Save a branch environment as template | `oduflow template-from-env my-branch --template-name default` |
+| Save a branch environment as template (keep other envs' changes) | `oduflow template-from-env my-branch --template-name default` |
+| Save a branch as template and reset all other envs | `oduflow template-from-env my-branch --template-name default --reset-env-changes` |
+| Re-apply a template's filestore to live envs | `oduflow refresh-template default` |
 | List all templates | `oduflow list-templates` |
 | Delete a template | `oduflow delete-template myproject` |

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import datetime
 import json
 import logging
@@ -8,6 +9,7 @@ import pathlib
 import shutil
 import subprocess
 import time
+from collections.abc import Iterator
 from typing import Any
 
 import docker
@@ -283,6 +285,150 @@ def _unmount_filestore(env_name: str, team: TeamSettings) -> None:
             continue
 
     logger.warning("Could not unmount filestore overlay at %s", merged)
+
+
+def _wait_unmounted(merged: str, timeout: float = 3.0) -> None:
+    """Poll until ``merged`` is no longer a mount point (best-effort)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline and os.path.ismount(merged):
+        time.sleep(0.1)
+
+
+class RemountResult:
+    """Outcome of :func:`remount_template_overlays`."""
+
+    def __init__(self, affected: list[str]) -> None:
+        self.affected = affected
+        self.failures: list[tuple[str, str]] = []
+
+
+@contextlib.contextmanager
+def remount_template_overlays(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str,
+    *,
+    reset_upper: bool = False,
+    exclude_envs: tuple[str, ...] = (),
+) -> Iterator[RemountResult]:
+    """Safely mutate a template's lower filestore layer under live overlay envs.
+
+    Non-destructive template update (see issue #2): fuse-overlayfs keeps each
+    environment's changes in a separate ``upper`` layer, so we can unmount an
+    overlay while preserving its ``upper``/``work`` dirs, swap the read-only
+    lower layer (the template filestore), and remount against the new lower with
+    the same ``upper`` — keeping the environment's data.
+
+    Usage::
+
+        with remount_template_overlays(client, settings, team, name) as r:
+            # ... mutate team.get_template_filestore_path(name) ...
+        # r.affected / r.failures now describe what happened
+
+    On enter: for every overlay-mounted environment that uses ``template_name``
+    (excluding ``exclude_envs``), stop its Odoo container and unmount the
+    overlay, keeping ``upper``/``work``. The caller mutates the template
+    filestore inside the ``with`` block. On exit (always — even if the block
+    raised, so envs are never left without a lower layer): remount each
+    environment against the new lower reusing its preserved ``upper`` (unless
+    ``reset_upper=True``) and restart the container if it had been running.
+
+    Copy-mode environments (``use_overlay=False``) are not mounted, so they are
+    skipped — updating the lower layer does not affect their independent copy.
+    """
+    exclude = set(exclude_envs)
+    affected: list[dict[str, Any]] = []
+
+    for env in list_environments(settings, team):
+        env_name = env["env_name"]
+        if env_name in exclude:
+            continue
+        if env.get("template_name") != template_name:
+            continue
+        merged = get_filestore_paths(env_name, team.workspaces_dir)["merged"]
+        if not os.path.ismount(merged):
+            continue
+
+        container_name = get_resource_name(env_name, "odoo", settings.prefix)
+        image = env.get("odoo_image") or "odoo:17.0"
+        was_running = False
+        try:
+            container = client.containers.get(container_name)
+            was_running = container.status == "running"
+            if container.image.tags:
+                image = container.image.tags[0]
+        except docker.errors.NotFound:
+            pass
+
+        affected.append(
+            {
+                "env_name": env_name,
+                "container_name": container_name,
+                "image": image,
+                "env_db": get_db_name(env_name, team.team_id),
+                "was_running": was_running,
+            }
+        )
+
+    result = RemountResult([a["env_name"] for a in affected])
+
+    # Stop containers and unmount overlays (keeping upper/work).
+    for a in affected:
+        try:
+            try:
+                client.containers.get(a["container_name"]).stop(timeout=10)
+            except docker.errors.NotFound:
+                pass
+            _unmount_filestore(a["env_name"], team)
+            _wait_unmounted(
+                get_filestore_paths(a["env_name"], team.workspaces_dir)["merged"]
+            )
+            logger.info("Unmounted overlay for env %s", a["env_name"])
+        except Exception as exc:  # noqa: BLE001 - best-effort, reported via result
+            logger.warning("Could not unmount overlay for %s: %s", a["env_name"], exc)
+            result.failures.append((a["env_name"], f"unmount: {exc}"))
+
+    try:
+        yield result
+    finally:
+        for a in affected:
+            env_name = a["env_name"]
+            paths = get_filestore_paths(env_name, team.workspaces_dir)
+            try:
+                if os.path.ismount(paths["merged"]):
+                    # Unmount failed earlier — don't stack a second mount.
+                    result.failures.append(
+                        (env_name, "still mounted, skipped remount")
+                    )
+                else:
+                    if reset_upper:
+                        for key in ("upper", "work"):
+                            d = paths[key]
+                            if os.path.isdir(d):
+                                shutil.rmtree(d)
+                                os.makedirs(d, mode=0o777, exist_ok=True)
+                    _mount_filestore(
+                        client,
+                        settings,
+                        team,
+                        env_name,
+                        a["env_db"],
+                        a["image"],
+                        {},
+                        template_name=template_name,
+                    )
+                    logger.info("Remounted overlay for env %s", env_name)
+                if a["was_running"]:
+                    try:
+                        client.containers.get(a["container_name"]).start()
+                    except docker.errors.NotFound:
+                        pass
+                    except docker.errors.APIError:
+                        pass  # already running
+            except Exception as exc:  # noqa: BLE001 - best-effort, reported via result
+                logger.warning("Could not remount overlay for %s: %s", env_name, exc)
+                result.failures.append((env_name, f"remount: {exc}"))
 
 
 def _install_apt_packages(container, repo_path: str) -> str:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -845,10 +845,15 @@ def init_template(
 
 
 def publish_env_as_template(
-    settings: Settings, team: TeamSettings, env_name: str, template_name: str
-) -> dict[str, str]:
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    template_name: str,
+    *,
+    reset_env_changes: bool = False,
+) -> dict[str, object]:
     from oduflow.docker_ops import env_ops
-    from oduflow.naming import get_db_name, get_filestore_paths
+    from oduflow.naming import get_db_name, get_filestore_paths, get_resource_name
 
     client = get_client()
     tpl_db = get_template_db_name(template_name, team.team_id)
@@ -881,129 +886,104 @@ def publish_env_as_template(
     # 2. Reload template DB from new dump
     reload_template(settings, team, template_name=template_name, dump_path=dump_path)
 
-    # 3. Collect active envs that use THIS template AND overlay mount
-    active_envs = env_ops.list_environments(settings, team)
-    affected_envs = [
-        e["env_name"]
-        for e in active_envs
-        if e.get("template_name") == template_name
-        and os.path.ismount(
-            get_filestore_paths(e["env_name"], team.workspaces_dir)["merged"]
-        )
-    ]
-
-    # 4. Snapshot the source env's merged filestore (while overlay is still mounted)
+    # ------------------------------------------------------------------
+    # 3-7. Swap the template's lower filestore non-destructively (issue #2).
+    # ------------------------------------------------------------------
+    # The SOURCE env's deltas become the new lower layer, so it is always reset.
+    # OTHER overlay envs on this template keep their upper deltas by default;
+    # reset_env_changes=True resets them to the new baseline instead.
     env_paths = get_filestore_paths(env_name, team.workspaces_dir)
     branch_merged = env_paths["merged"]
     template_filestore_path = team.get_template_filestore_path(template_name)
+    source_container = get_resource_name(env_name, "odoo", settings.prefix)
+    source_is_overlay = os.path.isdir(branch_merged) and os.path.ismount(branch_merged)
 
-    if os.path.isdir(branch_merged) and os.path.ismount(branch_merged):
-        # Overlay-mounted filestore — snapshot while still mounted
+    # Snapshot the source env's merged filestore while it is still mounted.
+    snapshot_dir: str | None = None
+    if os.path.isdir(branch_merged):
         snapshot_dir = branch_merged + "_snapshot"
         if os.path.exists(snapshot_dir):
             shutil.rmtree(snapshot_dir)
         shutil.copytree(branch_merged, snapshot_dir)
-        logger.info("Snapshot of merged filestore created for env %s", env_name)
-    elif os.path.isdir(branch_merged) and not os.path.ismount(branch_merged):
-        # Plain (non-overlay) filestore — e.g. env created with template=none
-        snapshot_dir = branch_merged + "_snapshot"
-        if os.path.exists(snapshot_dir):
-            shutil.rmtree(snapshot_dir)
-        shutil.copytree(branch_merged, snapshot_dir)
-        logger.info("Snapshot of plain filestore created for env %s", env_name)
+        logger.info("Snapshot of filestore created for env %s", env_name)
     else:
-        snapshot_dir = None
         logger.warning(
             "Branch filestore %s not found, skipping filestore update", branch_merged
         )
 
-    # 5. Unmount all overlays
-    for affected_env in affected_envs:
-        try:
-            env_ops._unmount_filestore(affected_env, team)
-            logger.info("Unmounted overlay for env %s", affected_env)
-        except Exception as e:
-            logger.warning("Could not unmount overlay for %s: %s", affected_env, e)
+    try:
+        sc = client.containers.get(source_container)
+        source_was_running = sc.status == "running"
+        source_image = sc.image.tags[0] if sc.image.tags else "odoo:17.0"
+    except (docker.errors.NotFound, IndexError):
+        source_was_running = False
+        source_image = "odoo:17.0"
 
-    # 6. Replace template filestore with snapshot
-    if snapshot_dir and os.path.isdir(snapshot_dir):
-        if os.path.exists(template_filestore_path):
-            shutil.rmtree(template_filestore_path)
+    with env_ops.remount_template_overlays(
+        client,
+        settings,
+        team,
+        template_name,
+        reset_upper=reset_env_changes,
+        exclude_envs=(env_name,),
+    ) as remount:
+        # Unmount the source overlay (after snapshot) so its lower can change.
+        if source_is_overlay:
+            try:
+                client.containers.get(source_container).stop(timeout=10)
+            except docker.errors.NotFound:
+                pass
+            env_ops._unmount_filestore(env_name, team)
+            env_ops._wait_unmounted(branch_merged)
 
-        os.makedirs(os.path.dirname(template_filestore_path), exist_ok=True)
-        try:
-            os.rename(snapshot_dir, template_filestore_path)
-        except OSError:
-            shutil.copytree(snapshot_dir, template_filestore_path)
-            shutil.rmtree(snapshot_dir)
-        logger.info("Template filestore replaced from env %s", env_name)
+        # Replace template filestore with the snapshot.
+        if snapshot_dir and os.path.isdir(snapshot_dir):
+            if os.path.exists(template_filestore_path):
+                shutil.rmtree(template_filestore_path)
+            os.makedirs(os.path.dirname(template_filestore_path), exist_ok=True)
+            try:
+                os.rename(snapshot_dir, template_filestore_path)
+            except OSError:
+                shutil.copytree(snapshot_dir, template_filestore_path)
+                shutil.rmtree(snapshot_dir)
+            logger.info("Template filestore replaced from env %s", env_name)
 
-        promoted_container_name = f"{settings.prefix}{env_name.replace('/', '-')}-odoo"
-        try:
-            pc = client.containers.get(promoted_container_name)
-            promoted_image = pc.image.tags[0] if pc.image.tags else "odoo:17.0"
-        except (docker.errors.NotFound, IndexError):
-            promoted_image = "odoo:17.0"
-        odoo_uid_gid = get_odoo_uid_gid(client, promoted_image)
-        uid_str, gid_str = odoo_uid_gid.split(":")
-        chown_recursive(
-            template_filestore_path, int(uid_str), int(gid_str), client, promoted_image
-        )
-        logger.info("Template filestore chowned to %s", odoo_uid_gid)
+            odoo_uid_gid = get_odoo_uid_gid(client, source_image)
+            uid_str, gid_str = odoo_uid_gid.split(":")
+            chown_recursive(
+                template_filestore_path,
+                int(uid_str),
+                int(gid_str),
+                client,
+                source_image,
+            )
+            logger.info("Template filestore chowned to %s", odoo_uid_gid)
 
-    # 7. Reset filestores to new template baseline
-    for affected_env in affected_envs:
-        try:
-            bp = get_filestore_paths(affected_env, team.workspaces_dir)
-
-            if os.path.ismount(bp["merged"]):
-                env_ops._unmount_filestore(affected_env, team)
-                deadline = time.time() + 3.0
-                while time.time() < deadline and os.path.ismount(bp["merged"]):
-                    time.sleep(0.1)
-                if os.path.ismount(bp["merged"]):
-                    logger.warning(
-                        "Overlay for %s still mounted after retry, skipping remount",
-                        affected_env,
-                    )
-                    continue
-
+        # Remount the source overlay against the new lower (always reset) + restart.
+        if source_is_overlay:
             for key in ("upper", "work"):
-                d = bp[key]
+                d = env_paths[key]
                 if os.path.isdir(d):
                     shutil.rmtree(d)
                     os.makedirs(d, mode=0o777, exist_ok=True)
-
-            odoo_container_name = (
-                f"{settings.prefix}{affected_env.replace('/', '-')}-odoo"
-            )
-            try:
-                container = client.containers.get(odoo_container_name)
-                image = container.image.tags[0] if container.image.tags else "odoo:17.0"
-            except (docker.errors.NotFound, IndexError):
-                image = "odoo:17.0"
-
-            env_db = get_db_name(affected_env, team.team_id)
             env_ops._mount_filestore(
                 client,
                 settings,
                 team,
-                affected_env,
-                env_db,
-                image,
+                env_name,
+                get_db_name(env_name, team.team_id),
+                source_image,
                 {},
                 template_name=template_name,
             )
-            logger.info("Filestore reset for env %s", affected_env)
+            if source_was_running:
+                try:
+                    client.containers.get(source_container).start()
+                except (docker.errors.NotFound, docker.errors.APIError):
+                    pass
 
-            try:
-                container = client.containers.get(odoo_container_name)
-                container.restart(timeout=10)
-                logger.info("Restarted container %s", odoo_container_name)
-            except docker.errors.NotFound:
-                pass
-        except Exception as e:
-            logger.warning("Could not reset filestore for %s: %s", affected_env, e)
+    affected_envs = remount.affected
+    remount_failures = remount.failures
 
     # Save template metadata from source environment
     promoted_container_name = f"{settings.prefix}{env_name.replace('/', '-')}-odoo"
@@ -1045,6 +1025,51 @@ def publish_env_as_template(
         "filestore": template_filestore_path,
         "template_db": tpl_db,
         "affected_envs": affected_envs,
+        "remount_failures": remount_failures,
+        "reset_env_changes": reset_env_changes,
+    }
+
+
+def refresh_template(
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str,
+    *,
+    reset_env_changes: bool = False,
+) -> dict[str, object]:
+    """Re-apply a template's current on-disk filestore to live overlay envs.
+
+    Non-destructive by default: each affected environment is unmounted and
+    remounted against the template's current lower layer while keeping its
+    ``upper`` deltas. Pass ``reset_env_changes=True`` to discard those deltas
+    and reset every affected environment to the template baseline.
+
+    Useful after the template filestore was changed on disk, or to re-sync an
+    environment that was busy/skipped during an import or save.
+    """
+    from oduflow.docker_ops import env_ops
+
+    client = get_client()
+    tpl_db = get_template_db_name(template_name, team.team_id)
+
+    with env_ops.remount_template_overlays(
+        client,
+        settings,
+        team,
+        template_name,
+        reset_upper=reset_env_changes,
+    ) as remount:
+        # The unmount→remount cycle performed by the context manager is itself
+        # the operation; nothing to mutate here.
+        pass
+
+    return {
+        "status": "refreshed",
+        "template_name": template_name,
+        "template_db": tpl_db,
+        "affected_envs": remount.affected,
+        "remount_failures": remount.failures,
+        "reset_env_changes": reset_env_changes,
     }
 
 
@@ -1211,6 +1236,9 @@ def import_from_odoo(
     logger.info("Backup downloaded in %.1fs (%.1f MB)", download_elapsed, zip_size_mb)
 
     # 3. Extract ZIP
+    from oduflow.docker_ops import env_ops
+
+    client = get_client()
     template_dir = team.get_template_dir(template_name)
     template_sql_path = os.path.join(template_dir, "dump.sql")
     template_filestore_path = team.get_template_filestore_path(template_name)
@@ -1218,51 +1246,79 @@ def import_from_odoo(
     os.makedirs(template_dir, exist_ok=True)
 
     manifest = {}
+    affected_envs: list[str] = []
+    remount_failures: list[tuple[str, str]] = []
     try:
-        with zipfile.ZipFile(tmp_zip, "r") as zf:
-            # Extract manifest.json
-            if "manifest.json" in zf.namelist():
-                with zf.open("manifest.json") as mf:
-                    manifest = json.load(mf)
+        # Swap the template's filestore (the overlay lower layer) non-destructively:
+        # live overlay envs are unmounted (keeping their upper deltas) and remounted
+        # against the new lower on exit. See issue #2.
+        with env_ops.remount_template_overlays(
+            client, settings, team, template_name
+        ) as remount:
+            with zipfile.ZipFile(tmp_zip, "r") as zf:
+                # Extract manifest.json
+                if "manifest.json" in zf.namelist():
+                    with zf.open("manifest.json") as mf:
+                        manifest = json.load(mf)
 
-            # Extract dump.sql
-            with zf.open("dump.sql") as src, open(template_sql_path, "wb") as dst:
-                shutil.copyfileobj(src, dst)
-            logger.info("Extracted dump.sql to %s", template_sql_path)
+                # Extract dump.sql
+                with zf.open("dump.sql") as src, open(template_sql_path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                logger.info("Extracted dump.sql to %s", template_sql_path)
 
-            # Extract filestore
-            if os.path.exists(template_filestore_path):
-                shutil.rmtree(template_filestore_path)
-            os.makedirs(template_filestore_path, exist_ok=True)
+                # Extract filestore
+                if os.path.exists(template_filestore_path):
+                    shutil.rmtree(template_filestore_path)
+                os.makedirs(template_filestore_path, exist_ok=True)
 
-            fs_prefix = "filestore/"
-            for member in zf.namelist():
-                if not member.startswith(fs_prefix):
-                    continue
-                rel = member[len(fs_prefix) :]
-                if not rel:
-                    continue
-                # Skip checklist/ symlink-like entries
-                if rel.startswith("checklist/"):
-                    continue
-                target = os.path.join(template_filestore_path, rel)
-                if member.endswith("/"):
-                    os.makedirs(target, exist_ok=True)
-                else:
-                    os.makedirs(os.path.dirname(target), exist_ok=True)
-                    with zf.open(member) as src, open(target, "wb") as dst:
-                        shutil.copyfileobj(src, dst)
+                fs_prefix = "filestore/"
+                for member in zf.namelist():
+                    if not member.startswith(fs_prefix):
+                        continue
+                    rel = member[len(fs_prefix) :]
+                    if not rel:
+                        continue
+                    # Skip checklist/ symlink-like entries
+                    if rel.startswith("checklist/"):
+                        continue
+                    target = os.path.join(template_filestore_path, rel)
+                    if member.endswith("/"):
+                        os.makedirs(target, exist_ok=True)
+                    else:
+                        os.makedirs(os.path.dirname(target), exist_ok=True)
+                        with zf.open(member) as src, open(target, "wb") as dst:
+                            shutil.copyfileobj(src, dst)
 
-            fs_count = sum(
-                1
-                for f in pathlib.Path(template_filestore_path).rglob("*")
-                if f.is_file()
-            )
-            logger.info(
-                "Extracted filestore to %s (%d files)",
-                template_filestore_path,
-                fs_count,
-            )
+                fs_count = sum(
+                    1
+                    for f in pathlib.Path(template_filestore_path).rglob("*")
+                    if f.is_file()
+                )
+                logger.info(
+                    "Extracted filestore to %s (%d files)",
+                    template_filestore_path,
+                    fs_count,
+                )
+
+            # chown the new lower layer so the odoo user can read it through the
+            # overlay once it is remounted.
+            major = manifest.get("major_version", "")
+            if major:
+                try:
+                    uid_gid = get_odoo_uid_gid(client, f"odoo:{major}")
+                    uid_str, gid_str = uid_gid.split(":")
+                    chown_recursive(
+                        template_filestore_path,
+                        int(uid_str),
+                        int(gid_str),
+                        client,
+                        f"odoo:{major}",
+                    )
+                    logger.info("Template filestore chowned to %s", uid_gid)
+                except Exception as exc:  # noqa: BLE001 - chown is best-effort
+                    logger.warning("Could not chown template filestore: %s", exc)
+        affected_envs = remount.affected
+        remount_failures = remount.failures
     finally:
         if os.path.exists(tmp_zip):
             os.remove(tmp_zip)
@@ -1297,6 +1353,8 @@ def import_from_odoo(
         "template_db": result["template_db"],
         "restore_seconds": result.get("restore_seconds", 0),
         "zip_size_mb": round(zip_size_mb, 1),
+        "affected_envs": affected_envs,
+        "remount_failures": remount_failures,
     }
 
 

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sys
+from typing import cast
 
 from fastmcp import FastMCP, Context
 from fastmcp.exceptions import ToolError
@@ -488,31 +489,46 @@ def create_environment(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
-def save_as_template(env_name: str, template_name: str, ctx: Context = None) -> str:
+@with_team_lock
+def save_as_template(
+    env_name: str,
+    template_name: str,
+    reset_env_changes: bool = False,
+    ctx: Context = None,
+) -> str:
     """
     Save an environment as the new template (DB + filestore).
 
     Replaces the template database and filestore with the data from the specified
-    environment. If other environments use this template with overlay-mounted filestores,
-    their filestore deltas will be reset to the new baseline — this is destructive
-    for those environments. If no other environments share this template, the
-    operation is safe.
+    environment. Other environments that use this template with overlay-mounted
+    filestores are remounted against the new baseline: by default their filestore
+    changes (the overlay upper layer) are PRESERVED — non-destructive. Set
+    reset_env_changes=True to discard those changes and reset every affected
+    environment to the new baseline. The source environment itself is always
+    reset (its data just became the new template).
 
     Requires EXPLICIT user permission and confirmation before execution.
     If the user has not clearly and unambiguously asked you to save
-    a specific environment as template, DO NOT call this tool.
+    a specific environment as template, DO NOT call this tool. Setting
+    reset_env_changes=True is destructive for other environments — only do so
+    when the user explicitly asks to reset them.
 
     Args:
         env_name: The name of the environment whose DB and filestore will become the new template.
         template_name: Name of the template profile to publish into.
+        reset_env_changes: If True, discard other environments' filestore deltas (destructive). Default False (preserve).
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
     result = system_ops.publish_env_as_template(
-        settings, team, env_name, template_name=template_name
+        settings,
+        team,
+        env_name,
+        template_name=template_name,
+        reset_env_changes=reset_env_changes,
     )
-    affected = result.get("affected_envs", [])
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
     lines = [
         f"Environment '{result['env_name']}' saved as template '{template_name}'.",
         f"Template DB: {result['template_db']}",
@@ -520,9 +536,15 @@ def save_as_template(env_name: str, template_name: str, ctx: Context = None) -> 
         f"Filestore: {result['filestore']}",
     ]
     if affected:
-        lines.append(f"⚠️ Reset filestore overlays for: {', '.join(affected)}")
+        verb = "Reset" if reset_env_changes else "Remounted (changes preserved)"
+        lines.append(f"{verb} filestore overlays for: {', '.join(affected)}")
     else:
         lines.append("No other environments were affected.")
+    if failures:
+        lines.append(
+            "⚠️ Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
     return "\n".join(lines)
 
 
@@ -594,6 +616,67 @@ def import_template_from_odoo(
         f"Backup size: {result['zip_size_mb']} MB",
         f"DB restore time: {result['restore_seconds']}s",
     ]
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    if affected:
+        lines.append(
+            "Remounted (changes preserved) filestore overlays for: "
+            + ", ".join(affected)
+        )
+    if failures:
+        lines.append(
+            "⚠️ Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
+    return "\n".join(lines)
+
+
+@mcp.tool()
+@handle_errors
+@with_team_lock
+def refresh_template(
+    template_name: str,
+    reset_env_changes: bool = False,
+    ctx: Context = None,
+) -> str:
+    """
+    Re-apply a template's current filestore to live overlay environments.
+
+    Unmounts and remounts every overlay-mounted environment that uses this
+    template against the template's current on-disk filestore. By default each
+    environment's filestore changes (the overlay upper layer) are PRESERVED —
+    non-destructive. Set reset_env_changes=True to discard those changes and
+    reset every affected environment to the template baseline (destructive).
+
+    Use this after the template filestore was changed on disk, or to re-sync an
+    environment that was busy/skipped during an import or save.
+
+    Requires EXPLICIT user permission, especially with reset_env_changes=True.
+
+    Args:
+        template_name: Name of the template profile to re-apply.
+        reset_env_changes: If True, discard environments' filestore deltas (destructive). Default False (preserve).
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = system_ops.refresh_template(
+        settings, team, template_name, reset_env_changes=reset_env_changes
+    )
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    if affected:
+        verb = "Reset" if reset_env_changes else "Remounted (changes preserved)"
+        lines = [f"{verb} filestore overlays for: {', '.join(affected)}"]
+    else:
+        lines = [
+            f"No live overlay environments use template '{template_name}'; "
+            "nothing to do."
+        ]
+    if failures:
+        lines.append(
+            "⚠️ Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
     return "\n".join(lines)
 
 
@@ -2382,17 +2465,63 @@ def _run_init_template(
 
 
 def _run_template_from_env(
-    settings: Settings, team: TeamSettings, branch: str, template_name: str = ""
+    settings: Settings,
+    team: TeamSettings,
+    branch: str,
+    template_name: str = "",
+    reset_env_changes: bool = False,
 ) -> None:
     result = system_ops.publish_env_as_template(
-        settings, team, env_name=branch, template_name=template_name
+        settings,
+        team,
+        env_name=branch,
+        template_name=template_name,
+        reset_env_changes=reset_env_changes,
     )
-    print(
-        f"Environment '{result['env_name']}' saved as template '{template_name}'.\n"
-        f"Template DB: {result['template_db']}\n"
-        f"Dump: {result['dump']}\n"
-        f"Filestore: {result['filestore']}"
+    lines = [
+        f"Environment '{result['env_name']}' saved as template '{template_name}'.",
+        f"Template DB: {result['template_db']}",
+        f"Dump: {result['dump']}",
+        f"Filestore: {result['filestore']}",
+    ]
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    if affected:
+        verb = "Reset" if reset_env_changes else "Remounted (changes preserved)"
+        lines.append(f"{verb} filestore overlays for: {', '.join(affected)}")
+    if failures:
+        lines.append(
+            "Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
+    print("\n".join(lines))
+
+
+def _run_refresh_template(
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str,
+    reset_env_changes: bool = False,
+) -> None:
+    result = system_ops.refresh_template(
+        settings, team, template_name, reset_env_changes=reset_env_changes
     )
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    if affected:
+        verb = "Reset" if reset_env_changes else "Remounted (changes preserved)"
+        lines = [f"{verb} filestore overlays for: {', '.join(affected)}"]
+    else:
+        lines = [
+            f"No live overlay environments use template '{template_name}'; "
+            "nothing to do."
+        ]
+    if failures:
+        lines.append(
+            "Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
+    print("\n".join(lines))
 
 
 def _run_delete_template(
@@ -2420,15 +2549,28 @@ def _run_import_template(
         db_name=db_name,
         template_name=template_name,
     )
-    print(
-        f"Template '{result['template_name']}' imported successfully!\n"
-        f"Source: {result['source_url']} (db: {result['source_db']})\n"
-        f"Odoo version: {result['odoo_version']}\n"
-        f"Odoo image: {result['odoo_image']}\n"
-        f"Template DB: {result['template_db']}\n"
-        f"Backup size: {result['zip_size_mb']} MB\n"
-        f"DB restore time: {result['restore_seconds']}s"
-    )
+    lines = [
+        f"Template '{result['template_name']}' imported successfully!",
+        f"Source: {result['source_url']} (db: {result['source_db']})",
+        f"Odoo version: {result['odoo_version']}",
+        f"Odoo image: {result['odoo_image']}",
+        f"Template DB: {result['template_db']}",
+        f"Backup size: {result['zip_size_mb']} MB",
+        f"DB restore time: {result['restore_seconds']}s",
+    ]
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    if affected:
+        lines.append(
+            "Remounted (changes preserved) filestore overlays for: "
+            + ", ".join(affected)
+        )
+    if failures:
+        lines.append(
+            "Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
+    print("\n".join(lines))
 
 
 def _run_list_templates(settings: Settings, team: TeamSettings) -> None:
@@ -2695,7 +2837,26 @@ def main() -> None:
     )
     p_tfe.add_argument("branch", help="Branch name to use as template source")
     p_tfe.add_argument("--template-name", required=True, help="Template profile name")
+    p_tfe.add_argument(
+        "--reset-env-changes",
+        action="store_true",
+        help="Discard other environments' filestore changes (destructive). "
+        "Default: preserve them.",
+    )
     p_tfe.add_argument("--team", default="1", help="Team ID (default: 1)")
+
+    p_refresh = sub.add_parser(
+        "refresh-template",
+        help="Re-apply a template's filestore to live overlay envs (non-destructive)",
+    )
+    p_refresh.add_argument("template_name", help="Template profile name")
+    p_refresh.add_argument(
+        "--reset-env-changes",
+        action="store_true",
+        help="Discard environments' filestore changes (destructive). "
+        "Default: preserve them.",
+    )
+    p_refresh.add_argument("--team", default="1", help="Team ID (default: 1)")
 
     p_drop_tpl = sub.add_parser(
         "delete-template", help="Delete a template profile (template DB + files)"
@@ -2888,7 +3049,20 @@ def main() -> None:
 
     if args.command == "template-from-env":
         _run_template_from_env(
-            _settings, _cli_team(), branch=args.branch, template_name=args.template_name
+            _settings,
+            _cli_team(),
+            branch=args.branch,
+            template_name=args.template_name,
+            reset_env_changes=args.reset_env_changes,
+        )
+        return
+
+    if args.command == "refresh-template":
+        _run_refresh_template(
+            _settings,
+            _cli_team(),
+            template_name=args.template_name,
+            reset_env_changes=args.reset_env_changes,
         )
         return
 

--- a/src/oduflow/sync.py
+++ b/src/oduflow/sync.py
@@ -7,7 +7,8 @@ import os
 import subprocess
 from typing import Any
 
-from oduflow.docker_ops import system_ops
+from oduflow.docker_ops import env_ops, system_ops
+from oduflow.docker_ops.client import get_client
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -27,11 +28,18 @@ def sync_template_from_source(
     template_dir = team.get_template_dir(template_name)
     os.makedirs(template_dir, exist_ok=True)
 
-    # Sync files
-    if source.startswith("s3://"):
-        _run_s3_sync(source, template_dir)
-    else:
-        _run_local_sync(source, template_dir)
+    client = get_client()
+
+    # Sync files. The sync overwrites the template filestore (the overlay lower
+    # layer), so do it non-destructively: live overlay envs are unmounted
+    # (keeping their upper deltas) and remounted against the new lower on exit.
+    with env_ops.remount_template_overlays(
+        client, settings, team, template_name
+    ) as remount:
+        if source.startswith("s3://"):
+            _run_s3_sync(source, template_dir)
+        else:
+            _run_local_sync(source, template_dir)
 
     # Validate dump exists after sync
     dump_path = team.get_template_sql_path(template_name)
@@ -49,6 +57,8 @@ def sync_template_from_source(
         "sync_source": source,
         "template_dir": template_dir,
         "dump_path": dump_path,
+        "affected_envs": remount.affected,
+        "remount_failures": remount.failures,
         **result,
     }
 

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -117,7 +117,8 @@ MCP endpoint: `http://<host>:8000/mcp`
 | Tool | When to use |
 |---|---|
 | `list_templates` | List available database template profiles |
-| `save_as_template(env_name)` | Make a branch the new template baseline. ⚠️ Destructive only if other environments share this template with overlay mounts. Requires explicit user permission |
+| `save_as_template(env_name, reset_env_changes=False)` | Make a branch the new template baseline. Other overlay environments on this template are remounted against the new baseline, **keeping their filestore changes by default** (non-destructive); `reset_env_changes=True` discards them. The source env is always reset. Requires explicit user permission |
+| `refresh_template(template_name, reset_env_changes=False)` | Re-apply a template's current filestore to live overlay environments, keeping their changes (non-destructive); `reset_env_changes=True` resets them to the template baseline. Use after the template filestore changed on disk or to re-sync a skipped env. Requires explicit user permission |
 | `delete_template(template_name)` | ⚠️ **Destructive**. Remove a template profile. Requires explicit user permission |
 
 ---

--- a/tests/test_template_update.py
+++ b/tests/test_template_update.py
@@ -1,0 +1,309 @@
+"""Tests for non-destructive template updates (issue #2).
+
+The core under test is ``env_ops.remount_template_overlays`` — the context
+manager that unmounts overlay environments (keeping their ``upper`` deltas),
+lets the caller swap the template's lower filestore layer, and remounts them.
+"""
+
+import contextlib
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import docker
+import pytest
+
+from oduflow.docker_ops import env_ops, system_ops
+from oduflow.naming import get_filestore_paths, get_resource_name
+from oduflow.settings import Settings, TeamSettings
+
+
+def _make_team_and_settings(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    return team, settings
+
+
+class FakeContainer:
+    def __init__(self, status="running", tags=("odoo:17.0",)):
+        self.status = status
+        self.image = SimpleNamespace(tags=list(tags))
+        self.stop_calls = 0
+        self.start_calls = 0
+
+    def stop(self, timeout=None):
+        self.stop_calls += 1
+        self.status = "exited"
+
+    def start(self):
+        self.start_calls += 1
+        self.status = "running"
+
+
+class FakeContainers:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get(self, name):
+        try:
+            return self.mapping[name]
+        except KeyError:
+            raise docker.errors.NotFound(name)
+
+
+class FakeClient:
+    def __init__(self, mapping):
+        self.containers = FakeContainers(mapping)
+
+
+def _build(tmp_path, envs, mounted_envs, statuses=None):
+    """Set up workspaces + fakes.
+
+    ``envs``: list of (env_name, template_name).
+    ``mounted_envs``: iterable of env names whose overlay is currently mounted.
+    ``statuses``: optional dict env_name -> container status.
+    """
+    statuses = statuses or {}
+    team, settings = _make_team_and_settings(tmp_path)
+    mounted: set[str] = set()
+    mapping: dict[str, FakeContainer] = {}
+    env_dicts: list[dict] = []
+    for env_name, tpl in envs:
+        paths = get_filestore_paths(env_name, team.workspaces_dir)
+        os.makedirs(paths["upper"], exist_ok=True)
+        os.makedirs(paths["work"], exist_ok=True)
+        with open(os.path.join(paths["upper"], "marker.txt"), "w") as f:
+            f.write("delta")
+        env_dicts.append(
+            {"env_name": env_name, "template_name": tpl, "odoo_image": "odoo:17.0"}
+        )
+        mapping[get_resource_name(env_name, "odoo", settings.prefix)] = FakeContainer(
+            status=statuses.get(env_name, "running")
+        )
+        if env_name in mounted_envs:
+            mounted.add(paths["merged"])
+    client = FakeClient(mapping)
+    return team, settings, client, mounted, env_dicts, mapping
+
+
+@contextlib.contextmanager
+def _patched(team, env_dicts, mounted):
+    """Patch list_environments, (un)mount primitives and os.path.ismount."""
+
+    def fake_unmount(env_name, team_):
+        mounted.discard(get_filestore_paths(env_name, team_.workspaces_dir)["merged"])
+
+    mount_mock = MagicMock()
+    with (
+        patch.object(env_ops, "list_environments", return_value=env_dicts),
+        patch.object(env_ops, "_unmount_filestore", side_effect=fake_unmount)
+        as unmount_mock,
+        patch.object(env_ops, "_mount_filestore", mount_mock),
+        patch("os.path.ismount", side_effect=lambda p: p in mounted),
+    ):
+        yield unmount_mock, mount_mock
+
+
+def _marker(team, env_name):
+    return os.path.join(
+        get_filestore_paths(env_name, team.workspaces_dir)["upper"], "marker.txt"
+    )
+
+
+class TestRemountTemplateOverlays:
+    def test_preserves_upper_by_default(self, tmp_path):
+        team, settings, client, mounted, env_dicts, mapping = _build(
+            tmp_path, [("env1", "t"), ("env2", "t")], {"env1", "env2"}
+        )
+        with _patched(team, env_dicts, mounted) as (unmount_mock, mount_mock):
+            with env_ops.remount_template_overlays(
+                client, settings, team, "t"
+            ) as result:
+                pass
+
+        assert set(result.affected) == {"env1", "env2"}
+        assert result.failures == []
+        # Deltas preserved.
+        assert os.path.exists(_marker(team, "env1"))
+        assert os.path.exists(_marker(team, "env2"))
+        # Each env unmounted + remounted.
+        assert unmount_mock.call_count == 2
+        assert mount_mock.call_count == 2
+        # Containers cycled.
+        for c in mapping.values():
+            assert c.stop_calls == 1
+            assert c.start_calls == 1
+
+    def test_reset_upper_wipes_deltas(self, tmp_path):
+        team, settings, client, mounted, env_dicts, _ = _build(
+            tmp_path, [("env1", "t")], {"env1"}
+        )
+        with _patched(team, env_dicts, mounted) as (_, mount_mock):
+            with env_ops.remount_template_overlays(
+                client, settings, team, "t", reset_upper=True
+            ):
+                pass
+
+        # Delta removed, upper dir recreated empty.
+        assert not os.path.exists(_marker(team, "env1"))
+        assert os.path.isdir(
+            get_filestore_paths("env1", team.workspaces_dir)["upper"]
+        )
+        assert mount_mock.call_count == 1
+
+    def test_skips_other_template_and_unmounted(self, tmp_path):
+        team, settings, client, mounted, env_dicts, _ = _build(
+            tmp_path,
+            [("env1", "t"), ("env2", "other"), ("env3", "t")],
+            {"env1", "env2"},  # env3 uses t but is NOT mounted
+        )
+        with _patched(team, env_dicts, mounted) as (unmount_mock, mount_mock):
+            with env_ops.remount_template_overlays(
+                client, settings, team, "t"
+            ) as result:
+                pass
+
+        assert result.affected == ["env1"]
+        assert unmount_mock.call_count == 1
+        assert mount_mock.call_count == 1
+
+    def test_exclude_envs(self, tmp_path):
+        team, settings, client, mounted, env_dicts, _ = _build(
+            tmp_path, [("env1", "t"), ("env2", "t")], {"env1", "env2"}
+        )
+        with _patched(team, env_dicts, mounted) as (unmount_mock, mount_mock):
+            with env_ops.remount_template_overlays(
+                client, settings, team, "t", exclude_envs=("env1",)
+            ) as result:
+                pass
+
+        assert result.affected == ["env2"]
+        # env1 untouched.
+        assert os.path.exists(_marker(team, "env1"))
+        assert unmount_mock.call_count == 1
+        assert mount_mock.call_count == 1
+
+    def test_remounts_even_if_block_raises(self, tmp_path):
+        team, settings, client, mounted, env_dicts, _ = _build(
+            tmp_path, [("env1", "t")], {"env1"}
+        )
+        with _patched(team, env_dicts, mounted) as (_, mount_mock):
+            with pytest.raises(ValueError):
+                with env_ops.remount_template_overlays(client, settings, team, "t"):
+                    raise ValueError("boom")
+        # finally still remounted.
+        assert mount_mock.call_count == 1
+
+    def test_stopped_env_not_restarted(self, tmp_path):
+        team, settings, client, mounted, env_dicts, mapping = _build(
+            tmp_path,
+            [("env1", "t")],
+            {"env1"},
+            statuses={"env1": "exited"},
+        )
+        with _patched(team, env_dicts, mounted) as (unmount_mock, mount_mock):
+            with env_ops.remount_template_overlays(client, settings, team, "t"):
+                pass
+
+        # Still unmounted + remounted, but never started back up.
+        assert unmount_mock.call_count == 1
+        assert mount_mock.call_count == 1
+        container = mapping[get_resource_name("env1", "odoo", settings.prefix)]
+        assert container.start_calls == 0
+
+    def test_partial_unmount_failure_isolated(self, tmp_path):
+        team, settings, client, mounted, env_dicts, _ = _build(
+            tmp_path, [("env1", "t"), ("env2", "t")], {"env1", "env2"}
+        )
+
+        def fake_unmount(env_name, team_):
+            if env_name == "env1":
+                raise RuntimeError("device busy")
+            mounted.discard(
+                get_filestore_paths(env_name, team_.workspaces_dir)["merged"]
+            )
+
+        mount_mock = MagicMock()
+        with (
+            patch.object(env_ops, "list_environments", return_value=env_dicts),
+            patch.object(env_ops, "_unmount_filestore", side_effect=fake_unmount),
+            patch.object(env_ops, "_mount_filestore", mount_mock),
+            patch("os.path.ismount", side_effect=lambda p: p in mounted),
+        ):
+            with env_ops.remount_template_overlays(
+                client, settings, team, "t"
+            ) as result:
+                pass
+
+        failed_envs = {env for env, _ in result.failures}
+        assert "env1" in failed_envs
+        # env2 still remounted; env1 (still mounted) skipped.
+        assert mount_mock.call_count == 1
+
+    def test_no_affected_envs(self, tmp_path):
+        team, settings, client, mounted, env_dicts, _ = _build(
+            tmp_path, [("env1", "other")], set()
+        )
+        with _patched(team, env_dicts, mounted) as (unmount_mock, mount_mock):
+            with env_ops.remount_template_overlays(
+                client, settings, team, "t"
+            ) as result:
+                pass
+
+        assert result.affected == []
+        assert unmount_mock.call_count == 0
+        assert mount_mock.call_count == 0
+
+
+class TestRefreshTemplate:
+    def _fake_remount(self, captured, affected):
+        @contextlib.contextmanager
+        def _cm(client, settings, team, name, *, reset_upper=False, exclude_envs=()):
+            captured["reset_upper"] = reset_upper
+            captured["name"] = name
+            captured["exclude_envs"] = exclude_envs
+            yield env_ops.RemountResult(list(affected))
+
+        return _cm
+
+    def test_preserves_by_default(self, tmp_path):
+        team, settings = _make_team_and_settings(tmp_path)
+        captured: dict = {}
+        with (
+            patch.object(system_ops, "get_client", return_value=MagicMock()),
+            patch.object(
+                env_ops,
+                "remount_template_overlays",
+                self._fake_remount(captured, ["env1", "env2"]),
+            ),
+        ):
+            out = system_ops.refresh_template(settings, team, "t")
+
+        assert captured["reset_upper"] is False
+        assert captured["name"] == "t"
+        assert out["status"] == "refreshed"
+        assert out["affected_envs"] == ["env1", "env2"]
+        assert out["reset_env_changes"] is False
+
+    def test_reset_forwarded(self, tmp_path):
+        team, settings = _make_team_and_settings(tmp_path)
+        captured: dict = {}
+        with (
+            patch.object(system_ops, "get_client", return_value=MagicMock()),
+            patch.object(
+                env_ops,
+                "remount_template_overlays",
+                self._fake_remount(captured, []),
+            ),
+        ):
+            out = system_ops.refresh_template(
+                settings, team, "t", reset_env_changes=True
+            )
+
+        assert captured["reset_upper"] is True
+        assert out["affected_envs"] == []
+        assert out["reset_env_changes"] is True


### PR DESCRIPTION
Resolves #2. Adds a reusable `remount_template_overlays()` context manager (in `env_ops`) that unmounts a template's live overlay environments while keeping their `upper` deltas, lets the caller swap the template's lower filestore layer, and remounts them against the new lower — so environment data is preserved.

It's wired into every operation that mutates the template lower layer so they no longer corrupt live mounts or wipe deltas: `import_from_odoo`/`import-template` (now safe + chowns the new lower), `publish_env_as_template`/`save_as_template`/`template-from-env` (preserves other envs' filestore changes by default, with `reset_env_changes`/`--reset-env-changes` to opt into the old reset; the source env is always reset), and `sync_template_from_source`/`reload-template --source`.

Also adds a `refresh_template` MCP tool + `refresh-template` CLI subcommand to re-apply a template's current filestore to live overlay envs, switches `save_as_template` to a team lock (it touches the whole fleet), and updates the docs, the bundled agent guide, and unit tests covering the helper and `refresh_template`.