### PR TITLE
docs: document refresh_template MCP tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -138,6 +138,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets
 - `save_as_template` / `delete_template` / `list_templates` — template management
 - `import_template_from_odoo` — import a template from a running Odoo instance
+- `refresh_template` — re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` is destructive)
 - `setup_repo_auth` — cache git credentials for private repositories
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
 - `get_agent_instructions` — get AI agent instructions for using Oduflow
@@ -1624,6 +1625,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
+| `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -152,6 +152,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets
 - `save_as_template` / `delete_template` / `list_templates` — template management
 - `import_template_from_odoo` — import a template from a running Odoo instance
+- `refresh_template` — re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` is destructive)
 - `setup_repo_auth` — cache git credentials for private repositories
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
 - `get_agent_instructions` — get AI agent instructions for using Oduflow

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -38,6 +38,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
+| `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |


### PR DESCRIPTION
## What

Adds the `refresh_template` MCP tool to the documentation. It was the only `@mcp.tool()` in `server.py` missing from the docs (54 tools in source, 53 documented).

## Why

`refresh_template` re-applies a template's filestore to live overlay environments. The CLI command `oduflow refresh-template` was already documented (in `cli.md` / `templates.md`), but the **MCP tool** was absent from the MCP Tools Reference and from both `llms.txt` / `llms-full.txt`.

## Changes

- `docs/mcp-tools.md` — new row in the **Template Management** table (⚠️ marks the destructive `reset_env_changes=True` mode)
- `docs/llms-full.txt` — same table row + bullet in the tool list
- `docs/llms.txt` — bullet in the tool list

After this, all 54 MCP tools are documented; no phantom (documented-but-nonexistent) entries.