### PR TITLE
feat: update_service changes any setting (privileged/net_admin) + MCP docs sync

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -134,7 +134,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `reset_admin_password` — reset the admin user password (default: "test")
 - `read_output` — read from a cached tool output by ID (paginate, grep, errors, tail)
 - `list_environments` / `get_environment_info` — inspect environments
-- `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_logs` / `run_service_command` — manage auxiliary services
+- `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_info` / `get_service_logs` / `run_service_command` — manage auxiliary services
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets
 - `save_as_template` / `delete_template` / `list_templates` — template management
 - `import_template_from_odoo` — import a template from a running Odoo instance
@@ -1632,6 +1632,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `restart_service` | | Restart a service container |
 | `update_service` | ✓ | Pull latest image and/or change service settings (env vars, image, port, hostname, host_mode, volumes); recreates the container when anything changes |
 | `list_services` | | List all managed service containers |
+| `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |
 | **Volumes** | | |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1323,6 +1323,10 @@ oduflow call update_service meilisearch --env_vars "MEILI_MASTER_KEY=newkey,MEIL
 # Change the image (tag) of a running service
 oduflow call update_service meilisearch --image getmeili/meilisearch:v1.8
 
+# Toggle Linux capabilities / privileged mode on a running service (recreates it)
+oduflow call update_service wireguard --net_admin true
+oduflow call update_service wireguard --privileged true
+
 # Delete a service
 oduflow call delete_service redis
 ```
@@ -1332,7 +1336,7 @@ oduflow call delete_service redis
 The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
-2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`) — each override **fully replaces** the current value
+2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
 3. Pulls the target image (the override, or the current one)
 4. Decides whether to recreate:
     - If neither the image digest nor any setting changed → reports "already up-to-date"
@@ -1630,7 +1634,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Pull latest image and/or change service settings (env vars, image, port, hostname, host_mode, volumes); recreates the container when anything changes |
+| `update_service` | ✓ | Pull latest image and/or change any service setting (env vars, image, port, hostname, host_mode, volumes, privileged, net_admin); recreates the container when anything changes and preserves the rest |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -146,7 +146,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `reset_admin_password` — reset the admin user password (default: "test")
 - `read_output` — read from a cached tool output by ID (paginate, grep, errors, tail)
 - `list_environments` / `get_environment_info` — inspect environments
-- `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_logs` / `run_service_command` — manage auxiliary services
+- `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_info` / `get_service_logs` / `run_service_command` — manage auxiliary services
 - `create_volume` / `list_volumes` / `inspect_volume` / `delete_volume` — manage Docker volumes
 - `read_file_in_volume` / `write_file_in_volume` / `search_in_volume` / `delete_file_in_volume` — manage files inside Docker volumes
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -43,7 +43,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Pull latest image and/or change service settings (env vars, image, port, hostname, host_mode, volumes); recreates the container when anything changes |
+| `update_service` | ✓ | Pull latest image and/or change any service setting (env vars, image, port, hostname, host_mode, volumes, privileged, net_admin); recreates the container when anything changes and preserves the rest |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |

--- a/docs/services.md
+++ b/docs/services.md
@@ -64,6 +64,10 @@ oduflow call update_service meilisearch --env_vars "MEILI_MASTER_KEY=newkey,MEIL
 # Change the image (tag) of a running service
 oduflow call update_service meilisearch --image getmeili/meilisearch:v1.8
 
+# Toggle Linux capabilities / privileged mode on a running service (recreates it)
+oduflow call update_service wireguard --net_admin true
+oduflow call update_service wireguard --privileged true
+
 # Delete a service
 oduflow call delete_service redis
 
@@ -71,18 +75,18 @@ oduflow call delete_service redis
 oduflow call run_service_command redis "redis-cli ping"
 ```
 
-### Inspecting a Service Before Recreating It
+### Changing a Service
 
-When you need to delete and recreate a service (e.g. to change the image tag or a single env var), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
+`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port, hostname, `host_mode`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand.
 
-For a plain image refresh prefer `update_service`, which captures and preserves every setting automatically.
+If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
 
 ## Service Update Flow
 
 The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
-2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`) — each override **fully replaces** the current value
+2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
 3. Pulls the target image (the override, or the current one)
 4. Decides whether to recreate:
     - If neither the image digest nor any setting changed → reports "already up-to-date"

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -48,7 +48,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 |---|---|---|
 | `GET` | `/api/services` | List all managed services |
 | `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
-| `POST` | `/api/services/{name}/update` | Update (pull latest image & recreate) |
+| `POST` | `/api/services/{name}/update` | Update a service — pull latest image and/or change settings (JSON body, all optional: `env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`); recreates on any change |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
 | `GET` | `/api/services/{name}/logs?n=200` | Get service logs |

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -389,6 +389,8 @@ def update_service(
     hostname_override: str | None = None,
     host_mode_override: bool | None = None,
     volume_override: list[dict[str, str]] | None = None,
+    cap_add_override: list[str] | None = None,
+    privileged_override: bool | None = None,
 ) -> dict[str, str]:
     """Pull the latest image for a service and re-create it with the same settings.
 
@@ -524,6 +526,12 @@ def update_service(
         config_changed = True
     if volume_override is not None and volume_override != (old_volumes or []):
         old_volumes = volume_override or None
+        config_changed = True
+    if cap_add_override is not None and cap_add_override != (cap_add or []):
+        cap_add = cap_add_override or None
+        config_changed = True
+    if privileged_override is not None and privileged_override != privileged:
+        privileged = privileged_override
         config_changed = True
 
     # Determine the image to pull (override or current)

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -15,7 +15,6 @@ from docker import DockerClient
 
 from oduflow.docker_ops.client import chown_recursive, get_client, get_odoo_uid_gid
 from oduflow.errors import (
-    ConflictError,
     ExternalCommandError,
     NotFoundError,
     PrerequisiteNotMetError,

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1682,12 +1682,17 @@ def update_service(
     hostname: str = "",
     host_mode: bool | None = None,
     volumes: str = "",
+    privileged: bool | None = None,
+    net_admin: bool | None = None,
     ctx: Context = None,
 ) -> str:
     """
     Update a managed auxiliary service container. Pulls the latest image and
-    optionally changes settings (env vars, image, port, hostname, host_mode,
-    volumes). The container is recreated when the image or any setting changes.
+    optionally changes any setting (env vars, image, port, hostname, host_mode,
+    volumes, privileged, net_admin). The container is recreated when the image or
+    any setting changes; settings that are not overridden are preserved. This is
+    the preferred way to change a service — you do not need to delete and
+    recreate it manually.
 
     Args:
         name: The name of the service to update (e.g. "redis", "meilisearch").
@@ -1697,6 +1702,8 @@ def update_service(
         hostname: New hostname for traefik routing. Leave empty to keep current hostname.
         host_mode: Run in host network mode. Leave unset (null) to keep current mode.
         volumes: Comma-separated volume mounts that fully replace existing volumes (e.g. "mydata:/data,config:/etc/app:ro"). Leave empty to keep current volumes.
+        privileged: Run the container in privileged mode (full host access). Leave unset (null) to keep current mode. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
+        net_admin: Add (True) or remove (False) the NET_ADMIN Linux capability — required for VPN/WireGuard, tun/tap, and iptables. Leave unset (null) to keep current capabilities.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -1712,6 +1719,10 @@ def update_service(
     if volumes:
         parsed_volumes = volume_ops.parse_volume_mounts(volumes)
 
+    cap_add_override = None
+    if net_admin is not None:
+        cap_add_override = ["NET_ADMIN"] if net_admin else []
+
     result = service_ops.update_service(
         settings,
         team,
@@ -1722,6 +1733,8 @@ def update_service(
         hostname_override=hostname or None,
         host_mode_override=host_mode,
         volume_override=parsed_volumes,
+        cap_add_override=cap_add_override,
+        privileged_override=privileged,
     )
 
     if result.get("image_updated"):

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -104,14 +104,14 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 |---|---|
 | `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access. The image is always pulled fresh, so mutable tags like `:latest` get the current version |
 | `get_service_info(name)` | **Use this before recreating a service.** Returns full live state: image + digest, port, hostname, URL, `host_mode`, `volumes`, env vars, `cap_add`, `privileged`, restart count, started_at, whether a preset exists |
-| `update_service(name, env_vars?, image?, port?, hostname?, host_mode?, volumes?)` | Change settings on a running service. Without overrides, pulls the latest image. With any override, fully replaces that setting and recreates the container. `env_vars` is a full replacement, not a merge |
+| `update_service(name, env_vars?, image?, port?, hostname?, host_mode?, volumes?, privileged?, net_admin?)` | Change **any** setting on a running service. Without overrides, pulls the latest image. With any override, fully replaces that setting and recreates the container, preserving everything else. `env_vars` and `volumes` are full replacements, not merges. This is the preferred way to change a service |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
 | `restore_service(name)` | Recreate a service from its saved preset after deletion (volumes, host_mode, cap_add, env are all preserved) |
 | `list_service_presets` | List saved service presets (configurations that can be restored after a service is deleted) |
 | `delete_service_preset(name)` | Remove a saved service preset |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 
-> **Recreating a service:** if you are about to `delete_service` and then `create_service` for the same service (e.g. to change the image or a single parameter), **call `get_service_info(name)` first** and reuse its `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged` in the new `create_service` call. Otherwise you will silently drop volumes, env vars, capabilities, or host_mode and the recreated service will be broken. For a plain image refresh prefer `update_service`, which preserves everything automatically.
+> **Changing a service:** use `update_service` for **any** change — image, env vars, port, hostname, host_mode, volumes, privileged, or net_admin. It recreates the container automatically and preserves every setting you don't override, so you almost never need to `delete_service` + `create_service` by hand. (If you do recreate manually — e.g. to rename a service — call `get_service_info(name)` first and replay its `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged` in the new `create_service` call, otherwise you'll silently drop them.)
 
 ### Volumes
 

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 2
+Version: 3
 
 ## What is Oduflow
 
@@ -61,6 +61,7 @@ MCP endpoint: `http://<host>:8000/mcp`
 | `write_file_in_odoo(env_name, path, content, user?)` | Write a text file inside the container (CSV imports, scripts, configs). Uses tar stream — no shell escaping issues. Do NOT use for source code. |
 | `http_request_to_odoo(env_name, path, method?, body?, headers?, session_id?)` | HTTP request to the running Odoo instance. Test controllers, JSON-RPC, REST endpoints. |
 | `search_in_odoo(env_name, pattern, path?, glob?, max_results?)` | Grep for a pattern inside container files. Fixed-string search with file/line numbers. |
+| `reset_admin_password(env_name, new_password?)` | Reset the admin user's password in the environment's Odoo database (default: `"test"`). Useful to log into a template-based env whose admin password is unknown |
 
 ### Debugging & Logs
 
@@ -86,6 +87,17 @@ MCP endpoint: `http://<host>:8000/mcp`
 |---|---|
 | `setup_repo_auth(repo_url)` | Cache git credentials for a private repo. URL format: `https://user:PAT@github.com/owner/repo.git`. Call once, before `create_environment` |
 
+### Extra Addons (Enterprise & third-party repos)
+
+Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are cloned once on the server and then become available to environments. For private repos, call `setup_repo_auth` first.
+
+| Tool | When to use |
+|---|---|
+| `add_extra_repo(name, repo_url)` | Clone an extra addons repository so its modules become available when creating or rebuilding environments |
+| `list_extra_repos` | List all cloned extra addons repositories |
+| `update_extra_repo(name)` | Fetch the latest changes from the remote for an extra addons repository |
+| `delete_extra_repo(name)` | Remove a cloned extra addons repository |
+
 ### Auxiliary Services
 
 | Tool | When to use |
@@ -95,6 +107,8 @@ MCP endpoint: `http://<host>:8000/mcp`
 | `update_service(name, env_vars?, image?, port?, hostname?, host_mode?, volumes?)` | Change settings on a running service. Without overrides, pulls the latest image. With any override, fully replaces that setting and recreates the container. `env_vars` is a full replacement, not a merge |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
 | `restore_service(name)` | Recreate a service from its saved preset after deletion (volumes, host_mode, cap_add, env are all preserved) |
+| `list_service_presets` | List saved service presets (configurations that can be restored after a service is deleted) |
+| `delete_service_preset(name)` | Remove a saved service preset |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 
 > **Recreating a service:** if you are about to `delete_service` and then `create_service` for the same service (e.g. to change the image or a single parameter), **call `get_service_info(name)` first** and reuse its `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged` in the new `create_service` call. Otherwise you will silently drop volumes, env vars, capabilities, or host_mode and the recreated service will be broken. For a plain image refresh prefer `update_service`, which preserves everything automatically.
@@ -117,9 +131,17 @@ MCP endpoint: `http://<host>:8000/mcp`
 | Tool | When to use |
 |---|---|
 | `list_templates` | List available database template profiles |
+| `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?)` | Import a template from a running Odoo instance via its database manager API (downloads a full backup and restores it as a new template). Requires explicit user permission |
 | `save_as_template(env_name, reset_env_changes=False)` | Make a branch the new template baseline. Other overlay environments on this template are remounted against the new baseline, **keeping their filestore changes by default** (non-destructive); `reset_env_changes=True` discards them. The source env is always reset. Requires explicit user permission |
 | `refresh_template(template_name, reset_env_changes=False)` | Re-apply a template's current filestore to live overlay environments, keeping their changes (non-destructive); `reset_env_changes=True` resets them to the template baseline. Use after the template filestore changed on disk or to re-sync a skipped env. Requires explicit user permission |
 | `delete_template(template_name)` | ⚠️ **Destructive**. Remove a template profile. Requires explicit user permission |
+
+### Reference & Guides
+
+| Tool | When to use |
+|---|---|
+| `get_odoo_development_guide(version)` | Fetch Odoo development standards and constraints for a specific Odoo version (15–19). Read it before writing or refactoring module code |
+| `get_agent_instructions` | Re-fetch this instruction document (the one you are reading) — e.g. after a context reset |
 
 ---
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -543,6 +543,14 @@ def _build_routes(
                 if body and "host_mode" in body and body["host_mode"] is not None
                 else None
             )
+            privileged_override = (
+                bool(body["privileged"])
+                if body and "privileged" in body and body["privileged"] is not None
+                else None
+            )
+            cap_add_override = None
+            if body and "net_admin" in body and body["net_admin"] is not None:
+                cap_add_override = ["NET_ADMIN"] if bool(body["net_admin"]) else []
 
             result = service_ops.update_service(
                 get_settings(),
@@ -554,6 +562,8 @@ def _build_routes(
                 hostname_override=hostname_override,
                 host_mode_override=host_mode_override,
                 volume_override=volume_override,
+                cap_add_override=cap_add_override,
+                privileged_override=privileged_override,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -252,7 +252,35 @@ class TestUpdateServiceTool:
             hostname_override=None,
             host_mode_override=None,
             volume_override=None,
+            cap_add_override=None,
+            privileged_override=None,
         )
+
+    @patch("oduflow.docker_ops.service_ops.update_service")
+    def test_update_net_admin_and_privileged_mapping(self, mock_update):
+        mock_update.return_value = {
+            "name": "vpn",
+            "container_name": "oduflow-svc-vpn",
+            "url": "http://localhost:1194",
+            "image": "vpn:latest",
+        }
+        _get_tool_fn("update_service")(name="vpn", net_admin=True, privileged=False)
+        _, kwargs = mock_update.call_args
+        assert kwargs["cap_add_override"] == ["NET_ADMIN"]
+        assert kwargs["privileged_override"] is False
+
+    @patch("oduflow.docker_ops.service_ops.update_service")
+    def test_update_net_admin_false_clears_cap(self, mock_update):
+        mock_update.return_value = {
+            "name": "vpn",
+            "container_name": "oduflow-svc-vpn",
+            "url": "http://localhost:1194",
+            "image": "vpn:latest",
+        }
+        _get_tool_fn("update_service")(name="vpn", net_admin=False)
+        _, kwargs = mock_update.call_args
+        assert kwargs["cap_add_override"] == []
+        assert kwargs["privileged_override"] is None
 
     @patch("oduflow.docker_ops.service_ops.update_service")
     def test_update_not_found(self, mock_update):

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -847,6 +847,157 @@ class TestUpdateService:
         container.stop.assert_called_once()
         container.remove.assert_called_once_with(v=True)
 
+    def test_update_net_admin_override_adds_cap(self, mock_docker_client):
+        """cap_add_override adds NET_ADMIN and recreates the container."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "redis", cap_add_override=["NET_ADMIN"]
+            )
+
+        assert result["config_updated"] is True
+        assert result["image_updated"] is False
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["cap_add"] == ["NET_ADMIN"]
+
+    def test_update_clear_net_admin(self, mock_docker_client):
+        """cap_add_override=[] removes a previously set capability."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+            "cap_add": ["NET_ADMIN"],
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "redis", cap_add_override=[]
+            )
+
+        assert result["config_updated"] is True
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert "cap_add" not in run_kwargs[1]
+
+    def test_update_privileged_override(self, mock_docker_client):
+        """privileged_override switches the service to privileged mode and recreates."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "redis", privileged_override=True
+            )
+
+        assert result["config_updated"] is True
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["privileged"] is True
+
+    def test_update_caps_unchanged_no_recreate(self, mock_docker_client):
+        """Capability overrides equal to current values do not trigger a recreate."""
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        pulled_image = MagicMock()
+        pulled_image.id = container.image.id
+        mock_docker_client.images.pull.return_value = pulled_image
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.networks.get.return_value = MagicMock()
+
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+            "cap_add": ["NET_ADMIN"],
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "redis",
+                cap_add_override=["NET_ADMIN"],
+                privileged_override=False,
+            )
+
+        assert result["config_updated"] is False
+        assert result["image_updated"] is False
+        container.stop.assert_not_called()
+
 
 class TestGetServiceInfo:
     def _make_container(self, image_tags, image_id, labels, attrs, status="running"):


### PR DESCRIPTION
Two clean commits.

## 1. `docs:` document get_service_info and remaining MCP tools in LLMS and agent guide
Brings every MCP tool into the docs:
- `llms.txt` / `llms-full.txt`: add the missing `get_service_info`.
- `agent_instructions.md` (Version 3): add the 10 tools the quick reference omitted — Extra Addons (`add`/`list`/`update`/`delete_extra_repo`), service presets (`list`/`delete_service_preset`), `import_template_from_odoo`, `reset_admin_password`, and a Reference & Guides section. All 54 `@mcp.tool()` tools are now covered across `mcp-tools.md`, `llms.txt`, `llms-full.txt` and the agent guide.

## 2. `feat:` update_service can change privileged and net_admin
`update_service` could change env vars, image, port, hostname, host_mode and volumes, but **not** `privileged` / `net_admin` — those forced a manual `delete_service` + `create_service`. Now it changes **any** setting and recreates the container, preserving everything not overridden.

- `service_ops.update_service`: new `cap_add_override` / `privileged_override`, wired into the config-changed check and the recreate path.
- `update_service` MCP tool: new `privileged` / `net_admin` params (tri-state, `None` = keep). `net_admin` maps to `cap_add=["NET_ADMIN"]`; `net_admin=False` clears it.
- REST `POST /api/services/{name}/update` accepts the same two fields.
- Tests: add/clear NET_ADMIN, privileged toggle, no-recreate-when-unchanged, and MCP-tool mapping.
- Docs (`mcp-tools.md`, `services.md`, `web-api.md`, `llms-full.txt`, agent guide): `update_service` is now the way to change any setting; manual recreate is reduced to the rename case.
- Drop an unused module-level `ConflictError` import in `system_ops.py` (re-imported locally where used) so ruff is clean.

## Verification
- `ruff check src/oduflow tests` — clean
- `pytest -m "not integration and not heavyweight"` — 321 passed