### PR TITLE
feat: env vars on create + rename rebuild_environment to update_environment

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **`rebuild_environment` renamed to `update_environment`** — the tool (and its REST route `/api/environments/{branch}/update`) now also accepts `odoo_image` and `env_vars` to switch the image and replace container environment variables. Called with no arguments it behaves exactly like the old `rebuild_environment` (re-create the container, preserving DB and filestore).
+
+### Features
+
+- **Environment variables for environments** — `create_environment` accepts `env_vars` (comma-separated `KEY=VALUE`) to inject container environment variables on top of the database connection variables; `update_environment` can replace them later. Env vars are persisted on the container, reported by `get_environment_info`, and editable from the web dashboard create form.
+
 ## v1.20.1 (since v1.15.1)
 
 ### Breaking Changes

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -13,7 +13,12 @@ oduflow call create_environment feature-login "" none https://github.com/owner/r
 
 # Create with JSON arguments (more explicit)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:17.0"}'
+
+# Inject container environment variables (comma-separated KEY=VALUE)
+oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","env_vars":"WORKERS=2,LIMIT_TIME_CPU=600"}'
 ```
+
+`env_vars` are added on top of the database connection variables (`HOST`/`USER`/`PASSWORD`). They are stored on the container and can later be replaced with [`update_environment`](#lifecycle-management).
 
 When creating an environment, Oduflow:
 
@@ -155,8 +160,11 @@ oduflow call start_environment feature-login
 # Restart the Odoo container
 oduflow call restart_environment feature-login
 
-# Rebuild the container from scratch (keeps database and filestore)
-oduflow call rebuild_environment feature-login
+# Re-create the container (keeps database and filestore)
+oduflow call update_environment feature-login
+
+# Switch image and/or replace env vars (keeps database and filestore)
+oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odoo:17.0
 
 # Tear down everything (container, database, filestore, workspace)
 oduflow call delete_environment feature-login

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -84,7 +84,7 @@ src/oduflow/
     client.py           # docker.from_env() wrapper + UID/GID auto-detection
     system_ops.py       # init_system / destroy_system / reload_template / init_template /
                         # save_env_as_template / delete_template / list_templates
-    env_ops.py          # create / delete / start / stop / restart / rebuild / list / status / pull /
+    env_ops.py          # create / delete / start / stop / restart / update / list / status / pull /
                         # apt/pip auto-install / filestore overlay mount
     odoo_ops.py         # install / upgrade / test / logs / shell / search / run_command
     service_ops.py      # create / delete / update / list / logs for auxiliary services

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -114,10 +114,10 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 ## Core MCP Tools
 
-- `create_environment` — provision a new Odoo environment for a branch
+- `create_environment` — provision a new Odoo environment for a branch (optional `env_vars` injects container environment variables)
 - `delete_environment` — tear down an environment
 - `start_environment` / `stop_environment` / `restart_environment` — lifecycle control
-- `rebuild_environment` — re-create the container from the same image, preserving DB and filestore
+- `update_environment` — re-create the container preserving DB and filestore (optional `odoo_image` switches image, `env_vars` replaces container environment variables)
 - `install_odoo_modules` — install Odoo modules
 - `upgrade_odoo_modules` — upgrade Odoo modules
 - `run_odoo_tests` — run Odoo tests for specific modules
@@ -1084,8 +1084,11 @@ oduflow call start_environment feature-login
 # Restart the Odoo container
 oduflow call restart_environment feature-login
 
-# Rebuild the container from scratch (keeps database and filestore)
-oduflow call rebuild_environment feature-login
+# Re-create the container (keeps database and filestore)
+oduflow call update_environment feature-login
+
+# Switch image and/or replace env vars (keeps database and filestore)
+oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odoo:17.0
 
 # Tear down everything (container, database, filestore, workspace)
 oduflow call delete_environment feature-login
@@ -1494,8 +1497,8 @@ oduflow call create_environment feature-x "" default https://github.com/company/
 When running in HTTP mode, a web dashboard is available at the server root (`http://<host>:<port>/`). It provides:
 
 - **Environment list** with status indicators (running / stopped / partial)
-- **Environment actions**: Start / Stop / Restart / Recreate / Protect / Delete
-- **Environment creation** form (branch, repo URL, Odoo image, template, extra addons)
+- **Environment actions**: Start / Stop / Restart / Update / Recreate / Protect / Delete
+- **Environment creation** form (branch, repo URL, Odoo image, template, extra addons, environment variables)
 - **Environment protection** — toggle to prevent accidental deletion
 - **Live log viewer** for each environment
 - **Interactive terminal** — WebSocket-based Odoo Python shell directly in the browser
@@ -1515,10 +1518,11 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/environments` | List all environments |
-| `POST` | `/api/environments/create` | Create a new environment (JSON body: `env_name`, `repo_url`, `odoo_image`, `template_name`) |
+| `POST` | `/api/environments/create` | Create a new environment (JSON body: `env_name`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user`) |
 | `POST` | `/api/environments/{branch}/start` | Start an environment |
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart an environment |
+| `POST` | `/api/environments/{branch}/update` | Re-create the container, preserving DB and filestore (JSON body, all optional: `env_vars`, `odoo_image`) |
 | `POST` | `/api/environments/{branch}/sync` | Pull latest code and auto-install/upgrade/restart |
 | `POST` | `/api/environments/{branch}/recreate` | Recreate an environment (delete + create with the same parameters) |
 | `POST` | `/api/environments/{branch}/delete` | Delete an environment |
@@ -1600,14 +1604,14 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore) |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `env_vars` injects container environment variables |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
-| `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
+| `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, env vars, workspace, container status, CPU/RAM stats |
 | `start_environment` | | Start a stopped environment |
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
-| `rebuild_environment` | ✓ | Re-create the container from the same image, preserving DB and filestore |
+| `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
@@ -2294,7 +2298,7 @@ src/oduflow/
     client.py           # docker.from_env() wrapper + UID/GID auto-detection
     system_ops.py       # init_system / destroy_system / reload_template / init_template /
                         # save_env_as_template / delete_template / list_templates
-    env_ops.py          # create / delete / start / stop / restart / rebuild / list / status / pull /
+    env_ops.py          # create / delete / start / stop / restart / update / list / status / pull /
                         # apt/pip auto-install / filestore overlay mount
     odoo_ops.py         # install / upgrade / test / logs / shell / search / run_command
     service_ops.py      # create / delete / update / list / logs for auxiliary services

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -126,10 +126,10 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 ## Core MCP Tools
 
-- `create_environment` — provision a new Odoo environment for a branch
+- `create_environment` — provision a new Odoo environment for a branch (optional `env_vars` injects container environment variables)
 - `delete_environment` — tear down an environment
 - `start_environment` / `stop_environment` / `restart_environment` — lifecycle control
-- `rebuild_environment` — re-create the container from the same image, preserving DB and filestore
+- `update_environment` — re-create the container preserving DB and filestore (optional `odoo_image` switches image, `env_vars` replaces container environment variables)
 - `install_odoo_modules` — install Odoo modules
 - `upgrade_odoo_modules` — upgrade Odoo modules
 - `run_odoo_tests` — run Odoo tests for specific modules

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -7,14 +7,14 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore) |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `env_vars` injects container environment variables |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
 | `start_environment` | | Start a stopped environment |
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
-| `rebuild_environment` | ✓ | Re-create the container from the same image, preserving DB and filestore |
+| `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -7,8 +7,8 @@
 When running in HTTP mode, a web dashboard is available at the server root (`http://<host>:<port>/`). It provides:
 
 - **Environment list** with status indicators (running / stopped / partial)
-- **Environment actions**: Start / Stop / Restart / Recreate / Protect / Delete
-- **Environment creation** form (branch, repo URL, Odoo image, template, extra addons)
+- **Environment actions**: Start / Stop / Restart / Update / Recreate / Protect / Delete
+- **Environment creation** form (branch, repo URL, Odoo image, template, extra addons, environment variables)
 - **Environment protection** — toggle to prevent accidental deletion
 - **Live log viewer** for each environment
 - **Interactive terminal** — WebSocket-based Odoo Python shell directly in the browser
@@ -28,10 +28,11 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/environments` | List all environments |
-| `POST` | `/api/environments/create` | Create a new environment (JSON body: `env_name`, `repo_url`, `odoo_image`, `template_name`) |
+| `POST` | `/api/environments/create` | Create a new environment (JSON body: `env_name`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user`) |
 | `POST` | `/api/environments/{branch}/start` | Start an environment |
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart an environment |
+| `POST` | `/api/environments/{branch}/update` | Re-create the container, preserving DB and filestore (JSON body, all optional: `env_vars`, `odoo_image`) |
 | `POST` | `/api/environments/{branch}/sync` | Pull latest code and auto-install/upgrade/restart |
 | `POST` | `/api/environments/{branch}/recreate` | Recreate an environment (delete + create with the same parameters) |
 | `POST` | `/api/environments/{branch}/delete` | Delete an environment |

--- a/scripts/create_env.py
+++ b/scripts/create_env.py
@@ -28,6 +28,7 @@ def create_environment(
     repo_url: str = "",
     odoo_image: str = "",
     extra_addons: str = "",
+    env_vars: str = "",
 ) -> dict:
     url = f"{server_url.rstrip('/')}/api/environments/create"
     payload = {"branch_name": branch_name}
@@ -39,6 +40,8 @@ def create_environment(
         payload["odoo_image"] = odoo_image
     if extra_addons:
         payload["extra_addons"] = extra_addons
+    if env_vars:
+        payload["env_vars"] = env_vars
 
     data = json.dumps(payload).encode()
     req = urllib.request.Request(url, data=data, method="POST")
@@ -73,6 +76,8 @@ def main() -> None:
                         help="Odoo Docker image (default: from template metadata)")
     parser.add_argument("--extra-addons", default="",
                         help="Extra addons, e.g. 'enterprise:18.0,themes'")
+    parser.add_argument("--env", default="",
+                        help="Environment variables, comma-separated KEY=VALUE (e.g. 'WORKERS=2,LIMIT_TIME_CPU=600')")
     parser.add_argument("--password", default="",
                         help="UI password (default: env ODUFLOW_UI_PASSWORD or interactive prompt)")
     args = parser.parse_args()
@@ -89,6 +94,7 @@ def main() -> None:
         repo_url=args.repo_url,
         odoo_image=args.odoo_image,
         extra_addons=args.extra_addons,
+        env_vars=args.env,
     )
 
     if result.get("ok"):

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -585,6 +585,7 @@ def create_environment(
     git_user: str = "",
     sanitize: bool = True,
     auto_install_modules: list[str] | None = None,
+    env_vars: dict[str, str] | None = None,
 ) -> dict[str, str]:
     env_name = env_name or branch
     start_time = time.time()
@@ -648,6 +649,8 @@ def create_environment(
         labels["oduflow.git_user"] = git_user
     if auto_install_modules:
         labels["oduflow.auto_install_modules"] = ",".join(auto_install_modules)
+    if env_vars:
+        labels["oduflow.env_vars"] = json.dumps(env_vars)
 
     if settings.routing_mode == "traefik":
         slug = slugify_branch(env_name)
@@ -814,6 +817,7 @@ def create_environment(
         "HOST": settings.shared_db_container,
         "USER": env_creds["pg_user"],
         "PASSWORD": env_creds["pg_password"],
+        **(env_vars or {}),
     }
     odoo_volumes = {repo_path: {"bind": "/mnt/extra-addons", "mode": "rw"}}
 
@@ -1370,6 +1374,7 @@ def get_environment_info(
             json.loads(labels.get("oduflow.extra_addons", "{}")),
         )
         result["auto_install_modules"] = labels.get("oduflow.auto_install_modules", "")
+        result["env_vars"] = json.loads(labels.get("oduflow.env_vars", "{}"))
         result["created_at"] = labels.get("oduflow.created_at", "") or odoo_container.attrs.get(
             "Created", ""
         )
@@ -1586,10 +1591,24 @@ def pull_environment(
     }
 
 
-def rebuild_environment(
-    settings: Settings, team: TeamSettings, env_name: str
-) -> dict[str, str]:
-    """Rebuild an environment by re-creating its container while preserving DB, repo and filestore."""
+def update_environment(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    *,
+    env_override: dict[str, str] | None = None,
+    image_override: str | None = None,
+) -> dict[str, Any]:
+    """Re-create an environment's container, preserving DB, repo and filestore.
+
+    With no overrides this simply rebuilds the container from its current image
+    and configuration (useful when the container is broken). Optionally pulls a
+    different ``image_override`` and/or fully replaces the user-supplied
+    environment variables with ``env_override`` (an explicit dict; an empty dict
+    clears them). The PostgreSQL connection variables (HOST/USER/PASSWORD) are
+    always re-derived from the environment credentials, and image-baked env
+    comes from the image itself.
+    """
     client = get_client()
     odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
 
@@ -1603,21 +1622,28 @@ def rebuild_environment(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
 
-    # Image
+    # Image (current → target). Capture the current digest so we can report
+    # whether the running image actually changed after the pull.
     try:
-        odoo_image = container.image.tags[0]
+        current_image = container.image.tags[0]
     except (IndexError, Exception):
-        odoo_image = container.attrs["Config"]["Image"]
+        current_image = container.attrs["Config"]["Image"]
+    odoo_image = image_override or current_image
+    try:
+        old_digest = container.image.id
+    except Exception:
+        old_digest = container.attrs.get("Image", "")
 
     # Labels
     labels = dict(container.labels)
 
-    # Environment – parse "KEY=VALUE" list into a dict
-    raw_env = container.attrs["Config"].get("Env") or []
-    env_dict: dict[str, str] = {}
-    for entry in raw_env:
-        key, _, value = entry.partition("=")
-        env_dict[key] = value
+    # User-supplied environment variables: an explicit override wins (full
+    # replace), otherwise restore from the persisted label. The DB connection
+    # variables are added back from the credentials below.
+    if env_override is not None:
+        user_env = dict(env_override)
+    else:
+        user_env = json.loads(labels.get("oduflow.env_vars", "{}"))
 
     # Volumes / bind mounts – parse "host:container:mode" strings
     raw_binds = container.attrs.get("HostConfig", {}).get("Binds") or []
@@ -1645,7 +1671,7 @@ def rebuild_environment(
                 pass
 
     logger.info(
-        "Rebuilding environment – stopping old container",
+        "Updating environment – stopping old container",
         extra={"env_name": env_name, "container": odoo_container_name},
     )
 
@@ -1702,6 +1728,20 @@ def rebuild_environment(
         except Exception as exc:
             logger.warning("Could not re-create PG role: %s", exc)
 
+    # Build the container environment from fresh credentials + user env, and
+    # keep the persisted labels (image + env vars) in sync with the new config.
+    env_dict = {
+        "HOST": settings.shared_db_container,
+        "USER": creds["pg_user"],
+        "PASSWORD": creds["pg_password"],
+        **user_env,
+    }
+    labels[settings.image_label] = odoo_image
+    if user_env:
+        labels["oduflow.env_vars"] = json.dumps(user_env)
+    else:
+        labels.pop("oduflow.env_vars", None)
+
     # Verify extra addons worktrees are intact
     extra_addons_json = labels.get("oduflow.extra_addons", "")
     if extra_addons_json:
@@ -1733,9 +1773,11 @@ def rebuild_environment(
     if settings.routing_mode == "port" and host_port is not None:
         run_kwargs["ports"] = {"8069/tcp": host_port}
 
+    image_updated = False
     try:
         logger.info("Pulling image %s", odoo_image)
-        client.images.pull(odoo_image)
+        new_image_obj = client.images.pull(odoo_image)
+        image_updated = bool(old_digest) and new_image_obj.id != old_digest
     except Exception as exc:
         logger.warning("Could not pull image %s, using local copy: %s", odoo_image, exc)
 
@@ -1787,7 +1829,7 @@ def rebuild_environment(
     env_db = get_db_name(env_name)
     workspace = get_workspace_path(env_name, team.workspaces_dir)
     logger.info(
-        "Environment rebuilt",
+        "Environment updated",
         extra={"env_name": env_name, "url": url, "container": odoo_container_name},
     )
 
@@ -1796,5 +1838,8 @@ def rebuild_environment(
         "odoo_container": odoo_container_name,
         "database": env_db,
         "workspace": workspace,
+        "image": odoo_image,
+        "image_updated": image_updated,
+        "env_vars": user_env,
         "setup_logs": setup_logs,
     }

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -356,6 +356,7 @@ def create_environment(
     extra_addons: str = "",
     sanitize: bool = True,
     auto_install_modules: str = "",
+    env_vars: str = "",
     ctx: Context = None,
 ) -> str:
     """
@@ -370,6 +371,7 @@ def create_environment(
         extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:18.0,custom-themes:main"). Each entry must include a branch after a colon.
         sanitize: Sanitize the database after provisioning (default: True). Disables incoming/outgoing mail servers and runs custom scripts from the .odoo_sanitize/ folder in the repository.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
+        env_vars: Comma-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). These are added on top of the database connection variables (HOST/USER/PASSWORD).
     """
     import json
 
@@ -428,6 +430,11 @@ def create_environment(
             if auto_install_modules
             else []
         )
+        parsed_env = None
+        if env_vars:
+            parsed_env = dict(
+                item.split("=", 1) for item in env_vars.split(",") if "=" in item
+            )
         result = env_ops.create_environment(
             settings,
             team,
@@ -440,6 +447,7 @@ def create_environment(
             git_user=effective_git_user,
             sanitize=sanitize,
             auto_install_modules=auto_install_list or None,
+            env_vars=parsed_env,
         )
 
         from oduflow.telemetry import record_env_created
@@ -470,6 +478,10 @@ def create_environment(
             lines.append(f"Extra Addons: {extras_display}")
         if auto_install_list:
             lines.append(f"Auto-install modules: {', '.join(auto_install_list)}")
+        if parsed_env:
+            lines.append(
+                "Env vars: " + ", ".join(f"{k}={v}" for k, v in parsed_env.items())
+            )
         setup_logs = result.get("setup_logs", [])
         if setup_logs:
             lines.append("\n--- Setup Log ---")
@@ -913,27 +925,57 @@ def restart_environment(env_name: str, wait: bool = True, ctx: Context = None) -
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def rebuild_environment(env_name: str, ctx: Context = None) -> str:
+def update_environment(
+    env_name: str,
+    env_vars: str = "",
+    odoo_image: str = "",
+    ctx: Context = None,
+) -> str:
     """
-    Rebuild the Odoo container for an environment without losing the database or filestore.
+    Re-create the Odoo container for an environment without losing the database
+    or filestore. Pulls the target image and re-creates the container.
 
-    Use this when the container is broken (e.g. packages were accidentally removed,
-    system files corrupted) and you need a fresh container from the same image,
+    With no arguments this simply rebuilds the container from its current image
+    and configuration — use it when the container is broken (e.g. packages were
+    accidentally removed, system files corrupted) and you need a fresh container
     reconnected to the existing database and filestore.
 
+    Pass odoo_image to switch to a different image, and/or env_vars to change the
+    environment variables. The database and filestore are always preserved.
+
     Args:
-        env_name: The name of the environment to rebuild.
+        env_name: The name of the environment to update.
+        env_vars: Comma-separated KEY=VALUE pairs that fully replace the current user-supplied env vars (e.g. "WORKERS=4,LIMIT_TIME_CPU=900"). Leave empty to keep the current env vars. The database connection variables (HOST/USER/PASSWORD) are always preserved.
+        odoo_image: New Docker image with tag to pull and run (e.g. "odoo:17.0"). Leave empty to keep the current image.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
-    result = env_ops.rebuild_environment(settings, team, env_name)
+    parsed_env = None
+    if env_vars:
+        parsed_env = dict(
+            item.split("=", 1) for item in env_vars.split(",") if "=" in item
+        )
+    result = env_ops.update_environment(
+        settings,
+        team,
+        env_name,
+        env_override=parsed_env,
+        image_override=odoo_image or None,
+    )
     lines = [
-        "Environment rebuilt successfully!",
+        "Environment updated successfully!",
         f"URL: {result['url']}",
         f"Odoo Container: {result['odoo_container']}",
         f"Database: {result['database']}",
         f"Workspace: {result['workspace']}",
+        f"Image: {result.get('image', '')}"
+        + (" (updated)" if result.get("image_updated") else ""),
     ]
+    env_result = result.get("env_vars") or {}
+    if env_result:
+        lines.append(
+            "Env vars: " + ", ".join(f"{k}={v}" for k, v in env_result.items())
+        )
     setup_logs = result.get("setup_logs", [])
     if setup_logs:
         lines.append("\n--- Setup Log ---")
@@ -977,6 +1019,9 @@ def get_environment_info(env_name: str, ctx: Context = None) -> str:
     if info.get("extra_addons"):
         addons = ", ".join(f"{k}:{v}" for k, v in info["extra_addons"].items())
         lines.append(f"Extra addons: {addons}")
+    if info.get("env_vars"):
+        env_display = ", ".join(f"{k}={v}" for k, v in info["env_vars"].items())
+        lines.append(f"Env vars: {env_display}")
     if info.get("workspace"):
         lines.append(f"Workspace: {info['workspace']}")
     for key in ("odoo", "db"):

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -31,12 +31,12 @@ MCP endpoint: `http://<host>:8000/mcp`
 | Tool | When to use |
 |---|---|
 | `list_environments` | Check existing environments before creating a new one |
-| `create_environment(branch, env_name?, repo_url, odoo_image, template_name?)` | Provision an environment. `branch` is the git branch; `env_name` defaults to the branch name. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects |
+| `create_environment(branch, env_name?, repo_url, odoo_image, template_name?, env_vars?)` | Provision an environment. `branch` is the git branch; `env_name` defaults to the branch name. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects. `env_vars` is a comma-separated `KEY=VALUE` list injected into the Odoo container |
 | `get_environment_info(env_name)` | Get full environment details: database name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
 | `delete_environment(env_name)` | Tear down when the task is complete or cancelled |
 | `start_environment` / `stop_environment` | Resume or pause a stopped environment |
 | `restart_environment(env_name)` | Restart the Odoo container (rarely needed — `pull_and_apply` handles this) |
-| `rebuild_environment(env_name)` | Recreate the container from scratch if it's broken, without losing DB or filestore |
+| `update_environment(env_name, env_vars, odoo_image)` | Recreate the container without losing DB or filestore — to fix a broken container, switch image, or change env vars |
 
 ### Code → Environment Sync
 
@@ -93,7 +93,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 
 | Tool | When to use |
 |---|---|
-| `add_extra_repo(name, repo_url)` | Clone an extra addons repository so its modules become available when creating or rebuilding environments |
+| `add_extra_repo(name, repo_url)` | Clone an extra addons repository so its modules become available when creating or updating environments |
 | `list_extra_repos` | List all cloned extra addons repositories |
 | `update_extra_repo(name)` | Fetch the latest changes from the remote for an extra addons repository |
 | `delete_extra_repo(name)` | Remove a cloned extra addons repository |

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -596,6 +596,11 @@
         <input type="text" id="cr-auto-install" placeholder="e.g. sale,purchase,stock">
         <div style="font-size:11px;color:var(--text-dim);margin-top:4px;">Comma-separated list of modules to install after provisioning</div>
       </div>
+      <div class="form-group">
+        <label for="cr-env-vars">Environment variables</label>
+        <input type="text" id="cr-env-vars" placeholder="e.g. WORKERS=2,LIMIT_TIME_CPU=600">
+        <div style="font-size:11px;color:var(--text-dim);margin-top:4px;">Comma-separated KEY=VALUE pairs injected into the Odoo container</div>
+      </div>
 
       <div class="form-actions">
         <button class="btn" onclick="closeCreateModal()">Cancel</button>
@@ -1046,8 +1051,8 @@ function renderEnvironments(envs) {
           '<button class="btn btn-protect' + (env.protected ? ' active' : '') + '" ' +
             'onclick="doProtect(\'' + escAttr(env.branch) + '\',' + (env.protected ? 'true' : 'false') + ')">' +
             (env.protected ? '🔒 Protected' : '🔓 Protect') + '</button>' +
-          '<button class="btn btn-restart" onclick="doRebuild(\'' + escAttr(env.branch) + '\')" ' +
-            (env.protected ? 'disabled title="Environment is protected"' : '') + '>Rebuild</button>' +
+          '<button class="btn btn-restart" onclick="doUpdate(\'' + escAttr(env.branch) + '\')" ' +
+            (env.protected ? 'disabled title="Environment is protected"' : '') + '>Update</button>' +
           '<button class="btn btn-restart" onclick="doRecreate(\'' + escAttr(env.branch) + '\')" ' +
             (env.protected ? 'disabled title="Environment is protected"' : '') + '>Recreate</button>' +
           '<button class="btn btn-delete" onclick="doDelete(\'' + escAttr(env.branch) + '\')" ' +
@@ -1158,17 +1163,17 @@ async function loadStats() {
   }
 }
 
-async function doRebuild(branch) {
-  if (!confirm('Rebuild environment "' + branch + '"? This will recreate the container but keep the database and filestore.')) return;
+async function doUpdate(branch) {
+  if (!confirm('Update environment "' + branch + '"? This will recreate the container but keep the database and filestore.')) return;
   const card = document.querySelector('[data-branch="' + branch + '"]');
   if (card) card.querySelectorAll('.btn').forEach(b => b.disabled = true);
   try {
-    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/rebuild', { method: 'POST' });
+    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/update', { method: 'POST' });
     const data = await r.json();
     if (data.ok) {
-      showToast(branch + ': rebuilt');
+      showToast(branch + ': updated');
     } else {
-      showToast(data.error || 'Rebuild failed', true);
+      showToast(data.error || 'Update failed', true);
     }
   } catch (e) {
     showToast('Connection error: ' + e.message, true);
@@ -1496,6 +1501,7 @@ function openCreateModal() {
   document.getElementById('cr-repo').value = '';
   document.getElementById('cr-image').value = '';
   document.getElementById('cr-auto-install').value = '';
+  document.getElementById('cr-env-vars').value = '';
 
   var errEl = document.getElementById('create-error');
   errEl.style.display = 'none';
@@ -1541,6 +1547,7 @@ async function submitCreate() {
   var template = document.getElementById('cr-template').value;
   var gitUser = document.getElementById('cr-git-user').value;
   var autoInstall = document.getElementById('cr-auto-install').value.trim();
+  var envVars = document.getElementById('cr-env-vars').value.trim();
   var errEl = document.getElementById('create-error');
 
   if (!branch) {
@@ -1570,6 +1577,7 @@ async function submitCreate() {
       git_user: gitUser,
       extra_addons: extraAddonsObj,
       auto_install_modules: autoInstall,
+      env_vars: envVars,
     };
     var r = await fetch(API + '/create', {
       method: 'POST',

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -239,8 +239,23 @@ def _build_routes(
         finally:
             locks.release_env(branch)
 
-    def api_rebuild(request: Request) -> JSONResponse:
+    async def api_update(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        env_vars_raw = (body.get("env_vars") or "").strip() if body else ""
+        odoo_image = (body.get("odoo_image") or "").strip() if body else ""
+        env_override = None
+        if env_vars_raw:
+            import re
+
+            env_override = dict(
+                item.split("=", 1)
+                for item in re.split(r"[\n,]+", env_vars_raw)
+                if "=" in item
+            )
         try:
             locks.acquire_env(branch)
         except BusyError as e:
@@ -248,12 +263,18 @@ def _build_routes(
         try:
             settings = get_settings()
             team = _get_ui_team(request)
-            result = env_ops.rebuild_environment(settings, team, branch)
+            result = env_ops.update_environment(
+                settings,
+                team,
+                branch,
+                env_override=env_override,
+                image_override=odoo_image or None,
+            )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
         except Exception as e:
-            logger.exception("Unexpected error in api_rebuild")
+            logger.exception("Unexpected error in api_update")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
         finally:
             locks.release_env(branch)
@@ -291,6 +312,7 @@ def _build_routes(
             extra_addons_raw = labels.get("oduflow.extra_addons", "{}")
             extra_addons = json.loads(extra_addons_raw) or None
             git_user = labels.get("oduflow.git_user", "")
+            env_vars = json.loads(labels.get("oduflow.env_vars", "{}")) or None
 
             env_ops.delete_environment(settings, team, branch)
             result = env_ops.create_environment(
@@ -302,6 +324,7 @@ def _build_routes(
                 template_name=template_name,
                 extra_addons=extra_addons,
                 git_user=git_user,
+                env_vars=env_vars,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -324,6 +347,16 @@ def _build_routes(
             template_name_raw = (body.get("template_name") or "").strip()
             extra_addons_raw = body.get("extra_addons")
             auto_install_raw = (body.get("auto_install_modules") or "").strip()
+            env_vars_raw = (body.get("env_vars") or "").strip()
+            env_vars = None
+            if env_vars_raw:
+                import re
+
+                env_vars = dict(
+                    item.split("=", 1)
+                    for item in re.split(r"[\n,]+", env_vars_raw)
+                    if "=" in item
+                )
             if not env_name:
                 return JSONResponse(
                     {"ok": False, "error": "env_name is required."},
@@ -388,6 +421,7 @@ def _build_routes(
                 extra_addons=extra_dict,
                 git_user=git_user,
                 auto_install_modules=auto_install_list or None,
+                env_vars=env_vars,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -1288,7 +1322,7 @@ def _build_routes(
             "/api/environments/{branch:path}/unprotect", api_unprotect, methods=["POST"]
         ),
         Route("/api/environments/{branch:path}/note", api_set_note, methods=["POST"]),
-        Route("/api/environments/{branch:path}/rebuild", api_rebuild, methods=["POST"]),
+        Route("/api/environments/{branch:path}/update", api_update, methods=["POST"]),
         Route(
             "/api/environments/{branch:path}/recreate", api_recreate, methods=["POST"]
         ),

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -288,6 +288,205 @@ class TestCreateEnvironment:
         mock_odoo.restart.assert_called_once()
 
 
+class TestCreateEnvironmentEnvVars:
+    @patch(
+        "oduflow.extra_addons.generate_odoo_conf",
+        return_value="/tmp/flow-test/workspaces/feature-env/odoo.conf",
+    )
+    @patch("oduflow.docker_ops.env_ops._copy_file_to_container")
+    @patch("oduflow.docker_ops.env_ops._create_pg_role")
+    @patch(
+        "oduflow.docker_ops.env_ops.create_credentials",
+        return_value={"pg_user": "u_1_feature-env", "pg_password": "test-pw"},
+    )
+    @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
+    @patch("oduflow.docker_ops.env_ops.get_odoo_uid_gid", return_value="100:101")
+    @patch("oduflow.docker_ops.env_ops._exec_sql")
+    @patch("oduflow.docker_ops.env_ops._db_exists", return_value=False)
+    @patch("oduflow.docker_ops.env_ops._mount_filestore")
+    @patch("oduflow.docker_ops.env_ops._get_used_ports", return_value=set())
+    @patch("oduflow.docker_ops.env_ops.allocate_port", return_value=50002)
+    @patch("oduflow.docker_ops.env_ops.subprocess.run")
+    @patch("oduflow.docker_ops.env_ops.os.chmod")
+    @patch("oduflow.docker_ops.env_ops.os.makedirs")
+    @patch("oduflow.docker_ops.env_ops.os.path.exists", return_value=False)
+    def test_create_merges_env_vars_and_label(
+        self,
+        mock_exists,
+        mock_makedirs,
+        mock_chmod,
+        mock_run,
+        mock_alloc,
+        mock_used,
+        mock_mount,
+        mock_db_exists,
+        mock_sql,
+        mock_uid_gid,
+        mock_ready,
+        mock_creds,
+        mock_role,
+        mock_copy_conf,
+        mock_gen_conf,
+        mock_docker_client,
+    ):
+        import json
+
+        mock_odoo = MagicMock()
+        mock_odoo.exec_run.return_value = (0, b"OK")
+        mock_docker_client.containers.run.return_value = mock_odoo
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        env_ops.create_environment(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/env",
+            "https://github.com/org/repo.git",
+            "odoo:15.0",
+            template_name=None,
+            env_vars={"FOO": "bar", "BAZ": "qux"},
+        )
+
+        run_kwargs = mock_docker_client.containers.run.call_args.kwargs
+        environment = run_kwargs["environment"]
+        assert environment["FOO"] == "bar"
+        assert environment["BAZ"] == "qux"
+        assert environment["HOST"] == TEST_SETTINGS.shared_db_container
+        assert environment["USER"] == "u_1_feature-env"
+        stored = json.loads(run_kwargs["labels"]["oduflow.env_vars"])
+        assert stored == {"FOO": "bar", "BAZ": "qux"}
+
+
+class TestUpdateEnvironment:
+    def _make_container(self):
+        container = MagicMock()
+        container.image.tags = ["odoo:15.0"]
+        container.image.id = "sha256:old"
+        container.labels = {
+            "oduflow.template": "none",
+            TEST_SETTINGS.image_label: "odoo:15.0",
+            "oduflow.env_vars": '{"OLD": "1"}',
+        }
+        container.attrs = {
+            "Config": {
+                "Env": ["HOST=db", "USER=old", "PASSWORD=x", "OLD=1"],
+                "Cmd": ["odoo", "-d", "oduflow_1_main", "--dev=xml"],
+                "Image": "odoo:15.0",
+            },
+            "HostConfig": {
+                "Binds": ["/host/repo:/mnt/extra-addons:rw"],
+                "PortBindings": {"8069/tcp": [{"HostPort": "50000"}]},
+            },
+        }
+        return container
+
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements", return_value=(False, "")
+    )
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value="")
+    @patch("oduflow.docker_ops.env_ops._resolve_instance_conf")
+    @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=False)
+    @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=False)
+    @patch("oduflow.docker_ops.env_ops._create_pg_role")
+    @patch(
+        "oduflow.docker_ops.env_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "pw"},
+    )
+    def test_update_image_and_env_override(
+        self,
+        mock_creds,
+        mock_role,
+        mock_isdir,
+        mock_isfile,
+        mock_resolve_conf,
+        mock_apt,
+        mock_pip,
+        mock_docker_client,
+    ):
+        import json
+
+        mock_resolve_conf.return_value.exists.return_value = False
+        container = self._make_container()
+        mock_docker_client.containers.get.return_value = container
+        new_image = MagicMock()
+        new_image.id = "sha256:new"
+        mock_docker_client.images.pull.return_value = new_image
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        result = env_ops.update_environment(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "main",
+            env_override={"FOO": "new"},
+            image_override="odoo:17.0",
+        )
+
+        run_kwargs = mock_docker_client.containers.run.call_args.kwargs
+        assert run_kwargs["image"] == "odoo:17.0"
+        assert run_kwargs["environment"] == {
+            "HOST": TEST_SETTINGS.shared_db_container,
+            "USER": "u_1_main",
+            "PASSWORD": "pw",
+            "FOO": "new",
+        }
+        assert run_kwargs["labels"][TEST_SETTINGS.image_label] == "odoo:17.0"
+        assert json.loads(run_kwargs["labels"]["oduflow.env_vars"]) == {"FOO": "new"}
+        mock_docker_client.images.pull.assert_called_once_with("odoo:17.0")
+        assert result["image"] == "odoo:17.0"
+        assert result["image_updated"] is True
+        assert result["env_vars"] == {"FOO": "new"}
+
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements", return_value=(False, "")
+    )
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value="")
+    @patch("oduflow.docker_ops.env_ops._resolve_instance_conf")
+    @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=False)
+    @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=False)
+    @patch("oduflow.docker_ops.env_ops._create_pg_role")
+    @patch(
+        "oduflow.docker_ops.env_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "pw"},
+    )
+    def test_update_no_overrides_keeps_label_env(
+        self,
+        mock_creds,
+        mock_role,
+        mock_isdir,
+        mock_isfile,
+        mock_resolve_conf,
+        mock_apt,
+        mock_pip,
+        mock_docker_client,
+    ):
+        mock_resolve_conf.return_value.exists.return_value = False
+        container = self._make_container()
+        mock_docker_client.containers.get.return_value = container
+        same_image = MagicMock()
+        same_image.id = "sha256:old"
+        mock_docker_client.images.pull.return_value = same_image
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        result = env_ops.update_environment(TEST_SETTINGS, TEST_TEAM, "main")
+
+        run_kwargs = mock_docker_client.containers.run.call_args.kwargs
+        # No image override → current image is reused and re-pulled
+        assert run_kwargs["image"] == "odoo:15.0"
+        mock_docker_client.images.pull.assert_called_once_with("odoo:15.0")
+        # No env override → env restored from the persisted label
+        assert run_kwargs["environment"]["OLD"] == "1"
+        assert result["env_vars"] == {"OLD": "1"}
+        assert result["image_updated"] is False
+
+    @patch(
+        "oduflow.docker_ops.env_ops.load_credentials",
+        return_value={"pg_user": "u_1_xyz", "pg_password": "pw"},
+    )
+    def test_update_missing_raises(self, mock_creds, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        with pytest.raises(NotFoundError, match="does not exist"):
+            env_ops.update_environment(TEST_SETTINGS, TEST_TEAM, "xyz")
+
+
 class TestDeleteEnvironment:
     @patch("oduflow.docker_ops.env_ops._drop_pg_role")
     @patch(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -71,6 +71,91 @@ class TestCreateEnvironmentTool:
         assert "Database: oduflow_1_main" in result
         assert "Template: none (init from scratch)" in result
 
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_create_with_env_vars(self, mock_create):
+        mock_create.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+        }
+        result = _call_tool(
+            "create_environment",
+            branch="main",
+            template_name="none",
+            repo_url="https://repo.url",
+            odoo_image="odoo:17.0",
+            env_vars="FOO=bar,BAZ=qux",
+        )
+        assert mock_create.call_args.kwargs["env_vars"] == {
+            "FOO": "bar",
+            "BAZ": "qux",
+        }
+        assert "Env vars: FOO=bar, BAZ=qux" in result
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_create_without_env_vars(self, mock_create):
+        mock_create.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+        }
+        _call_tool(
+            "create_environment",
+            branch="main",
+            template_name="none",
+            repo_url="https://repo.url",
+            odoo_image="odoo:17.0",
+        )
+        assert mock_create.call_args.kwargs["env_vars"] is None
+
+
+class TestUpdateEnvironmentTool:
+    @patch("oduflow.docker_ops.env_ops.update_environment")
+    def test_update_rebuild_only(self, mock_update):
+        mock_update.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+            "image": "odoo:17.0",
+            "image_updated": False,
+            "env_vars": {},
+        }
+        result = _call_tool("update_environment", env_name="main")
+        assert mock_update.call_args.kwargs == {
+            "env_override": None,
+            "image_override": None,
+        }
+        assert "Environment updated successfully!" in result
+        assert "Image: odoo:17.0" in result
+        assert "(updated)" not in result
+
+    @patch("oduflow.docker_ops.env_ops.update_environment")
+    def test_update_image_and_env(self, mock_update):
+        mock_update.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+            "image": "odoo:17.0",
+            "image_updated": True,
+            "env_vars": {"FOO": "new"},
+        }
+        result = _call_tool(
+            "update_environment",
+            env_name="main",
+            env_vars="FOO=new",
+            odoo_image="odoo:17.0",
+        )
+        assert mock_update.call_args.kwargs == {
+            "env_override": {"FOO": "new"},
+            "image_override": "odoo:17.0",
+        }
+        assert "Image: odoo:17.0 (updated)" in result
+        assert "Env vars: FOO=new" in result
+
 
 class TestDeleteEnvironmentTool:
     @patch("oduflow.docker_ops.env_ops.delete_environment")


### PR DESCRIPTION
`create_environment` gains an `env_vars` parameter (comma-separated `KEY=VALUE`) that injects environment variables into the Odoo container on top of the DB connection vars, persisted in the `oduflow.env_vars` label and reported by `get_environment_info`. `rebuild_environment` is renamed to `update_environment` (breaking) and gains `odoo_image` and `env_vars` overrides to switch the image and fully replace env vars while preserving DB and filestore — called with no arguments it behaves exactly like the old rebuild. The change is wired through the MCP tools, Web UI (new REST route `/api/environments/{branch}/update` plus dashboard create form and button), and the `create_env.py` CLI script. Docs, `llms.txt`/`llms-full.txt`, agent instructions, `web-api.md`, and the changelog are updated accordingly. Adds 8 unit tests; the full unit suite passes (329).