### PR TITLE
docs: document self-hosted OAuth

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,6 +115,13 @@ port = 8000                 # HTTP server port
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik"
 
+# ── OAuth (optional) ──────────────────────────────────
+# Set to the public URL of this instance to turn Oduflow into a self-hosted
+# OAuth 2.1 Authorization Server (for Claude.ai and other OAuth MCP clients).
+# Each team's auth_token doubles as client_id, client_secret, and access token.
+[oauth]
+# oauth_base_url = "https://oduflow.example.com"
+
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"               # PostgreSQL user for the shared database container
@@ -152,6 +159,12 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
 | `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` |
+
+### OAuth settings
+
+| Key | Default | Description |
+|---|---|---|
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance. When set, Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect. Each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. Empty = plain Bearer-token auth only. See [Authentication & Security](security.md) |
 
 ### Database settings
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -372,6 +372,13 @@ port = 8000                 # HTTP server port
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik"
 
+# ── OAuth (optional) ──────────────────────────────────
+# Set to the public URL of this instance to turn Oduflow into a self-hosted
+# OAuth 2.1 Authorization Server (for Claude.ai and other OAuth MCP clients).
+# Each team's auth_token doubles as client_id, client_secret, and access token.
+[oauth]
+# oauth_base_url = "https://oduflow.example.com"
+
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"               # PostgreSQL user for the shared database container
@@ -408,6 +415,12 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
 | `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` |
+
+### OAuth settings
+
+| Key | Default | Description |
+|---|---|---|
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance. When set, Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect. Each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. Empty = plain Bearer-token auth only |
 
 ### Database settings
 
@@ -1968,6 +1981,57 @@ auth_token = "secret-token-team-2"
 
 The token is used to both authenticate and identify the team. This is implemented via FastMCP's `StaticTokenVerifier`.
 
+## Self-hosted OAuth (for Claude.ai and other MCP clients)
+
+Oduflow can act as its own OAuth 2.1 Authorization Server, so MCP clients that require an OAuth flow (e.g. Claude.ai Remote MCP, MCP Inspector) can connect without any external identity provider.
+
+When the OAuth flow completes, the issued `access_token` is exactly the team's `auth_token` from `oduflow.toml` — so the same value works as a plain Bearer token for CLI clients.
+
+### Setup
+
+In `oduflow.toml`, set the public URL of this instance and an `auth_token` per team:
+
+```toml
+[oauth]
+oauth_base_url = "https://your-server.com"
+
+[team.1]
+auth_token = "secret-token-team-1"
+```
+
+That's it. Oduflow now exposes:
+
+- `GET /.well-known/oauth-authorization-server` — discovery metadata
+- `GET /authorize` — authorization endpoint (Authorization Code + PKCE)
+- `POST /token` — token endpoint
+
+Dynamic Client Registration (`/register`) is **disabled** — clients must use the preregistered credentials.
+
+### Connecting from Claude.ai
+
+1. Go to Claude.ai Settings → Connectors → Add custom MCP
+2. Enter your Oduflow URL: `https://your-server.com/mcp`
+3. In the OAuth fields enter the team's `auth_token` as **both** `Client ID` **and** `Client Secret`:
+
+   ```
+   Client ID     = secret-token-team-1
+   Client Secret = secret-token-team-1
+   ```
+
+4. Claude.ai performs the OAuth flow against your Oduflow instance, receives an access token, and connects.
+
+The team is identified by the `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
+
+### Bearer-only mode (CLI / automation)
+
+For curl, IDE clients, or anything that doesn't need OAuth, simply send the `auth_token` as a Bearer header:
+
+```
+Authorization: Bearer secret-token-team-1
+```
+
+This works whether or not `oauth_base_url` is configured.
+
 ## Web Dashboard Auth
 
 The web dashboard and REST API use HTTP Basic authentication with a **separate** password:
@@ -1987,8 +2051,10 @@ MCP auth and Web UI auth are configured independently per team:
 Warnings are logged on startup for each team:
 
 ```
-INFO  [team.1] http://localhost:8000/ (MCP token OFF, UI auth OFF)
+INFO  [team.1] http://localhost:8000/ (MCP token OFF, OAuth OFF, UI auth OFF)
 ```
+
+When OAuth is enabled the status reads `OAuth ON (self-hosted)`.
 
 ## Git Credentials
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -47,6 +47,9 @@ port = 8000                           # HTTP port
 mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 # acme_email = "admin@example.com"    # required for traefik mode
 
+[oauth]
+# oauth_base_url = "https://oduflow.example.com"  # enable self-hosted OAuth (for Claude.ai); auth_token = client_id = client_secret = access token
+
 [database]
 user = "odoo"
 password = "odoo"
@@ -123,6 +126,10 @@ The server starts on `http://0.0.0.0:8000`. MCP endpoint: `http://<host>:8000/mc
 ### Claude Desktop / Amp
 
 Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
+
+### Claude.ai (self-hosted OAuth)
+
+For OAuth-based MCP clients like Claude.ai Remote MCP, set `[oauth].oauth_base_url` to this instance's public URL. Oduflow then runs its own OAuth 2.1 Authorization Server (no external IdP). In Claude.ai add a custom MCP at `https://<your-oduflow-host>/mcp` and enter the team's `auth_token` as **both** Client ID and Client Secret. The issued access token equals the `auth_token`, so the same value also works as a plain Bearer token.
 
 ## Core MCP Tools
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,6 +81,17 @@ ui_password = "my-dashboard-password"    # Basic auth for Web Dashboard (user: a
 
 MCP auth and Web Dashboard auth are independent — they use different tokens and different mechanisms (Bearer vs Basic).
 
+### Self-hosted OAuth (Claude.ai)
+
+Some MCP clients (e.g. Claude.ai Remote MCP) require an OAuth flow instead of a static Bearer token. Oduflow can act as its own OAuth 2.1 Authorization Server — no external identity provider needed. Set the public URL of this instance in `oduflow.toml`:
+
+```toml
+[oauth]
+oauth_base_url = "https://oduflow.example.com"
+```
+
+Each team's `auth_token` then doubles as `client_id`, `client_secret`, and the issued access token. See [Authentication & Security](security.md#self-hosted-oauth-for-claudeai-and-other-mcp-clients) for the full setup and how to connect from Claude.ai.
+
 ### MCP client configuration
 
 Point your MCP client (Cursor, Cline, Amp, etc.) to the server with the Authorization header:


### PR DESCRIPTION
Documents the self-hosted OAuth 2.1 Authorization Server feature across the docs that were previously missing it. Adds an `[oauth].oauth_base_url` block and "OAuth settings" table to the Configuration Reference (`installation.md`), and a "Self-hosted OAuth (Claude.ai)" subsection to the Quick Start so it surfaces in that page's table of contents. Syncs the LLM-readable docs: `llms-full.txt` had an outdated embedded copy of the security page (no OAuth section, stale startup-log line) which is now updated, and `llms.txt` gains the `[oauth]` config and a Claude.ai OAuth connection note. Changelog entry is intentionally deferred until after the next release. Verified with `mkdocs build --strict` (no warnings) and confirmed the cross-page OAuth anchor resolves.