### PR TITLE
fix: pick Odoo test port flag by version (--gevent-port is 16+ only)

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -212,7 +212,9 @@ This runs `odoo --test-enable --stop-after-init --workers 0 --http-port 8089 --g
 (`-u`); `-i` on an already-installed module is a no-op that never enters the test phase ("0 of 0
 tests"). Because `--no-http` has no effect under `--test-enable` (tests require a live HTTP
 server), the test server's HTTP and gevent ports are moved off the defaults (8069/8072) — already
-held by the running Odoo container — to avoid a port conflict. `--workers 0` makes the run
+held by the running Odoo container — to avoid a port conflict. On Odoo 15.0 and earlier the port
+flag is `--longpolling-port` instead (Odoo 16.0 renamed it to `--gevent-port`); Oduflow detects the
+environment's Odoo version and uses the right one automatically. `--workers 0` makes the run
 deterministic (Odoo recommends single-worker mode for unit tests).
 
 ## Smart Pull — Intelligent Change Detection

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 import docker
@@ -12,6 +13,47 @@ from oduflow.naming import get_db_name, get_resource_name
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
+
+
+def _detect_odoo_major(container: Any, image_label: str) -> int | None:
+    """Best-effort major version of the Odoo running in *container*.
+
+    Fast path: parse the version out of the image tag stored in the
+    ``oduflow.image`` label (e.g. ``odoo:15.0`` → 15). For custom-tagged images
+    that carry no version (e.g. ``oduist/customer_odoo``) it falls back to asking
+    the already-running binary via ``odoo --version`` — authoritative and
+    independent of the image name. Returns ``None`` if the version can't be
+    determined.
+    """
+    image = container.labels.get(image_label, "")
+    match = re.search(r"odoo[:/](\d+)", image)
+    if match:
+        return int(match.group(1))
+
+    try:
+        _code, out = container.exec_run("odoo --version")
+        text = out.decode("utf-8") if isinstance(out, bytes) else str(out)
+        match = re.search(r"(\d+)\.\d+", text)
+        if match:
+            return int(match.group(1))
+    except Exception as exc:  # noqa: BLE001 - version detection is best-effort
+        logger.warning("Could not detect Odoo version from container: %s", exc)
+    return None
+
+
+def _longpoll_port_flag(container: Any, image_label: str) -> str:
+    """CLI flag for the test server's long-polling/gevent port, per Odoo version.
+
+    Odoo 16.0 renamed ``--longpolling-port`` to ``--gevent-port``; the new flag
+    does not exist on 15.0 and earlier (Odoo aborts on the unknown option), while
+    the old name still works as a deprecated alias on 16+. Pick the flag the
+    running Odoo actually understands, defaulting to the modern ``--gevent-port``
+    when the version can't be determined.
+    """
+    major = _detect_odoo_major(container, image_label)
+    if major is not None and major < 16:
+        return "--longpolling-port"
+    return "--gevent-port"
 
 
 def run_environment_tests(
@@ -38,9 +80,12 @@ def run_environment_tests(
     # --no-http has no effect under --test-enable (tests need a live HTTP server),
     # so instead of disabling HTTP we move the test server's HTTP and gevent ports
     # off the defaults (8069/8072) already held by the running Odoo container.
+    # Odoo 16.0 renamed --longpolling-port to --gevent-port, so pick the flag the
+    # environment's Odoo version actually understands.
+    port_flag = _longpoll_port_flag(container, settings.image_label)
     cmd = (
         f"odoo --test-enable --stop-after-init --workers 0 "
-        f"--http-port 8089 --gevent-port 8090 -u {modules} "
+        f"--http-port 8089 {port_flag} 8090 -u {modules} "
         f"--db_host={settings.shared_db_container} "
         f"-r {creds['pg_user']} -w {creds['pg_password']} "
         f"--database={env_db}"

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -665,6 +665,7 @@ class TestRunEnvironmentTests:
     )
     def test_run(self, mock_load_creds, mock_docker_client):
         container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
         container.exec_run.return_value = (0, b"All tests passed")
         mock_docker_client.containers.get.return_value = container
 
@@ -685,8 +686,53 @@ class TestRunEnvironmentTests:
         # (tests need a live HTTP server), so the test server's ports are moved off
         # the defaults to avoid the bind conflict.
         assert "--http-port 8089" in args
+        # Odoo 17 → modern --gevent-port flag.
         assert "--gevent-port 8090" in args
         assert "--workers 0" in args
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_run_odoo_15_uses_longpolling_port(
+        self, mock_load_creds, mock_docker_client
+    ):
+        # Odoo 15.0 has no --gevent-port (introduced in 16.0); it must get the
+        # legacy --longpolling-port instead, parsed from the image tag.
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:15.0"}
+        container.exec_run.return_value = (0, b"All tests passed")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_environment_tests(TEST_SETTINGS, TEST_TEAM, "main", "base")
+
+        args = container.exec_run.call_args[0][0]
+        assert "--longpolling-port 8090" in args
+        assert "--gevent-port" not in args
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_run_custom_image_detects_version_via_binary(
+        self, mock_load_creds, mock_docker_client
+    ):
+        # Custom-tagged image carries no version in the tag, so the major version
+        # is resolved from `odoo --version` on the live container.
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "oduist/customer_odoo"}
+        container.exec_run.side_effect = [
+            (0, b"Odoo Server 15.0\n"),  # odoo --version probe
+            (0, b"All tests passed"),  # actual test run
+        ]
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_environment_tests(TEST_SETTINGS, TEST_TEAM, "main", "base")
+
+        assert container.exec_run.call_args_list[0][0][0] == "odoo --version"
+        test_cmd = container.exec_run.call_args_list[1][0][0]
+        assert "--longpolling-port 8090" in test_cmd
+        assert "--gevent-port" not in test_cmd
 
 
 class TestGetLogs:


### PR DESCRIPTION
`run_odoo_tests` always passed `--gevent-port`, which Odoo 16.0 introduced as the rename of `--longpolling-port`; on Odoo 15.0 and earlier that flag does not exist, so the test run aborted on the unknown option.

`run_environment_tests` now detects the environment's Odoo major version — fast path from the image tag in the `oduflow.image` label, falling back to `odoo --version` on the live container for custom-tagged images like `oduist/customer_odoo` — and emits `--longpolling-port` on ≤15 or `--gevent-port` on 16+ (the modern default when the version can't be determined). Adds unit tests covering the tag-parse and `odoo --version` paths, and updates the docs to note the version-dependent flag.