### PR TITLE
docs: use Odoo 19.0 in all examples and default image fallbacks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ All template commands accept `--team` to specify the team ID (default: `1`).
 
 ```bash
 # Generate a clean template from a Docker image
-oduflow init-template --odoo-image odoo:17.0 --template-name myproject [--modules base,web,sale] [--force] [--team 1]
+oduflow init-template --odoo-image odoo:19.0 --template-name myproject [--modules base,web,sale] [--force] [--team 1]
 
 # Save a branch environment as the new template.
 # Other environments on this template keep their filestore changes by default;
@@ -129,7 +129,7 @@ You can invoke any registered MCP tool directly from the terminal using `oduflow
 oduflow call
 
 # Call a tool with positional arguments (mapped to parameters in order)
-oduflow call create_environment dev "" "" https://github.com/owner/repo.git odoo:17.0
+oduflow call create_environment dev "" "" https://github.com/owner/repo.git odoo:19.0
 oduflow call delete_environment dev
 oduflow call list_environments
 oduflow call get_environment_logs main 50
@@ -137,7 +137,7 @@ oduflow call run_odoo_command dev "ls /mnt/extra-addons"
 oduflow call create_service redis redis:7 6379
 
 # Call a tool with JSON-encoded arguments
-oduflow call create_environment '{"branch":"dev","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:17.0","template_name":"myproject"}'
+oduflow call create_environment '{"branch":"dev","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0","template_name":"myproject"}'
 
 # Service with NET_ADMIN capability (VPN / tun / iptables)
 oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -66,7 +66,7 @@ To set up a template database:
 
 ```bash
 # From scratch (clean Odoo with specified modules)
-docker exec oduflow oduflow init-template --odoo-image odoo:17.0 --template-name default --modules base,web,contacts
+docker exec oduflow oduflow init-template --odoo-image odoo:19.0 --template-name default --modules base,web,contacts
 
 # Or import from a running Odoo instance
 docker exec oduflow oduflow import-template https://my-odoo.example.com master_password --template-name default

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -6,13 +6,13 @@
 
 ```bash
 # Create with a named template (env_name, template_name, repo_url, odoo_image)
-oduflow call create_environment feature-login "" myproject https://github.com/owner/repo.git odoo:17.0
+oduflow call create_environment feature-login "" myproject https://github.com/owner/repo.git odoo:19.0
 
 # Create without a template (fresh Odoo with -i base)
-oduflow call create_environment feature-login "" none https://github.com/owner/repo.git odoo:17.0
+oduflow call create_environment feature-login "" none https://github.com/owner/repo.git odoo:19.0
 
 # Create with JSON arguments (more explicit)
-oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:17.0"}'
+oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0"}'
 
 # Inject container environment variables (comma-separated KEY=VALUE)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","env_vars":"WORKERS=2,LIMIT_TIME_CPU=600"}'
@@ -136,7 +136,7 @@ Python scripts receive the following environment variables: `ODOO_DB`, `DB_HOST`
 Pass `sanitize=false` when creating an environment to skip all sanitization (both team-level and per-project):
 
 ```bash
-oduflow call create_environment '{"branch":"my-branch","template_name":"mytemplate","repo_url":"https://...","odoo_image":"odoo:17.0","sanitize":false}'
+oduflow call create_environment '{"branch":"my-branch","template_name":"mytemplate","repo_url":"https://...","odoo_image":"odoo:19.0","sanitize":false}'
 ```
 
 !!! note
@@ -164,7 +164,7 @@ oduflow call restart_environment feature-login
 oduflow call update_environment feature-login
 
 # Switch image and/or replace env vars (keeps database and filestore)
-oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odoo:17.0
+oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odoo:19.0
 
 # Tear down everything (container, database, filestore, workspace)
 oduflow call delete_environment feature-login

--- a/docs/extra-addons.md
+++ b/docs/extra-addons.md
@@ -15,7 +15,7 @@ Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise, th
     feature-x/
       repo/              ← main project repo (existing)
       extra/
-        enterprise/      ← git worktree (branch 17.0)
+        enterprise/      ← git worktree (branch 19.0)
         custom-themes/   ← git worktree (branch main)
 ```
 
@@ -37,11 +37,11 @@ oduflow call add_extra_repo enterprise https://github.com/odoo/enterprise.git
 When creating an environment, specify which extra repos to mount:
 
 ```bash
-# Mount enterprise addons on branch 17.0
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:17.0 "enterprise:17.0"
+# Mount enterprise addons on branch 19.0
+oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0"
 
 # Mount multiple extra repos
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:17.0 "enterprise:17.0,custom-themes:main"
+oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0,custom-themes:main"
 ```
 
 Oduflow automatically:
@@ -109,7 +109,7 @@ Delete and recreate the environment. The new environment will get a fresh worktr
 
 ```bash
 oduflow call delete_environment feature-x
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:17.0 "enterprise:17.0"
+oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0"
 ```
 
 !!! tip

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -73,7 +73,7 @@ oduflow init              # Create shared Docker network, PostgreSQL, team direc
 
 ```bash
 # From scratch
-oduflow init-template --odoo-image odoo:17.0 --template-name default
+oduflow init-template --odoo-image odoo:19.0 --template-name default
 
 # From production dump
 # Place dump.sql and filestore/ into {data_dir}/team_1/templates/default/ then:
@@ -543,7 +543,7 @@ The most common workflow — test your changes against real production data:
 
 ```bash
 # Create an environment for your feature branch
-oduflow call create_environment feature-login "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment feature-login "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # Make changes, push to remote, then pull into the environment
 oduflow call pull_and_apply feature-login
@@ -559,7 +559,7 @@ Reproduce a production bug with real data:
 
 ```bash
 # Spin up an environment with production data
-oduflow call create_environment bug-12345 "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment bug-12345 "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # Debug inside the container
 oduflow call run_odoo_command bug-12345 "python3 -c 'import odoo; ...'"
@@ -573,7 +573,7 @@ oduflow call run_odoo_command bug-12345 "psql -h oduflow-db -U odoo -d oduflow_b
 Run Odoo tests in an isolated environment:
 
 ```bash
-oduflow call create_environment test-suite "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment test-suite "" default https://github.com/company/odoo-addons.git odoo:19.0
 oduflow call run_odoo_tests test-suite sale_custom,invoice_custom
 oduflow call delete_environment test-suite
 ```
@@ -584,10 +584,10 @@ Start a new Odoo project from scratch:
 
 ```bash
 # Generate a clean template with common modules
-oduflow init-template --odoo-image odoo:17.0 --template-name default --modules base,web,contacts,sale,purchase,stock
+oduflow init-template --odoo-image odoo:19.0 --template-name default --modules base,web,contacts,sale,purchase,stock
 
 # Now create environments that start with your customized setup
-oduflow call create_environment dev "" default https://github.com/company/new-project.git odoo:17.0
+oduflow call create_environment dev "" default https://github.com/company/new-project.git odoo:19.0
 ```
 
 ## 🔄 Multiple Odoo Versions
@@ -597,18 +597,18 @@ Manage environments across different Odoo versions using named templates:
 ```bash
 # Set up templates for different versions
 oduflow init-template --odoo-image odoo:15.0 --template-name v15
-oduflow init-template --odoo-image odoo:17.0 --template-name v17
+oduflow init-template --odoo-image odoo:19.0 --template-name v19
 
 # Create environments targeting specific versions
 oduflow call create_environment legacy-fix "" v15 https://github.com/company/v15-addons.git odoo:15.0
-oduflow call create_environment new-feature "" v17 https://github.com/company/v17-addons.git odoo:17.0
+oduflow call create_environment new-feature "" v19 https://github.com/company/v19-addons.git odoo:19.0
 ```
 
 ## 🤖 AI-Assisted Development
 
 Let your AI coding agent manage Odoo environments. Configure your MCP client (Cursor, Cline, Amp) to connect to `http://<host>:8000/mcp`, then:
 
-> *"Create an Odoo 17 environment for the `feature-payment-gateway` branch from our repo. Install the `sale` and `payment` modules, then run the tests."*
+> *"Create an Odoo 19 environment for the `feature-payment-gateway` branch from our repo. Install the `sale` and `payment` modules, then run the tests."*
 
 The agent will call the appropriate MCP tools in sequence:
 
@@ -680,7 +680,7 @@ Set up a full-stack development environment:
 
 ```bash
 # Create the Odoo environment
-oduflow call create_environment dev "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment dev "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # Add Redis for caching
 oduflow call create_service redis redis:7 6379
@@ -699,7 +699,7 @@ Use `oduflow call` in your CI pipeline:
 # .github/workflows/test.yml
 steps:
   - name: Create test environment
-    run: oduflow call create_environment ci-${{ github.sha }} "" default ${{ github.repository }} odoo:17.0
+    run: oduflow call create_environment ci-${{ github.sha }} "" default ${{ github.repository }} odoo:19.0
 
   - name: Install and test
     run: |
@@ -768,7 +768,7 @@ Evolve your template as the project grows:
 
 ```bash
 # 1. Create an environment for template changes
-oduflow call create_environment template-update "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment template-update "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # 2. Install new modules
 oduflow call install_odoo_modules template-update accounting,hr,project
@@ -801,13 +801,13 @@ If you don't have a production database dump — for example, you're starting a 
 ### Generate a clean template
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name default
+oduflow init-template --odoo-image odoo:19.0 --template-name default
 ```
 
 If a `dump.sql` or filestore already exists, the command will refuse to run. Use `--force` to overwrite:
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name default --force
+oduflow init-template --odoo-image odoo:19.0 --template-name default --force
 ```
 
 This will:
@@ -821,13 +821,13 @@ This will:
 ### Install additional modules during generation
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name default --modules base,web,contacts,sale
+oduflow init-template --odoo-image odoo:19.0 --template-name default --modules base,web,contacts,sale
 ```
 
 ### Named templates for different projects
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name myproject-v17
+oduflow init-template --odoo-image odoo:19.0 --template-name myproject-v19
 oduflow init-template --odoo-image odoo:15.0 --template-name legacy-v15
 ```
 
@@ -906,13 +906,13 @@ Each template profile can contain a `metadata.json` file that stores defaults an
 
 ```json
 {
-  "odoo_image": "odoo:17.0",
+  "odoo_image": "odoo:19.0",
   "repo_url": "https://github.com/company/addons.git",
-  "extra_addons": {"enterprise": "17.0"},
+  "extra_addons": {"enterprise": "19.0"},
   "use_overlay": true,
   "source_url": "https://my-odoo.example.com",
   "source_db": "production",
-  "odoo_version": "17.0+e",
+  "odoo_version": "19.0+e",
   "pg_version": "15.0"
 }
 ```
@@ -925,9 +925,9 @@ The `use_overlay` flag determines whether new environments use fuse-overlayfs (f
 
 | Scenario | Command |
 |---|---|
-| New project, no existing database | `oduflow init-template --odoo-image odoo:17.0 --template-name default` |
-| Regenerate template from scratch | `oduflow init-template --odoo-image odoo:17.0 --template-name default --force` |
-| Named template for a specific project | `oduflow init-template --odoo-image odoo:17.0 --template-name myproject` |
+| New project, no existing database | `oduflow init-template --odoo-image odoo:19.0 --template-name default` |
+| Regenerate template from scratch | `oduflow init-template --odoo-image odoo:19.0 --template-name default --force` |
+| Named template for a specific project | `oduflow init-template --odoo-image odoo:19.0 --template-name myproject` |
 | Have a production dump file | Place dump at `{data_dir}/team_{ID}/templates/default/dump.sql` and run `oduflow reload-template default` |
 | Need to install modules or configure the template | Create an env, configure it, then `oduflow template-from-env my-branch --template-name default` |
 | Update the template from a newer production dump | `oduflow reload-template default --dump-path /path/to/new.dump` |
@@ -948,13 +948,13 @@ The `use_overlay` flag determines whether new environments use fuse-overlayfs (f
 
 ```bash
 # Create with a named template (env_name, template_name, repo_url, odoo_image)
-oduflow call create_environment feature-login "" myproject https://github.com/owner/repo.git odoo:17.0
+oduflow call create_environment feature-login "" myproject https://github.com/owner/repo.git odoo:19.0
 
 # Create without a template (fresh Odoo with -i base)
-oduflow call create_environment feature-login "" none https://github.com/owner/repo.git odoo:17.0
+oduflow call create_environment feature-login "" none https://github.com/owner/repo.git odoo:19.0
 
 # Create with JSON arguments (more explicit)
-oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:17.0"}'
+oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0"}'
 ```
 
 When creating an environment, Oduflow:
@@ -1073,7 +1073,7 @@ Python scripts receive the following environment variables: `ODOO_DB`, `DB_HOST`
 Pass `sanitize=false` when creating an environment to skip all sanitization (both team-level and per-project):
 
 ```bash
-oduflow call create_environment '{"branch":"my-branch","template_name":"mytemplate","repo_url":"https://...","odoo_image":"odoo:17.0","sanitize":false}'
+oduflow call create_environment '{"branch":"my-branch","template_name":"mytemplate","repo_url":"https://...","odoo_image":"odoo:19.0","sanitize":false}'
 ```
 
 !!! note
@@ -1101,7 +1101,7 @@ oduflow call restart_environment feature-login
 oduflow call update_environment feature-login
 
 # Switch image and/or replace env vars (keeps database and filestore)
-oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odoo:17.0
+oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odoo:19.0
 
 # Tear down everything (container, database, filestore, workspace)
 oduflow call delete_environment feature-login
@@ -1397,7 +1397,7 @@ Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise, th
     feature-x/
       repo/              ← main project repo (existing)
       extra/
-        enterprise/      ← git worktree (branch 17.0)
+        enterprise/      ← git worktree (branch 19.0)
         custom-themes/   ← git worktree (branch main)
 ```
 
@@ -1419,11 +1419,11 @@ oduflow call add_extra_repo enterprise https://github.com/odoo/enterprise.git
 When creating an environment, specify which extra repos to mount:
 
 ```bash
-# Mount enterprise addons on branch 17.0
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:17.0 "enterprise:17.0"
+# Mount enterprise addons on branch 19.0
+oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0"
 
 # Mount multiple extra repos
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:17.0 "enterprise:17.0,custom-themes:main"
+oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0,custom-themes:main"
 ```
 
 Oduflow automatically:
@@ -1491,7 +1491,7 @@ Delete and recreate the environment. The new environment will get a fresh worktr
 
 ```bash
 oduflow call delete_environment feature-x
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:17.0 "enterprise:17.0"
+oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0"
 ```
 
 !!! tip
@@ -1724,7 +1724,7 @@ All template commands accept `--team` to specify the team ID (default: `1`).
 
 ```bash
 # Generate a clean template from a Docker image
-oduflow init-template --odoo-image odoo:17.0 --template-name myproject [--modules base,web,sale] [--force] [--team 1]
+oduflow init-template --odoo-image odoo:19.0 --template-name myproject [--modules base,web,sale] [--force] [--team 1]
 
 # Save a branch environment as the new template
 oduflow template-from-env <branch> --template-name myproject [--team 1]
@@ -1803,7 +1803,7 @@ You can invoke any registered MCP tool directly from the terminal using `oduflow
 oduflow call
 
 # Call a tool with positional arguments (mapped to parameters in order)
-oduflow call create_environment dev "" "" https://github.com/owner/repo.git odoo:17.0
+oduflow call create_environment dev "" "" https://github.com/owner/repo.git odoo:19.0
 oduflow call delete_environment dev
 oduflow call list_environments
 oduflow call get_environment_logs main 50
@@ -1811,7 +1811,7 @@ oduflow call run_odoo_command dev "ls /mnt/extra-addons"
 oduflow call create_service redis redis:7 6379
 
 # Call a tool with JSON-encoded arguments
-oduflow call create_environment '{"branch":"dev","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:17.0","template_name":"myproject"}'
+oduflow call create_environment '{"branch":"dev","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0","template_name":"myproject"}'
 
 # Type coercion is automatic: int, bool, and float parameters are cast from strings
 oduflow call get_environment_logs dev 500
@@ -1948,7 +1948,7 @@ Containers are labeled with `oduflow.team={team_id}` for filtering.
 CLI template and service commands accept a `--team` flag:
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name myproject --team 2
+oduflow init-template --odoo-image odoo:19.0 --template-name myproject --team 2
 oduflow list-templates --team 2
 oduflow cleanup --team 2
 ```
@@ -2182,7 +2182,7 @@ To set up a template database:
 
 ```bash
 # From scratch (clean Odoo with specified modules)
-docker exec oduflow oduflow init-template --odoo-image odoo:17.0 --template-name default --modules base,web,contacts
+docker exec oduflow oduflow init-template --odoo-image odoo:19.0 --template-name default --modules base,web,contacts
 
 # Or import from a running Odoo instance
 docker exec oduflow oduflow import-template https://my-odoo.example.com master_password --template-name default

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -84,7 +84,7 @@ During upgrade, bundled files are overwritten. Add `# KEEP` as the first line of
 
 ```bash
 # From scratch
-oduflow init-template --odoo-image odoo:17.0 --template-name default
+oduflow init-template --odoo-image odoo:19.0 --template-name default
 
 # From production dump
 # Place dump.sql and filestore/ into {data_dir}/team_1/templates/default/ then:

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -77,7 +77,7 @@ Containers are labeled with `oduflow.team={team_id}` for filtering.
 CLI template and service commands accept a `--team` flag:
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name myproject --team 2
+oduflow init-template --odoo-image odoo:19.0 --template-name myproject --team 2
 oduflow list-templates --team 2
 oduflow cleanup --team 2
 ```

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -13,13 +13,13 @@ If you don't have a production database dump — for example, you're starting a 
 ### Generate a clean template
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name default
+oduflow init-template --odoo-image odoo:19.0 --template-name default
 ```
 
 If a `dump.sql` or filestore already exists, the command will refuse to run. Use `--force` to overwrite:
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name default --force
+oduflow init-template --odoo-image odoo:19.0 --template-name default --force
 ```
 
 This will:
@@ -33,13 +33,13 @@ This will:
 ### Install additional modules during generation
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name default --modules base,web,contacts,sale
+oduflow init-template --odoo-image odoo:19.0 --template-name default --modules base,web,contacts,sale
 ```
 
 ### Named templates for different projects
 
 ```bash
-oduflow init-template --odoo-image odoo:17.0 --template-name myproject-v17
+oduflow init-template --odoo-image odoo:19.0 --template-name myproject-v19
 oduflow init-template --odoo-image odoo:15.0 --template-name legacy-v15
 ```
 
@@ -143,13 +143,13 @@ Each template profile can contain a `metadata.json` file that stores defaults an
 
 ```json
 {
-  "odoo_image": "odoo:17.0",
+  "odoo_image": "odoo:19.0",
   "repo_url": "https://github.com/company/addons.git",
-  "extra_addons": {"enterprise": "17.0"},
+  "extra_addons": {"enterprise": "19.0"},
   "use_overlay": true,
   "source_url": "https://my-odoo.example.com",
   "source_db": "production",
-  "odoo_version": "17.0+e",
+  "odoo_version": "19.0+e",
   "pg_version": "15.0"
 }
 ```
@@ -162,9 +162,9 @@ The `use_overlay` flag determines whether new environments use fuse-overlayfs (f
 
 | Scenario | Command |
 |---|---|
-| New project, no existing database | `oduflow init-template --odoo-image odoo:17.0 --template-name default` |
-| Regenerate template from scratch | `oduflow init-template --odoo-image odoo:17.0 --template-name default --force` |
-| Named template for a specific project | `oduflow init-template --odoo-image odoo:17.0 --template-name myproject` |
+| New project, no existing database | `oduflow init-template --odoo-image odoo:19.0 --template-name default` |
+| Regenerate template from scratch | `oduflow init-template --odoo-image odoo:19.0 --template-name default --force` |
+| Named template for a specific project | `oduflow init-template --odoo-image odoo:19.0 --template-name myproject` |
 | Have a production dump file | Place dump at `{data_dir}/team_{ID}/templates/default/dump.sql` and run `oduflow reload-template default` |
 | Need to install modules or configure the template | Create an env, configure it, then `oduflow template-from-env my-branch --template-name default` |
 | Update the template from a newer production dump | `oduflow reload-template default --dump-path /path/to/new.dump` |

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -6,7 +6,7 @@ The most common workflow — test your changes against real production data:
 
 ```bash
 # Create an environment for your feature branch
-oduflow call create_environment feature-login "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment feature-login "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # Make changes, push to remote, then pull into the environment
 oduflow call pull_and_apply feature-login
@@ -22,7 +22,7 @@ Reproduce a production bug with real data:
 
 ```bash
 # Spin up an environment with production data
-oduflow call create_environment bug-12345 "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment bug-12345 "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # Debug inside the container
 oduflow call run_odoo_command bug-12345 "python3 -c 'import odoo; ...'"
@@ -36,7 +36,7 @@ oduflow call run_odoo_command bug-12345 "psql -h oduflow-db -U odoo -d oduflow_b
 Run Odoo tests in an isolated environment:
 
 ```bash
-oduflow call create_environment test-suite "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment test-suite "" default https://github.com/company/odoo-addons.git odoo:19.0
 oduflow call run_odoo_tests test-suite sale_custom,invoice_custom
 oduflow call delete_environment test-suite
 ```
@@ -47,10 +47,10 @@ Start a new Odoo project from scratch:
 
 ```bash
 # Generate a clean template with common modules
-oduflow init-template --odoo-image odoo:17.0 --template-name default --modules base,web,contacts,sale,purchase,stock
+oduflow init-template --odoo-image odoo:19.0 --template-name default --modules base,web,contacts,sale,purchase,stock
 
 # Now create environments that start with your customized setup
-oduflow call create_environment dev "" default https://github.com/company/new-project.git odoo:17.0
+oduflow call create_environment dev "" default https://github.com/company/new-project.git odoo:19.0
 ```
 
 ## 🔄 Multiple Odoo Versions
@@ -60,18 +60,18 @@ Manage environments across different Odoo versions using named templates:
 ```bash
 # Set up templates for different versions
 oduflow init-template --odoo-image odoo:15.0 --template-name v15
-oduflow init-template --odoo-image odoo:17.0 --template-name v17
+oduflow init-template --odoo-image odoo:19.0 --template-name v19
 
 # Create environments targeting specific versions
 oduflow call create_environment legacy-fix "" v15 https://github.com/company/v15-addons.git odoo:15.0
-oduflow call create_environment new-feature "" v17 https://github.com/company/v17-addons.git odoo:17.0
+oduflow call create_environment new-feature "" v19 https://github.com/company/v19-addons.git odoo:19.0
 ```
 
 ## 🤖 AI-Assisted Development
 
 Let your AI coding agent manage Odoo environments. Configure your MCP client (Cursor, Cline, Amp) to connect to `http://<host>:8000/mcp`, then:
 
-> *"Create an Odoo 17 environment for the `feature-payment-gateway` branch from our repo. Install the `sale` and `payment` modules, then run the tests."*
+> *"Create an Odoo 19 environment for the `feature-payment-gateway` branch from our repo. Install the `sale` and `payment` modules, then run the tests."*
 
 The agent will call the appropriate MCP tools in sequence:
 
@@ -143,7 +143,7 @@ Set up a full-stack development environment:
 
 ```bash
 # Create the Odoo environment
-oduflow call create_environment dev "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment dev "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # Add Redis for caching
 oduflow call create_service redis redis:7 6379
@@ -162,7 +162,7 @@ Use `oduflow call` in your CI pipeline:
 # .github/workflows/test.yml
 steps:
   - name: Create test environment
-    run: oduflow call create_environment ci-${{ github.sha }} "" default ${{ github.repository }} odoo:17.0
+    run: oduflow call create_environment ci-${{ github.sha }} "" default ${{ github.repository }} odoo:19.0
 
   - name: Install and test
     run: |
@@ -231,7 +231,7 @@ Evolve your template as the project grows:
 
 ```bash
 # 1. Create an environment for template changes
-oduflow call create_environment template-update "" default https://github.com/company/odoo-addons.git odoo:17.0
+oduflow call create_environment template-update "" default https://github.com/company/odoo-addons.git odoo:19.0
 
 # 2. Install new modules
 oduflow call install_odoo_modules template-update accounting,hr,project

--- a/mcp-ref.md
+++ b/mcp-ref.md
@@ -210,7 +210,7 @@ def _make_summary(cached: CachedOutput) -> str:
 
 **Что видит агент (пример):**
 ```
-2024-01-15 12:00:00 INFO odoo.service.server: Odoo version 17.0-20240115
+2024-01-15 12:00:00 INFO odoo.service.server: Odoo version 19.0-20240115
 2024-01-15 12:00:00 INFO odoo.service.server: Using configuration file /etc/odoo/odoo.conf
 ... (первые 20 строк) ...
 
@@ -445,7 +445,7 @@ def run_db_query(
 → Ответ (помещается в контекст):
   Error. Modules: supply. Exit code: 1.
 
-  2024-01-15 INFO odoo.service.server: Odoo version 17.0
+  2024-01-15 INFO odoo.service.server: Odoo version 19.0
   ...
 
   --- Errors/Warnings (3 occurrences) ---

--- a/scripts/create_env.py
+++ b/scripts/create_env.py
@@ -75,7 +75,7 @@ def main() -> None:
     parser.add_argument("--odoo-image", default="",
                         help="Odoo Docker image (default: from template metadata)")
     parser.add_argument("--extra-addons", default="",
-                        help="Extra addons, e.g. 'enterprise:18.0,themes'")
+                        help="Extra addons, e.g. 'enterprise:19.0,themes'")
     parser.add_argument("--env", default="",
                         help="Environment variables, comma-separated KEY=VALUE (e.g. 'WORKERS=2,LIMIT_TIME_CPU=600')")
     parser.add_argument("--password", default="",

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -351,7 +351,7 @@ def remount_template_overlays(
             continue
 
         container_name = get_resource_name(env_name, "odoo", settings.prefix)
-        image = env.get("odoo_image") or "odoo:17.0"
+        image = env.get("odoo_image") or "odoo:19.0"
         was_running = False
         try:
             container = client.containers.get(container_name)

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -616,7 +616,7 @@ def init_template(
     settings: Settings,
     team: TeamSettings,
     template_name: str,
-    odoo_image: str = "odoo:17.0",
+    odoo_image: str = "odoo:19.0",
     modules: str = "base",
     force: bool = False,
 ) -> dict[str, str]:
@@ -913,10 +913,10 @@ def publish_env_as_template(
     try:
         sc = client.containers.get(source_container)
         source_was_running = sc.status == "running"
-        source_image = sc.image.tags[0] if sc.image.tags else "odoo:17.0"
+        source_image = sc.image.tags[0] if sc.image.tags else "odoo:19.0"
     except (docker.errors.NotFound, IndexError):
         source_was_running = False
-        source_image = "odoo:17.0"
+        source_image = "odoo:19.0"
 
     with env_ops.remount_template_overlays(
         client,

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -335,7 +335,7 @@ def _parse_extra_addons(raw: str) -> dict[str, str]:
             result[name.strip()] = branch.strip()
         else:
             raise ValueError(
-                f"Extra addon '{item}' must include a branch (e.g. '{item}:18.0')."
+                f"Extra addon '{item}' must include a branch (e.g. '{item}:19.0')."
             )
     return result
 
@@ -363,12 +363,12 @@ def create_environment(
     Provision a new ephemeral Odoo environment.
 
     Args:
-        branch: The git branch to clone (e.g. "18.0", "feature/my-feature").
-        env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="18.0").
+        branch: The git branch to clone (e.g. "19.0", "feature/my-feature").
+        env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="19.0").
         template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden).
         repo_url: URL of the git repository to clone. Optional when template_name is specified (loaded from template metadata).
-        odoo_image: Full Docker image name with tag (e.g. "odoo:17.0"). Optional when template_name is specified (loaded from template metadata).
-        extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:18.0,custom-themes:main"). Each entry must include a branch after a colon.
+        odoo_image: Full Docker image name with tag (e.g. "odoo:19.0"). Optional when template_name is specified (loaded from template metadata).
+        extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:19.0,custom-themes:main"). Each entry must include a branch after a colon.
         sanitize: Sanitize the database after provisioning (default: True). Disables incoming/outgoing mail servers and runs custom scripts from the .odoo_sanitize/ folder in the repository.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
         env_vars: Comma-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). These are added on top of the database connection variables (HOST/USER/PASSWORD).
@@ -728,7 +728,7 @@ def get_odoo_development_guide(version: str, ctx: Context = None) -> str:
     Get Odoo development standards and constraints guide for a specific Odoo version.
 
     Args:
-        version: Odoo version number (e.g. "17", "17.0", "18", "18.0"). Both "17" and "17.0" formats are accepted.
+        version: Odoo version number (e.g. "18", "18.0", "19", "19.0"). Both "19" and "19.0" formats are accepted.
     """
     import pathlib
 
@@ -946,7 +946,7 @@ def update_environment(
     Args:
         env_name: The name of the environment to update.
         env_vars: Comma-separated KEY=VALUE pairs that fully replace the current user-supplied env vars (e.g. "WORKERS=4,LIMIT_TIME_CPU=900"). Leave empty to keep the current env vars. The database connection variables (HOST/USER/PASSWORD) are always preserved.
-        odoo_image: New Docker image with tag to pull and run (e.g. "odoo:17.0"). Leave empty to keep the current image.
+        odoo_image: New Docker image with tag to pull and run (e.g. "odoo:19.0"). Leave empty to keep the current image.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -2875,7 +2875,7 @@ def main() -> None:
         help="Generate template dump and filestore from a clean Odoo image",
     )
     p_init_tpl.add_argument(
-        "--odoo-image", required=True, help="Docker image for Odoo (e.g. odoo:17.0)"
+        "--odoo-image", required=True, help="Docker image for Odoo (e.g. odoo:19.0)"
     )
     p_init_tpl.add_argument(
         "--modules",

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -288,7 +288,7 @@ Step 4: get_environment_logs — If something went wrong, check for migration IN
 ```
 Agent: list_environments → no environment for "feature-invoice-pdf"
 
-Agent: create_environment("feature-invoice-pdf", "https://github.com/company/addons.git", "odoo:17.0")
+Agent: create_environment("feature-invoice-pdf", "https://github.com/company/addons.git", "odoo:19.0")
 → Environment created at http://server:50042
 
 Agent: [writes code for the module]

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -579,7 +579,7 @@
       </div>
       <div class="form-group">
         <label for="cr-image">Odoo image</label>
-        <input type="text" id="cr-image" placeholder="e.g. odoo:17.0">
+        <input type="text" id="cr-image" placeholder="e.g. odoo:19.0">
       </div>
       <div class="form-group">
         <label for="cr-template">Template</label>

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -111,7 +111,7 @@ def _parse_extra_addons(raw: str) -> dict[str, str]:
             result[name.strip()] = branch.strip()
         else:
             raise ValueError(
-                f"Extra addon '{item}' must include a branch (e.g. '{item}:18.0')."
+                f"Extra addon '{item}' must include a branch (e.g. '{item}:19.0')."
             )
     return result
 


### PR DESCRIPTION
Replaces Odoo 17.0/18.0 example versions with 19.0 across the docs (`docs/*.md`, `llms.txt`, `llms-full.txt`), `mcp-ref.md`, MCP tool docstrings, CLI help texts, error messages, the dashboard placeholder, and agent guide examples. Also bumps the runtime fallback image defaults in `env_ops.py` and `system_ops.py` from `odoo:17.0` to `odoo:19.0`.

Intentionally untouched: version-specific facts (the `--longpolling-port` → `--gevent-port` rename in 16.0, health-check availability in 16+), legacy `v15` examples in multi-version sections, per-version agent guides, the README supported-range badge, and test fixtures.

Verified with `ruff check` (clean) and the unit test suite (331 passed).