### PR TITLE
Stdio live-mount + explicit pull_and_apply guardrail; greenfield & role fixes

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -573,6 +573,67 @@ def _cleanup_old_environment(
         shutil.rmtree(workspace_path)
 
 
+def _init_empty_database(
+    client: DockerClient,
+    settings: Settings,
+    odoo_image: str,
+    env_db: str,
+    odoo_env: dict,
+    odoo_volumes: dict,
+    env_name: str,
+) -> str:
+    """Initialize a fresh empty database with ``-i base`` in an isolated,
+    short-lived container, then remove it. Returns a setup-log line.
+
+    This runs *before* the long-running serving container exists, so the init
+    is the only Odoo process touching the database. It avoids the registry
+    signaling race that occurs when the serving PID1 (``odoo -d <db> --dev=xml``)
+    and an in-container ``-i base`` exec set up the registry concurrently and
+    collide on ``CREATE TABLE orm_signaling_registry`` (``UniqueViolation`` in
+    the pg catalog). ``-i base`` is explicit, so it works regardless of whether
+    the image build auto-initializes an empty DB on plain ``-d``.
+    """
+    init_name = get_resource_name(env_name, "odoo-init", settings.prefix)
+    try:
+        client.containers.get(init_name).remove(force=True)
+    except docker.errors.NotFound:
+        pass
+
+    init_container = client.containers.run(
+        image=odoo_image,
+        name=init_name,
+        detach=True,
+        network=settings.shared_network,
+        environment=odoo_env,
+        volumes=odoo_volumes,
+        command=f"odoo -d {env_db} -i base --stop-after-init --no-http",
+    )
+    exit_code: int = -1
+    logs = ""
+    try:
+        result = init_container.wait(timeout=600)
+        exit_code = (
+            result.get("StatusCode", -1) if isinstance(result, dict) else int(result)
+        )
+        try:
+            logs = init_container.logs().decode("utf-8", errors="replace")
+        except Exception:
+            logs = ""
+    finally:
+        try:
+            init_container.remove(force=True)
+        except docker.errors.APIError:
+            pass
+
+    if exit_code != 0:
+        logger.error(
+            "Base init failed (exit %s)", exit_code, extra={"env_name": env_name}
+        )
+        return f"[INIT] odoo -i base FAILED (exit {exit_code}):\n{logs[-4000:]}"
+    logger.info("Base init completed", extra={"env_name": env_name})
+    return "[INIT] odoo -i base completed successfully"
+
+
 def create_environment(
     settings: Settings,
     team: TeamSettings,
@@ -936,52 +997,37 @@ def create_environment(
     except Exception as exc:
         logger.warning("Could not pull image %s, using local copy: %s", odoo_image, exc)
 
+    setup_logs: list[str] = []
+
+    # Greenfield (no template): initialize the empty DB with `-i base` in an
+    # isolated, short-lived container BEFORE the serving container exists, so
+    # the init is the only Odoo process touching the DB. This avoids the
+    # registry-signaling race between the serving PID1 and an in-container
+    # `-i base` exec (UniqueViolation on orm_signaling_registry).
+    if template_name is None:
+        logger.info(
+            "No template — initialising Odoo with -i base (isolated container)",
+            extra={"env_name": env_name},
+        )
+        setup_logs.append(
+            _init_empty_database(
+                client, settings, odoo_image, env_db, odoo_env, odoo_volumes, env_name
+            )
+        )
+
     container = client.containers.run(**run_kwargs)
 
     if odoo_conf_to_copy:
         _copy_file_to_container(container, odoo_conf_to_copy, "/etc/odoo")
 
-    setup_logs: list[str] = []
-
-    if template_name is None:
-        logger.info(
-            "No template — initialising Odoo with -i base",
-            extra={"env_name": env_name},
-        )
-        apt_log = _install_apt_packages(container, repo_path)
-        if apt_log:
-            setup_logs.append(apt_log)
-        _, pip_log = _install_pip_requirements(container, repo_path, restart=False)
-        if pip_log:
-            setup_logs.append(pip_log)
-        init_cmd = (
-            f"/entrypoint.sh odoo -d {env_db} -i base --stop-after-init --no-http"
-        )
-        exit_code, output = container.exec_run(init_cmd)
-        output_str = (
-            output.decode("utf-8") if isinstance(output, bytes) else str(output)
-        )
-        if exit_code != 0:
-            logger.error(
-                "Odoo base init failed (exit %d): %s",
-                exit_code,
-                output_str,
-                extra={"env_name": env_name},
-            )
-            setup_logs.append(
-                f"[INIT] odoo -i base FAILED (exit {exit_code}):\n{output_str}"
-            )
-        else:
-            setup_logs.append("[INIT] odoo -i base completed successfully")
-        container.restart()
-        logger.info("Container restarted after base init", extra={"env_name": env_name})
-    else:
-        apt_log = _install_apt_packages(container, repo_path)
-        if apt_log:
-            setup_logs.append(apt_log)
-        _, pip_log = _install_pip_requirements(container, repo_path)
-        if pip_log:
-            setup_logs.append(pip_log)
+    # Install repo apt/pip dependencies onto the serving container (both paths).
+    # base needs no custom deps, so this runs after the DB is ready.
+    apt_log = _install_apt_packages(container, repo_path)
+    if apt_log:
+        setup_logs.append(apt_log)
+    _, pip_log = _install_pip_requirements(container, repo_path)
+    if pip_log:
+        setup_logs.append(pip_log)
 
     # --- Sanitize environment database ---
     if sanitize and template_name is not None:

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -586,6 +586,7 @@ def create_environment(
     sanitize: bool = True,
     auto_install_modules: list[str] | None = None,
     env_vars: dict[str, str] | None = None,
+    local_path: str = "",
 ) -> dict[str, str]:
     env_name = env_name or branch
     start_time = time.time()
@@ -629,7 +630,15 @@ def create_environment(
 
     _cleanup_old_environment(client, settings, team, env_name)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
-    repo_path = get_repo_path(env_name, team.workspaces_dir)
+    # Live-mount mode (stdio/local): bind-mount the agent's own checkout
+    # directly instead of cloning. The repo lives OUTSIDE the managed
+    # workspace, so it is never touched by cleanup/delete.
+    local_mount = bool(local_path)
+    repo_path = (
+        os.path.abspath(local_path)
+        if local_mount
+        else get_repo_path(env_name, team.workspaces_dir)
+    )
     env_db = get_db_name(env_name, team.team_id)
 
     labels = {
@@ -647,6 +656,8 @@ def create_environment(
         labels["oduflow.extra_addons"] = json.dumps(extra_addons)
     if git_user:
         labels["oduflow.git_user"] = git_user
+    if local_mount:
+        labels["oduflow.local_path"] = repo_path
     if auto_install_modules:
         labels["oduflow.auto_install_modules"] = ",".join(auto_install_modules)
     if env_vars:
@@ -683,52 +694,68 @@ def create_environment(
 
     os.makedirs(workspace_path, exist_ok=True)
 
-    git_env = git_env_for_team(team.git_credentials_file())
-
-    from oduflow.git_ops import inject_credential_user
-
-    clone_url = inject_credential_user(repo_url, git_user)
-
-    auth_keywords = (
-        "Authentication failed",
-        "could not read Username",
-        "Permission denied",
-        "Repository not found",
-        "terminal prompts disabled",
-        "Invalid username or password",
-    )
-
-    try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--branch",
-                branch,
-                "--depth",
-                "1",
-                clone_url,
-                repo_path,
-            ],
-            check=True,
-            capture_output=True,
-            timeout=60,
-            env=git_env,
-        )
-    except subprocess.CalledProcessError as e:
-        error_msg = e.stderr.decode("utf-8") if e.stderr else str(e)
-        if any(kw.lower() in error_msg.lower() for kw in auth_keywords):
-            raise RepoAuthError(
-                f"Git authentication failed for {sanitize_repo_url(repo_url)}. "
-                f"Call 'setup_repo_auth' first to cache credentials."
+    if local_mount:
+        # No clone: the agent's checkout is bind-mounted live. The directory
+        # must already exist on the host (validated in the tool layer too).
+        if not os.path.isdir(repo_path):
+            raise PrerequisiteNotMetError(
+                f"local_path does not exist or is not a directory: {repo_path}"
             )
-        raise ExternalCommandError("git clone", e.returncode, error_msg)
-    except subprocess.TimeoutExpired:
-        raise ExternalCommandError(
-            "git clone",
-            -1,
-            "Repository clone timed out (60s). Repository may be too large or network is slow.",
+        logger.info("Live-mount mode: using local checkout at %s", repo_path)
+        # Baseline for non-git change detection: first pull_and_apply diffs
+        # against this snapshot. (Git checkouts use working-tree diff instead.)
+        try:
+            with open(_mtime_snapshot_path(env_name, team), "w") as _snap:
+                json.dump(_scan_mtimes(repo_path), _snap)
+        except OSError:
+            pass
+    else:
+        git_env = git_env_for_team(team.git_credentials_file())
+
+        from oduflow.git_ops import inject_credential_user
+
+        clone_url = inject_credential_user(repo_url, git_user)
+
+        auth_keywords = (
+            "Authentication failed",
+            "could not read Username",
+            "Permission denied",
+            "Repository not found",
+            "terminal prompts disabled",
+            "Invalid username or password",
         )
+
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--branch",
+                    branch,
+                    "--depth",
+                    "1",
+                    clone_url,
+                    repo_path,
+                ],
+                check=True,
+                capture_output=True,
+                timeout=60,
+                env=git_env,
+            )
+        except subprocess.CalledProcessError as e:
+            error_msg = e.stderr.decode("utf-8") if e.stderr else str(e)
+            if any(kw.lower() in error_msg.lower() for kw in auth_keywords):
+                raise RepoAuthError(
+                    f"Git authentication failed for {sanitize_repo_url(repo_url)}. "
+                    f"Call 'setup_repo_auth' first to cache credentials."
+                )
+            raise ExternalCommandError("git clone", e.returncode, error_msg)
+        except subprocess.TimeoutExpired:
+            raise ExternalCommandError(
+                "git clone",
+                -1,
+                "Repository clone timed out (60s). Repository may be too large or network is slow.",
+            )
 
     # --- Extra addons worktrees ---
     extra_mount_paths = []
@@ -1012,6 +1039,7 @@ def create_environment(
         "setup_logs": setup_logs,
     }
     result["extra_addons"] = extra_addons or {}
+    result["local_path"] = repo_path if local_mount else ""
     result["elapsed_seconds"] = round(time.time() - start_time, 1)
     return result
 
@@ -1424,20 +1452,210 @@ def get_environment_info(
     return result
 
 
-def pull_environment(
-    settings: Settings, team: TeamSettings, env_name: str
+def _is_git_repo(path: str) -> bool:
+    try:
+        r = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+        )
+        return r.returncode == 0 and r.stdout.strip() == "true"
+    except OSError:
+        return False
+
+
+def _git_working_changes(repo_path: str) -> list[str]:
+    """Paths changed in the working tree vs HEAD plus untracked files.
+
+    Returned relative to *repo_path* — suitable for ``classify_changes``. This
+    is "since the last commit", so committing after applying gives the cleanest
+    signal; otherwise cumulative uncommitted edits are re-evaluated each call.
+    """
+    changed: list[str] = []
+    try:
+        tracked = subprocess.run(
+            ["git", "-C", repo_path, "diff", "--name-only", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        if tracked.returncode == 0:
+            changed.extend(tracked.stdout.splitlines())
+    except OSError:
+        pass
+    try:
+        untracked = subprocess.run(
+            ["git", "-C", repo_path, "ls-files", "--others", "--exclude-standard"],
+            capture_output=True,
+            text=True,
+        )
+        if untracked.returncode == 0:
+            changed.extend(untracked.stdout.splitlines())
+    except OSError:
+        pass
+    return [f for f in changed if f]
+
+
+_MTIME_SKIP_DIRS = {".git", "__pycache__", ".idea", ".vscode", "node_modules"}
+
+
+def _scan_mtimes(root: str) -> dict[str, float]:
+    """Map of relative-path -> mtime for files under *root* (cheap: stat only)."""
+    out: dict[str, float] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _MTIME_SKIP_DIRS]
+        for f in filenames:
+            if f.endswith((".pyc", ".pyo")):
+                continue
+            fp = os.path.join(dirpath, f)
+            try:
+                out[os.path.relpath(fp, root)] = os.path.getmtime(fp)
+            except OSError:
+                pass
+    return out
+
+
+def _mtime_snapshot_path(env_name: str, team: TeamSettings) -> str:
+    return os.path.join(
+        get_workspace_path(env_name, team.workspaces_dir), ".oduflow_mtimes.json"
+    )
+
+
+def _detect_local_changes(
+    repo_path: str, env_name: str, team: TeamSettings
+) -> tuple[str | None, list[str]]:
+    """Return ``(base_ref, changed_files)`` for a live-mounted checkout.
+
+    Git checkout → working-tree diff vs HEAD + untracked, ``base_ref="HEAD"``
+    (enables deep field/manifest guardrail checks). Non-git → mtime snapshot
+    diff, ``base_ref=None`` (path-only guardrail). The snapshot is refreshed
+    every call so each apply reports changes since the previous one.
+    """
+    if _is_git_repo(repo_path):
+        return "HEAD", _git_working_changes(repo_path)
+
+    snap_path = _mtime_snapshot_path(env_name, team)
+    current = _scan_mtimes(repo_path)
+    old: dict[str, float] = {}
+    if os.path.isfile(snap_path):
+        try:
+            with open(snap_path) as f:
+                old = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            old = {}
+    changed = [p for p, m in current.items() if old.get(p) != m]
+    try:
+        with open(snap_path, "w") as f:
+            json.dump(current, f)
+    except OSError:
+        pass
+    return None, changed
+
+
+def _apply_actions(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    odoo_container_name: str,
+    *,
+    to_install: list[str],
+    to_upgrade: list[str],
+    do_restart: bool,
+    changed_files: list[str],
 ) -> dict[str, Any]:
-    from oduflow.git_analysis import classify_changes
+    """Run install/upgrade/restart and build the result dict (shared by the
+    explicit and auto paths of :func:`pull_environment`)."""
+    from oduflow.docker_ops.odoo_ops import (
+        install_odoo_modules,
+        upgrade_odoo_modules,
+    )
+
+    if to_install or to_upgrade:
+        messages: list[str] = []
+        odoo_output_parts: list[str] = []
+        last_exit_code = 0
+        if to_install:
+            res = install_odoo_modules(settings, team, env_name, *to_install)
+            last_exit_code = res["exit_code"]
+            messages.append(f"Installed modules: {','.join(to_install)}")
+            if res.get("output"):
+                odoo_output_parts.append(res["output"])
+        if to_upgrade:
+            res = upgrade_odoo_modules(settings, team, env_name, *to_upgrade)
+            last_exit_code = res["exit_code"]
+            messages.append(f"Upgraded modules: {','.join(to_upgrade)}")
+            if res.get("output"):
+                odoo_output_parts.append(res["output"])
+        client.containers.get(odoo_container_name).restart()
+        messages.append("Container restarted.")
+        logger.info(
+            "Container restarted after module update", extra={"env_name": env_name}
+        )
+        return {
+            "action": "install" if to_install else "upgrade",
+            "modules_installed": to_install,
+            "modules_upgraded": to_upgrade,
+            "exit_code": last_exit_code,
+            "changed_files": changed_files,
+            "message": " ".join(messages),
+            "output": "\n".join(odoo_output_parts),
+        }
+
+    if do_restart:
+        client.containers.get(odoo_container_name).restart()
+        logger.info("Container restarted", extra={"env_name": env_name})
+        return {
+            "action": "restart",
+            "changed_files": changed_files,
+            "message": "Container restarted.",
+        }
+
+    if changed_files:
+        return {
+            "action": "refresh",
+            "changed_files": changed_files,
+            "message": (
+                "Only XML/JS changes detected. Refresh your browser "
+                "(--dev=xml is active)."
+            ),
+        }
+    return {"action": "none", "message": "No changes detected."}
+
+
+def pull_environment(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    *,
+    install: list[str] | None = None,
+    upgrade: list[str] | None = None,
+    restart: bool = False,
+    strict: bool = False,
+) -> dict[str, Any]:
+    """Sync code into an environment and apply the right Odoo action.
+
+    Code-delivery mode is chosen from the env's labels:
+
+    * **git** (default) — ``git pull`` the branch (and extra-addon worktrees)
+      into the managed clone, which is bind-mounted into the container.
+    * **live-mount** (``oduflow.local_path`` label, stdio/local only) — the
+      agent's checkout is already bind-mounted, so there is nothing to pull;
+      changes are detected straight from the working tree.
+
+    Action selection:
+
+    * **explicit** — when any of ``install`` / ``upgrade`` / ``restart`` is
+      given, do exactly that. A guardrail compares the request against what the
+      changed files suggest and returns non-blocking ``warnings`` (or, with
+      ``strict=True``, refuses with ``action="blocked"``).
+    * **auto** — otherwise fall back to ``classify_changes`` (unchanged legacy
+      behavior), useful for pulling commits you did not author.
+    """
+    from oduflow.git_analysis import guardrail_warnings, recommend
     from oduflow.git_ops import pull_repo
 
     client = get_client()
     odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
-    repo_path = get_repo_path(env_name, team.workspaces_dir)
-
-    if not os.path.isdir(repo_path):
-        raise NotFoundError(
-            f"Repository for branch '{env_name}' not found at {repo_path}"
-        )
 
     try:
         container_obj = client.containers.get(odoo_container_name)
@@ -1446,149 +1664,112 @@ def pull_environment(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
 
-    _trace("pull_environment(%s): git pull started", env_name)
-    git_branch = container_obj.labels.get("oduflow.git_branch", env_name)
-    old_head, changed_files = pull_repo(
-        repo_path, git_branch, cred_file=team.git_credentials_file()
-    )
+    local_path = container_obj.labels.get("oduflow.local_path", "")
+    is_local = bool(local_path)
+    repo_path = local_path or get_repo_path(env_name, team.workspaces_dir)
 
-    # --- Pull extra addon worktrees ---
-    extra_changed_files: list[str] = []
-    extra_addons_raw = container_obj.labels.get("oduflow.extra_addons", "{}")
-    try:
-        extra_addons = json.loads(extra_addons_raw)
-    except (json.JSONDecodeError, TypeError):
-        extra_addons = {}
+    if not os.path.isdir(repo_path):
+        raise NotFoundError(
+            f"Repository for environment '{env_name}' not found at {repo_path}"
+        )
 
-    if extra_addons:
-        from oduflow.extra_addons import pull_extra_worktree
+    # --- 1. Sync code + detect changed files and a diff base ---
+    if is_local:
+        _trace("pull_environment(%s): live-mount, detecting local changes", env_name)
+        base_ref, all_changed = _detect_local_changes(repo_path, env_name, team)
+    else:
+        _trace("pull_environment(%s): git pull started", env_name)
+        git_branch = container_obj.labels.get("oduflow.git_branch", env_name)
+        old_head, changed_files = pull_repo(
+            repo_path, git_branch, cred_file=team.git_credentials_file()
+        )
+        base_ref = old_head
 
-        workspace_path = get_workspace_path(env_name, team.workspaces_dir)
-        extra_dir = os.path.join(workspace_path, "extra")
-        for repo_name, branch in extra_addons.items():
-            wt_path = os.path.join(extra_dir, repo_name)
-            if not os.path.isdir(wt_path):
-                _trace(
-                    "pull_environment(%s): extra worktree %s not found, skipping",
-                    env_name,
-                    wt_path,
-                )
-                continue
-            _trace(
-                "pull_environment(%s): pulling extra addon %s@%s",
-                env_name,
-                repo_name,
-                branch,
+        extra_changed_files: list[str] = []
+        try:
+            extra_addons = json.loads(
+                container_obj.labels.get("oduflow.extra_addons", "{}")
             )
-            _extra_old, extra_files = pull_extra_worktree(
-                team, repo_name, branch, wt_path
-            )
-            extra_changed_files.extend(extra_files)
-            if extra_files:
-                _trace(
-                    "pull_environment(%s): extra addon %s: %d files changed",
-                    env_name,
-                    repo_name,
-                    len(extra_files),
-                )
+        except (json.JSONDecodeError, TypeError):
+            extra_addons = {}
+        if extra_addons:
+            from oduflow.extra_addons import pull_extra_worktree
 
-    all_changed = changed_files + extra_changed_files
-    if not all_changed:
-        _trace("pull_environment(%s): no changes, already up to date", env_name)
-        return {"action": "none", "message": "Already up to date."}
+            extra_dir = os.path.join(
+                get_workspace_path(env_name, team.workspaces_dir), "extra"
+            )
+            for repo_name, branch in extra_addons.items():
+                wt_path = os.path.join(extra_dir, repo_name)
+                if not os.path.isdir(wt_path):
+                    continue
+                _extra_old, extra_files = pull_extra_worktree(
+                    team, repo_name, branch, wt_path
+                )
+                extra_changed_files.extend(extra_files)
+        all_changed = changed_files + extra_changed_files
 
     _trace(
-        "pull_environment(%s): %d files changed: %s",
+        "pull_environment(%s): %d changed files: %s",
         env_name,
         len(all_changed),
         all_changed,
     )
 
-    analysis = classify_changes(all_changed, repo_path, base_ref=old_head)
-    action = analysis["action"]
-    _trace("pull_environment(%s): classify result action=%s", env_name, action)
-
-    if action in ("install", "upgrade"):
-        from oduflow.docker_ops.odoo_ops import (
-            install_odoo_modules,
-            upgrade_odoo_modules,
-        )
-
-        to_install = analysis["modules_to_install"]
-        to_upgrade = analysis["modules_to_upgrade"]
-        messages = []
-        last_exit_code = 0
-        odoo_output_parts: list[str] = []
-
-        if to_install:
-            _trace("pull_environment(%s): installing modules %s", env_name, to_install)
-            res = install_odoo_modules(settings, team, env_name, *to_install)
-            last_exit_code = res["exit_code"]
-            _trace(
-                "pull_environment(%s): install exit_code=%d",
-                env_name,
-                last_exit_code,
-            )
-            messages.append(f"Installed modules: {','.join(to_install)}")
-            if res.get("output"):
-                odoo_output_parts.append(res["output"])
-
-        if to_upgrade:
-            _trace("pull_environment(%s): upgrading modules %s", env_name, to_upgrade)
-            res = upgrade_odoo_modules(settings, team, env_name, *to_upgrade)
-            last_exit_code = res["exit_code"]
-            _trace(
-                "pull_environment(%s): upgrade exit_code=%d",
-                env_name,
-                last_exit_code,
-            )
-            messages.append(f"Upgraded modules: {','.join(to_upgrade)}")
-            if res.get("output"):
-                odoo_output_parts.append(res["output"])
-
-        container = client.containers.get(odoo_container_name)
-        container.restart()
-        _trace(
-            "pull_environment(%s): container RESTARTED after install/upgrade",
-            env_name,
-        )
-        logger.info(
-            "Container restarted after module update", extra={"env_name": env_name}
-        )
-        messages.append("Container restarted.")
-        return {
-            "action": action,
-            "modules_installed": to_install,
-            "modules_upgraded": to_upgrade,
-            "exit_code": last_exit_code,
-            "changed_files": all_changed,
-            "message": " ".join(messages),
-            "output": "\n".join(odoo_output_parts),
-        }
-
-    if action == "restart":
-        container = client.containers.get(odoo_container_name)
-        container.restart()
-        _trace(
-            "pull_environment(%s): container RESTARTED (Python files changed)",
-            env_name,
-        )
-        logger.info("Container restarted after pull", extra={"env_name": env_name})
-        return {
-            "action": "restart",
-            "changed_files": all_changed,
-            "message": "Container restarted (Python files changed).",
-        }
-
-    _trace(
-        "pull_environment(%s): NO restart, action=refresh (hot-reload only)",
-        env_name,
+    # --- 2. Determine actions: explicit (agent-driven) vs auto (classify) ---
+    explicit = bool(install) or bool(upgrade) or restart
+    recommended = (
+        recommend(all_changed, repo_path, base_ref)
+        if all_changed
+        else {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
     )
-    return {
-        "action": "refresh",
-        "changed_files": all_changed,
-        "message": "Only XML/JS changes detected. Refresh your browser (--dev=xml is active).",
-    }
+
+    warnings: list[str] = []
+    if explicit:
+        to_install = list(install or [])
+        to_upgrade = list(upgrade or [])
+        do_restart = bool(restart)
+        if all_changed:
+            warnings = guardrail_warnings(
+                recommended, to_install, to_upgrade, do_restart
+            )
+        if strict and warnings:
+            return {
+                "action": "blocked",
+                "warnings": warnings,
+                "changed_files": all_changed,
+                "message": (
+                    "Guardrail (strict) blocked apply: the requested action looks "
+                    "incomplete for the detected changes. Re-call with the suggested "
+                    "install/upgrade, or pass strict=False to apply anyway."
+                ),
+            }
+    else:
+        if not all_changed:
+            return {
+                "action": "none",
+                "message": (
+                    "No local changes detected." if is_local else "Already up to date."
+                ),
+            }
+        to_install = list(recommended.get("modules_to_install", []))
+        to_upgrade = list(recommended.get("modules_to_upgrade", []))
+        do_restart = recommended.get("action") == "restart"
+
+    # --- 3. Execute ---
+    result = _apply_actions(
+        client,
+        settings,
+        team,
+        env_name,
+        odoo_container_name,
+        to_install=to_install,
+        to_upgrade=to_upgrade,
+        do_restart=do_restart,
+        changed_files=all_changed,
+    )
+    if warnings:
+        result["warnings"] = warnings
+    return result
 
 
 def update_environment(

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -501,6 +501,15 @@ def reload_template(
 
     _copy_file_to_container(db_container, resolved_dump, "/tmp")
 
+    # pg_restore runs with --no-owner so restored objects are owned by the
+    # restoring superuser, not by whatever role the dump recorded. For
+    # env-derived templates that role is the source env's per-env role
+    # (u_<team>_<env>), which is dropped when the env is deleted — keeping it as
+    # owner makes deletion fail with "objects depend on it" and leaks an orphan
+    # role. create_environment re-assigns ownership to the new per-env role when
+    # provisioning from a template. (--no-owner is meaningful only at restore
+    # time for archive formats. The psql path for plain-SQL/external dumps is
+    # left untouched.)
     restore_tool = "psql" if use_psql else "pg_restore"
     if is_gzipped:
         if use_psql:
@@ -510,7 +519,7 @@ def reload_template(
         else:
             pipeline = (
                 f"gunzip -c /tmp/{tmp_name} | "
-                f"pg_restore -U {settings.db_user} -d {tpl_db}"
+                f"pg_restore --no-owner -U {settings.db_user} -d {tpl_db}"
             )
         restore_cmd = ["bash", "-c", f"set -o pipefail; {pipeline}"]
     else:
@@ -527,6 +536,7 @@ def reload_template(
         else:
             restore_cmd = [
                 "pg_restore",
+                "--no-owner",
                 "-U",
                 settings.db_user,
                 "-d",
@@ -866,7 +876,9 @@ def publish_env_as_template(
     _wait_pg_ready(client, settings)
     db_container = client.containers.get(settings.shared_db_container)
 
-    # 1. pg_dump branch DB → new template dump
+    # 1. pg_dump branch DB → new template dump. Ownership is stripped at restore
+    # time (pg_restore --no-owner in reload_template), NOT here: --no-owner is
+    # ignored by pg_dump for the -Fc archive format.
     dump_path = team.get_template_sql_path(template_name)
     os.makedirs(os.path.dirname(dump_path), exist_ok=True)
     dump_file = f"/tmp/{env_db}.dump"

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -344,3 +344,126 @@ def _check_manifest_changes(
 
     _trace("_check_manifest(%s) -> no significant changes", module)
     return None
+
+
+def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
+    """Path-only classification used when no git *base_ref* is available
+    (a non-git live-mount).
+
+    Coarser than :func:`classify_changes`: with no access to old file content
+    it cannot tell a field change from a method change in a ``.py`` (treated as
+    *restart*), nor a new module from a changed one (a changed
+    ``__manifest__.py`` is treated as *upgrade*). Returns the same dict shape.
+    """
+    if not changed_files:
+        return {
+            "action": "none",
+            "modules_to_upgrade": [],
+            "modules_to_install": [],
+            "details": {},
+        }
+
+    py_changed = False
+    xml_hot: list[str] = []
+    xml_security: list[str] = []
+    js_changed: list[str] = []
+    modules_to_upgrade: set[str] = set()
+
+    for f in changed_files:
+        ext = os.path.splitext(f)[1].lower()
+        module = _get_module_name(f, repo_path)
+
+        if os.path.basename(f) == "__manifest__.py" and module:
+            modules_to_upgrade.add(module)
+            continue
+        if ext == ".py":
+            py_changed = True
+            continue
+        if ext == ".xml":
+            if (_is_security_path(f) or _is_data_path(f)) and module:
+                xml_security.append(f)
+                modules_to_upgrade.add(module)
+            else:
+                xml_hot.append(f)
+            continue
+        if ext == ".js":
+            js_changed.append(f)
+
+    details = {
+        "py_changed": py_changed,
+        "xml_hot": xml_hot,
+        "xml_security": xml_security,
+        "manifest_upgrade": sorted(modules_to_upgrade),
+        "manifest_install": [],
+        "js_changed": js_changed,
+    }
+
+    if modules_to_upgrade:
+        return {
+            "action": "upgrade",
+            "modules_to_install": [],
+            "modules_to_upgrade": sorted(modules_to_upgrade),
+            "details": details,
+        }
+    if py_changed:
+        return {
+            "action": "restart",
+            "modules_to_upgrade": [],
+            "modules_to_install": [],
+            "details": details,
+        }
+    return {
+        "action": "refresh",
+        "modules_to_upgrade": [],
+        "modules_to_install": [],
+        "details": details,
+    }
+
+
+def recommend(changed_files: list[str], repo_path: str, base_ref: str | None) -> dict:
+    """Recommended Odoo action for *changed_files*.
+
+    Full :func:`classify_changes` (git-based deep checks) when a *base_ref* is
+    available, else path-only :func:`shallow_classify`.
+    """
+    if base_ref:
+        return classify_changes(changed_files, repo_path, base_ref=base_ref)
+    return shallow_classify(changed_files, repo_path)
+
+
+def guardrail_warnings(
+    recommended: dict,
+    to_install: list[str],
+    to_upgrade: list[str],
+    do_restart: bool,
+) -> list[str]:
+    """Non-blocking warnings comparing the agent's requested action against
+    what the changed files suggest.
+
+    Flags only likely *under*-actions (a needed install/upgrade/restart that
+    appears to be missing) — the agent stays in charge and may legitimately
+    request more than recommended. Returns an empty list when the request
+    covers everything (e.g. in auto mode, where requested == recommended).
+    """
+    warnings: list[str] = []
+    rec_install = set(recommended.get("modules_to_install", []))
+    rec_upgrade = set(recommended.get("modules_to_upgrade", []))
+    requested = set(to_install) | set(to_upgrade)
+
+    for m in sorted(rec_install - set(to_install)):
+        warnings.append(
+            f"Module '{m}' looks new (manifest added) — consider install='{m}' "
+            "(-i); a restart alone won't pick it up."
+        )
+    for m in sorted(rec_upgrade - requested):
+        warnings.append(
+            f"Module '{m}' has data/schema changes (manifest, security/data XML, or a "
+            f"changed field) — consider upgrade='{m}' (-u); a restart won't load "
+            "them into the database."
+        )
+    if recommended.get("action") == "restart" and not do_restart and not requested:
+        warnings.append(
+            "Python code changed — a restart is recommended; an XML/JS-only refresh "
+            "won't reload it."
+        )
+    return warnings

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -434,8 +434,18 @@ def create_environment(
                 effective_repo_url = local_path
         else:
             if not effective_repo_url:
+                sources = [
+                    "repo_url",
+                    "template_name (which supplies repo_url from its metadata)",
+                ]
+                if settings_module.TRANSPORT == "stdio":
+                    sources.append(
+                        "local_path=<abs path> (local live-mount fast-path, stdio only)"
+                    )
                 raise ValueError(
-                    "repo_url is required (not found in template metadata either)."
+                    "No code source for the environment — provide one of: "
+                    + "; ".join(sources)
+                    + "."
                 )
             git_ops.validate_repo_url(effective_repo_url)
 

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -21,6 +21,7 @@ from oduflow.docker_ops import (
     volume_ops,
 )
 from oduflow import git_ops
+from oduflow import settings as settings_module
 from oduflow.errors import FlowError
 from oduflow.locking import LockManager
 from oduflow.output_cache import OutputCache, CachedOutput
@@ -357,6 +358,7 @@ def create_environment(
     sanitize: bool = True,
     auto_install_modules: str = "",
     env_vars: str = "",
+    local_path: str = "",
     ctx: Context = None,
 ) -> str:
     """
@@ -372,6 +374,7 @@ def create_environment(
         sanitize: Sanitize the database after provisioning (default: True). Disables incoming/outgoing mail servers and runs custom scripts from the .odoo_sanitize/ folder in the repository.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
         env_vars: Comma-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). These are added on top of the database connection variables (HOST/USER/PASSWORD).
+        local_path: LOCAL FAST-PATH (stdio transport only). Absolute path to a checkout on THIS host. When set, Oduflow skips git clone and bind-mounts the directory live into the container — your file edits are visible instantly, no git push/pull needed. After editing, call pull_and_apply with explicit install/upgrade/restart to apply. repo_url is not required in this mode. Rejected over http transport.
     """
     import json
 
@@ -414,11 +417,28 @@ def create_environment(
                 if not auto_install_modules:
                     auto_install_modules = metadata.get("auto_install_modules", "")
 
-        if not effective_repo_url:
-            raise ValueError(
-                "repo_url is required (not found in template metadata either)."
-            )
-        git_ops.validate_repo_url(effective_repo_url)
+        local_path = (local_path or "").strip()
+        if local_path:
+            if settings_module.TRANSPORT != "stdio":
+                raise ValueError(
+                    "local_path (live-mount) is only available with the stdio "
+                    "(local) transport, not over http."
+                )
+            local_path = os.path.abspath(os.path.expanduser(local_path))
+            if not os.path.isdir(local_path):
+                raise ValueError(
+                    f"local_path does not exist or is not a directory: {local_path}"
+                )
+            # Live-mount: no remote URL required; label the env with the path.
+            if not effective_repo_url:
+                effective_repo_url = local_path
+        else:
+            if not effective_repo_url:
+                raise ValueError(
+                    "repo_url is required (not found in template metadata either)."
+                )
+            git_ops.validate_repo_url(effective_repo_url)
+
         if not effective_odoo_image:
             raise ValueError(
                 "odoo_image is required (not found in template metadata either)."
@@ -448,6 +468,7 @@ def create_environment(
             sanitize=sanitize,
             auto_install_modules=auto_install_list or None,
             env_vars=parsed_env,
+            local_path=local_path,
         )
 
         from oduflow.telemetry import record_env_created
@@ -471,6 +492,11 @@ def create_environment(
         ]
         if resolved_env_name != branch:
             lines.insert(2, f"Git Branch: {branch}")
+        if result.get("local_path"):
+            lines.append(
+                f"Live-mount: {result['local_path']} "
+                "(edit files directly; call pull_and_apply to apply)"
+            )
         if extra_dict:
             extras_display = ", ".join(
                 f"{name} ({b})" for name, b in extra_dict.items()
@@ -1083,25 +1109,74 @@ def start_environment(env_name: str, wait: bool = True, ctx: Context = None) -> 
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def pull_and_apply(env_name: str, ctx: Context = None) -> str:
+def pull_and_apply(
+    env_name: str,
+    install: str = "",
+    upgrade: str = "",
+    restart: bool = False,
+    strict: bool = False,
+    ctx: Context = None,
+) -> str:
     """
-    Pull latest changes from the remote repository for an environment
-    and take appropriate action based on what changed.
+    Sync the latest code into an environment and apply the right Odoo action.
 
-    Pulls both the main repository and any extra addon worktrees.
+    Works for both code-delivery modes (chosen automatically per environment):
+    - git: pulls the branch (and extra-addon worktrees) into the managed clone.
+    - live-mount (stdio/local, from create_environment(local_path=...)): your
+      edits are already live on disk; this just applies them — no git needed.
 
-    Analyzes changed files and automatically:
-    - Upgrades modules if __manifest__.py version/data/assets changed, or security XML changed
-    - Restarts the container if Python files changed
-    - Does nothing if only XML/JS changed (--dev=xml hot-reloads XML; JS assets are reloaded on browser refresh)
+    Two ways to drive it:
+    - EXPLICIT (recommended — you know what you changed): pass `install` /
+      `upgrade` (comma-separated module names) and/or `restart=True`. A guardrail
+      compares your request against the detected changes and appends non-blocking
+      warnings if something looks missing (e.g. you only restarted but a module's
+      data/schema changed and needs -u). With `strict=True` it refuses instead of
+      warning.
+    - AUTO (leave install/upgrade/restart empty): Oduflow analyzes changed files
+      and decides install/upgrade/restart/refresh itself. Best when pulling
+      commits you did not author.
+
+    Decision rules — what to pass explicitly:
+    - Only view/QWeb XML, JS, CSS changed → nothing; refresh the browser.
+    - Python logic/methods changed (no new fields/models) → restart=True.
+    - A field/model, security or data records, ir.cron, mail templates, or
+      manifest data/depends changed → upgrade="module" (-u): these live in the
+      database and a restart won't load them.
+    - A brand-new module was added → install="module" (-i).
+
+    Errors and tracebacks are returned directly in this response — do NOT call
+    get_environment_logs to check for them.
 
     Args:
-        env_name: The name of the environment to pull updates for.
+        env_name: The environment to apply changes to.
+        install: Comma-separated modules to install (-i).
+        upgrade: Comma-separated modules to upgrade (-u).
+        restart: Restart the Odoo container (for Python-only changes).
+        strict: If True, refuse to apply when the guardrail finds a likely
+            missing action (default False: warn but apply anyway).
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
-    result = env_ops.pull_environment(settings, team, env_name)
+    install_list = [m.strip() for m in install.split(",") if m.strip()]
+    upgrade_list = [m.strip() for m in upgrade.split(",") if m.strip()]
+    result = env_ops.pull_environment(
+        settings,
+        team,
+        env_name,
+        install=install_list or None,
+        upgrade=upgrade_list or None,
+        restart=restart,
+        strict=strict,
+    )
     action = result["action"]
+    warnings = result.get("warnings") or []
+
+    if action == "blocked":
+        lines = ["BLOCKED by guardrail (strict mode):"]
+        lines.extend(f"  ⚠ {w}" for w in warnings)
+        lines.append("")
+        lines.append(result["message"])
+        return "\n".join(lines)
 
     if action == "none":
         return result["message"]
@@ -1116,6 +1191,9 @@ def pull_and_apply(env_name: str, ctx: Context = None) -> str:
         header_lines.append(f"  - {f}")
     if len(result.get("changed_files", [])) > 20:
         header_lines.append(f"  ... and {len(result['changed_files']) - 20} more")
+    if warnings:
+        header_lines.append("Guardrail warnings (applied anyway):")
+        header_lines.extend(f"  ⚠ {w}" for w in warnings)
 
     header = "\n".join(header_lines)
     output = result.get("output", "")
@@ -3052,6 +3130,9 @@ def main() -> None:
     if args.command is None:
         # No subcommand → start the MCP server
         _ensure_initialized(_settings)
+        # Record the active transport so tools can gate local-only features
+        # (e.g. create_environment(local_path=...)) to stdio.
+        settings_module.TRANSPORT = args.transport
         if args.transport == "stdio":
             _start_stdio()
         else:

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -16,6 +16,12 @@ logger = logging.getLogger("oduflow")
 
 TRACE: bool = False
 
+# Active MCP transport for the running server ("stdio" | "http").
+# Set in server.main() before the server starts. Tools use this to gate
+# local-only features (e.g. create_environment(local_path=...)) that must
+# never be exposed over a remote/http transport.
+TRANSPORT: str = "stdio"
+
 
 @dataclass(frozen=True)
 class TeamSettings:

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -31,7 +31,7 @@ MCP endpoint: `http://<host>:8000/mcp`
 | Tool | When to use |
 |---|---|
 | `list_environments` | Check existing environments before creating a new one |
-| `create_environment(branch, env_name?, repo_url, odoo_image, template_name?, env_vars?)` | Provision an environment. `branch` is the git branch; `env_name` defaults to the branch name. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects. `env_vars` is a comma-separated `KEY=VALUE` list injected into the Odoo container |
+| `create_environment(branch, env_name?, repo_url, odoo_image, template_name?, env_vars?, local_path?)` | Provision an environment. `branch` is the git branch; `env_name` defaults to the branch name. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects. `env_vars` is a comma-separated `KEY=VALUE` list injected into the Odoo container. **Local fast-path (stdio only):** pass `local_path="/abs/path/to/checkout"` to bind-mount your local working copy live instead of cloning — edits apply with no git push (see "Local Fast-Path" below). |
 | `get_environment_info(env_name)` | Get full environment details: database name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
 | `delete_environment(env_name)` | Tear down when the task is complete or cancelled |
 | `start_environment` / `stop_environment` | Resume or pause a stopped environment |
@@ -42,7 +42,7 @@ MCP endpoint: `http://<host>:8000/mcp`
 
 | Tool | When to use |
 |---|---|
-| `pull_and_apply(env_name)` | **Always call after every `git push`**. Oduflow analyzes changed files and automatically decides: install new modules, upgrade changed modules, restart for Python changes, or do nothing for XML/JS (hot-reloaded). You do NOT need to call `restart` or `upgrade` manually. **Errors and tracebacks are returned directly in the tool response** — do NOT call `get_environment_logs` to check for errors after this tool. |
+| `pull_and_apply(env_name, install?, upgrade?, restart?, strict?)` | Sync code and apply the right action. **git mode:** call after every `git push`. **live-mount mode:** call after editing files (no push needed). **Auto** (no args): Oduflow analyzes the diff and decides install/upgrade/restart/refresh — best when pulling commits you did not author. **Explicit** (recommended when you authored the edits): pass `install`/`upgrade` (comma-separated modules) and/or `restart=True` per the decision rules below; a guardrail warns if your action looks incomplete (`strict=True` refuses instead). **Errors and tracebacks are returned directly in the tool response** — do NOT call `get_environment_logs` after this tool. |
 
 ### Odoo Module Operations
 
@@ -184,9 +184,10 @@ The summary footer looks like:
 4. **Show the URL**: Always display the environment URL to the user after creation.
 
 ### Sync & Work Cycle
-1. After every `git push`, **always** call `pull_and_apply`. It handles install/upgrade/restart automatically.
-2. Do **not** call `restart_environment` or `upgrade_odoo_modules` manually unless debugging a specific issue — `pull_and_apply` already does the right thing.
-3. After `pull_and_apply`, **read the tool response** for errors. Do NOT call `get_environment_logs` — install/upgrade output is returned directly and does not appear in container logs.
+1. After every `git push` (git mode) — or after editing files directly (live-mount mode) — call `pull_and_apply`.
+2. When **you** authored the edits, pass the action explicitly (`install` / `upgrade` / `restart`) per the decision rules below — you know what you changed, so don't make Oduflow guess. Leave them empty (auto mode) only when pulling commits you did not author.
+3. Do **not** call `restart_environment` or `upgrade_odoo_modules` separately for a normal sync — `pull_and_apply` does it in one call.
+4. After `pull_and_apply`, **read the tool response** for errors and any guardrail ⚠ warnings. Do NOT call `get_environment_logs` — install/upgrade output is returned directly and does not appear in container logs.
 
 ### Debugging Loop
 ```
@@ -213,7 +214,7 @@ The environment container runs **remotely** and has access only to the git repos
 - Run any git commands (`git rebase`, `git pull`, `git checkout`, `git stash`, etc.)
 - Modify module files in any way
 
-**If you need to change code** — always do it locally, then `git commit` → `git push` → `pull_and_apply`. This is the only correct way to deliver code changes to the environment.
+**If you need to change code** — in **git mode**, do it locally, then `git commit` → `git push` → `pull_and_apply`. In **live-mount mode** (env created with `local_path`), edit the files in that local directory directly and call `pull_and_apply` — no commit/push required (the directory is bind-mounted live into the container). Either way, never edit code *inside* the container.
 
 **Non-standard operations** (e.g., `apt install`, `pip install`, modifying system configs) are possible but **require explicit user confirmation** before proceeding — explain what you want to do and why.
 
@@ -243,6 +244,40 @@ When you call `pull_and_apply`, Oduflow analyzes every changed file:
 | `*.xml` (views) / `*.js` / `*.css` / `*.scss` | **Nothing** — hot-reloaded via `--dev=xml` (refresh browser) |
 
 Priority: install > upgrade > restart > refresh (no action).
+
+This auto-classification runs when you call `pull_and_apply` **without** `install`/`upgrade`/`restart`. Use it for pulling commits you did not author. When you authored the edits, prefer the explicit form (next section).
+
+---
+
+## Apply Decision Rules (explicit mode)
+
+When you changed the code yourself, you already know what to do — tell `pull_and_apply` directly. Pick by **where the changed thing lives**:
+
+| You changed… | It lives in… | Pass |
+|---|---|---|
+| view/QWeb XML, JS, CSS, static assets | the browser / read from file | nothing — just refresh the browser (`--dev=xml` is active) |
+| Python logic/methods only (no new/changed fields or models) | the worker process | `restart=True` |
+| a **field** or model (`fields.*`, new model, `_inherit`/`_name`), security/data records, `ir.cron`, mail templates, `ir.model.access`, or manifest `data`/`depends` | the **database** (loaded only on install/upgrade) | `upgrade="module"` (-u) |
+| a brand-new, not-yet-installed module | — | `install="module"` (-i) |
+
+⚠️ **Sharp edge:** editing a `.py` to add/change a **field** needs `upgrade` (-u), not `restart` — even though it feels like a code change. A restart reloads code but won't touch the DB schema/registry.
+
+### Guardrail
+In explicit mode, Oduflow cross-checks your action against the detected diff and appends non-blocking ⚠ warnings if something looks missing (e.g. you restarted but a module's data/schema changed and needs `-u`). It still applies what you asked — read the warnings and re-call with the correction if it's right. Pass `strict=True` to make it refuse instead of warn.
+
+---
+
+## Local Fast-Path (stdio transport)
+
+When Oduflow runs locally (stdio) on the same machine as you, skip the GitHub round-trip entirely:
+
+1. `create_environment(branch=..., odoo_image=..., template_name=..., local_path="/abs/path/to/your/checkout")` — bind-mounts your working copy live into the container instead of cloning. `repo_url` is not needed.
+2. Edit files in that directory with your normal tools. Changes are visible inside the container **instantly** (no commit, no push, no clone).
+3. `pull_and_apply(env_name, upgrade="my_module")` (or `restart=True`, or `install=...`) to apply — per the decision rules above. XML view edits need no call at all: just refresh the browser.
+
+Notes:
+- `local_path` is **rejected over http transport** (a remote server must not mount client paths).
+- Change detection uses your checkout's git working tree (uncommitted edits included), so committing after applying gives the cleanest signal. A non-git directory falls back to file-mtime detection with a coarser guardrail.
 
 ---
 

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -1,0 +1,110 @@
+"""Unit tests for the apply guardrail: shallow_classify, recommend, and
+guardrail_warnings (pure functions — no Docker, no git)."""
+
+from oduflow.git_analysis import guardrail_warnings, recommend, shallow_classify
+
+
+class TestShallowClassify:
+    def test_empty(self):
+        assert shallow_classify([])["action"] == "none"
+
+    def test_python_only_restart(self):
+        r = shallow_classify(["sale/models/sale.py"])
+        assert r["action"] == "restart"
+
+    def test_security_xml_upgrade(self):
+        r = shallow_classify(["sale/security/groups.xml"])
+        assert r["action"] == "upgrade"
+        assert "sale" in r["modules_to_upgrade"]
+
+    def test_data_xml_upgrade(self):
+        r = shallow_classify(["sale/data/cron.xml"])
+        assert r["action"] == "upgrade"
+        assert "sale" in r["modules_to_upgrade"]
+
+    def test_view_xml_refresh(self):
+        r = shallow_classify(["sale/views/sale_views.xml"])
+        assert r["action"] == "refresh"
+
+    def test_new_manifest_upgrade(self):
+        r = shallow_classify(["sale/__manifest__.py"])
+        assert r["action"] == "upgrade"
+        assert "sale" in r["modules_to_upgrade"]
+
+    def test_js_refresh(self):
+        r = shallow_classify(["sale/static/src/js/widget.js"])
+        assert r["action"] == "refresh"
+
+    def test_upgrade_beats_restart(self):
+        # A module with both a .py and a security XML change → upgrade wins.
+        r = shallow_classify(["sale/models/sale.py", "sale/security/groups.xml"])
+        assert r["action"] == "upgrade"
+
+
+class TestRecommend:
+    def test_no_base_ref_uses_shallow(self):
+        # Without git there is no old content; a .py change can only be a
+        # restart (field changes are undetectable) — shallow path.
+        r = recommend(["sale/models/sale.py"], "/tmp/does-not-exist", None)
+        assert r["action"] == "restart"
+
+    def test_no_base_ref_security_upgrade(self):
+        r = recommend(["sale/security/groups.xml"], "/tmp/does-not-exist", None)
+        assert r["action"] == "upgrade"
+        assert "sale" in r["modules_to_upgrade"]
+
+
+class TestGuardrailWarnings:
+    def test_no_warnings_when_upgrade_covered(self):
+        rec = {
+            "action": "upgrade",
+            "modules_to_install": [],
+            "modules_to_upgrade": ["sale"],
+        }
+        assert guardrail_warnings(rec, [], ["sale"], False) == []
+
+    def test_missing_upgrade_warns(self):
+        rec = {
+            "action": "upgrade",
+            "modules_to_install": [],
+            "modules_to_upgrade": ["sale"],
+        }
+        # Agent only asked for a restart — the DB-data change is unapplied.
+        warns = guardrail_warnings(rec, [], [], True)
+        assert any("sale" in w and "-u" in w for w in warns)
+
+    def test_missing_install_warns(self):
+        rec = {
+            "action": "install",
+            "modules_to_install": ["newmod"],
+            "modules_to_upgrade": [],
+        }
+        warns = guardrail_warnings(rec, [], [], False)
+        assert any("newmod" in w and "-i" in w for w in warns)
+
+    def test_python_restart_missing_warns(self):
+        rec = {
+            "action": "restart",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+        warns = guardrail_warnings(rec, [], [], False)
+        assert any("restart" in w.lower() for w in warns)
+
+    def test_install_request_covers_recommended_upgrade(self):
+        # Requesting -i for a module also satisfies a recommended -u for it.
+        rec = {
+            "action": "upgrade",
+            "modules_to_install": [],
+            "modules_to_upgrade": ["sale"],
+        }
+        assert guardrail_warnings(rec, ["sale"], [], False) == []
+
+    def test_over_request_does_not_warn(self):
+        # Asking for more than recommended is allowed (no warning).
+        rec = {
+            "action": "refresh",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+        assert guardrail_warnings(rec, [], ["sale"], False) == []

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -164,6 +164,7 @@ class TestCreateEnvironment:
     ):
         mock_odoo = MagicMock()
         mock_odoo.exec_run.return_value = (0, b"OK")
+        mock_odoo.wait.return_value = {"StatusCode": 0}
         mock_docker_client.containers.run.return_value = mock_odoo
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
@@ -181,7 +182,8 @@ class TestCreateEnvironment:
         assert mock_sql.call_count == 2
         mock_creds.assert_called_once()
         mock_role.assert_called_once()
-        mock_docker_client.containers.run.assert_called_once()
+        # Greenfield: isolated init container + serving container = 2 run calls.
+        assert mock_docker_client.containers.run.call_count == 2
         mock_alloc.assert_called_once()
 
     @patch("oduflow.docker_ops.env_ops._db_exists", return_value=True)
@@ -263,6 +265,7 @@ class TestCreateEnvironment:
     ):
         mock_odoo = MagicMock()
         mock_odoo.exec_run.return_value = (0, b"OK")
+        mock_odoo.wait.return_value = {"StatusCode": 0}
         mock_docker_client.containers.run.return_value = mock_odoo
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
@@ -282,12 +285,13 @@ class TestCreateEnvironment:
         assert "TEMPLATE" not in create_db_call[0][2]
         # Should NOT mount filestore
         mock_mount.assert_not_called()
-        # Should run -i base --stop-after-init
-        init_cmd = mock_odoo.exec_run.call_args[0][0]
-        assert "-i base" in init_cmd
-        assert "--stop-after-init" in init_cmd
-        # Should restart after init
-        mock_odoo.restart.assert_called_once()
+        # Greenfield init runs `-i base` in a SEPARATE isolated container
+        # (the FIRST containers.run), before the serving container — so the
+        # serving PID1 never races it. containers.run is called twice.
+        assert mock_docker_client.containers.run.call_count == 2
+        init_run = mock_docker_client.containers.run.call_args_list[0]
+        assert "-i base" in init_run.kwargs["command"]
+        assert "--stop-after-init" in init_run.kwargs["command"]
 
     @patch(
         "oduflow.extra_addons.generate_odoo_conf",
@@ -332,6 +336,7 @@ class TestCreateEnvironment:
     ):
         mock_odoo = MagicMock()
         mock_odoo.exec_run.return_value = (0, b"OK")
+        mock_odoo.wait.return_value = {"StatusCode": 0}
         mock_docker_client.containers.run.return_value = mock_odoo
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -363,6 +363,41 @@ class TestCreateEnvironment:
         assert run_kwargs["volumes"][abs_local]["bind"] == "/mnt/extra-addons"
 
 
+class TestReloadTemplate:
+    @patch("oduflow.docker_ops.system_ops._update_template_sizes")
+    @patch("oduflow.docker_ops.system_ops._copy_file_to_container")
+    @patch("oduflow.docker_ops.system_ops._is_text_dump", return_value=False)
+    @patch("oduflow.docker_ops.system_ops._db_exists", return_value=False)
+    @patch("oduflow.docker_ops.system_ops._exec_sql", return_value="5")
+    @patch("oduflow.docker_ops.system_ops._wait_pg_ready")
+    @patch("oduflow.docker_ops.system_ops.os.path.isfile", return_value=True)
+    def test_restore_uses_no_owner(
+        self,
+        mock_isfile,
+        mock_wait,
+        mock_sql,
+        mock_db_exists,
+        mock_text,
+        mock_copy,
+        mock_sizes,
+        mock_docker_client,
+    ):
+        # Custom-format dumps must be restored with --no-owner so the template
+        # is not pinned to the source env's per-env role; otherwise deleting the
+        # source env leaves an undroppable orphan role. (--no-owner is honored
+        # only at restore time for -Fc archives, not at pg_dump time.)
+        db_container = MagicMock()
+        db_container.exec_run.return_value = (0, b"")
+        mock_docker_client.containers.get.return_value = db_container
+
+        system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
+
+        restore_cmd = db_container.exec_run.call_args[0][0]
+        joined = " ".join(restore_cmd)
+        assert "pg_restore" in joined
+        assert "--no-owner" in joined
+
+
 class TestPullEnvironmentLocal:
     @patch("oduflow.docker_ops.env_ops._apply_actions")
     @patch("oduflow.docker_ops.env_ops._detect_local_changes")

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import docker
 from unittest.mock import MagicMock, patch
@@ -286,6 +288,146 @@ class TestCreateEnvironment:
         assert "--stop-after-init" in init_cmd
         # Should restart after init
         mock_odoo.restart.assert_called_once()
+
+    @patch(
+        "oduflow.extra_addons.generate_odoo_conf",
+        return_value="/tmp/flow-test/workspaces/feature-local/odoo.conf",
+    )
+    @patch("oduflow.docker_ops.env_ops._copy_file_to_container")
+    @patch("oduflow.docker_ops.env_ops._create_pg_role")
+    @patch(
+        "oduflow.docker_ops.env_ops.create_credentials",
+        return_value={"pg_user": "u_1_feature-local", "pg_password": "test-pw"},
+    )
+    @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
+    @patch("oduflow.docker_ops.env_ops.get_odoo_uid_gid", return_value="100:101")
+    @patch("oduflow.docker_ops.env_ops._exec_sql")
+    @patch("oduflow.docker_ops.env_ops._db_exists", return_value=False)
+    @patch("oduflow.docker_ops.env_ops._mount_filestore")
+    @patch("oduflow.docker_ops.env_ops._get_used_ports", return_value=set())
+    @patch("oduflow.docker_ops.env_ops.allocate_port", return_value=50002)
+    @patch("oduflow.docker_ops.env_ops.subprocess.run")
+    @patch("oduflow.docker_ops.env_ops.os.chmod")
+    @patch("oduflow.docker_ops.env_ops.os.makedirs")
+    @patch("oduflow.docker_ops.env_ops.os.path.exists", return_value=False)
+    def test_create_local_path_skips_clone(
+        self,
+        mock_exists,
+        mock_makedirs,
+        mock_chmod,
+        mock_run,
+        mock_alloc,
+        mock_used,
+        mock_mount,
+        mock_db_exists,
+        mock_sql,
+        mock_uid_gid,
+        mock_ready,
+        mock_creds,
+        mock_role,
+        mock_copy_conf,
+        mock_gen_conf,
+        mock_docker_client,
+        tmp_path,
+    ):
+        mock_odoo = MagicMock()
+        mock_odoo.exec_run.return_value = (0, b"OK")
+        mock_docker_client.containers.run.return_value = mock_odoo
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        local_dir = str(tmp_path)
+        result = env_ops.create_environment(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/local",
+            "",  # no repo_url in live-mount mode
+            "odoo:17.0",
+            template_name=None,
+            local_path=local_dir,
+        )
+
+        # No git clone was invoked.
+        for call in mock_run.call_args_list:
+            assert "clone" not in (call.args[0] if call.args else [])
+        # Result and container label point at the live-mount directory.
+        abs_local = os.path.abspath(local_dir)
+        assert result["local_path"] == abs_local
+        run_kwargs = mock_docker_client.containers.run.call_args.kwargs
+        assert run_kwargs["labels"]["oduflow.local_path"] == abs_local
+        # The local dir is bind-mounted to /mnt/extra-addons.
+        assert run_kwargs["volumes"][abs_local]["bind"] == "/mnt/extra-addons"
+
+
+class TestPullEnvironmentLocal:
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
+    @patch("oduflow.docker_ops.env_ops._detect_local_changes")
+    @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=True)
+    def test_local_explicit_guardrail_warns(
+        self, mock_isdir, mock_detect, mock_apply, mock_docker_client
+    ):
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": "/some/local"}
+        mock_docker_client.containers.get.return_value = container
+        # A security XML change recommends -u of 'sale'.
+        mock_detect.return_value = ("HEAD", ["sale/security/ir_rule.xml"])
+        mock_apply.return_value = {
+            "action": "restart",
+            "changed_files": ["sale/security/ir_rule.xml"],
+            "message": "Container restarted.",
+        }
+
+        result = env_ops.pull_environment(
+            TEST_SETTINGS, TEST_TEAM, "feature/local", restart=True
+        )
+
+        assert result["action"] == "restart"
+        assert any("sale" in w for w in result.get("warnings", []))
+        mock_apply.assert_called_once()
+        mock_detect.assert_called_once()
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
+    @patch("oduflow.docker_ops.env_ops._detect_local_changes")
+    @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=True)
+    def test_local_strict_blocks(
+        self, mock_isdir, mock_detect, mock_apply, mock_docker_client
+    ):
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": "/some/local"}
+        mock_docker_client.containers.get.return_value = container
+        mock_detect.return_value = ("HEAD", ["sale/security/ir_rule.xml"])
+
+        result = env_ops.pull_environment(
+            TEST_SETTINGS, TEST_TEAM, "feature/local", restart=True, strict=True
+        )
+
+        assert result["action"] == "blocked"
+        assert any("sale" in w for w in result["warnings"])
+        mock_apply.assert_not_called()
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
+    @patch("oduflow.docker_ops.env_ops._detect_local_changes")
+    @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=True)
+    def test_local_explicit_correct_no_warn(
+        self, mock_isdir, mock_detect, mock_apply, mock_docker_client
+    ):
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": "/some/local"}
+        mock_docker_client.containers.get.return_value = container
+        mock_detect.return_value = ("HEAD", ["sale/security/ir_rule.xml"])
+        mock_apply.return_value = {
+            "action": "upgrade",
+            "modules_upgraded": ["sale"],
+            "changed_files": ["sale/security/ir_rule.xml"],
+            "message": "Upgraded.",
+        }
+
+        result = env_ops.pull_environment(
+            TEST_SETTINGS, TEST_TEAM, "feature/local", upgrade=["sale"]
+        )
+
+        assert result["action"] == "upgrade"
+        assert not result.get("warnings")
+        mock_apply.assert_called_once()
 
 
 class TestCreateEnvironmentEnvVars:


### PR DESCRIPTION
Adds a **stdio local fast-path**: `create_environment(local_path=...)` bind-mounts the agent's own checkout live into the container instead of cloning, and `pull_and_apply` becomes transport-agnostic with explicit `install`/`upgrade`/`restart` plus a warn-by-default guardrail that cross-checks the requested action against the detected diff (the legacy `classify_changes` auto-mode is kept as a fallback). The "no code source" error is now transport-aware and suggests `local_path` on stdio.

Also fixes two provisioning bugs surfaced while testing: greenfield (`template_name=none`) creation initialized the empty DB with `odoo -i base` via `docker exec` while the serving PID 1 ran against the same DB, colliding on `CREATE TABLE orm_signaling_registry` (`UniqueViolation`) — now the DB is initialized in an isolated short-lived container before the serving container starts. And env-derived templates were restored without `--no-owner`, so they kept the source env's per-env role as object owner and deleting the env left an undroppable orphan role — restore now uses `pg_restore --no-owner`.

Includes unit tests (guardrail, shallow classify, live-mount create, template restore) and updates the bundled agent instructions with the local fast-path and apply decision rules.