### PR TITLE
Web UI: session-cookie auth with login form; fix Console/SQL terminals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 
     "packaging",
     "cryptography",
+    "itsdangerous",
     "tomli>=2.0; python_version < '3.11'",
 ]
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -594,9 +594,7 @@ def reload_template(
             if os.path.isfile(old_path):
                 os.remove(old_path)
                 logger.info("Removed old dump %s", old_path)
-        if not os.path.exists(dest_path) or not os.path.samefile(
-            dump_path, dest_path
-        ):
+        if not os.path.exists(dest_path) or not os.path.samefile(dump_path, dest_path):
             shutil.copy2(dump_path, dest_path)
         logger.info("Saved dump to workspace: %s", dest_path)
 
@@ -853,6 +851,34 @@ def init_template(
     return result
 
 
+def _source_env_metadata(settings: Settings, labels: dict) -> dict:
+    """Template metadata describing the source environment's code origin.
+
+    A live-mounted environment (``oduflow.local_path`` label) has no repo URL;
+    record the path instead so create-from-template can re-establish the
+    live-mount (stdio transport only).
+    """
+    metadata: dict[str, object] = {"odoo_image": labels.get(settings.image_label, "")}
+    live_path = labels.get("oduflow.local_path", "")
+    if live_path:
+        metadata["local_path"] = live_path
+        metadata["repo_url"] = ""
+    else:
+        metadata["repo_url"] = labels.get(settings.repo_label, "")
+    metadata["git_user"] = labels.get("oduflow.git_user", "")
+    raw_extras = labels.get("oduflow.extra_addons", "")
+    if raw_extras:
+        try:
+            parsed = json.loads(raw_extras)
+            metadata["extra_addons"] = _normalize_extra_addons(parsed)
+        except (json.JSONDecodeError, TypeError):
+            pass
+    raw_auto = labels.get("oduflow.auto_install_modules", "")
+    if raw_auto:
+        metadata["auto_install_modules"] = raw_auto
+    return metadata
+
+
 def publish_env_as_template(
     settings: Settings,
     team: TeamSettings,
@@ -1001,19 +1027,7 @@ def publish_env_as_template(
     metadata = {}
     try:
         pc = client.containers.get(promoted_container_name)
-        metadata["odoo_image"] = pc.labels.get(settings.image_label, "")
-        metadata["repo_url"] = pc.labels.get(settings.repo_label, "")
-        metadata["git_user"] = pc.labels.get("oduflow.git_user", "")
-        raw_extras = pc.labels.get("oduflow.extra_addons", "")
-        if raw_extras:
-            try:
-                parsed = json.loads(raw_extras)
-                metadata["extra_addons"] = _normalize_extra_addons(parsed)
-            except (json.JSONDecodeError, TypeError):
-                pass
-        raw_auto = pc.labels.get("oduflow.auto_install_modules", "")
-        if raw_auto:
-            metadata["auto_install_modules"] = raw_auto
+        metadata = _source_env_metadata(settings, pc.labels)
     except docker.errors.NotFound:
         pass
     fs_size = (

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -367,7 +367,7 @@ def create_environment(
     Args:
         branch: The git branch to clone (e.g. "19.0", "feature/my-feature").
         env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="19.0").
-        template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden).
+        template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden). A template saved from a live-mounted environment supplies local_path instead of repo_url and recreates the live-mount (stdio transport only; over http pass repo_url explicitly).
         repo_url: URL of the git repository to clone. Optional when template_name is specified (loaded from template metadata).
         odoo_image: Full Docker image name with tag (e.g. "odoo:19.0"). Optional when template_name is specified (loaded from template metadata).
         extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:19.0,custom-themes:main"). Each entry must include a branch after a colon.
@@ -393,6 +393,8 @@ def create_environment(
         effective_repo_url = repo_url
         effective_odoo_image = odoo_image
         effective_git_user = ""
+        local_path = (local_path or "").strip()
+        local_path_from_template = False
         if resolved_template:
             metadata_path = team.get_template_metadata_path(resolved_template)
             if os.path.isfile(metadata_path):
@@ -416,10 +418,24 @@ def create_environment(
                             )
                 if not auto_install_modules:
                     auto_install_modules = metadata.get("auto_install_modules", "")
+                # The template's live-mount path applies only when the caller
+                # gave no code source of their own (explicit repo_url wins, so
+                # http clients can still clone from a real remote).
+                if not local_path and not repo_url and metadata.get("local_path"):
+                    local_path = metadata["local_path"]
+                    local_path_from_template = True
 
-        local_path = (local_path or "").strip()
         if local_path:
             if settings_module.TRANSPORT != "stdio":
+                if local_path_from_template:
+                    raise ValueError(
+                        f"Template '{resolved_template}' was saved from a "
+                        "live-mounted environment, so it provides a local_path "
+                        "instead of a repo_url. Live-mount is only available "
+                        "with the stdio (local) transport — pass repo_url= "
+                        "explicitly to clone over http, or create the "
+                        "environment via the local (stdio) server."
+                    )
                 raise ValueError(
                     "local_path (live-mount) is only available with the stdio "
                     "(local) transport, not over http."
@@ -1935,7 +1951,7 @@ def get_service_info(name: str, ctx: Context = None) -> str:
     team = _resolve_team(ctx)
     info = service_ops.get_service_info(settings, team, name)
 
-    digest = (info.get("image_digest") or "")
+    digest = info.get("image_digest") or ""
     digest_short = digest[:19] if digest else ""
 
     lines = [f"Service '{info['name']}': {info['status']}"]
@@ -2637,8 +2653,7 @@ def _run_template_from_env(
         lines.append(f"{verb} filestore overlays for: {', '.join(affected)}")
     if failures:
         lines.append(
-            "Remount issues:\n"
-            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+            "Remount issues:\n" + "\n".join(f"- {env}: {msg}" for env, msg in failures)
         )
     print("\n".join(lines))
 
@@ -2664,8 +2679,7 @@ def _run_refresh_template(
         ]
     if failures:
         lines.append(
-            "Remount issues:\n"
-            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+            "Remount issues:\n" + "\n".join(f"- {env}: {msg}" for env, msg in failures)
         )
     print("\n".join(lines))
 
@@ -2713,8 +2727,7 @@ def _run_import_template(
         )
     if failures:
         lines.append(
-            "Remount issues:\n"
-            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+            "Remount issues:\n" + "\n".join(f"- {env}: {msg}" for env, msg in failures)
         )
     print("\n".join(lines))
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -476,6 +476,7 @@
     </label>
     <button id="refresh-btn" onclick="loadEnvironments()">Refresh</button>
     <button class="btn-create" onclick="openCreateModal()">+ Create</button>
+    <button class="btn" onclick="logout()" title="Sign out">Logout</button>
   </div>
 </header>
 
@@ -866,6 +867,26 @@
   </div>
 </div>
 <script>
+// Redirect to the login page whenever a request is rejected as unauthenticated
+// (e.g. the session cookie expired while the tab was open).
+(function () {
+  const _fetch = window.fetch;
+  window.fetch = function () {
+    return _fetch.apply(this, arguments).then(function (resp) {
+      if (resp.status === 401) { window.location.href = '/login'; }
+      return resp;
+    });
+  };
+})();
+
+function logout() {
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = '/logout';
+  document.body.appendChild(form);
+  form.submit();
+}
+
 const API = '/api/environments';
 const API_TEMPLATES = '/api/templates';
 const MIN_INTERVAL = 5;

--- a/src/oduflow/templates/login.html
+++ b/src/oduflow/templates/login.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Oduflow — Sign in</title>
+  <link rel="icon" href="/favicon.ico">
+  <style>
+    :root {
+      --bg: #0d1117;
+      --surface: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-dim: #8b949e;
+      --accent: #58a6ff;
+      --red: #f85149;
+      --radius: 8px;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .card {
+      width: 100%;
+      max-width: 320px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 32px 28px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .card img.logo { height: 36px; align-self: center; }
+    .card h1 {
+      font-size: 18px;
+      font-weight: 600;
+      text-align: center;
+      margin-bottom: 4px;
+    }
+    label {
+      font-size: 13px;
+      color: var(--text-dim);
+    }
+    input[type="password"] {
+      width: 100%;
+      background: var(--bg);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 9px 11px;
+      font-size: 14px;
+    }
+    input[type="password"]:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+    button {
+      margin-top: 6px;
+      background: var(--accent);
+      color: #0d1117;
+      border: none;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { filter: brightness(1.08); }
+    .error {
+      background: rgba(248, 81, 73, 0.12);
+      border: 1px solid var(--red);
+      color: var(--red);
+      border-radius: 6px;
+      padding: 8px 11px;
+      font-size: 13px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <form class="card" method="post" action="/login">
+    <img class="logo" src="/logo.png" alt="Oduflow logo">
+    <h1>Sign in</h1>
+    <!--ERROR-->
+    <label for="password">Password</label>
+    <input id="password" name="password" type="password"
+           autocomplete="current-password" autofocus required>
+    <button type="submit">Sign in</button>
+  </form>
+</body>
+</html>

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -509,6 +509,7 @@ def _build_routes(
             extra_addons = json.loads(extra_addons_raw) or None
             git_user = labels.get("oduflow.git_user", "")
             env_vars = json.loads(labels.get("oduflow.env_vars", "{}")) or None
+            local_path = labels.get("oduflow.local_path", "")
 
             env_ops.delete_environment(settings, team, branch)
             result = env_ops.create_environment(
@@ -521,6 +522,7 @@ def _build_routes(
                 extra_addons=extra_addons,
                 git_user=git_user,
                 env_vars=env_vars,
+                local_path=local_path,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -593,6 +595,20 @@ def _build_routes(
                             extra_dict = _normalize_extra_addons(raw) or None
                     if not auto_install_raw:
                         auto_install_raw = metadata.get("auto_install_modules", "")
+                    if not repo_url and metadata.get("local_path"):
+                        return JSONResponse(
+                            {
+                                "ok": False,
+                                "error": (
+                                    f"Template '{resolved_template}' was saved "
+                                    "from a live-mounted environment and has no "
+                                    "repo_url. Provide repo_url explicitly, or "
+                                    "create the environment via the local "
+                                    "(stdio) server."
+                                ),
+                            },
+                            status_code=400,
+                        )
 
             if not repo_url or not odoo_image:
                 return JSONResponse(

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -12,7 +12,12 @@ import secrets
 
 from itsdangerous import BadData, URLSafeTimedSerializer
 from starlette.requests import HTTPConnection, Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import (
+    HTMLResponse,
+    JSONResponse,
+    RedirectResponse,
+    Response,
+)
 from starlette.routing import Route, WebSocketRoute
 from starlette.types import ASGIApp, Receive, Scope, Send
 from starlette.websockets import WebSocket
@@ -33,9 +38,11 @@ from oduflow.licensing import get_license_info, install_license_from_text
 
 logger = logging.getLogger("oduflow")
 
-_AUTH_REALM = "Oduflow Dashboard"
 _AUTH_USER = "admin"
 _AUTH_COOKIE = "oduflow_ui_auth"
+# Reachable without authentication: the login flow and static brand assets
+# (so the login page can render its logo/favicon).
+_PUBLIC_PATHS = frozenset({"/login", "/logout", "/favicon.ico", "/logo.png"})
 _SESSION_SALT = "oduflow.ui-auth.v1"
 _SESSION_MAX_AGE = 7 * 24 * 3600  # 7 days
 _SECRET_FILENAME = ".ui_session_secret"
@@ -146,6 +153,11 @@ class BasicAuthMiddleware:
             await self._app(scope, receive, send)
             return
 
+        path = scope.get("path", "")
+        if scope["type"] == "http" and path in _PUBLIC_PATHS:
+            await self._app(scope, receive, send)
+            return
+
         conn = HTTPConnection(scope)
         team = self._check_credentials(conn.headers.get("authorization", ""))
         if not team:
@@ -155,17 +167,21 @@ class BasicAuthMiddleware:
         if team:
             scope.setdefault("state", {})["team"] = team
             await self._app(scope, receive, send)
+            return
+
+        # Unauthenticated. Browsers get a login page (no Basic dialog); API
+        # clients and WebSocket handshakes get a machine-readable rejection.
+        if scope["type"] == "websocket":
+            ws = WebSocket(scope, receive, send)
+            await ws.close(code=1008)
+        elif path.startswith("/api/"):
+            response: Response = JSONResponse(
+                {"ok": False, "error": "Unauthorized"}, status_code=401
+            )
+            await response(scope, receive, send)
         else:
-            if scope["type"] == "websocket":
-                ws = WebSocket(scope, receive, send)
-                await ws.close(code=1008)
-            else:
-                response = Response(
-                    "Unauthorized",
-                    status_code=401,
-                    headers={"WWW-Authenticate": f'Basic realm="{_AUTH_REALM}"'},
-                )
-                await response(scope, receive, send)
+            response = RedirectResponse("/login", status_code=302)
+            await response(scope, receive, send)
 
     def _check_credentials(self, auth_header: str) -> "TeamSettings | None":
         if not auth_header.startswith("Basic "):
@@ -191,6 +207,30 @@ def _is_secure_request(request: Request) -> bool:
 
 
 _TEMPLATE_DIR = pathlib.Path(__file__).resolve().parent / "templates"
+
+
+def _render_login(error: str = "") -> str:
+    """Render the login page, optionally with a server-controlled error banner."""
+    html = (_TEMPLATE_DIR / "login.html").read_text(encoding="utf-8")
+    banner = f'<div class="error">{error}</div>' if error else ""
+    return html.replace("<!--ERROR-->", banner)
+
+
+async def _read_login_password(request: Request) -> str:
+    """Extract the password from a login POST, accepting either an HTML form
+    (application/x-www-form-urlencoded) or a JSON body. Parsed directly so the
+    UI needs no python-multipart dependency."""
+    import urllib.parse
+
+    body = await request.body()
+    if "application/json" in request.headers.get("content-type", ""):
+        try:
+            data = json.loads(body or b"{}")
+        except (ValueError, TypeError):
+            return ""
+        return str((data or {}).get("password") or "").strip()
+    parsed = urllib.parse.parse_qs(body.decode("utf-8", "replace"))
+    return (parsed.get("password", [""])[0]).strip()
 
 
 def _error_response(e: FlowError) -> JSONResponse:
@@ -248,20 +288,49 @@ def _build_routes(
     locks: LockManager,
 ) -> list[Route]:
 
+    def _set_session_cookie(
+        response: Response, team: TeamSettings, request: Request
+    ) -> None:
+        response.set_cookie(
+            _AUTH_COOKIE,
+            _make_ui_token(team, get_settings()),
+            max_age=_SESSION_MAX_AGE,
+            httponly=True,
+            samesite="strict",
+            secure=_is_secure_request(request),
+            path="/",
+        )
+
     def dashboard(request: Request) -> HTMLResponse:
         html_path = _TEMPLATE_DIR / "dashboard.html"
         response = HTMLResponse(html_path.read_text(encoding="utf-8"))
         team = getattr(request.state, "team", None)
         if team is not None and team.ui_password:
-            response.set_cookie(
-                _AUTH_COOKIE,
-                _make_ui_token(team, get_settings()),
-                max_age=_SESSION_MAX_AGE,
-                httponly=True,
-                samesite="strict",
-                secure=_is_secure_request(request),
-                path="/",
-            )
+            _set_session_cookie(response, team, request)
+        return response
+
+    async def login(request: Request) -> Response:
+        settings = get_settings()
+        # Auth disabled entirely -> the dashboard is open, no login needed.
+        if not any(t.ui_password for t in settings.teams.values()):
+            return RedirectResponse("/", status_code=302)
+        # Already signed in (valid session cookie) -> go straight to the app.
+        token = request.cookies.get(_AUTH_COOKIE)
+        if token and _check_cookie_token(token, settings) is not None:
+            return RedirectResponse("/", status_code=302)
+        if request.method == "POST":
+            password = await _read_login_password(request)
+            team = settings.get_team_by_ui_password(password) if password else None
+            if team is not None:
+                response: Response = RedirectResponse("/", status_code=303)
+                _set_session_cookie(response, team, request)
+                return response
+            return HTMLResponse(_render_login("Invalid password."), status_code=401)
+        return HTMLResponse(_render_login())
+
+    def logout(request: Request) -> RedirectResponse:
+        response = RedirectResponse("/login", status_code=303)
+        response.delete_cookie(_AUTH_COOKIE, path="/", samesite="strict")
         return response
 
     def favicon(request: Request) -> Response:
@@ -1430,6 +1499,8 @@ def _build_routes(
 
     return [
         Route("/", dashboard, methods=["GET"]),
+        Route("/login", login, methods=["GET", "POST"]),
+        Route("/logout", logout, methods=["POST"]),
         Route("/favicon.ico", favicon, methods=["GET"]),
         Route("/logo.png", logo, methods=["GET"]),
         Route("/api/license", api_license, methods=["GET"]),

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -8,8 +8,10 @@ import json
 import logging
 import os
 import pathlib
+import secrets
 
-from starlette.requests import Request
+from itsdangerous import BadData, URLSafeTimedSerializer
+from starlette.requests import HTTPConnection, Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import Route, WebSocketRoute
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -34,33 +36,104 @@ logger = logging.getLogger("oduflow")
 _AUTH_REALM = "Oduflow Dashboard"
 _AUTH_USER = "admin"
 _AUTH_COOKIE = "oduflow_ui_auth"
+_SESSION_SALT = "oduflow.ui-auth.v1"
+_SESSION_MAX_AGE = 7 * 24 * 3600  # 7 days
+_SECRET_FILENAME = ".ui_session_secret"
+
+# Cached per data dir (process-wide; the server runs against a single one).
+_secrets_cache: dict[str, str] = {}
+_signers: dict[str, URLSafeTimedSerializer] = {}
 
 
-def _make_ui_token(team: "TeamSettings") -> str:
-    """Signed bearer token for a team, used as a cookie so WebSocket handshakes
-    (which cannot send an Authorization header) can authenticate."""
-    mac = hmac.new(
-        team.ui_password.encode("utf-8"),
-        team.team_id.encode("utf-8"),
-        hashlib.sha256,
+def _load_or_create_secret(data_dir: str) -> str:
+    """Load the persistent UI-session signing secret from the data dir, creating
+    it on first use. Persisting it means a server restart does not invalidate
+    live sessions."""
+    path = os.path.join(data_dir, _SECRET_FILENAME)
+    try:
+        existing = pathlib.Path(path).read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    except FileNotFoundError:
+        pass
+    os.makedirs(data_dir, exist_ok=True)
+    secret = secrets.token_hex(32)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        # Another worker created it between our read and write; use theirs.
+        return pathlib.Path(path).read_text(encoding="utf-8").strip()
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(secret)
+    return secret
+
+
+def _get_secret(settings: Settings) -> str:
+    """Return the cached persistent server-side signing secret for this server."""
+    key = settings.base_data_dir or ""
+    secret = _secrets_cache.get(key)
+    if secret is None:
+        secret = _load_or_create_secret(key) if key else secrets.token_hex(32)
+        _secrets_cache[key] = secret
+    return secret
+
+
+def _get_signer(settings: Settings) -> URLSafeTimedSerializer:
+    """Return the cached itsdangerous signer for this server's session cookies.
+
+    The signing key is a persistent server-side secret (NOT the team password),
+    so a leaked cookie reveals nothing about the password and cannot be
+    brute-forced offline.
+    """
+    key = settings.base_data_dir or ""
+    signer = _signers.get(key)
+    if signer is None:
+        signer = URLSafeTimedSerializer(_get_secret(settings), salt=_SESSION_SALT)
+        _signers[key] = signer
+    return signer
+
+
+def _password_fingerprint(secret: str, ui_password: str) -> str:
+    """A fingerprint of the team password, keyed by the server secret. Embedded
+    in the token so that changing ui_password invalidates outstanding cookies
+    immediately, while a leaked cookie still cannot be used to brute-force the
+    password offline (the key is the server secret, not public)."""
+    return hmac.new(
+        secret.encode("utf-8"), ui_password.encode("utf-8"), hashlib.sha256
     ).hexdigest()
-    return f"{team.team_id}.{mac}"
+
+
+def _make_ui_token(team: "TeamSettings", settings: Settings) -> str:
+    """Signed, timestamped session token for a team, stored as a cookie so
+    WebSocket handshakes (which cannot send an Authorization header) can
+    authenticate. Expires after `_SESSION_MAX_AGE`; carries a password
+    fingerprint so a password change revokes it at once."""
+    fingerprint = _password_fingerprint(_get_secret(settings), team.ui_password)
+    return _get_signer(settings).dumps([team.team_id, fingerprint])
 
 
 def _check_cookie_token(token: str, settings: Settings) -> "TeamSettings | None":
-    """Validate a cookie token produced by `_make_ui_token` and return its team."""
-    if not token or "." not in token:
+    """Validate a cookie token from `_make_ui_token`: verify its signature, that
+    it is within `_SESSION_MAX_AGE`, and that the embedded password fingerprint
+    still matches the team's current ui_password, then return its team."""
+    if not token:
         return None
-    team_id, mac = token.rsplit(".", 1)
+    try:
+        data = _get_signer(settings).loads(token, max_age=_SESSION_MAX_AGE)
+    except BadData:
+        return None
+    if not (isinstance(data, list) and len(data) == 2):
+        return None
+    team_id, fingerprint = data
+    if not isinstance(team_id, str) or not isinstance(fingerprint, str):
+        return None
     team = settings.teams.get(team_id)
     if not team or not team.ui_password:
         return None
-    expected = hmac.new(
-        team.ui_password.encode("utf-8"),
-        team.team_id.encode("utf-8"),
-        hashlib.sha256,
-    ).hexdigest()
-    return team if hmac.compare_digest(mac, expected) else None
+    expected = _password_fingerprint(_get_secret(settings), team.ui_password)
+    if not hmac.compare_digest(fingerprint, expected):
+        return None
+    return team
 
 
 class BasicAuthMiddleware:
@@ -73,14 +146,10 @@ class BasicAuthMiddleware:
             await self._app(scope, receive, send)
             return
 
-        headers = dict(scope.get("headers", []))
-        auth_header = headers.get(b"authorization", b"").decode()
-
-        team = self._check_credentials(auth_header)
+        conn = HTTPConnection(scope)
+        team = self._check_credentials(conn.headers.get("authorization", ""))
         if not team:
-            token = self._parse_cookie(
-                headers.get(b"cookie", b"").decode(), _AUTH_COOKIE
-            )
+            token = conn.cookies.get(_AUTH_COOKIE)
             if token:
                 team = _check_cookie_token(token, self._get_settings())
         if team:
@@ -110,13 +179,15 @@ class BasicAuthMiddleware:
             return None
         return self._get_settings().get_team_by_ui_password(password)
 
-    @staticmethod
-    def _parse_cookie(cookie_header: str, name: str) -> "str | None":
-        for part in cookie_header.split(";"):
-            key, _, value = part.strip().partition("=")
-            if key == name:
-                return value
-        return None
+
+def _is_secure_request(request: Request) -> bool:
+    """Whether the browser sees this connection as HTTPS, honouring a single
+    X-Forwarded-Proto hop (first value, case-insensitive). Drives the cookie
+    Secure attribute without guessing from routing_mode."""
+    if request.url.scheme == "https":
+        return True
+    forwarded = request.headers.get("x-forwarded-proto", "")
+    return forwarded.split(",")[0].strip().lower() == "https"
 
 
 _TEMPLATE_DIR = pathlib.Path(__file__).resolve().parent / "templates"
@@ -181,19 +252,14 @@ def _build_routes(
         html_path = _TEMPLATE_DIR / "dashboard.html"
         response = HTMLResponse(html_path.read_text(encoding="utf-8"))
         team = getattr(request.state, "team", None)
-        if team is not None and getattr(team, "ui_password", ""):
-            settings = get_settings()
-            secure = (
-                request.url.scheme == "https"
-                or request.headers.get("x-forwarded-proto") == "https"
-                or settings.routing_mode == "traefik"
-            )
+        if team is not None and team.ui_password:
             response.set_cookie(
                 _AUTH_COOKIE,
-                _make_ui_token(team),
+                _make_ui_token(team, get_settings()),
+                max_age=_SESSION_MAX_AGE,
                 httponly=True,
                 samesite="strict",
-                secure=secure,
+                secure=_is_secure_request(request),
                 path="/",
             )
         return response

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -24,13 +26,41 @@ from oduflow.docker_ops.odoo_ops import get_environment_logs
 from oduflow.docker_ops.stats import get_container_stats, get_system_stats
 from oduflow.errors import BusyError, FlowError, NotFoundError
 from oduflow.locking import LockManager
-from oduflow.settings import TeamSettings
+from oduflow.settings import Settings, TeamSettings
 from oduflow.licensing import get_license_info, install_license_from_text
 
 logger = logging.getLogger("oduflow")
 
 _AUTH_REALM = "Oduflow Dashboard"
 _AUTH_USER = "admin"
+_AUTH_COOKIE = "oduflow_ui_auth"
+
+
+def _make_ui_token(team: "TeamSettings") -> str:
+    """Signed bearer token for a team, used as a cookie so WebSocket handshakes
+    (which cannot send an Authorization header) can authenticate."""
+    mac = hmac.new(
+        team.ui_password.encode("utf-8"),
+        team.team_id.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{team.team_id}.{mac}"
+
+
+def _check_cookie_token(token: str, settings: Settings) -> "TeamSettings | None":
+    """Validate a cookie token produced by `_make_ui_token` and return its team."""
+    if not token or "." not in token:
+        return None
+    team_id, mac = token.rsplit(".", 1)
+    team = settings.teams.get(team_id)
+    if not team or not team.ui_password:
+        return None
+    expected = hmac.new(
+        team.ui_password.encode("utf-8"),
+        team.team_id.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return team if hmac.compare_digest(mac, expected) else None
 
 
 class BasicAuthMiddleware:
@@ -47,6 +77,12 @@ class BasicAuthMiddleware:
         auth_header = headers.get(b"authorization", b"").decode()
 
         team = self._check_credentials(auth_header)
+        if not team:
+            token = self._parse_cookie(
+                headers.get(b"cookie", b"").decode(), _AUTH_COOKIE
+            )
+            if token:
+                team = _check_cookie_token(token, self._get_settings())
         if team:
             scope.setdefault("state", {})["team"] = team
             await self._app(scope, receive, send)
@@ -73,6 +109,14 @@ class BasicAuthMiddleware:
         if user != _AUTH_USER:
             return None
         return self._get_settings().get_team_by_ui_password(password)
+
+    @staticmethod
+    def _parse_cookie(cookie_header: str, name: str) -> "str | None":
+        for part in cookie_header.split(";"):
+            key, _, value = part.strip().partition("=")
+            if key == name:
+                return value
+        return None
 
 
 _TEMPLATE_DIR = pathlib.Path(__file__).resolve().parent / "templates"
@@ -135,7 +179,24 @@ def _build_routes(
 
     def dashboard(request: Request) -> HTMLResponse:
         html_path = _TEMPLATE_DIR / "dashboard.html"
-        return HTMLResponse(html_path.read_text(encoding="utf-8"))
+        response = HTMLResponse(html_path.read_text(encoding="utf-8"))
+        team = getattr(request.state, "team", None)
+        if team is not None and getattr(team, "ui_password", ""):
+            settings = get_settings()
+            secure = (
+                request.url.scheme == "https"
+                or request.headers.get("x-forwarded-proto") == "https"
+                or settings.routing_mode == "traefik"
+            )
+            response.set_cookie(
+                _AUTH_COOKIE,
+                _make_ui_token(team),
+                httponly=True,
+                samesite="strict",
+                secure=secure,
+                path="/",
+            )
+        return response
 
     def favicon(request: Request) -> Response:
         ico_path = _TEMPLATE_DIR / "favicon.ico"

--- a/tests/test_template_local_path.py
+++ b/tests/test_template_local_path.py
@@ -1,0 +1,219 @@
+"""Tests for template code-source metadata.
+
+A template saved from a live-mounted environment must record ``local_path``
+(not a bogus path in ``repo_url``), and creating from such a template must
+re-establish the live-mount over stdio, fail with a clear message over http,
+and let an explicit repo_url override the template's local_path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow.docker_ops.system_ops import _source_env_metadata
+from oduflow.settings import Settings, TeamSettings
+
+from tool_helpers import call_tool as _call_tool  # noqa: E402
+
+
+def _make_env(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path / "team"),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        disable_telemetry=True,
+        teams={"1": team},
+    )
+    return settings, team
+
+
+@pytest.fixture
+def tool_env(tmp_path):
+    """Inject per-test settings/team into the MCP server module."""
+    import oduflow.server as server
+
+    settings, team = _make_env(tmp_path)
+    old = server._settings
+    server._settings = settings
+    with patch("oduflow.server._resolve_team", return_value=team):
+        yield settings, team
+    server._settings = old
+
+
+def _write_template(team: TeamSettings, name: str, metadata: dict) -> None:
+    path = team.get_template_metadata_path(name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(metadata, f)
+
+
+_CREATE_RESULT = {
+    "url": "http://localhost:50000",
+    "odoo_container": "oduflow-t-odoo",
+    "database": "oduflow_1_t",
+    "workspace": "/tmp/ws",
+}
+
+
+# --- save_as_template metadata -------------------------------------------
+
+
+class TestSourceEnvMetadata:
+    SETTINGS = Settings(teams={})
+
+    def test_git_env_records_repo_url(self):
+        labels = {
+            self.SETTINGS.image_label: "odoo:19.0",
+            self.SETTINGS.repo_label: "https://github.com/x/y.git",
+        }
+        metadata = _source_env_metadata(self.SETTINGS, labels)
+        assert metadata["repo_url"] == "https://github.com/x/y.git"
+        assert "local_path" not in metadata
+
+    def test_live_mount_env_records_local_path(self):
+        # Live-mount envs carry the path in BOTH labels (repo label included);
+        # the metadata must not present that path as a repo URL.
+        labels = {
+            self.SETTINGS.image_label: "odoo:19.0",
+            self.SETTINGS.repo_label: "/Users/dev/addons",
+            "oduflow.local_path": "/Users/dev/addons",
+        }
+        metadata = _source_env_metadata(self.SETTINGS, labels)
+        assert metadata["local_path"] == "/Users/dev/addons"
+        assert metadata["repo_url"] == ""
+
+
+# --- create_environment from a live-mount template ------------------------
+
+
+class TestCreateFromLiveMountTemplate:
+    @patch("oduflow.settings.TRANSPORT", "stdio")
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_stdio_recreates_live_mount(self, mock_create, tool_env, tmp_path):
+        settings, team = tool_env
+        code_dir = tmp_path / "addons"
+        code_dir.mkdir()
+        _write_template(
+            team,
+            "tpl",
+            {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": str(code_dir)},
+        )
+        mock_create.return_value = {**_CREATE_RESULT, "local_path": str(code_dir)}
+
+        result = _call_tool("create_environment", branch="t", template_name="tpl")
+
+        assert mock_create.call_args.kwargs["local_path"] == str(code_dir)
+        assert "Live-mount:" in result
+
+    @patch("oduflow.settings.TRANSPORT", "http")
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_http_rejects_with_clear_error(self, mock_create, tool_env, tmp_path):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "tpl",
+            {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": "/x/addons"},
+        )
+        with pytest.raises(ValueError, match="live-mounted environment"):
+            _call_tool("create_environment", branch="t", template_name="tpl")
+        mock_create.assert_not_called()
+
+    @patch("oduflow.settings.TRANSPORT", "http")
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_http_explicit_repo_url_overrides(self, mock_create, tool_env, tmp_path):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "tpl",
+            {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": "/x/addons"},
+        )
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        result = _call_tool(
+            "create_environment",
+            branch="t",
+            template_name="tpl",
+            repo_url="https://github.com/x/y.git",
+        )
+
+        assert mock_create.call_args.args[3] == "https://github.com/x/y.git"
+        assert mock_create.call_args.kwargs["local_path"] == ""
+        assert "Environment provisioned successfully!" in result
+
+    @patch("oduflow.settings.TRANSPORT", "stdio")
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_stdio_missing_dir_fails(self, mock_create, tool_env, tmp_path):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "tpl",
+            {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": "/gone/addons"},
+        )
+        with pytest.raises(ValueError, match="does not exist"):
+            _call_tool("create_environment", branch="t", template_name="tpl")
+        mock_create.assert_not_called()
+
+
+# --- Web UI ----------------------------------------------------------------
+
+
+def _web_app(settings):
+    from starlette.applications import Starlette
+
+    from oduflow.locking import LockManager
+    from oduflow.web_ui import mount_web_ui
+
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return app
+
+
+class TestWebUILiveMountTemplate:
+    def test_create_returns_clear_error(self, tmp_path):
+        from starlette.testclient import TestClient
+
+        settings, team = _make_env(tmp_path)
+        _write_template(
+            team,
+            "tpl",
+            {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": "/x/addons"},
+        )
+        client = TestClient(_web_app(settings))
+        resp = client.post(
+            "/api/environments/create",
+            json={"env_name": "t", "template_name": "tpl"},
+        )
+        assert resp.status_code == 400
+        assert "live-mounted environment" in resp.json()["error"]
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    @patch("oduflow.docker_ops.env_ops.delete_environment")
+    @patch("oduflow.docker_ops.client.get_client")
+    def test_recreate_passes_local_path(
+        self, mock_client, mock_delete, mock_create, tmp_path
+    ):
+        from starlette.testclient import TestClient
+
+        settings, team = _make_env(tmp_path)
+        container = MagicMock()
+        container.labels = {
+            settings.repo_label: "/x/addons",
+            settings.image_label: "odoo:19.0",
+            "oduflow.local_path": "/x/addons",
+            "oduflow.template": "none",
+        }
+        mock_client.return_value.containers.get.return_value = container
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        client = TestClient(_web_app(settings))
+        resp = client.post("/api/environments/main/recreate")
+
+        assert resp.status_code == 200
+        assert mock_create.call_args.kwargs["local_path"] == "/x/addons"

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -3,13 +3,18 @@ handshakes (which cannot carry an Authorization header) authenticate.
 
 Regression: the Console/SQL terminal buttons opened WebSocket connections that
 ``BasicAuthMiddleware`` rejected with HTTP 403, because the browser never sends
-HTTP Basic credentials on a WebSocket upgrade. The fix mints a signed cookie on
-dashboard load and validates it for both HTTP and WebSocket scopes.
+HTTP Basic credentials on a WebSocket upgrade. The fix mints a signed session
+cookie on dashboard load and validates it for both HTTP and WebSocket scopes.
+
+The cookie is an ``itsdangerous`` timed token signed with a persistent
+server-side secret (stored in the data dir), so it survives restarts, expires
+after ``_SESSION_MAX_AGE``, and never exposes the team password.
 """
 
 from __future__ import annotations
 
 import base64
+import tempfile
 
 import pytest
 from starlette.applications import Starlette
@@ -17,11 +22,13 @@ from starlette.routing import Router, WebSocketRoute
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
+from oduflow import web_ui
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import (
     _AUTH_COOKIE,
     BasicAuthMiddleware,
     _check_cookie_token,
+    _get_signer,
     _make_ui_token,
     mount_web_ui,
 )
@@ -29,10 +36,15 @@ from oduflow.locking import LockManager
 
 _PW = "s3cret"
 
+# A single shared data dir so every ``_settings()`` instance reads the same
+# persisted signing secret (mirrors one real server with one data dir).
+_DATA_DIR = tempfile.mkdtemp(prefix="oduflow-uiauth-test-")
+
 
 def _settings(routing_mode: str = "port") -> Settings:
     return Settings(
         routing_mode=routing_mode,
+        base_data_dir=_DATA_DIR,
         teams={
             "1": TeamSettings(team_id="1", ui_password=_PW),
         },
@@ -61,14 +73,14 @@ def _full_app(settings: Settings) -> Starlette:
 
 def test_token_roundtrip():
     settings = _settings()
-    token = _make_ui_token(_team(settings))
-    assert token.startswith("1.")
+    token = _make_ui_token(_team(settings), settings)
     assert _check_cookie_token(token, settings) is _team(settings)
 
 
 def test_token_rejects_tampered_and_garbage():
     settings = _settings()
-    token = _make_ui_token(_team(settings))
+    token = _make_ui_token(_team(settings), settings)
+    # Flip the last character -> signature no longer verifies.
     assert (
         _check_cookie_token(token[:-1] + ("0" if token[-1] != "0" else "1"), settings)
         is None
@@ -76,16 +88,72 @@ def test_token_rejects_tampered_and_garbage():
     assert _check_cookie_token("1.deadbeef", settings) is None
     assert _check_cookie_token("nope", settings) is None
     assert _check_cookie_token("", settings) is None
-    # Unknown team id
-    assert _check_cookie_token("99." + token.split(".", 1)[1], settings) is None
 
 
-def test_parse_cookie():
-    parse = BasicAuthMiddleware._parse_cookie
-    assert parse("a=1; oduflow_ui_auth=tok; b=2", _AUTH_COOKIE) == "tok"
-    assert parse("oduflow_ui_auth=tok", _AUTH_COOKIE) == "tok"
-    assert parse("", _AUTH_COOKIE) is None
-    assert parse("other=1", _AUTH_COOKIE) is None
+def test_token_rejects_unknown_team():
+    settings = _settings()
+    # Validly-signed (same secret) but for a team that is not configured.
+    token = _get_signer(settings).dumps(["99", "deadbeef"])
+    assert _check_cookie_token(token, settings) is None
+
+
+def test_token_rejects_foreign_secret(tmp_path):
+    settings = _settings()
+    token = _make_ui_token(_team(settings), settings)
+    # A different data dir => a different signing secret => token must not pass.
+    other = Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1", ui_password=_PW)},
+    )
+    web_ui._signers.pop(str(tmp_path), None)
+    web_ui._secrets_cache.pop(str(tmp_path), None)
+    assert _check_cookie_token(token, other) is None
+
+
+def test_token_expires(monkeypatch):
+    settings = _settings()
+    token = _make_ui_token(_team(settings), settings)
+    # Any positive age now exceeds the (negative) max age -> SignatureExpired.
+    monkeypatch.setattr(web_ui, "_SESSION_MAX_AGE", -1)
+    assert _check_cookie_token(token, settings) is None
+
+
+def test_secret_persists_across_restart():
+    """A persistent server secret means tokens survive a process restart."""
+    settings = _settings()
+    token = _make_ui_token(_team(settings), settings)
+    # Simulate a restart: drop the in-memory caches; the secret file in the
+    # data dir is re-read, yielding the same key.
+    web_ui._signers.clear()
+    web_ui._secrets_cache.clear()
+    assert _check_cookie_token(token, settings) is _team(settings)
+
+
+def test_token_revoked_on_password_change():
+    """Changing ui_password invalidates outstanding cookies immediately."""
+    settings = _settings()
+    token = _make_ui_token(_team(settings), settings)
+    # Same team, same data dir/secret, but a new password: the embedded
+    # fingerprint no longer matches -> the cookie is rejected at once.
+    changed = Settings(
+        routing_mode="port",
+        base_data_dir=_DATA_DIR,
+        teams={"1": TeamSettings(team_id="1", ui_password="new-password")},
+    )
+    assert _check_cookie_token(token, changed) is None
+
+
+def test_token_rejected_when_ui_password_cleared():
+    settings = _settings()
+    token = _make_ui_token(_team(settings), settings)
+    # Auth turned off for the team afterwards -> cookie no longer authenticates.
+    disabled = Settings(
+        routing_mode="port",
+        base_data_dir=_DATA_DIR,
+        teams={"1": TeamSettings(team_id="1", ui_password="")},
+    )
+    assert _check_cookie_token(token, disabled) is None
 
 
 # --- HTTP dashboard ------------------------------------------------------
@@ -106,6 +174,7 @@ def test_dashboard_basic_sets_cookie():
     assert f"{_AUTH_COOKIE}=" in set_cookie
     assert "httponly" in set_cookie.lower()
     assert "samesite=strict" in set_cookie.lower()
+    assert "max-age=" in set_cookie.lower()
     # The minted cookie validates back to the team.
     token = client.cookies.get(_AUTH_COOKIE)
     assert _check_cookie_token(token, _settings()) is not None
@@ -115,7 +184,7 @@ def test_dashboard_cookie_fallback_without_basic():
     """The core regression: a request carrying only the cookie (no Authorization
     header) is the exact shape of a browser WebSocket handshake."""
     settings = _settings()
-    token = _make_ui_token(_team(settings))
+    token = _make_ui_token(_team(settings), settings)
     client = TestClient(_full_app(settings))
     client.cookies.set(_AUTH_COOKIE, token)
     resp = client.get("/")
@@ -129,6 +198,18 @@ def test_dashboard_invalid_cookie_rejected():
     assert resp.status_code == 401
 
 
+def test_non_ascii_cookie_does_not_crash():
+    """A malformed/non-ASCII cookie must be rejected cleanly, never raise.
+
+    The previous HMAC implementation called ``hmac.compare_digest`` on the raw
+    cookie value, which raises ``TypeError`` on non-ASCII input (an
+    unauthenticated 500). ``itsdangerous`` rejects it as ``BadData`` instead.
+    """
+    settings = _settings()
+    assert _check_cookie_token("1.é", settings) is None
+    assert _check_cookie_token("é", settings) is None
+
+
 def test_cookie_secure_flag():
     # plain http, port mode -> no Secure
     client = TestClient(_full_app(_settings("port")))
@@ -140,10 +221,17 @@ def test_cookie_secure_flag():
     resp = client.get("/", headers=headers)
     assert "secure" in resp.headers.get("set-cookie", "").lower()
 
-    # routing_mode=traefik -> Secure even on plain http
+    # Chained proxies "https, http": first hop is https -> Secure
+    headers = {**_basic("admin", _PW), "X-Forwarded-Proto": "https, http"}
+    resp = client.get("/", headers=headers)
+    assert "secure" in resp.headers.get("set-cookie", "").lower()
+
+    # traefik mode but reached over plain http with no X-Forwarded-Proto:
+    # NOT Secure, otherwise the browser would silently drop the cookie and the
+    # terminal buttons would stay broken on that origin.
     client = TestClient(_full_app(_settings("traefik")))
     resp = client.get("/", headers=_basic("admin", _PW))
-    assert "secure" in resp.headers.get("set-cookie", "").lower()
+    assert "secure" not in resp.headers.get("set-cookie", "").lower()
 
 
 # --- WebSocket handshake -------------------------------------------------
@@ -167,7 +255,7 @@ _WS_URL = "/api/environments/main/terminal"
 
 def test_ws_accepts_valid_cookie():
     settings = _settings()
-    token = _make_ui_token(_team(settings))
+    token = _make_ui_token(_team(settings), settings)
     client = TestClient(_ws_app(settings))
     with client.websocket_connect(
         _WS_URL, headers={"cookie": f"{_AUTH_COOKIE}={token}"}

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -159,11 +159,71 @@ def test_token_rejected_when_ui_password_cleared():
 # --- HTTP dashboard ------------------------------------------------------
 
 
-def test_dashboard_requires_auth():
+def test_dashboard_redirects_to_login_when_unauthenticated():
     client = TestClient(_full_app(_settings()))
-    resp = client.get("/")
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/login"
+    # No Basic dialog is triggered anymore.
+    assert "www-authenticate" not in {k.lower() for k in resp.headers}
+
+
+def test_login_page_is_public():
+    client = TestClient(_full_app(_settings()))
+    resp = client.get("/login")
+    assert resp.status_code == 200
+    assert "password" in resp.text.lower()
+
+
+def test_login_success_sets_cookie_and_redirects():
+    client = TestClient(_full_app(_settings()))
+    resp = client.post("/login", data={"password": _PW}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+    assert f"{_AUTH_COOKIE}=" in resp.headers.get("set-cookie", "")
+    # The minted cookie now authenticates the dashboard without Basic.
+    assert client.get("/").status_code == 200
+
+
+def test_login_wrong_password_rejected():
+    client = TestClient(_full_app(_settings()))
+    resp = client.post("/login", data={"password": "nope"}, follow_redirects=False)
     assert resp.status_code == 401
-    assert "Basic" in resp.headers.get("www-authenticate", "")
+    assert _AUTH_COOKIE not in resp.headers.get("set-cookie", "")
+
+
+def test_login_redirects_when_already_authenticated():
+    settings = _settings()
+    token = _make_ui_token(_team(settings), settings)
+    client = TestClient(_full_app(settings))
+    client.cookies.set(_AUTH_COOKIE, token)
+    resp = client.get("/login", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/"
+
+
+def test_logout_clears_cookie():
+    client = TestClient(_full_app(_settings()))
+    client.post("/login", data={"password": _PW})
+    resp = client.post("/logout", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/login"
+    set_cookie = resp.headers.get("set-cookie", "").lower()
+    assert _AUTH_COOKIE in set_cookie
+    assert "max-age=0" in set_cookie or "expires=" in set_cookie
+
+
+def test_api_unauthenticated_is_401_without_basic_challenge():
+    client = TestClient(_full_app(_settings()))
+    resp = client.get("/api/license", follow_redirects=False)
+    assert resp.status_code == 401
+    assert "www-authenticate" not in {k.lower() for k in resp.headers}
+
+
+def test_api_basic_auth_still_works():
+    client = TestClient(_full_app(_settings()))
+    resp = client.get("/api/license", headers=_basic("admin", _PW))
+    assert resp.status_code == 200
 
 
 def test_dashboard_basic_sets_cookie():
@@ -191,11 +251,12 @@ def test_dashboard_cookie_fallback_without_basic():
     assert resp.status_code == 200
 
 
-def test_dashboard_invalid_cookie_rejected():
+def test_dashboard_invalid_cookie_redirects_to_login():
     client = TestClient(_full_app(_settings()))
     client.cookies.set(_AUTH_COOKIE, "1.deadbeef")
-    resp = client.get("/")
-    assert resp.status_code == 401
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/login"
 
 
 def test_non_ascii_cookie_does_not_crash():

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -1,0 +1,198 @@
+"""Tests for Web UI auth, focused on the cookie fallback that lets WebSocket
+handshakes (which cannot carry an Authorization header) authenticate.
+
+Regression: the Console/SQL terminal buttons opened WebSocket connections that
+``BasicAuthMiddleware`` rejected with HTTP 403, because the browser never sends
+HTTP Basic credentials on a WebSocket upgrade. The fix mints a signed cookie on
+dashboard load and validates it for both HTTP and WebSocket scopes.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from starlette.applications import Starlette
+from starlette.routing import Router, WebSocketRoute
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocket, WebSocketDisconnect
+
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import (
+    _AUTH_COOKIE,
+    BasicAuthMiddleware,
+    _check_cookie_token,
+    _make_ui_token,
+    mount_web_ui,
+)
+from oduflow.locking import LockManager
+
+_PW = "s3cret"
+
+
+def _settings(routing_mode: str = "port") -> Settings:
+    return Settings(
+        routing_mode=routing_mode,
+        teams={
+            "1": TeamSettings(team_id="1", ui_password=_PW),
+        },
+    )
+
+
+def _team(settings: Settings) -> TeamSettings:
+    return settings.teams["1"]
+
+
+def _basic(user: str, password: str) -> dict[str, str]:
+    blob = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {blob}"}
+
+
+def _full_app(settings: Settings) -> Starlette:
+    """The real web UI sub-app (auto-wrapped in BasicAuthMiddleware since a team
+    has a ui_password)."""
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return app
+
+
+# --- token helpers -------------------------------------------------------
+
+
+def test_token_roundtrip():
+    settings = _settings()
+    token = _make_ui_token(_team(settings))
+    assert token.startswith("1.")
+    assert _check_cookie_token(token, settings) is _team(settings)
+
+
+def test_token_rejects_tampered_and_garbage():
+    settings = _settings()
+    token = _make_ui_token(_team(settings))
+    assert (
+        _check_cookie_token(token[:-1] + ("0" if token[-1] != "0" else "1"), settings)
+        is None
+    )
+    assert _check_cookie_token("1.deadbeef", settings) is None
+    assert _check_cookie_token("nope", settings) is None
+    assert _check_cookie_token("", settings) is None
+    # Unknown team id
+    assert _check_cookie_token("99." + token.split(".", 1)[1], settings) is None
+
+
+def test_parse_cookie():
+    parse = BasicAuthMiddleware._parse_cookie
+    assert parse("a=1; oduflow_ui_auth=tok; b=2", _AUTH_COOKIE) == "tok"
+    assert parse("oduflow_ui_auth=tok", _AUTH_COOKIE) == "tok"
+    assert parse("", _AUTH_COOKIE) is None
+    assert parse("other=1", _AUTH_COOKIE) is None
+
+
+# --- HTTP dashboard ------------------------------------------------------
+
+
+def test_dashboard_requires_auth():
+    client = TestClient(_full_app(_settings()))
+    resp = client.get("/")
+    assert resp.status_code == 401
+    assert "Basic" in resp.headers.get("www-authenticate", "")
+
+
+def test_dashboard_basic_sets_cookie():
+    client = TestClient(_full_app(_settings()))
+    resp = client.get("/", headers=_basic("admin", _PW))
+    assert resp.status_code == 200
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert f"{_AUTH_COOKIE}=" in set_cookie
+    assert "httponly" in set_cookie.lower()
+    assert "samesite=strict" in set_cookie.lower()
+    # The minted cookie validates back to the team.
+    token = client.cookies.get(_AUTH_COOKIE)
+    assert _check_cookie_token(token, _settings()) is not None
+
+
+def test_dashboard_cookie_fallback_without_basic():
+    """The core regression: a request carrying only the cookie (no Authorization
+    header) is the exact shape of a browser WebSocket handshake."""
+    settings = _settings()
+    token = _make_ui_token(_team(settings))
+    client = TestClient(_full_app(settings))
+    client.cookies.set(_AUTH_COOKIE, token)
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+
+def test_dashboard_invalid_cookie_rejected():
+    client = TestClient(_full_app(_settings()))
+    client.cookies.set(_AUTH_COOKIE, "1.deadbeef")
+    resp = client.get("/")
+    assert resp.status_code == 401
+
+
+def test_cookie_secure_flag():
+    # plain http, port mode -> no Secure
+    client = TestClient(_full_app(_settings("port")))
+    resp = client.get("/", headers=_basic("admin", _PW))
+    assert "secure" not in resp.headers.get("set-cookie", "").lower()
+
+    # X-Forwarded-Proto: https -> Secure
+    headers = {**_basic("admin", _PW), "X-Forwarded-Proto": "https"}
+    resp = client.get("/", headers=headers)
+    assert "secure" in resp.headers.get("set-cookie", "").lower()
+
+    # routing_mode=traefik -> Secure even on plain http
+    client = TestClient(_full_app(_settings("traefik")))
+    resp = client.get("/", headers=_basic("admin", _PW))
+    assert "secure" in resp.headers.get("set-cookie", "").lower()
+
+
+# --- WebSocket handshake -------------------------------------------------
+
+
+async def _stub_ws(websocket: WebSocket) -> None:
+    await websocket.accept()
+    await websocket.send_text("ok")
+    await websocket.close()
+
+
+def _ws_app(settings: Settings):
+    router = Router(
+        routes=[WebSocketRoute("/api/environments/{branch:path}/terminal", _stub_ws)]
+    )
+    return BasicAuthMiddleware(router, lambda: settings)
+
+
+_WS_URL = "/api/environments/main/terminal"
+
+
+def test_ws_accepts_valid_cookie():
+    settings = _settings()
+    token = _make_ui_token(_team(settings))
+    client = TestClient(_ws_app(settings))
+    with client.websocket_connect(
+        _WS_URL, headers={"cookie": f"{_AUTH_COOKIE}={token}"}
+    ) as ws:
+        assert ws.receive_text() == "ok"
+
+
+def test_ws_rejects_without_cookie():
+    client = TestClient(_ws_app(_settings()))
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(_WS_URL):
+            pass
+
+
+def test_ws_rejects_invalid_cookie():
+    client = TestClient(_ws_app(_settings()))
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            _WS_URL, headers={"cookie": f"{_AUTH_COOKIE}=1.deadbeef"}
+        ):
+            pass
+
+
+def test_ws_accepts_basic_header():
+    """Header path still works (e.g. non-browser clients)."""
+    client = TestClient(_ws_app(_settings()))
+    with client.websocket_connect(_WS_URL, headers=_basic("admin", _PW)) as ws:
+        assert ws.receive_text() == "ok"


### PR DESCRIPTION
The Console/SQL terminal buttons failed with 403 because browsers do not send Basic credentials on WebSocket upgrades; the auth middleware now accepts a signed session cookie for both HTTP and WebSocket scopes.

The cookie is an itsdangerous token signed with a persistent server-side secret (not the team password), expires after 7 days, survives server restarts, and is revoked immediately when `ui_password` changes. The browser Basic-auth dialog is replaced with a proper login page and a Logout button, while Basic auth is retained for API/CLI clients.

Separately, templates saved from live-mounted environments now record `local_path` instead of a bogus `repo_url`, and create-from-template re-establishes the live-mount over stdio (with a clear error over http, where an explicitly passed `repo_url` always wins). New test suites cover the auth flows and the template code-source handling.