### PR TITLE
Fix license config path

### DIFF
--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -15,7 +15,7 @@ Oduflow is source-available under the [Polyform Noncommercial License 1.0.0](htt
 
 **Via CLI:**
 
-Copy the license file to `/etc/oduflow/license.key`. Oduflow reads it automatically on startup.
+Copy the license file to `<config-dir>/license.key`. The config directory is usually `/etc/oduflow`; when that path is not writable, Oduflow uses `~/.oduflow/conf`. Oduflow reads the license automatically on startup.
 
 **Via Web Dashboard:**
 

--- a/src/oduflow/licensing.py
+++ b/src/oduflow/licensing.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 logger = logging.getLogger("oduflow")
 
-LICENSE_PATH = "/etc/oduflow/license.key"
+LICENSE_FILENAME = "license.key"
 
 # License types
 TYPE_UNLICENSED = "unlicensed"
@@ -69,6 +69,14 @@ class LicenseInfo:
 _UNLICENSED = LicenseInfo(type=TYPE_UNLICENSED, name="", email="")
 
 
+def get_license_path(etc_dir: str | None = None) -> str:
+    if not etc_dir:
+        from oduflow.settings import _resolve_etc_dir
+
+        etc_dir = _resolve_etc_dir()
+    return os.path.join(etc_dir, LICENSE_FILENAME)
+
+
 def _verify_license_text(raw: str) -> LicenseInfo:
     from cryptography.hazmat.primitives.asymmetric import padding
     from cryptography.hazmat.primitives import hashes
@@ -105,30 +113,35 @@ def _verify_license_text(raw: str) -> LicenseInfo:
     )
 
 
-def get_license_info() -> LicenseInfo:
-    if not os.path.isfile(LICENSE_PATH):
+def get_license_info(etc_dir: str | None = None) -> LicenseInfo:
+    license_path = get_license_path(etc_dir)
+    if not os.path.isfile(license_path):
         return _UNLICENSED
     try:
-        raw = open(LICENSE_PATH, "r").read()
+        raw = open(license_path, "r", encoding="utf-8").read()
         return _verify_license_text(raw)
     except Exception as e:
-        logger.warning("Invalid license file %s: %s", LICENSE_PATH, e)
+        logger.warning("Invalid license file %s: %s", license_path, e)
         return _UNLICENSED
 
 
-def install_license(source_path: str) -> LicenseInfo:
-    raw = open(source_path, "r").read()
+def install_license(source_path: str, etc_dir: str | None = None) -> LicenseInfo:
+    raw = open(source_path, "r", encoding="utf-8").read()
     info = _verify_license_text(raw)
-    os.makedirs(os.path.dirname(LICENSE_PATH), exist_ok=True)
-    shutil.copy2(source_path, LICENSE_PATH)
+    license_path = get_license_path(etc_dir)
+    os.makedirs(os.path.dirname(license_path), exist_ok=True)
+    shutil.copy2(source_path, license_path)
     logger.info("License installed: %s", info.label)
     return info
 
 
-def install_license_from_text(key_text: str) -> LicenseInfo:
+def install_license_from_text(
+    key_text: str, etc_dir: str | None = None
+) -> LicenseInfo:
     info = _verify_license_text(key_text)
-    os.makedirs(os.path.dirname(LICENSE_PATH), exist_ok=True)
-    with open(LICENSE_PATH, "w") as f:
+    license_path = get_license_path(etc_dir)
+    os.makedirs(os.path.dirname(license_path), exist_ok=True)
+    with open(license_path, "w", encoding="utf-8") as f:
         f.write(key_text.strip())
     logger.info("License installed: %s", info.label)
     return info

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1088,7 +1088,8 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
     def api_license(request: Request) -> JSONResponse:
-        info = get_license_info()
+        settings = get_settings()
+        info = get_license_info(settings.etc_dir)
         return JSONResponse({"ok": True, "license": info.to_dict()})
 
     async def api_license_activate(request: Request) -> JSONResponse:
@@ -1099,7 +1100,8 @@ def _build_routes(
                 return JSONResponse(
                     {"ok": False, "error": "License key is required."}, status_code=400
                 )
-            info = install_license_from_text(key_text)
+            settings = get_settings()
+            info = install_license_from_text(key_text, settings.etc_dir)
             return JSONResponse({"ok": True, "license": info.to_dict()})
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1,0 +1,52 @@
+from oduflow import licensing
+from oduflow.licensing import LicenseInfo, TYPE_BUSINESS, TYPE_INDIVIDUAL
+
+
+def _info() -> LicenseInfo:
+    return LicenseInfo(type=TYPE_INDIVIDUAL, name="Ada", email="ada@example.com")
+
+
+def test_install_license_from_text_writes_to_etc_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(licensing, "_verify_license_text", lambda raw: _info())
+
+    info = licensing.install_license_from_text(" fake-key \n", etc_dir=str(tmp_path))
+
+    assert info == _info()
+    assert (tmp_path / "license.key").read_text(encoding="utf-8") == "fake-key"
+
+
+def test_get_license_info_reads_from_etc_dir(tmp_path, monkeypatch):
+    license_path = tmp_path / "license.key"
+    license_path.write_text("fake-key", encoding="utf-8")
+    seen = {}
+
+    def verify(raw: str) -> LicenseInfo:
+        seen["raw"] = raw
+        return _info()
+
+    monkeypatch.setattr(licensing, "_verify_license_text", verify)
+
+    assert licensing.get_license_info(etc_dir=str(tmp_path)) == _info()
+    assert seen["raw"] == "fake-key"
+
+
+def test_license_path_falls_back_to_resolved_etc_dir(tmp_path, monkeypatch):
+    fallback = tmp_path / "conf"
+
+    def resolve_etc_dir() -> str:
+        return str(fallback)
+
+    monkeypatch.setattr("oduflow.settings._resolve_etc_dir", resolve_etc_dir)
+
+    assert licensing.get_license_path() == str(fallback / "license.key")
+
+
+def test_install_license_copies_to_etc_dir(tmp_path, monkeypatch):
+    source = tmp_path / "source.key"
+    dest_dir = tmp_path / "conf"
+    source.write_text("fake-file-key", encoding="utf-8")
+    expected = LicenseInfo(type=TYPE_BUSINESS, name="Oduist", email="ops@example.com")
+    monkeypatch.setattr(licensing, "_verify_license_text", lambda raw: expected)
+
+    assert licensing.install_license(str(source), etc_dir=str(dest_dir)) == expected
+    assert (dest_dir / "license.key").read_text(encoding="utf-8") == "fake-file-key"

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -23,6 +23,7 @@ from starlette.testclient import TestClient
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from oduflow import web_ui
+from oduflow.licensing import LicenseInfo, TYPE_INDIVIDUAL, TYPE_UNLICENSED
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import (
     _AUTH_COOKIE,
@@ -41,10 +42,11 @@ _PW = "s3cret"
 _DATA_DIR = tempfile.mkdtemp(prefix="oduflow-uiauth-test-")
 
 
-def _settings(routing_mode: str = "port") -> Settings:
+def _settings(routing_mode: str = "port", etc_dir: str = "") -> Settings:
     return Settings(
         routing_mode=routing_mode,
         base_data_dir=_DATA_DIR,
+        etc_dir=etc_dir,
         teams={
             "1": TeamSettings(team_id="1", ui_password=_PW),
         },
@@ -221,10 +223,40 @@ def test_api_unauthenticated_is_401_without_basic_challenge():
     assert "www-authenticate" not in {k.lower() for k in resp.headers}
 
 
-def test_api_basic_auth_still_works():
-    client = TestClient(_full_app(_settings()))
+def test_api_basic_auth_still_works(tmp_path):
+    client = TestClient(_full_app(_settings(etc_dir=str(tmp_path / "conf"))))
     resp = client.get("/api/license", headers=_basic("admin", _PW))
     assert resp.status_code == 200
+    assert resp.json()["license"]["type"] == TYPE_UNLICENSED
+
+
+def test_api_license_activate_uses_settings_etc_dir(tmp_path, monkeypatch):
+    calls = {}
+
+    def install_license_from_text(key_text: str, etc_dir: str | None = None):
+        calls["key_text"] = key_text
+        calls["etc_dir"] = etc_dir
+        return LicenseInfo(
+            type=TYPE_INDIVIDUAL,
+            name="Ada",
+            email="ada@example.com",
+        )
+
+    monkeypatch.setattr(
+        web_ui, "install_license_from_text", install_license_from_text
+    )
+    settings = _settings(etc_dir=str(tmp_path / "conf"))
+    client = TestClient(_full_app(settings))
+
+    resp = client.post(
+        "/api/license/activate",
+        headers=_basic("admin", _PW),
+        json={"key": " fake-key "},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["license"]["name"] == "Ada"
+    assert calls == {"key_text": "fake-key", "etc_dir": settings.etc_dir}
 
 
 def test_dashboard_basic_sets_cookie():


### PR DESCRIPTION
## Summary

- Store license keys under the resolved Oduflow config directory instead of hard-coding `/etc/oduflow/license.key`.
- Pass `settings.etc_dir` through the dashboard license API so activation uses the same config location as the running server.
- Add regression coverage for license path resolution and the dashboard license API returning `unlicensed` when no key exists.

## Root Cause

License storage used a fixed `/etc/oduflow/license.key` path, so dashboard activation failed when Oduflow had fallen back to a user-writable config directory. The first backend route update also used the wrong settings accessor inside `web_ui.py`, which could make `/api/license` fail and leave the existing badge hidden.

## Validation

- `.context/test-venv/bin/ruff check src/oduflow/licensing.py src/oduflow/web_ui.py tests/test_licensing.py tests/test_web_ui_auth.py`
- `.context/test-venv/bin/pytest tests/test_licensing.py tests/test_web_ui_auth.py`
- `git diff --check`
