### PR TITLE
Prepare v1.50.3 live-mount release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,23 @@
 # Changelog
 
-## v1.50.2 (since v1.50.1)
+## v1.50.3
+
+### Features
+
+- **Git-independent live-mount apply flow** — `local_path` environments now use an Oduflow-owned per-environment file snapshot instead of Git status to detect local changes. Git commits are optional in live-mount mode, non-git folders are supported as-is, and already-applied dirty/untracked files are no longer reported repeatedly.
+- **Config-gated live-mounts** — added `[server].allow_local_path` (default: `true`) to enable the single-developer live-mount workflow by default while still allowing operators to disable local bind mounts explicitly.
+- **Mode-aware agent instructions** — `get_agent_instructions` now starts with a dynamic code-delivery-mode preface. When a live-mounted environment is active, agents see the local workflow first, including the explicit `install`/`upgrade`/`restart` rules that apply to snapshot-based detection.
+
+### Bug Fixes
+
+- **Live-mount templates in Web UI** — environments created from templates that record `local_path` can now be recreated as live-mounts when `allow_local_path` is enabled, instead of always being rejected as HTTP-only.
+- **Local `pull_and_apply` repeat detection** — snapshots advance only after successful apply operations, and stay unchanged when strict guardrails block or install/upgrade fails.
+
+### Documentation
+
+- **Agent guide local workflow** — clarified the split between `repo_url` mode (`commit` → `push` → `pull_and_apply`) and `local_path` live-mount mode (edit local files directly; commits optional; pass explicit actions for database-affecting changes).
+
+## v1.50.2
 
 ### Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oduflow"
-version = "1.50.2"
+version = "1.50.3"
 description = "AI-first Odoo development and CI tool with reusable database templates, powered by MCP"
 authors = [
     { name = "Oduist" }

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -690,7 +690,7 @@ def create_environment(
 
     _cleanup_old_environment(client, settings, team, env_name)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
-    # Live-mount mode (stdio/local): bind-mount the agent's own checkout
+    # Live-mount mode: bind-mount the agent's own checkout
     # directly instead of cloning. The repo lives OUTSIDE the managed
     # workspace, so it is never touched by cleanup/delete.
     local_mount = bool(local_path)
@@ -699,6 +699,11 @@ def create_environment(
         if local_mount
         else get_repo_path(env_name, team.workspaces_dir)
     )
+    if local_mount and not settings.allow_local_path:
+        raise PrerequisiteNotMetError(
+            "local_path (live-mount) is disabled. Set allow_local_path = true "
+            "in oduflow.toml [server] to enable it."
+        )
     env_db = get_db_name(env_name, team.team_id)
 
     labels = {
@@ -762,13 +767,9 @@ def create_environment(
                 f"local_path does not exist or is not a directory: {repo_path}"
             )
         logger.info("Live-mount mode: using local checkout at %s", repo_path)
-        # Baseline for non-git change detection: first pull_and_apply diffs
-        # against this snapshot. (Git checkouts use working-tree diff instead.)
-        try:
-            with open(_mtime_snapshot_path(env_name, team), "w") as _snap:
-                json.dump(_scan_mtimes(repo_path), _snap)
-        except OSError:
-            pass
+        # Baseline for local change detection: first pull_and_apply diffs
+        # against this snapshot. Git is deliberately ignored in live-mount mode.
+        _write_local_snapshot(repo_path, env_name, team)
     else:
         git_env = git_env_for_team(team.git_credentials_file())
 
@@ -1272,6 +1273,7 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                 "repo_url": sanitize_repo_url(
                     container.labels.get(settings.repo_label, "")
                 ),
+                "local_path": container.labels.get("oduflow.local_path", ""),
                 "template_name": container.labels.get("oduflow.template", ""),
                 "extra_addons": _normalize_extra_addons(
                     json.loads(container.labels.get("oduflow.extra_addons", "{}")),
@@ -1527,72 +1529,85 @@ def get_environment_info(
     return result
 
 
-def _is_git_repo(path: str) -> bool:
-    try:
-        r = subprocess.run(
-            ["git", "-C", path, "rev-parse", "--is-inside-work-tree"],
-            capture_output=True,
-            text=True,
-        )
-        return r.returncode == 0 and r.stdout.strip() == "true"
-    except OSError:
-        return False
+_LOCAL_SNAPSHOT_SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    ".idea",
+    ".vscode",
+    "node_modules",
+}
+_LOCAL_SNAPSHOT_SKIP_SUFFIXES = (".pyc", ".pyo")
 
 
-def _git_working_changes(repo_path: str) -> list[str]:
-    """Paths changed in the working tree vs HEAD plus untracked files.
-
-    Returned relative to *repo_path* — suitable for ``classify_changes``. This
-    is "since the last commit", so committing after applying gives the cleanest
-    signal; otherwise cumulative uncommitted edits are re-evaluated each call.
-    """
-    changed: list[str] = []
-    try:
-        tracked = subprocess.run(
-            ["git", "-C", repo_path, "diff", "--name-only", "HEAD"],
-            capture_output=True,
-            text=True,
-        )
-        if tracked.returncode == 0:
-            changed.extend(tracked.stdout.splitlines())
-    except OSError:
-        pass
-    try:
-        untracked = subprocess.run(
-            ["git", "-C", repo_path, "ls-files", "--others", "--exclude-standard"],
-            capture_output=True,
-            text=True,
-        )
-        if untracked.returncode == 0:
-            changed.extend(untracked.stdout.splitlines())
-    except OSError:
-        pass
-    return [f for f in changed if f]
-
-
-_MTIME_SKIP_DIRS = {".git", "__pycache__", ".idea", ".vscode", "node_modules"}
-
-
-def _scan_mtimes(root: str) -> dict[str, float]:
-    """Map of relative-path -> mtime for files under *root* (cheap: stat only)."""
-    out: dict[str, float] = {}
+def _scan_local_snapshot(root: str) -> dict[str, dict[str, int]]:
+    """Map relative paths to cheap file fingerprints for live-mount mode."""
+    out: dict[str, dict[str, int]] = {}
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in _MTIME_SKIP_DIRS]
+        dirnames[:] = [d for d in dirnames if d not in _LOCAL_SNAPSHOT_SKIP_DIRS]
         for f in filenames:
-            if f.endswith((".pyc", ".pyo")):
+            if f.endswith(_LOCAL_SNAPSHOT_SKIP_SUFFIXES):
                 continue
             fp = os.path.join(dirpath, f)
             try:
-                out[os.path.relpath(fp, root)] = os.path.getmtime(fp)
+                st = os.stat(fp)
             except OSError:
-                pass
+                continue
+            out[os.path.relpath(fp, root)] = {
+                "size": int(st.st_size),
+                "mtime_ns": int(st.st_mtime_ns),
+            }
     return out
 
 
-def _mtime_snapshot_path(env_name: str, team: TeamSettings) -> str:
+def _local_snapshot_path(env_name: str, team: TeamSettings) -> str:
     return os.path.join(
-        get_workspace_path(env_name, team.workspaces_dir), ".oduflow_mtimes.json"
+        get_workspace_path(env_name, team.workspaces_dir), ".oduflow_local_state.json"
     )
+
+
+def _load_local_snapshot(env_name: str, team: TeamSettings) -> dict[str, dict[str, int]]:
+    snap_path = _local_snapshot_path(env_name, team)
+    if not os.path.isfile(snap_path):
+        return {}
+    try:
+        with open(snap_path) as f:
+            raw = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    if not isinstance(raw, dict):
+        return {}
+
+    # Current format stores {"version": 1, "files": {...}}. Older dev builds
+    # stored the file map directly; accept both so existing environments recover.
+    files = raw.get("files") if "files" in raw else raw
+    if not isinstance(files, dict):
+        return {}
+    return files
+
+
+def _write_local_snapshot(repo_path: str, env_name: str, team: TeamSettings) -> None:
+    snap_path = _local_snapshot_path(env_name, team)
+    try:
+        os.makedirs(os.path.dirname(snap_path), exist_ok=True)
+        with open(snap_path, "w") as f:
+            json.dump(
+                {
+                    "version": 1,
+                    "repo_path": repo_path,
+                    "files": _scan_local_snapshot(repo_path),
+                },
+                f,
+                sort_keys=True,
+            )
+    except OSError:
+        logger.warning(
+            "Could not write live-mount snapshot for %s", env_name, exc_info=True
+        )
 
 
 def _detect_local_changes(
@@ -1600,29 +1615,17 @@ def _detect_local_changes(
 ) -> tuple[str | None, list[str]]:
     """Return ``(base_ref, changed_files)`` for a live-mounted checkout.
 
-    Git checkout → working-tree diff vs HEAD + untracked, ``base_ref="HEAD"``
-    (enables deep field/manifest guardrail checks). Non-git → mtime snapshot
-    diff, ``base_ref=None`` (path-only guardrail). The snapshot is refreshed
-    every call so each apply reports changes since the previous one.
+    Live-mount mode is independent of Git: commits are the user's choice, and
+    Oduflow tracks only what has been successfully applied to Odoo. The diff is
+    computed from a per-env file snapshot and the snapshot is advanced only
+    after a successful apply.
     """
-    if _is_git_repo(repo_path):
-        return "HEAD", _git_working_changes(repo_path)
-
-    snap_path = _mtime_snapshot_path(env_name, team)
-    current = _scan_mtimes(repo_path)
-    old: dict[str, float] = {}
-    if os.path.isfile(snap_path):
-        try:
-            with open(snap_path) as f:
-                old = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            old = {}
-    changed = [p for p, m in current.items() if old.get(p) != m]
-    try:
-        with open(snap_path, "w") as f:
-            json.dump(current, f)
-    except OSError:
-        pass
+    current = _scan_local_snapshot(repo_path)
+    old = _load_local_snapshot(env_name, team)
+    changed = sorted(
+        {p for p, fingerprint in current.items() if old.get(p) != fingerprint}
+        | {p for p in old if p not in current}
+    )
     return None, changed
 
 
@@ -1713,9 +1716,9 @@ def pull_environment(
 
     * **git** (default) — ``git pull`` the branch (and extra-addon worktrees)
       into the managed clone, which is bind-mounted into the container.
-    * **live-mount** (``oduflow.local_path`` label, stdio/local only) — the
+    * **live-mount** (``oduflow.local_path`` label, gated by allow_local_path) — the
       agent's checkout is already bind-mounted, so there is nothing to pull;
-      changes are detected straight from the working tree.
+      changes are detected from Oduflow's last successful local snapshot.
 
     Action selection:
 
@@ -1723,8 +1726,8 @@ def pull_environment(
       given, do exactly that. A guardrail compares the request against what the
       changed files suggest and returns non-blocking ``warnings`` (or, with
       ``strict=True``, refuses with ``action="blocked"``).
-    * **auto** — otherwise fall back to ``classify_changes`` (unchanged legacy
-      behavior), useful for pulling commits you did not author.
+    * **auto** — otherwise fall back to ``classify_changes`` in git mode or
+      path-only ``shallow_classify`` in live-mount mode.
     """
     from oduflow.git_analysis import guardrail_warnings, recommend
     from oduflow.git_ops import pull_repo
@@ -1844,6 +1847,8 @@ def pull_environment(
     )
     if warnings:
         result["warnings"] = warnings
+    if is_local and int(result.get("exit_code", 0)) == 0:
+        _write_local_snapshot(repo_path, env_name, team)
     return result
 
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -856,7 +856,7 @@ def _source_env_metadata(settings: Settings, labels: dict) -> dict:
 
     A live-mounted environment (``oduflow.local_path`` label) has no repo URL;
     record the path instead so create-from-template can re-establish the
-    live-mount (stdio transport only).
+    live-mount when allow_local_path is enabled.
     """
     metadata: dict[str, object] = {"odoo_image": labels.get(settings.image_label, "")}
     live_path = labels.get("oduflow.local_path", "")

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -397,14 +397,14 @@ def create_environment(
     Args:
         branch: The git branch to clone (e.g. "19.0", "feature/my-feature").
         env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="19.0").
-        template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden). A template saved from a live-mounted environment supplies local_path instead of repo_url and recreates the live-mount (stdio transport only; over http pass repo_url explicitly).
+        template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden). A template saved from a live-mounted environment supplies local_path instead of repo_url and recreates the live-mount when allow_local_path is enabled.
         repo_url: URL of the git repository to clone. Optional when template_name is specified (loaded from template metadata).
         odoo_image: Full Docker image name with tag (e.g. "odoo:19.0"). Optional when template_name is specified (loaded from template metadata).
         extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:19.0,custom-themes:main"). Each entry must include a branch after a colon.
         sanitize: Sanitize the database after provisioning (default: True). Disables incoming/outgoing mail servers and runs custom scripts from the .odoo_sanitize/ folder in the repository.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
         env_vars: Comma-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). These are added on top of the database connection variables (HOST/USER/PASSWORD).
-        local_path: LOCAL FAST-PATH (stdio transport only). Absolute path to a checkout on THIS host. When set, Oduflow skips git clone and bind-mounts the directory live into the container — your file edits are visible instantly, no git push/pull needed. After editing, call pull_and_apply with explicit install/upgrade/restart to apply. repo_url is not required in this mode. Rejected over http transport.
+        local_path: LOCAL FAST-PATH. Absolute path to a checkout on THIS host. When set, Oduflow skips git clone and bind-mounts the directory live into the container — your file edits are visible instantly, no git push/pull needed. After editing, call pull_and_apply with explicit install/upgrade/restart to apply. repo_url is not required in this mode. Gated by allow_local_path (default: true).
     """
     import json
 
@@ -456,19 +456,19 @@ def create_environment(
                     local_path_from_template = True
 
         if local_path:
-            if settings_module.TRANSPORT != "stdio":
+            if not settings.allow_local_path:
                 if local_path_from_template:
                     raise ValueError(
                         f"Template '{resolved_template}' was saved from a "
                         "live-mounted environment, so it provides a local_path "
-                        "instead of a repo_url. Live-mount is only available "
-                        "with the stdio (local) transport — pass repo_url= "
-                        "explicitly to clone over http, or create the "
-                        "environment via the local (stdio) server."
+                        "instead of a repo_url. Set allow_local_path = true "
+                        "in oduflow.toml [server] to enable live-mount, or "
+                        "pass repo_url= explicitly."
                     )
                 raise ValueError(
-                    "local_path (live-mount) is only available with the stdio "
-                    "(local) transport, not over http."
+                    "local_path (live-mount) is disabled. Set "
+                    "allow_local_path = true in oduflow.toml [server] "
+                    "to enable it."
                 )
             local_path = os.path.abspath(os.path.expanduser(local_path))
             if not os.path.isdir(local_path):
@@ -484,10 +484,8 @@ def create_environment(
                     "repo_url",
                     "template_name (which supplies repo_url from its metadata)",
                 ]
-                if settings_module.TRANSPORT == "stdio":
-                    sources.append(
-                        "local_path=<abs path> (local live-mount fast-path, stdio only)"
-                    )
+                if settings.allow_local_path:
+                    sources.append("local_path=<abs path> (live-mount fast-path)")
                 raise ValueError(
                     "No code source for the environment — provide one of: "
                     + "; ".join(sources)
@@ -785,12 +783,43 @@ def get_agent_instructions(ctx: Context = None) -> str:
     """Get instructions for AI coding agents on how to use Oduflow MCP tools."""
     import pathlib
 
+    def _mode_preface() -> str:
+        settings = _get_settings()
+        try:
+            envs = env_ops.list_environments(settings, team)
+        except Exception:
+            envs = []
+
+        local_envs = [env for env in envs if env.get("local_path")]
+        if local_envs:
+            names = ", ".join(
+                f"{env['env_name']} ({env['local_path']})" for env in local_envs
+            )
+            return (
+                "## Current Code Delivery Mode\n\n"
+                f"Live-mount/local_path mode is active for: {names}\n\n"
+                "Use the local live-mount workflow for these environments:\n"
+                "1. Edit files directly in the mounted local folder; no git push is required.\n"
+                "2. Call `pull_and_apply` after edits. Prefer explicit actions when you authored the changes.\n"
+                "3. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade=\"module\")`.\n"
+                "4. If you add a new module, call `pull_and_apply(..., install=\"module\")`.\n"
+                "5. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.\n"
+                "6. Git commits are optional in live-mount mode and are not used by Oduflow to detect applied changes.\n\n"
+                "---\n\n"
+            )
+
+        return (
+            "## Current Code Delivery Mode\n\n"
+            "No live-mount/local_path environment was detected. Use the `repo_url` workflow unless you create an environment with `local_path`: edit locally, commit, push, then call `pull_and_apply` so Oduflow can pull the pushed commits.\n\n"
+            "---\n\n"
+        )
+
     team = _resolve_team(ctx)
     for name in ("agent_instructions.md", "agent_skill.md", "agent_guide.md"):
         skill_path = os.path.join(team.data_dir, "agent_guides", name)
         if os.path.isfile(skill_path):
             with open(skill_path, "r", encoding="utf-8") as f:
-                return f.read()
+                return _mode_preface() + f.read()
     for name in ("agent_instructions.md", "agent_skill.md", "agent_guide.md"):
         bundled = (
             pathlib.Path(__file__).resolve().parent
@@ -799,7 +828,7 @@ def get_agent_instructions(ctx: Context = None) -> str:
             / name
         )
         if bundled.is_file():
-            return bundled.read_text(encoding="utf-8")
+            return _mode_preface() + bundled.read_text(encoding="utf-8")
     return "Agent skill not found."
 
 
@@ -921,6 +950,8 @@ def list_environments(ctx: Context = None) -> str:
             output += f"  Image: {env['odoo_image']}\n"
         if env.get("repo_url"):
             output += f"  Repo: {env['repo_url']}\n"
+        if env.get("local_path"):
+            output += f"  Live-mount: {env['local_path']}\n"
         if env.get("template_name"):
             output += f"  Template: {env['template_name']}\n"
         for container in env["containers"]:
@@ -1182,7 +1213,7 @@ def pull_and_apply(
 
     Works for both code-delivery modes (chosen automatically per environment):
     - git: pulls the branch (and extra-addon worktrees) into the managed clone.
-    - live-mount (stdio/local, from create_environment(local_path=...)): your
+    - live-mount (from create_environment(local_path=...)): your
       edits are already live on disk; this just applies them — no git needed.
 
     Two ways to drive it:
@@ -3195,8 +3226,8 @@ def main() -> None:
     if args.command is None:
         # No subcommand → start the MCP server
         _ensure_initialized(_settings)
-        # Record the active transport so tools can gate local-only features
-        # (e.g. create_environment(local_path=...)) to stdio.
+        # Record the active transport for informational purposes.
+        # local_path is gated by allow_local_path in Settings.
         settings_module.TRANSPORT = args.transport
         if args.transport == "stdio":
             _start_stdio()

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -17,9 +17,8 @@ logger = logging.getLogger("oduflow")
 TRACE: bool = False
 
 # Active MCP transport for the running server ("stdio" | "http").
-# Set in server.main() before the server starts. Tools use this to gate
-# local-only features (e.g. create_environment(local_path=...)) that must
-# never be exposed over a remote/http transport.
+# Set in server.main() before the server starts. Mostly informational;
+# local_path is gated by the allow_local_path setting.
 TRANSPORT: str = "stdio"
 
 
@@ -84,6 +83,7 @@ class Settings:
     port: int = 8000
     trace: bool = False
     disable_telemetry: bool = False
+    allow_local_path: bool = True
 
     # Routing
     routing_mode: str = "port"
@@ -274,6 +274,7 @@ class Settings:
             port=int(server.get("port", 8000)),
             trace=trace,
             disable_telemetry=bool(server.get("disable_telemetry", False)),
+            allow_local_path=bool(server.get("allow_local_path", True)),
             routing_mode=str(routing.get("mode", "port")).strip().lower(),
             acme_email=str(routing.get("acme_email", "")).strip(),
             db_user=str(database.get("user", "odoo")),

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -9,7 +9,18 @@ MCP endpoint: `http://<host>:8000/mcp`
 
 ---
 
-## Core Workflow for Agents
+## Choose The Code Delivery Workflow First
+
+Before editing, identify how the environment receives code:
+
+- **`repo_url` mode:** Oduflow owns a managed clone. Edit locally, commit, push, then call `pull_and_apply` so Oduflow can pull the pushed commits.
+- **`local_path` live-mount mode:** Oduflow bind-mounts a local folder. Edit files directly in that folder; no push is required. Git commits are optional and are not used by Oduflow to decide what was applied.
+
+In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
+
+---
+
+## Core Workflow for Agents (`repo_url` mode)
 
 ```
 1. list_environments          — Check if an environment for the current branch exists
@@ -24,6 +35,20 @@ MCP endpoint: `http://<host>:8000/mcp`
 
 ---
 
+## Core Workflow for Agents (`local_path` live-mount mode)
+
+```
+1. list_environments          — Check if an environment already uses local_path
+2. create_environment         — If not, provision one with local_path="/abs/path"
+3. Write / edit files directly in the mounted local folder
+4. pull_and_apply             — Pass install/upgrade/restart explicitly when your edits require it
+5. If errors in response → fix code → repeat from step 4
+6. run_odoo_tests             — Run Odoo tests for the changed modules
+7. delete_environment         — Tear down when done
+```
+
+---
+
 ## MCP Tools Quick Reference
 
 ### Environment Lifecycle
@@ -31,7 +56,7 @@ MCP endpoint: `http://<host>:8000/mcp`
 | Tool | When to use |
 |---|---|
 | `list_environments` | Check existing environments before creating a new one |
-| `create_environment(branch, env_name?, repo_url, odoo_image, template_name?, env_vars?, local_path?)` | Provision an environment. `branch` is the git branch; `env_name` defaults to the branch name. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects. `env_vars` is a comma-separated `KEY=VALUE` list injected into the Odoo container. **Local fast-path (stdio only):** pass `local_path="/abs/path/to/checkout"` to bind-mount your local working copy live instead of cloning — edits apply with no git push (see "Local Fast-Path" below). |
+| `create_environment(branch, env_name?, repo_url, odoo_image, template_name?, env_vars?, local_path?)` | Provision an environment. `branch` is the git branch; `env_name` defaults to the branch name. Use the correct Odoo Docker image. Pass `template_name="none"` for greenfield projects. `env_vars` is a comma-separated `KEY=VALUE` list injected into the Odoo container. **Local fast-path / live-mount:** pass `local_path="/abs/path/to/checkout"` to bind-mount local files live instead of cloning — edits apply with no git push (see "Local Fast-Path / Live-Mount" below). |
 | `get_environment_info(env_name)` | Get full environment details: database name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
 | `delete_environment(env_name)` | Tear down when the task is complete or cancelled |
 | `start_environment` / `stop_environment` | Resume or pause a stopped environment |
@@ -251,7 +276,7 @@ When you call `pull_and_apply`, Oduflow analyzes every changed file:
 
 Priority: install > upgrade > restart > refresh (no action).
 
-This auto-classification runs when you call `pull_and_apply` **without** `install`/`upgrade`/`restart`. Use it for pulling commits you did not author. When you authored the edits, prefer the explicit form (next section).
+This auto-classification runs when you call `pull_and_apply` **without** `install`/`upgrade`/`restart`. In `repo_url` mode it can compare pulled commits with Git history, including field/manifest details. In `local_path` live-mount mode it is snapshot/path-based only, so it cannot reliably know whether a Python edit added a field or changed only method logic. Use auto mode for pulling commits you did not author. When you authored the edits, prefer the explicit form (next section).
 
 ---
 
@@ -273,17 +298,20 @@ In explicit mode, Oduflow cross-checks your action against the detected diff and
 
 ---
 
-## Local Fast-Path (stdio transport)
+## Local Fast-Path / Live-Mount
 
-When Oduflow runs locally (stdio) on the same machine as you, skip the GitHub round-trip entirely:
+When Oduflow runs on the same machine as the code, skip the GitHub round-trip entirely:
 
 1. `create_environment(branch=..., odoo_image=..., template_name=..., local_path="/abs/path/to/your/checkout")` — bind-mounts your working copy live into the container instead of cloning. `repo_url` is not needed.
-2. Edit files in that directory with your normal tools. Changes are visible inside the container **instantly** (no commit, no push, no clone).
-3. `pull_and_apply(env_name, upgrade="my_module")` (or `restart=True`, or `install=...`) to apply — per the decision rules above. XML view edits need no call at all: just refresh the browser.
+2. Edit files in that directory with your normal tools. Changes are visible inside the container **instantly** (no push, no clone).
+3. `pull_and_apply(env_name, upgrade="my_module")` (or `restart=True`, or `install=...`) to apply — per the decision rules above. XML view edits usually need no call at all: just refresh the browser.
 
 Notes:
-- `local_path` is **rejected over http transport** (a remote server must not mount client paths).
-- Change detection uses your checkout's git working tree (uncommitted edits included), so committing after applying gives the cleanest signal. A non-git directory falls back to file-mtime detection with a coarser guardrail.
+- `local_path` is controlled by `[server].allow_local_path` (default: `true`). Set it to `false` to disable live-mounts.
+- Live-mount change detection is snapshot-based and independent of Git. Oduflow records which local file state was last successfully applied and compares later calls against that snapshot.
+- In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
+- Git is optional in live-mount mode. Commit whenever you want for your own workflow; Oduflow does not require commits, create commits, or read Git state to apply local changes.
+- With `repo_url` mode, use the normal remote workflow: edit locally, commit, push, then call `pull_and_apply` so the managed clone can pull the pushed commits.
 
 ---
 

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -2,6 +2,7 @@
 [server]
 host = "0.0.0.0"
 port = 8000
+allow_local_path = true        # allow live-mount (bind local checkout) workflows
 # trace = false                    # verbose tracing for git analysis & env ops
 
 # ── Routing ───────────────────────────────────────────

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -612,6 +612,7 @@ def _build_routes(
                 extra_dict = extra_addons_raw or None
             elif isinstance(extra_addons_raw, str) and extra_addons_raw.strip():
                 extra_dict = _parse_extra_addons(extra_addons_raw.strip()) or None
+            local_path_from_meta = ""
             if resolved_template:
                 metadata_path = team.get_template_metadata_path(resolved_template)
                 if os.path.isfile(metadata_path):
@@ -630,25 +631,36 @@ def _build_routes(
                     if not auto_install_raw:
                         auto_install_raw = metadata.get("auto_install_modules", "")
                     if not repo_url and metadata.get("local_path"):
-                        return JSONResponse(
-                            {
-                                "ok": False,
-                                "error": (
-                                    f"Template '{resolved_template}' was saved "
-                                    "from a live-mounted environment and has no "
-                                    "repo_url. Provide repo_url explicitly, or "
-                                    "create the environment via the local "
-                                    "(stdio) server."
-                                ),
-                            },
-                            status_code=400,
-                        )
+                        if settings.allow_local_path:
+                            local_path_from_meta = metadata["local_path"]
+                        else:
+                            return JSONResponse(
+                                {
+                                    "ok": False,
+                                    "error": (
+                                        f"Template '{resolved_template}' was saved "
+                                        "from a live-mounted environment and has no "
+                                        "repo_url. Set allow_local_path = true in "
+                                        "oduflow.toml [server], or provide "
+                                        "repo_url explicitly."
+                                    ),
+                                },
+                                status_code=400,
+                            )
 
-            if not repo_url or not odoo_image:
+            if not repo_url and not local_path_from_meta:
                 return JSONResponse(
                     {
                         "ok": False,
-                        "error": "repo_url and odoo_image are required (not found in template metadata either).",
+                        "error": "repo_url is required (not found in template metadata either).",
+                    },
+                    status_code=400,
+                )
+            if not odoo_image:
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": "odoo_image is required (not found in template metadata either).",
                     },
                     status_code=400,
                 )
@@ -668,6 +680,7 @@ def _build_routes(
                 git_user=git_user,
                 auto_install_modules=auto_install_list or None,
                 env_vars=env_vars,
+                local_path=local_path_from_meta,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -354,6 +354,7 @@ class TestCreateEnvironment:
         # No git clone was invoked.
         for call in mock_run.call_args_list:
             assert "clone" not in (call.args[0] if call.args else [])
+            assert "init" not in (call.args[0] if call.args else [])
         # Result and container label point at the live-mount directory.
         abs_local = os.path.abspath(local_dir)
         assert result["local_path"] == abs_local
@@ -361,6 +362,35 @@ class TestCreateEnvironment:
         assert run_kwargs["labels"]["oduflow.local_path"] == abs_local
         # The local dir is bind-mounted to /mnt/extra-addons.
         assert run_kwargs["volumes"][abs_local]["bind"] == "/mnt/extra-addons"
+
+    def test_create_local_path_rejects_when_disabled(self, tmp_path):
+        settings = Settings(
+            base_data_dir="/tmp/flow-test",
+            db_user="odoo",
+            db_password="odoo",
+            etc_dir="/tmp/flow-test/etc",
+            allow_local_path=False,
+            teams={"1": TEST_TEAM},
+        )
+
+        with (
+            patch("oduflow.docker_ops.env_ops.get_client") as mock_get_client,
+            patch("oduflow.docker_ops.env_ops._ensure_system_ready"),
+            patch("oduflow.docker_ops.env_ops._cleanup_old_environment"),
+        ):
+            mock_get_client.return_value.containers.get.side_effect = (
+                docker.errors.NotFound("nf")
+            )
+            with pytest.raises(PrerequisiteNotMetError, match="local_path.*disabled"):
+                env_ops.create_environment(
+                    settings,
+                    TEST_TEAM,
+                    "feature/local",
+                    "",
+                    "odoo:17.0",
+                    template_name=None,
+                    local_path=str(tmp_path),
+                )
 
 
 class TestReloadTemplate:
@@ -399,17 +429,167 @@ class TestReloadTemplate:
 
 
 class TestPullEnvironmentLocal:
+    def test_local_snapshot_detects_added_modified_deleted(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+
+        modified = repo / "sale" / "models" / "sale.py"
+        deleted = repo / "sale" / "views" / "old.xml"
+        unchanged = repo / "sale" / "views" / "same.xml"
+        modified.parent.mkdir(parents=True)
+        deleted.parent.mkdir(parents=True)
+        modified.write_text("old")
+        deleted.write_text("<old/>")
+        unchanged.write_text("<same/>")
+
+        env_ops._write_local_snapshot(str(repo), "env", team)
+
+        old_stat = modified.stat()
+        modified.write_text("new")
+        os.utime(
+            modified,
+            ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000),
+        )
+        deleted.unlink()
+        added = repo / "sale" / "views" / "new.xml"
+        added.write_text("<new/>")
+
+        base_ref, changed = env_ops._detect_local_changes(str(repo), "env", team)
+
+        assert base_ref is None
+        assert changed == [
+            "sale/models/sale.py",
+            "sale/views/new.xml",
+            "sale/views/old.xml",
+        ]
+
+    def test_local_snapshot_repeated_after_advance_is_clean(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        path = repo / "sale" / "models" / "sale.py"
+        path.parent.mkdir(parents=True)
+        path.write_text("old")
+
+        env_ops._write_local_snapshot(str(repo), "env", team)
+        old_stat = path.stat()
+        path.write_text("new")
+        os.utime(path, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000))
+
+        assert env_ops._detect_local_changes(str(repo), "env", team)[1] == [
+            "sale/models/sale.py"
+        ]
+        env_ops._write_local_snapshot(str(repo), "env", team)
+        assert env_ops._detect_local_changes(str(repo), "env", team)[1] == []
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
+    def test_local_auto_uses_path_only_classification(
+        self, mock_apply, mock_docker_client, tmp_path
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        py_file = repo / "sale" / "models" / "sale.py"
+        py_file.parent.mkdir(parents=True)
+        py_file.write_text("old")
+        env_ops._write_local_snapshot(str(repo), "env", team)
+
+        old_stat = py_file.stat()
+        py_file.write_text("new")
+        os.utime(py_file, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000))
+
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": str(repo)}
+        mock_docker_client.containers.get.return_value = container
+        mock_apply.return_value = {
+            "action": "restart",
+            "changed_files": ["sale/models/sale.py"],
+            "message": "Container restarted.",
+        }
+
+        result = env_ops.pull_environment(TEST_SETTINGS, team, "env")
+
+        assert result["action"] == "restart"
+        assert mock_apply.call_args.kwargs["do_restart"] is True
+        assert env_ops._detect_local_changes(str(repo), "env", team)[1] == []
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
+    def test_local_failed_apply_does_not_advance_snapshot(
+        self, mock_apply, mock_docker_client, tmp_path
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        xml_file = repo / "sale" / "security" / "rules.xml"
+        xml_file.parent.mkdir(parents=True)
+        xml_file.write_text("<old/>")
+        env_ops._write_local_snapshot(str(repo), "env", team)
+
+        old_stat = xml_file.stat()
+        xml_file.write_text("<new/>")
+        os.utime(xml_file, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000))
+
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": str(repo)}
+        mock_docker_client.containers.get.return_value = container
+        mock_apply.return_value = {
+            "action": "upgrade",
+            "modules_upgraded": ["sale"],
+            "exit_code": 1,
+            "changed_files": ["sale/security/rules.xml"],
+            "message": "Upgraded modules: sale",
+        }
+
+        result = env_ops.pull_environment(TEST_SETTINGS, team, "env", upgrade=["sale"])
+
+        assert result["exit_code"] == 1
+        assert env_ops._detect_local_changes(str(repo), "env", team)[1] == [
+            "sale/security/rules.xml"
+        ]
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
+    def test_local_strict_block_does_not_advance_snapshot(
+        self, mock_apply, mock_docker_client, tmp_path
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        xml_file = repo / "sale" / "security" / "rules.xml"
+        xml_file.parent.mkdir(parents=True)
+        xml_file.write_text("<old/>")
+        env_ops._write_local_snapshot(str(repo), "env", team)
+
+        old_stat = xml_file.stat()
+        xml_file.write_text("<new/>")
+        os.utime(xml_file, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000))
+
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": str(repo)}
+        mock_docker_client.containers.get.return_value = container
+
+        result = env_ops.pull_environment(
+            TEST_SETTINGS, team, "env", restart=True, strict=True
+        )
+
+        assert result["action"] == "blocked"
+        mock_apply.assert_not_called()
+        assert env_ops._detect_local_changes(str(repo), "env", team)[1] == [
+            "sale/security/rules.xml"
+        ]
+
+    @patch("oduflow.docker_ops.env_ops._write_local_snapshot")
     @patch("oduflow.docker_ops.env_ops._apply_actions")
     @patch("oduflow.docker_ops.env_ops._detect_local_changes")
     @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=True)
     def test_local_explicit_guardrail_warns(
-        self, mock_isdir, mock_detect, mock_apply, mock_docker_client
+        self, mock_isdir, mock_detect, mock_apply, mock_write, mock_docker_client
     ):
         container = MagicMock()
         container.labels = {"oduflow.local_path": "/some/local"}
         mock_docker_client.containers.get.return_value = container
         # A security XML change recommends -u of 'sale'.
-        mock_detect.return_value = ("HEAD", ["sale/security/ir_rule.xml"])
+        mock_detect.return_value = (None, ["sale/security/ir_rule.xml"])
         mock_apply.return_value = {
             "action": "restart",
             "changed_files": ["sale/security/ir_rule.xml"],
@@ -424,17 +604,19 @@ class TestPullEnvironmentLocal:
         assert any("sale" in w for w in result.get("warnings", []))
         mock_apply.assert_called_once()
         mock_detect.assert_called_once()
+        mock_write.assert_called_once()
 
+    @patch("oduflow.docker_ops.env_ops._write_local_snapshot")
     @patch("oduflow.docker_ops.env_ops._apply_actions")
     @patch("oduflow.docker_ops.env_ops._detect_local_changes")
     @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=True)
     def test_local_strict_blocks(
-        self, mock_isdir, mock_detect, mock_apply, mock_docker_client
+        self, mock_isdir, mock_detect, mock_apply, mock_write, mock_docker_client
     ):
         container = MagicMock()
         container.labels = {"oduflow.local_path": "/some/local"}
         mock_docker_client.containers.get.return_value = container
-        mock_detect.return_value = ("HEAD", ["sale/security/ir_rule.xml"])
+        mock_detect.return_value = (None, ["sale/security/ir_rule.xml"])
 
         result = env_ops.pull_environment(
             TEST_SETTINGS, TEST_TEAM, "feature/local", restart=True, strict=True
@@ -443,17 +625,19 @@ class TestPullEnvironmentLocal:
         assert result["action"] == "blocked"
         assert any("sale" in w for w in result["warnings"])
         mock_apply.assert_not_called()
+        mock_write.assert_not_called()
 
+    @patch("oduflow.docker_ops.env_ops._write_local_snapshot")
     @patch("oduflow.docker_ops.env_ops._apply_actions")
     @patch("oduflow.docker_ops.env_ops._detect_local_changes")
     @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=True)
     def test_local_explicit_correct_no_warn(
-        self, mock_isdir, mock_detect, mock_apply, mock_docker_client
+        self, mock_isdir, mock_detect, mock_apply, mock_write, mock_docker_client
     ):
         container = MagicMock()
         container.labels = {"oduflow.local_path": "/some/local"}
         mock_docker_client.containers.get.return_value = container
-        mock_detect.return_value = ("HEAD", ["sale/security/ir_rule.xml"])
+        mock_detect.return_value = (None, ["sale/security/ir_rule.xml"])
         mock_apply.return_value = {
             "action": "upgrade",
             "modules_upgraded": ["sale"],
@@ -468,6 +652,7 @@ class TestPullEnvironmentLocal:
         assert result["action"] == "upgrade"
         assert not result.get("warnings")
         mock_apply.assert_called_once()
+        mock_write.assert_called_once()
 
 
 class TestCreateEnvironmentEnvVars:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -213,6 +213,50 @@ class TestListEnvironmentsTool:
         result = _call_tool("list_environments")
         assert "No active" in result
 
+    @patch("oduflow.docker_ops.env_ops.list_environments")
+    def test_list_shows_live_mount_path(self, mock_list):
+        mock_list.return_value = [
+            {
+                "env_name": "local",
+                "status": "running",
+                "url": "http://localhost:50000",
+                "local_path": "/Users/dev/addons",
+                "containers": [],
+            }
+        ]
+
+        result = _call_tool("list_environments")
+
+        assert "Live-mount: /Users/dev/addons" in result
+
+
+class TestAgentInstructionsTool:
+    @patch("oduflow.docker_ops.env_ops.list_environments")
+    def test_instructions_preface_local_mode(self, mock_list):
+        mock_list.return_value = [
+            {
+                "env_name": "test-local",
+                "local_path": "/Users/dev/addons",
+            }
+        ]
+
+        result = _call_tool("get_agent_instructions")
+
+        assert result.startswith("## Current Code Delivery Mode")
+        assert "Live-mount/local_path mode is active" in result
+        assert "upgrade=\"module\"" in result
+        assert "Git commits are optional" in result
+
+    @patch("oduflow.docker_ops.env_ops.list_environments")
+    def test_instructions_preface_repo_url_mode(self, mock_list):
+        mock_list.return_value = []
+
+        result = _call_tool("get_agent_instructions")
+
+        assert result.startswith("## Current Code Delivery Mode")
+        assert "No live-mount/local_path environment was detected" in result
+        assert "commit, push, then call `pull_and_apply`" in result
+
 
 class TestInfoTool:
     @patch("oduflow.docker_ops.env_ops.get_environment_info")

--- a/tests/test_template_local_path.py
+++ b/tests/test_template_local_path.py
@@ -2,8 +2,9 @@
 
 A template saved from a live-mounted environment must record ``local_path``
 (not a bogus path in ``repo_url``), and creating from such a template must
-re-establish the live-mount over stdio, fail with a clear message over http,
-and let an explicit repo_url override the template's local_path.
+re-establish the live-mount when allow_local_path is enabled, fail clearly
+when it is disabled, and let an explicit repo_url override the template's
+local_path.
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ from oduflow.settings import Settings, TeamSettings
 from tool_helpers import call_tool as _call_tool  # noqa: E402
 
 
-def _make_env(tmp_path):
+def _make_env(tmp_path, allow_local_path: bool = True):
     team = TeamSettings(
         team_id="1",
         data_dir=str(tmp_path / "team"),
@@ -29,6 +30,7 @@ def _make_env(tmp_path):
     settings = Settings(
         base_data_dir=str(tmp_path),
         disable_telemetry=True,
+        allow_local_path=allow_local_path,
         teams={"1": team},
     )
     return settings, team
@@ -94,9 +96,8 @@ class TestSourceEnvMetadata:
 
 
 class TestCreateFromLiveMountTemplate:
-    @patch("oduflow.settings.TRANSPORT", "stdio")
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_stdio_recreates_live_mount(self, mock_create, tool_env, tmp_path):
+    def test_recreates_live_mount_when_allowed(self, mock_create, tool_env, tmp_path):
         settings, team = tool_env
         code_dir = tmp_path / "addons"
         code_dir.mkdir()
@@ -112,22 +113,28 @@ class TestCreateFromLiveMountTemplate:
         assert mock_create.call_args.kwargs["local_path"] == str(code_dir)
         assert "Live-mount:" in result
 
-    @patch("oduflow.settings.TRANSPORT", "http")
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_http_rejects_with_clear_error(self, mock_create, tool_env, tmp_path):
-        settings, team = tool_env
+    def test_disabled_rejects_with_clear_error(self, mock_create, tmp_path):
+        import oduflow.server as server
+
+        settings, team = _make_env(tmp_path, allow_local_path=False)
+        old = server._settings
+        server._settings = settings
         _write_template(
             team,
             "tpl",
             {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": "/x/addons"},
         )
-        with pytest.raises(ValueError, match="live-mounted environment"):
-            _call_tool("create_environment", branch="t", template_name="tpl")
-        mock_create.assert_not_called()
+        try:
+            with patch("oduflow.server._resolve_team", return_value=team):
+                with pytest.raises(ValueError, match="live-mounted environment"):
+                    _call_tool("create_environment", branch="t", template_name="tpl")
+            mock_create.assert_not_called()
+        finally:
+            server._settings = old
 
-    @patch("oduflow.settings.TRANSPORT", "http")
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_http_explicit_repo_url_overrides(self, mock_create, tool_env, tmp_path):
+    def test_explicit_repo_url_overrides(self, mock_create, tool_env, tmp_path):
         settings, team = tool_env
         _write_template(
             team,
@@ -147,9 +154,8 @@ class TestCreateFromLiveMountTemplate:
         assert mock_create.call_args.kwargs["local_path"] == ""
         assert "Environment provisioned successfully!" in result
 
-    @patch("oduflow.settings.TRANSPORT", "stdio")
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_stdio_missing_dir_fails(self, mock_create, tool_env, tmp_path):
+    def test_missing_dir_fails(self, mock_create, tool_env, tmp_path):
         settings, team = tool_env
         _write_template(
             team,
@@ -176,10 +182,31 @@ def _web_app(settings):
 
 
 class TestWebUILiveMountTemplate:
-    def test_create_returns_clear_error(self, tmp_path):
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_create_passes_local_path_when_allowed(self, mock_create, tmp_path):
         from starlette.testclient import TestClient
 
         settings, team = _make_env(tmp_path)
+        code_dir = tmp_path / "addons"
+        code_dir.mkdir()
+        _write_template(
+            team,
+            "tpl",
+            {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": str(code_dir)},
+        )
+        mock_create.return_value = {**_CREATE_RESULT, "local_path": str(code_dir)}
+        client = TestClient(_web_app(settings))
+        resp = client.post(
+            "/api/environments/create",
+            json={"env_name": "t", "template_name": "tpl"},
+        )
+        assert resp.status_code == 200
+        assert mock_create.call_args.kwargs["local_path"] == str(code_dir)
+
+    def test_create_returns_clear_error_when_disabled(self, tmp_path):
+        from starlette.testclient import TestClient
+
+        settings, team = _make_env(tmp_path, allow_local_path=False)
         _write_template(
             team,
             "tpl",


### PR DESCRIPTION
## Summary
- make local live-mount apply detection independent of Git by tracking Oduflow-owned file snapshots
- add allow_local_path config gating and support live-mount template create/recreate through MCP and Web UI
- make agent instructions mode-aware and bump the package/changelog to v1.50.3

## Validation
- uv run --with pytest pytest -m "not integration and not heavyweight"
- uv run --with ruff ruff check src/oduflow tests
- git diff --check