### PR TITLE
Add MCP bootstrap instructions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.50.4
+
+### Features
+
+- **MCP bootstrap instructions** — the MCP initialize response now tells agents to load `get_agent_instructions` first and then call `get_odoo_development_guide(version=...)` before writing Odoo module code.
+
 ## v1.50.3
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oduflow"
-version = "1.50.3"
+version = "1.50.4"
 description = "AI-first Odoo development and CI tool with reusable database templates, powered by MCP"
 authors = [
     { name = "Oduist" }

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -49,7 +49,22 @@ _SUMMARY_ERROR_CONTEXT = 5
 
 _output_cache = OutputCache()
 
-mcp = FastMCP("Oduflow")
+_MCP_INSTRUCTIONS = """
+Before using Oduflow tools, call get_agent_instructions to load the current
+Oduflow workflow guide. It includes the active code delivery mode, including
+repo_url versus local_path/live-mount guidance.
+
+Before writing or refactoring Odoo module code, call
+get_odoo_development_guide(version="<major>") for the target Odoo version.
+Determine the version from the user request, existing environment info, or the
+odoo_image value; for example, odoo:18.0 means version="18".
+
+After create_environment returns an instruction to call
+get_odoo_development_guide(version="..."), follow it immediately before
+editing code.
+""".strip()
+
+mcp = FastMCP("Oduflow", instructions=_MCP_INSTRUCTIONS)
 _locks = LockManager()
 _settings: Settings | None = None
 _instance_id: str = ""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,6 +38,18 @@ def inject_team():
 from tool_helpers import call_tool as _call_tool  # noqa: E402
 
 
+class TestMCPBootstrapInstructions:
+    def test_instructions_point_agents_to_dynamic_guides(self):
+        import oduflow.server
+
+        instructions = oduflow.server.mcp.instructions
+
+        assert instructions
+        assert "get_agent_instructions" in instructions
+        assert "get_odoo_development_guide" in instructions
+        assert 'odoo:18.0 means version="18"' in instructions
+
+
 class TestCLIInitDestroy:
     @patch("oduflow.docker_ops.system_ops.destroy_system")
     def test_cli_destroy(self, mock_destroy):


### PR DESCRIPTION
## Summary

- add MCP initialize bootstrap instructions that point agents to `get_agent_instructions`
- tell agents to load `get_odoo_development_guide(version=...)` before Odoo module work
- bump release version to 1.50.4 and preserve the v1.50.3 changelog section

## Validation

- `uv run --with pytest pytest tests/test_server.py::TestMCPBootstrapInstructions tests/test_server.py::TestAgentInstructionsTool -q`
- `uv run --with ruff ruff check src/oduflow/server.py tests/test_server.py`