### PR TITLE
Dashboard: enlarge type scale + improve note UX

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,31 +22,31 @@ colors:
 typography:
   headline:
     fontFamily: "Outfit, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "1.25rem"
+    fontSize: "1.4375rem"
     fontWeight: 600
     lineHeight: 1.3
     letterSpacing: "normal"
   title:
     fontFamily: "Outfit, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "0.9375rem"
+    fontSize: "1.0625rem"
     fontWeight: 600
     lineHeight: 1.4
     letterSpacing: "normal"
   body:
     fontFamily: "Outfit, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "0.8125rem"
+    fontSize: "0.9375rem"
     fontWeight: 400
     lineHeight: 1.5
     letterSpacing: "normal"
   label:
     fontFamily: "Outfit, ui-sans-serif, system-ui, sans-serif"
-    fontSize: "0.75rem"
+    fontSize: "0.875rem"
     fontWeight: 600
     lineHeight: 1.4
     letterSpacing: "0.02em"
   mono:
     fontFamily: "Geist Mono, ui-monospace, SFMono-Regular, Consolas, monospace"
-    fontSize: "0.75rem"
+    fontSize: "0.875rem"
     fontWeight: 400
     lineHeight: 1.5
     letterSpacing: "normal"
@@ -207,15 +207,25 @@ Both faces are bundled with the package (woff2), never loaded from a CDN;
 until bundled, the system stack fallback is acceptable.
 
 ### Hierarchy
-Fixed rem scale, ratio ≈1.15 — product register, no fluid clamp.
-- **Headline** (600, 1.25rem, 1.3): The page title in the header. One per page.
-- **Title** (600, 0.9375rem, 1.4): Card titles — environment branch, service,
-  template, volume names.
-- **Body** (400, 0.8125rem, 1.5): Controls, form fields, modal copy, notes.
-- **Label** (600, 0.75rem, 0.02em): Badges, form labels, meta keys, tab text.
-  Uppercase only for status badges (≤2 words).
-- **Mono** (400, 0.75rem, 1.5): Logs, terminal, DB names, images, paths,
-  container names, sync output.
+Fixed rem scale via semantic `--text-*` tokens (declared in `:root`) — product
+register, no fluid clamp. The dense lower steps sit a tight ≈1.07 apart, so
+in-card hierarchy leans on weight and tone, not size (see The Weight-Not-Size
+Rule); the jump to Headline is the one wide step.
+- **Headline** (`--text-xl`, 600, 1.4375rem/23px, 1.3): The page title in the
+  header. One per page.
+- **Title** (`--text-lg`, 600, 1.0625rem/17px, 1.4): Card titles — environment
+  branch, service, template, volume names.
+- **Body** (`--text-sm`, 400, 0.9375rem/15px, 1.5): Controls, form fields,
+  modal copy, notes.
+- **Label** (`--text-xs`, 600, 0.875rem/14px, 0.02em): Badges, form labels,
+  meta keys, tab text. Uppercase only for status badges (≤2 words).
+- **Mono** (`--text-xs`, 400, 0.875rem/14px, 1.5): Logs, terminal, DB names,
+  images, paths, container names, sync output.
+
+Two further ramp steps carry text that falls between these roles:
+`--text-2xs` (0.8125rem/13px — header byline, port chips, the smallest meta)
+and `--text-md` (1rem/16px — tab labels, sync message). All UI font sizes
+reference one of these six tokens; raw `px` font sizes are not used.
 
 ### Named Rules
 **The Console Voice Rule.** Monospace is reserved for what the machine

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 
 <section class="odu-hero">
   <span class="odu-hero__eyebrow">⎇ AI-First Odoo Development</span>
-  <h1 class="odu-hero__title">Oduflow Documentation</h1>
+  <h1 class="odu-hero__title">Oduflow Docs</h1>
   <p class="odu-hero__subtitle">
     Provision isolated, ephemeral <strong>Odoo</strong> environments on Docker —
     one per git branch — and hand them to your AI agents over <strong>MCP</strong>.

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -267,7 +267,6 @@
     border-radius: var(--radius-sm);
   }
   .env-note:hover { border-color: var(--border); }
-  .env-note-empty { font-style: italic; opacity: 0.5; }
   /* A set note is the one human voice on a machine card: a message from a
      developer to whoever looks next. Amber = the attention channel. */
   .env-note-set {
@@ -371,6 +370,10 @@
   .btn-create.danger { background: var(--red); border-color: var(--red); }
   .btn-create:hover { opacity: 0.85; }
   .btn-create:disabled { opacity: 0.4; cursor: not-allowed; }
+  .btn.danger { color: var(--red); }
+  .btn.danger:hover, .btn.danger:focus-visible { border-color: var(--red); background: color-mix(in oklab, var(--red) 10%, transparent); }
+  /* Destructive note action sits apart from Cancel/Save on the left edge. */
+  #note-delete-btn { margin-right: auto; }
   .form-group { margin-bottom: 14px; }
   .form-group label {
     display: block;
@@ -1249,6 +1252,7 @@
         <textarea id="note-text" rows="4" placeholder="What is this environment for?"></textarea>
       </div>
       <div class="form-actions">
+        <button class="btn danger" id="note-delete-btn" onclick="deleteNote()">Delete note</button>
         <button class="btn" onclick="closeNoteModal()">Cancel</button>
         <button class="btn-create" onclick="saveNote()">Save note</button>
       </div>
@@ -1712,6 +1716,8 @@ function renderEnvironments(envs, force) {
                 (allStopped ? 'disabled' : '') + '>Open console</button>' +
               '<button role="menuitem" title="psql session on the environment database" onclick="openSqlConsole(\'' + escAttr(env.branch) + '\')" ' +
                 (allStopped ? 'disabled' : '') + '>Open SQL console</button>' +
+              '<button role="menuitem" title="' + (env.note ? 'Edit the note on this environment' : 'Add a note to this environment') + '" onclick="editNote(\'' + escAttr(env.branch) + '\')">' +
+                (env.note ? 'Edit note' : 'Add note') + '</button>' +
               '<button role="menuitem" title="' + (env.protected ? 'Allow Stop, Update, Recreate and Delete again' : 'Disable Stop, Update, Recreate and Delete') + '" onclick="doProtect(\'' + escAttr(env.branch) + '\',' + (env.protected ? 'true' : 'false') + ')" ' + dis + '>' +
                 (env.protected ? 'Unprotect' : 'Protect') + '</button>' +
               '<button role="menuitem" onclick="doUpdate(\'' + escAttr(env.branch) + '\')" ' + dis +
@@ -1733,12 +1739,6 @@ function renderEnvironments(envs, force) {
       urlHtml +
       metaHtml +
       extraHtml +
-      (!env.note
-        ? '<div class="env-note env-note-empty" role="button" tabindex="0" aria-label="Add note" ' +
-            'onclick="editNote(\'' + escAttr(env.branch) + '\')" title="Click to add a note">' +
-            'Add a note...' +
-          '</div>'
-        : '') +
       '<div class="containers">' + containerHtml + '</div>' +
     '</div>';
   }).join('');
@@ -1931,10 +1931,11 @@ var _noteBranch = '';
 
 function editNote(branch) {
   _noteBranch = branch;
-  var el = document.querySelector('.env-card[data-branch="' + branch + '"] .env-note');
-  var current = el && el.classList.contains('env-note-empty') ? '' : (el ? el.textContent : '');
+  var env = cachedEnvs.find(function(e) { return e.branch === branch; });
+  var hasNote = !!(env && env.note);
   document.getElementById('note-modal-title').textContent = 'Note — ' + branch;
-  document.getElementById('note-text').value = current;
+  document.getElementById('note-text').value = hasNote ? env.note : '';
+  document.getElementById('note-delete-btn').style.display = hasNote ? '' : 'none';
   showModal('note-modal');
   document.getElementById('note-text').focus();
 }
@@ -1944,9 +1945,7 @@ function closeNoteModal(event) {
   hideModal('note-modal');
 }
 
-async function saveNote() {
-  var branch = _noteBranch;
-  var note = document.getElementById('note-text').value.trim();
+async function _putNote(branch, note, okMsg) {
   try {
     var r = await fetch(API + '/' + encodeURIComponent(branch) + '/note', {
       method: 'POST',
@@ -1954,10 +1953,18 @@ async function saveNote() {
       body: JSON.stringify({note: note})
     });
     var data = await r.json();
-    if (data.ok) { showToast('Note updated'); closeNoteModal(); }
+    if (data.ok) { showToast(okMsg); closeNoteModal(); }
     else { showToast(data.error || 'Failed to update note', true); }
   } catch(e) { showToast('Connection error: ' + e.message, true); }
   await loadEnvironments(true);
+}
+
+async function saveNote() {
+  await _putNote(_noteBranch, document.getElementById('note-text').value.trim(), 'Note updated');
+}
+
+async function deleteNote() {
+  await _putNote(_noteBranch, '', 'Note deleted');
 }
 
 async function loadEnvironments(force) {

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -46,6 +46,13 @@
     --terminal-bg: #060a12;
     --font-sans: "Outfit", -apple-system, BlinkMacSystemFont, "Segoe UI", ui-sans-serif, system-ui, sans-serif;
     --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Consolas, monospace;
+    /* Type scale — semantic rem tokens (see DESIGN.md §3) */
+    --text-2xs: 0.8125rem;  /* 13px — micro labels: byline, badges, ports */
+    --text-xs:  0.875rem;   /* 14px — secondary UI: meta, labels, buttons, inputs, hints, mono meta */
+    --text-sm:  0.9375rem;  /* 15px — body / list text */
+    --text-md:  1rem;       /* 16px — tabs, sync message */
+    --text-lg:  1.0625rem;  /* 17px — entity titles (branch/template/service), modal h2 */
+    --text-xl:  1.4375rem;  /* 23px — header h1, modal close glyph */
     --radius: 0.625rem;
     --radius-sm: 0.425rem;
     --focus-ring: 0 0 0 3px color-mix(in oklab, var(--accent) 50%, transparent);
@@ -57,6 +64,7 @@
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body {
     font-family: var(--font-sans);
+    font-size: var(--text-sm);
     background: var(--bg);
     color: var(--text);
     padding: 24px;
@@ -78,10 +86,10 @@
   .brand-lockup { display: flex; align-items: center; gap: 10px; }
   .brand-lockup img { height: 28px; }
   .brand-copy { display: flex; flex-direction: column; gap: 1px; }
-  header h1 { font-size: 20px; font-weight: 600; line-height: 1.05; }
+  header h1 { font-size: var(--text-xl); font-weight: 600; line-height: 1.05; }
   .brand-byline {
     color: var(--text-dim);
-    font-size: 10.5px;
+    font-size: var(--text-2xs);
     font-weight: 500;
     line-height: 1.2;
     letter-spacing: 0.02em;
@@ -93,11 +101,11 @@
   }
   .brand-byline a:hover { color: var(--accent); }
   header .actions { display: flex; gap: 8px; align-items: center; }
-  .auto-label { font-size: 12px; color: var(--text-dim); }
+  .auto-label { font-size: var(--text-xs); color: var(--text-dim); }
   .docs-link {
     color: var(--text-dim);
     text-decoration: none;
-    font-size: 13px;
+    font-size: var(--text-sm);
     font-weight: 500;
     padding: 6px 8px;
     border-radius: var(--radius-sm);
@@ -111,7 +119,7 @@
     border-radius: var(--radius-sm);
     cursor: pointer;
     font-family: inherit;
-    font-size: 13px;
+    font-size: var(--text-sm);
   }
   .interval-input {
     width: 48px;
@@ -121,7 +129,7 @@
     border-radius: var(--radius-sm);
     padding: 2px 4px;
     font-family: inherit;
-    font-size: 12px;
+    font-size: var(--text-xs);
     text-align: center;
   }
   #refresh-btn:hover { border-color: var(--accent); }
@@ -129,12 +137,12 @@
     text-align: center;
     padding: 64px 0;
     color: var(--text-dim);
-    font-size: 15px;
+    font-size: var(--text-lg);
     line-height: 2.2;
   }
   .empty-hint code {
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: var(--text-xs);
     color: var(--text);
     background: var(--surface);
     border: 1px solid var(--border);
@@ -155,13 +163,13 @@
     margin-bottom: 12px;
   }
   .env-header .left { display: flex; align-items: center; gap: 10px; }
-  .branch-name { font-weight: 600; font-size: 15px; }
-  .git-branch { font-size: 12px; color: var(--text-dim); font-weight: 400; }
+  .branch-name { font-weight: 600; font-size: var(--text-lg); }
+  .git-branch { font-size: var(--text-xs); color: var(--text-dim); font-weight: 400; }
   .badge {
     display: inline-block;
     padding: 2px 8px;
     border-radius: 12px;
-    font-size: 11px;
+    font-size: var(--text-2xs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -185,7 +193,7 @@
     margin-bottom: 12px;
     box-shadow: 0 8px 24px rgba(0,0,0,0.4);
   }
-  .bulk-count { font-weight: 600; font-size: 13px; }
+  .bulk-count { font-weight: 600; font-size: var(--text-sm); }
   .bulk-actions { display: flex; gap: 8px; margin-left: auto; flex-wrap: wrap; }
   .select-box {
     display: inline-flex;
@@ -222,17 +230,17 @@
   .env-url a {
     color: var(--accent);
     text-decoration: none;
-    font-size: 13px;
+    font-size: var(--text-sm);
   }
   .env-url a:hover { text-decoration: underline; }
   .env-meta {
     display: flex;
     gap: 24px;
-    font-size: 12px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
     margin-bottom: 10px;
   }
-  .env-meta strong { color: var(--text); font-weight: 500; font-family: var(--font-mono); font-size: 11.5px; }
+  .env-meta strong { color: var(--text); font-weight: 500; font-family: var(--font-mono); font-size: var(--text-xs); }
   .repo-link {
     display: inline-flex;
     align-items: center;
@@ -250,7 +258,7 @@
   .repo-link svg { width: 14px; height: 14px; }
   .env-note {
     white-space: pre-line;
-    font-size: 12px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
     margin-bottom: 10px;
     padding: 4px 8px;
@@ -263,7 +271,7 @@
   /* A set note is the one human voice on a machine card: a message from a
      developer to whoever looks next. Amber = the attention channel. */
   .env-note-set {
-    font-size: 13px;
+    font-size: var(--text-sm);
     color: var(--text);
     background: color-mix(in oklab, var(--yellow) 8%, transparent);
     border-color: color-mix(in oklab, var(--yellow) 25%, transparent);
@@ -272,7 +280,7 @@
   .env-note-set:hover { border-color: color-mix(in oklab, var(--yellow) 50%, transparent); }
   .note-label {
     display: inline-block;
-    font-size: 11px;
+    font-size: var(--text-2xs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -287,7 +295,7 @@
   .copy-db:hover { border-bottom-color: var(--accent); color: var(--accent); }
   .containers {
     font-family: var(--font-mono);
-    font-size: 11.5px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
     margin-bottom: 12px;
   }
@@ -300,12 +308,12 @@
     background: var(--surface);
     color: var(--text);
     font-family: inherit;
-    font-size: 12px;
+    font-size: var(--text-xs);
     font-weight: 500;
     cursor: pointer;
     transition: border-color 0.15s, color 0.15s, background 0.15s;
   }
-  .btn-sm { font-size: 12px; padding: 3px 10px; }
+  .btn-sm { font-size: var(--text-xs); padding: 3px 10px; }
   .menu-wrap { position: relative; }
   .menu {
     position: absolute;
@@ -327,7 +335,7 @@
     border: none;
     color: var(--text);
     font-family: inherit;
-    font-size: 12px;
+    font-size: var(--text-xs);
     font-weight: 500;
     text-align: left;
     padding: 7px 10px;
@@ -357,7 +365,7 @@
     padding: 6px 14px;
     border-radius: var(--radius);
     cursor: pointer;
-    font-size: 13px;
+    font-size: var(--text-sm);
     font-weight: 600;
   }
   .btn-create.danger { background: var(--red); border-color: var(--red); }
@@ -366,7 +374,7 @@
   .form-group { margin-bottom: 14px; }
   .form-group label {
     display: block;
-    font-size: 13px;
+    font-size: var(--text-sm);
     font-weight: 500;
     margin-bottom: 4px;
     color: var(--text);
@@ -374,7 +382,7 @@
   .form-group input:not([type="checkbox"]), .form-group textarea {
     width: 100%;
     padding: 8px 10px;
-    font-size: 13px;
+    font-size: var(--text-sm);
     font-family: inherit;
     background: var(--bg);
     color: var(--text);
@@ -393,7 +401,7 @@
     background: var(--surface-raised);
     border-top: 1px solid var(--border);
   }
-  .form-error { color: var(--red); font-size: 12px; margin-bottom: 10px; display: none; }
+  .form-error { color: var(--red); font-size: var(--text-xs); margin-bottom: 10px; display: none; }
   .modal-overlay {
     position: fixed; top: 0; left: 0; right: 0; bottom: 0;
     background: rgba(0,0,0,0.72);
@@ -416,17 +424,17 @@
     display: flex; align-items: center; justify-content: space-between;
     padding: 12px 20px; border-bottom: 1px solid var(--border);
   }
-  .modal-header h2 { font-size: 15px; font-weight: 600; }
+  .modal-header h2 { font-size: var(--text-lg); font-weight: 600; }
   .modal-close {
     background: none; border: none; color: var(--text-dim);
-    font-size: 20px; cursor: pointer; padding: 0 4px;
+    font-size: var(--text-xl); cursor: pointer; padding: 0 4px;
   }
   .modal-close:hover { color: var(--text); }
   .modal-body {
     padding: 16px 20px; overflow-y: auto; flex: 1;
   }
   .modal-body pre {
-    margin: 0; font-size: 12px; line-height: 1.5;
+    margin: 0; font-size: var(--text-xs); line-height: 1.5;
     white-space: pre-wrap; word-break: break-all;
     color: var(--text-dim); font-family: var(--font-mono);
   }
@@ -441,29 +449,29 @@
     flex-shrink: 0;
   }
   .logs-toolbar input[type="text"] {
-    flex: 1; max-width: 260px; padding: 5px 8px; font-size: 12px;
+    flex: 1; max-width: 260px; padding: 5px 8px; font-size: var(--text-xs);
     background: var(--bg); color: var(--text); border: 1px solid var(--border);
     border-radius: var(--radius-sm); font-family: inherit;
   }
   .logs-toolbar input[type="text"]:focus { border-color: var(--accent); }
   .logs-toolbar select {
-    padding: 5px 6px; font-size: 12px; background: var(--bg); color: var(--text);
+    padding: 5px 6px; font-size: var(--text-xs); background: var(--bg); color: var(--text);
     border: 1px solid var(--border); border-radius: var(--radius-sm);
     font-family: inherit; cursor: pointer;
   }
   .logs-toolbar .logs-btn {
-    padding: 4px 10px; font-size: 12px; border: 1px solid var(--border);
+    padding: 4px 10px; font-size: var(--text-xs); border: 1px solid var(--border);
     border-radius: var(--radius-sm); background: var(--bg); color: var(--text-dim);
     cursor: pointer; white-space: nowrap; font-family: inherit;
   }
   .logs-toolbar .logs-btn:hover { border-color: var(--accent); color: var(--text); }
   .logs-toolbar .logs-btn.active { border-color: var(--green); color: var(--green); }
-  .logs-match-count { font-size: 12px; color: var(--text-dim); white-space: nowrap; }
+  .logs-match-count { font-size: var(--text-xs); color: var(--text-dim); white-space: nowrap; }
   .sync-result-action {
     display: inline-block;
     padding: 3px 10px;
     border-radius: 12px;
-    font-size: 12px;
+    font-size: var(--text-xs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -473,15 +481,15 @@
   .sync-action-refresh { background: color-mix(in oklab, var(--accent) 15%, transparent); color: var(--accent); }
   .sync-action-restart { background: color-mix(in oklab, var(--yellow) 15%, transparent); color: var(--yellow); }
   .sync-action-install, .sync-action-upgrade { background: color-mix(in oklab, var(--green) 15%, transparent); color: var(--green); }
-  .sync-message { font-size: 14px; margin-bottom: 12px; }
+  .sync-message { font-size: var(--text-md); margin-bottom: 12px; }
   .sync-section { margin-bottom: 12px; }
-  .sync-section-title { font-size: 12px; font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
+  .sync-section-title { font-size: var(--text-xs); font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
   .sync-modules { display: flex; flex-wrap: wrap; gap: 6px; }
-  .sync-module-tag { background: color-mix(in oklab, var(--accent) 10%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 30%, transparent); color: var(--accent); padding: 2px 8px; border-radius: 4px; font-size: 12px; font-family: var(--font-mono); }
+  .sync-module-tag { background: color-mix(in oklab, var(--accent) 10%, transparent); border: 1px solid color-mix(in oklab, var(--accent) 30%, transparent); color: var(--accent); padding: 2px 8px; border-radius: 4px; font-size: var(--text-xs); font-family: var(--font-mono); }
   .sync-files { max-height: 200px; overflow-y: auto; }
-  .sync-files code { display: block; font-size: 12px; line-height: 1.8; color: var(--text-dim); font-family: var(--font-mono); }
-  .sync-output { background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); padding: 10px; max-height: 200px; overflow-y: auto; font-size: 12px; line-height: 1.5; font-family: var(--font-mono); color: var(--text-dim); white-space: pre-wrap; word-break: break-all; }
-  .sync-exit-code { font-size: 12px; margin-top: 6px; }
+  .sync-files code { display: block; font-size: var(--text-xs); line-height: 1.8; color: var(--text-dim); font-family: var(--font-mono); }
+  .sync-output { background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); padding: 10px; max-height: 200px; overflow-y: auto; font-size: var(--text-xs); line-height: 1.5; font-family: var(--font-mono); color: var(--text-dim); white-space: pre-wrap; word-break: break-all; }
+  .sync-exit-code { font-size: var(--text-xs); margin-top: 6px; }
   .sync-exit-ok { color: var(--green); }
   .sync-exit-err { color: var(--red); }
   .toast {
@@ -492,7 +500,7 @@
     border: 1px solid var(--border-raised);
     border-radius: var(--radius);
     padding: 12px 20px;
-    font-size: 13px;
+    font-size: var(--text-sm);
     max-width: 400px;
     opacity: 0;
     transform: translateY(10px);
@@ -510,7 +518,7 @@
     border-radius: var(--radius-sm);
     color: var(--text);
     font-family: inherit;
-    font-size: 12px;
+    font-size: var(--text-xs);
     padding: 2px 8px;
     cursor: pointer;
   }
@@ -530,7 +538,7 @@
     display: inline-flex;
     gap: 12px;
     margin-left: 8px;
-    font-size: 11.5px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
   }
   .container-stats .stat-val { color: var(--text); font-weight: 500; }
@@ -545,7 +553,7 @@
     display: flex;
     align-items: center;
     gap: 24px;
-    font-size: 12px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
     z-index: var(--z-bar);
   }
@@ -584,7 +592,7 @@
     border: none;
     color: var(--text-dim);
     font-family: inherit;
-    font-size: 14px;
+    font-size: var(--text-md);
     font-weight: 500;
     padding: 8px 18px;
     cursor: pointer;
@@ -610,18 +618,18 @@
     align-items: center;
     justify-content: space-between;
   }
-  .tpl-name { font-weight: 600; font-size: 15px; }
+  .tpl-name { font-weight: 600; font-size: var(--text-lg); }
   .tpl-meta {
     display: flex;
     gap: 16px;
-    font-size: 12px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
   }
   .tpl-meta .tag {
     display: inline-block;
     padding: 2px 8px;
     border-radius: 12px;
-    font-size: 11px;
+    font-size: var(--text-2xs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -632,7 +640,7 @@
   .form-group select {
     width: 100%;
     padding: 8px 10px;
-    font-size: 13px;
+    font-size: var(--text-sm);
     font-family: inherit;
     background: var(--bg);
     color: var(--text);
@@ -654,15 +662,15 @@
     margin-bottom: 8px;
   }
   .svc-header .left { display: flex; align-items: center; gap: 10px; }
-  .svc-name { font-weight: 600; font-size: 15px; }
+  .svc-name { font-weight: 600; font-size: var(--text-lg); }
   .svc-meta {
     display: flex;
     gap: 24px;
-    font-size: 12px;
+    font-size: var(--text-xs);
     color: var(--text-dim);
     margin-bottom: 6px;
   }
-  .svc-meta strong { color: var(--text); font-weight: 500; font-family: var(--font-mono); font-size: 11.5px; }
+  .svc-meta strong { color: var(--text); font-weight: 500; font-family: var(--font-mono); font-size: var(--text-xs); }
   .svc-meta a { color: var(--accent); text-decoration: none; }
   .svc-meta a:hover { text-decoration: underline; }
   .svc-actions { display: flex; gap: 8px; flex-wrap: wrap; }
@@ -680,7 +688,7 @@
     border-radius: 14px;
     border: 0;
     background: none;
-    font-size: 11px;
+    font-size: var(--text-2xs);
     font-weight: 600;
     line-height: 1.2;
     letter-spacing: 0.3px;
@@ -776,20 +784,20 @@
     100% { opacity: 0; transform: scale(1.16); }
   }
   .tab-toolbar { display: flex; justify-content: flex-end; gap: 8px; margin-bottom: 12px; }
-  .hint { font-size: 12px; color: var(--text-dim); margin-top: 4px; }
+  .hint { font-size: var(--text-xs); color: var(--text-dim); margin-top: 4px; }
   .label-hint { color: var(--text-dim); font-weight: 400; }
   .check-row { display: flex; align-items: center; gap: 8px; }
   .check-row label { margin-bottom: 0; cursor: pointer; }
   .check-list { max-height: 120px; overflow-y: auto; padding: 4px 0; }
-  .check-item { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 13px; cursor: pointer; }
-  .branch-input { width: 100px; font-size: 12px; padding: 2px 6px; margin-left: auto; }
-  .section-subtitle { font-size: 14px; font-weight: 600; margin-bottom: 10px; color: var(--text-dim); }
-  .modal-note { font-size: 13px; color: var(--text-dim); margin-bottom: 16px; }
+  .check-item { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: var(--text-sm); cursor: pointer; }
+  .branch-input { width: 100px; font-size: var(--text-xs); padding: 2px 6px; margin-left: auto; }
+  .section-subtitle { font-size: var(--text-md); font-weight: 600; margin-bottom: 10px; color: var(--text-dim); }
+  .modal-note { font-size: var(--text-sm); color: var(--text-dim); margin-bottom: 16px; }
   .modal-note a { color: var(--accent); }
-  .mono-input { font-family: var(--font-mono); font-size: 12px; }
+  .mono-input { font-family: var(--font-mono); font-size: var(--text-xs); }
   .guide-viewer-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
-  .guide-viewer-title { font-size: 14px; font-weight: 600; color: var(--text); }
-  .guide-file { font-size: 12px; color: var(--text-dim); }
+  .guide-viewer-title { font-size: var(--text-md); font-weight: 600; color: var(--text); }
+  .guide-file { font-size: var(--text-xs); color: var(--text-dim); }
   .guide-card { cursor: pointer; }
   .guide-card:hover { border-color: var(--accent); }
   .guide-editor {
@@ -797,7 +805,7 @@
     min-height: 600px;
     padding: 16px;
     font-family: var(--font-mono);
-    font-size: 13px;
+    font-size: var(--text-sm);
     line-height: 1.6;
     background: var(--surface);
     color: var(--text);
@@ -810,16 +818,16 @@
   .preset-card { padding: 10px 16px; }
   .preset-head { display: flex; align-items: center; justify-content: space-between; }
   .preset-head .left { display: flex; align-items: center; gap: 10px; }
-  .preset-name { font-weight: 600; font-size: 13px; }
+  .preset-name { font-weight: 600; font-size: var(--text-sm); }
   .preset-actions { display: flex; gap: 6px; }
-  .preset-meta { font-size: 12px; color: var(--text-dim); margin-top: 4px; }
+  .preset-meta { font-size: var(--text-xs); color: var(--text-dim); margin-top: 4px; }
   .preset-meta span + span { margin-left: 12px; }
-  .preset-meta strong { font-family: var(--font-mono); font-size: 11.5px; }
+  .preset-meta strong { font-family: var(--font-mono); font-size: var(--text-xs); }
   .badge-preset { background: color-mix(in oklab, var(--accent) 12%, transparent); color: var(--accent); }
   .tpl-card-stacked { flex-direction: column; align-items: stretch; }
   .tpl-head { display: flex; align-items: center; justify-content: space-between; }
   .tpl-head-right { display: flex; align-items: center; gap: 8px; }
-  .tpl-meta strong { font-family: var(--font-mono); font-size: 11.5px; color: var(--text); font-weight: 500; }
+  .tpl-meta strong { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text); font-weight: 500; }
   .tag-plain { font-weight: 400 !important; text-transform: none !important; letter-spacing: normal !important; }
   @media (max-width: 880px) {
     body { padding: 16px; padding-bottom: 96px; }
@@ -1134,7 +1142,7 @@
       <div class="form-error" id="restore-svc-error"></div>
       <div class="form-group">
         <label for="restore-svc-select">Load from preset</label>
-        <select id="restore-svc-select" style="width:100%;padding:8px 10px;font-size:13px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);">
+        <select id="restore-svc-select" style="width:100%;padding:8px 10px;font-size:var(--text-sm);background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);">
           <option value="">Loading...</option>
         </select>
       </div>


### PR DESCRIPTION
Enlarges the dashboard type scale by ~2px: all 68 hardcoded px font-sizes are replaced with six semantic rem tokens in `:root`, with DESIGN.md synced to the new scale. Reworks the note UX — the always-present empty "Add a note…" row is removed, add/edit moves into each environment's More menu, and a Delete button is added to the note edit dialog. Also fixes the docs hero header (`docs/index.md`: "Oduflow Documentation" → "Oduflow Docs").