### PR TITLE
telemetry: send X-Oduflow-Telemetry marker

### DIFF
--- a/src/oduflow/telemetry.py
+++ b/src/oduflow/telemetry.py
@@ -10,6 +10,9 @@ from urllib.request import Request, urlopen
 
 _ENDPOINT = "https://oduflow.dev/usage"
 _TIMEOUT = 5
+# Optional shared marker. Must match the server's USAGE_TELEMETRY_TOKEN. Only a
+# speed bump against random scanners — this code is open source. Empty = disabled.
+_TELEMETRY_TOKEN = "5ae286c3f9a162c178577659db75f78259b01942f12ec357929f73e0a222c707"
 
 
 def _get_instance_id(etc_dir: str) -> tuple[str, bool]:
@@ -34,15 +37,18 @@ def _send_event(event: str, version: str, instance_id: str) -> None:
         payload = json.dumps(
             {"event": event, "version": version, "instance_id": instance_id}
         ).encode()
+        headers = {
+            "Content-Type": "application/json",
+            # A branded UA avoids edge bot-protection rules that block the
+            # default ``Python-urllib/x.y`` signature (Cloudflare error 1010).
+            "User-Agent": f"oduflow/{version}" if version else "oduflow",
+        }
+        if _TELEMETRY_TOKEN:
+            headers["X-Oduflow-Telemetry"] = _TELEMETRY_TOKEN
         req = Request(
             _ENDPOINT,
             data=payload,
-            headers={
-                "Content-Type": "application/json",
-                # A branded UA avoids edge bot-protection rules that block the
-                # default ``Python-urllib/x.y`` signature (Cloudflare error 1010).
-                "User-Agent": f"oduflow/{version}" if version else "oduflow",
-            },
+            headers=headers,
             method="POST",
         )
         urlopen(req, timeout=_TIMEOUT)

--- a/src/oduflow/telemetry.py
+++ b/src/oduflow/telemetry.py
@@ -37,7 +37,12 @@ def _send_event(event: str, version: str, instance_id: str) -> None:
         req = Request(
             _ENDPOINT,
             data=payload,
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                # A branded UA avoids edge bot-protection rules that block the
+                # default ``Python-urllib/x.y`` signature (Cloudflare error 1010).
+                "User-Agent": f"oduflow/{version}" if version else "oduflow",
+            },
             method="POST",
         )
         urlopen(req, timeout=_TIMEOUT)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -56,6 +56,8 @@ class TestSendEvent:
             "instance_id": "test-uuid",
         }
         assert req.get_header("Content-type") == "application/json"
+        # Branded UA so edge bot rules don't block the default urllib signature.
+        assert req.get_header("User-agent") == "oduflow/1.0.0"
 
     @patch("oduflow.telemetry.urlopen", side_effect=OSError("connection refused"))
     def test_swallows_network_errors(self, mock_urlopen):


### PR DESCRIPTION
Sends a shared marker header (`X-Oduflow-Telemetry`) with usage telemetry so the `oduflow.dev/usage` endpoint can drop requests that don't carry it.

A speed bump against random scanners, **not** real auth — this code is open source, so the value is public by nature. Must match the server's `USAGE_TELEMETRY_TOKEN`; if the server env is unset the header is simply ignored, so this is non-breaking.

Pairs with oduist/oduflow.dev#(usage telemetry anti-abuse PR).