### PR TITLE
CLI: await coroutine results in 'oduflow call'

### DIFF
--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2991,7 +2991,11 @@ def _run_call(argv: list[str]) -> None:
     print("-" * 60)
     logging.getLogger("oduflow").setLevel(logging.WARNING)
     try:
+        import asyncio
+
         result = tool_fn(**kwargs)
+        if inspect.isawaitable(result):
+            result = asyncio.run(result)
         print(result)
     except Exception as e:
         print(f"ERROR: {e}", file=sys.stderr)


### PR DESCRIPTION
## Problem

Running `oduflow call <tool>` against an async-wrapped tool printed the unawaited coroutine instead of the result:

```
$ oduflow call list_environments
Calling: list_environments({})
------------------------------------------------------------
<coroutine object list_environments at 0x10e9512a0>
.../server.py: RuntimeWarning: coroutine 'list_environments' was never awaited
```

**Root cause:** `_run_call` in `src/oduflow/server.py` printed the tool's return value directly. 26 of the 54 tools are wrapped by the `@handle_errors` decorator, which returns an `async def` wrapper (it offloads the sync body via `anyio.to_thread.run_sync`). For those tools the call returns a coroutine that is never awaited — hence the `repr` and the `RuntimeWarning`. Sync tools (no `@handle_errors`) worked fine, so the bug looked intermittent.

## Fix

Run awaitable results to completion via `asyncio.run()`, checking with `inspect.isawaitable()`. This mirrors the existing `call_tool` helper in `tests/tool_helpers.py`. Sync tools are unaffected.

## Verification

- `ruff check src/oduflow/server.py` — clean.
- `oduflow call list_environments` → `No active Flow environments found.` (real result, no `RuntimeWarning`, confirmed with `-W error::RuntimeWarning`).
- `oduflow call list_templates` → `No template profiles found.` (second async tool).
- `oduflow call` with no args → correct tool listing (sync path unaffected).