### PR TITLE
[codex] Make environment container names copyable

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1722,7 +1722,8 @@ function renderEnvironments(envs, force) {
     const containerHtml = env.containers
       .filter(c => c.status === 'running')
       .map(c =>
-        '<span>' + esc(c.name) + ' [' + esc(c.status) + ']' +
+        '<span><strong class="copy-db" role="button" tabindex="0" title="Copy container name" aria-label="Copy container name" onclick="copyToClipboard(\'' + escAttr(c.name) + '\')">' +
+        esc(c.name) + '</strong> [' + esc(c.status) + ']' +
         containerStatsHtml(c.name) + '</span>'
       ).join('');
 


### PR DESCRIPTION
## Summary
- Make running environment container names clickable in the dashboard.
- Reuse the existing DB copy affordance and clipboard toast behavior.
- Leave status text, stats binding, backend APIs, and service rendering unchanged.

## Validation
- `git diff --check`
- `pytest -m "not integration and not heavyweight"` (444 passed, 14 deselected, 1 warning)