### PR TITLE
specs: reconstruct architectural decision records from history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,33 @@ Before making any code changes, always:
 
 Do NOT write or modify any code until the user explicitly approves the plan.
 
+## Record Architectural Decisions
+
+When we add a **new architectural decision or a significant new capability**
+(not a bugfix, refactor, copy tweak, or other minor change), record it as a
+**decision record** in `specs/`.
+
+- **What counts:** a new pillar or a meaningful shift in how the system works —
+  a new subsystem, a change to the runtime/orchestration/tenancy/auth model, a
+  new major MCP capability, a delivery-mode change, etc. If you're unsure whether
+  it's "macro" enough, it probably isn't — skip it.
+- **Source of truth:** write the record **from the conversation/decisions that
+  produced the change** — the *why*, the forces and trade-offs, and the *what*
+  at a macro level. Do not transcribe code or list every file; capture the
+  reasoning a future reader needs, not the diff.
+- **Format:** one Markdown file per decision, ADR-style, named
+  `NNNN-short-slug.md`. Follow the shape of the existing records: a header block
+  (Status · Type · First introduced · Key code) then Context · Decision · How it
+  works (macro) · Consequences · (Evolution) · History (commit pointers). Keep it
+  to roughly a page — macro altitude, not implementation detail. Link related
+  records with `[[NNNN-slug]]`.
+- **Numbering:** records are numbered **chronologically** by when the decision
+  was first made. A genuinely new decision is the latest in time, so it simply
+  takes the next free number. Add a row to `specs/README.md` (the chronological
+  index).
+- **When:** add the record as part of the same change/PR that introduces the
+  capability, so the rationale is captured while it's fresh.
+
 ## Env
 
 If you run into any missing python dependency errors, try running your command with source .venv/bin/activate

--- a/specs/0001-mcp-orchestrated-ephemeral-per-branch-environments.md
+++ b/specs/0001-mcp-orchestrated-ephemeral-per-branch-environments.md
@@ -1,0 +1,71 @@
+# 0001 — MCP-orchestrated ephemeral per-branch Odoo environments
+
+**Status:** Adopted (foundational, still in force)
+**Type:** Architecture
+**First introduced:** `7d9dc70` "Initial concept" (2026-02-05)
+**Key code today:** `server.py` (FastMCP entry point + tools), `docker_ops/` (Docker SDK orchestration), `naming.py` (branch → resource names)
+
+## Context
+
+The developer works in a **branch-per-task** workflow and wants an AI coding
+agent to be able to spin up a *fully isolated* Odoo instance for any branch,
+exercise the code (install/upgrade modules, run tests, read logs), and tear it
+down — without a human clicking through a UI. The agent needs a programmatic,
+typed interface it can call directly from its tool-use loop.
+
+Forces at play:
+- Odoo environments are heavy (Odoo + PostgreSQL + filestore) and stateful.
+- An agent must not corrupt one branch's state by acting on another.
+- The interface must be machine-first: callable tools, structured results, no
+  hidden global "current environment".
+
+## Decision
+
+Build a single **MCP server on the FastMCP framework** that exposes Odoo
+environment lifecycle as a set of `@mcp.tool()` functions, and orchestrates
+**Docker** containers directly via the Docker SDK. The **git branch name is the
+primary key** for an environment: it derives the container/network names, the
+database name, and the host paths. One branch ⇒ one isolated, disposable
+environment.
+
+The seed toolset was `provision_env`, `teardown_env`, `execute_test`,
+`list_envs`; this grew into today's create/delete/install/upgrade/test/logs/exec
+surface, but the shape — *one tool call per lifecycle action, scoped by branch* —
+is unchanged.
+
+## How it works (macro)
+
+- **FastMCP entry point.** The server registers tools and is launched as one
+  process. The agent connects over MCP and calls tools by name.
+- **Branch-keyed isolation.** Every Docker resource is named and labelled from a
+  slugified branch name (`naming.py`), so listing/teardown can reliably find
+  exactly the resources belonging to one branch and nothing else.
+- **Docker as the runtime.** Official Odoo + PostgreSQL images are composed per
+  environment; the server talks to the Docker daemon rather than to a hosted
+  Odoo control plane. Provisioning returns a URL the agent (or human) can open.
+- **Ephemeral by design.** Environments are cheap to recreate and meant to be
+  torn down at end of task; persistence lives in templates and the per-branch DB,
+  not in long-lived snowflake servers.
+
+## Consequences
+
+- Established the project's identity: an **AI-first, MCP-native** Odoo dev/CI
+  tool, not a web app with an API bolted on. Every later capability is added as
+  another MCP tool plus its orchestration logic.
+- Branch-as-key made parallel, conflict-free work across branches natural — this
+  later motivated **granular per-branch locking** rather than a global mutex.
+- Direct Docker orchestration (vs. docker-compose/k8s) kept the dependency
+  surface small and the control flow explicit, at the cost of reimplementing
+  some compose-like wiring (networks, port mapping, volumes) in `docker_ops/`.
+- The "one process exposing tools" model set up later decisions about
+  **transport** (stdio vs HTTP) and **tenancy** (see [[0002-remote-multi-user-mcp-access]]).
+
+## History
+
+- `7d9dc70` (2026-02-05) — initial concept: FastMCP server + `odoo_manager.py`,
+  branch-scoped provision/teardown/test/list, Docker labels for tracking.
+- `d6918c6` (2026-02-10) — project renamed `flow` → `oduflow`; package and
+  resource prefixes updated, architecture unchanged.
+- `9a4428c`, later `docker_ops/` split — `odoo_manager.py` decomposed into
+  `client/system_ops/env_ops/odoo_ops/...` as the surface grew, preserving the
+  same per-branch orchestration model.

--- a/specs/0002-remote-multi-user-mcp-access.md
+++ b/specs/0002-remote-multi-user-mcp-access.md
@@ -1,0 +1,85 @@
+# 0002 — Remote, multi-user MCP access over streamable HTTP
+
+**Status:** Adopted; tenancy model later superseded (see Evolution)
+**Type:** Architecture
+**First introduced:** `37ebad3` "Multi user invironment" (2026-02-05), `150b481` "sse -> http" (2026-02-05)
+**Key code today:** `server.py` (transport selection, HTTP app), `web_ui.py`, `settings.py`, locking/tenancy modules
+
+## Context
+
+The founding design ([[0001-mcp-orchestrated-ephemeral-per-branch-environments]])
+ran the server over **stdio** for a single local agent. Two needs surfaced
+immediately:
+
+1. **Remote access** — the server must be reachable by an agent that is not the
+   local process ("It must be started so that I can connect remotely also").
+2. **Multiple users sharing one server** — several people (each with their own
+   agent) should share one Oduflow deployment without seeing or destroying each
+   other's environments, and should be able to use the *same branch name*
+   without colliding.
+
+A hard constraint was set on the interface: **authentication must not appear as
+a tool parameter**. Tools stay clean (`provision_env(branch_name)`), and identity
+is carried out-of-band in the transport, not in the agent-visible signature.
+
+## Decision
+
+Serve the MCP server over a **network transport** in addition to stdio, and
+**scope every environment to the calling identity** taken from the request
+context rather than from a tool argument.
+
+- **Transport:** start with SSE, then move to **streamable HTTP**
+  (`150b481`) as the remote transport; stdio remains the default for the
+  single-local-agent case. The HTTP app is what makes remote and multi-user use
+  possible at all.
+- **Identity from headers:** the caller's token is read from HTTP headers
+  (`get_http_headers()`), never from tool parameters. It is hashed into a short,
+  non-reversible `user_id` so the raw token never lands in Docker labels,
+  resource names, or logs.
+- **Identity-scoped resources:** the identity is stamped onto every Docker
+  resource and host path. List/teardown/test/install operations are filtered to
+  the caller's identity, giving each tenant an isolated namespace where branch
+  names are unique *per tenant*.
+
+## How it works (macro)
+
+- One server process can run in **stdio mode** (local, implicit single user) or
+  **HTTP mode** (remote, many users). The transport is selected at startup.
+- In HTTP mode, the per-request identity is resolved from headers and threaded
+  through to the orchestration layer, which labels/paths all resources with it.
+- Tool signatures never carry auth; the agent calls the same tools regardless of
+  who is connected.
+
+## Consequences
+
+- Cemented Oduflow as a potentially **multi-tenant, remotely hosted** service,
+  not just a localhost helper — enabling the later Web dashboard, hosted
+  deployments, and authentication work.
+- The "identity in transport, never in tool args" rule became a durable design
+  invariant carried into the OAuth work.
+- Per-tenant namespacing made **per-branch concurrency** safe across users and
+  fed directly into the granular locking design.
+
+## Evolution
+
+The *transport* decision (HTTP for remote, stdio default) is still in force. The
+*tenancy* mechanism changed shape twice:
+
+- `0a8ceab` (2026-02-12) — **multi-instance** isolation: separate Oduflow
+  instances, each with its own data dir / routing, instead of hashing a per-user
+  token into shared resources.
+- `ad3b382` / `14503a0` (2026-03-01) — **team-based multi-tenancy** replaced
+  instance-based isolation: tenancy is modelled as `[team.*]` sections in
+  `oduflow.toml`, with per-team locks and per-team resource scoping. This is the
+  current model and warrants its own decision record.
+- `97c3fc8`, `5f32f58` — auth hardened from a raw header token to **GitHub OAuth**
+  and then a **self-hosted OAuth Authorization Server** for HTTP transport
+  (separate decision record).
+
+## History
+
+- `37ebad3` (2026-02-05) — multi-user: token→`user_id` hash, resources/paths/labels
+  scoped per user, scoped `list/teardown/test/provision`, no auth in tool args.
+- `150b481` (2026-02-05) — switched remote transport SSE → streamable HTTP.
+- `81457b1` / `ed4a265` — `stateless_http=True` and running sync MCP tools in a
+  thread pool to unblock concurrent HTTP requests.

--- a/specs/0003-database-templates-and-filestore-isolation.md
+++ b/specs/0003-database-templates-and-filestore-isolation.md
@@ -1,0 +1,104 @@
+# 0003 — Database templates + filestore isolation (copy vs fuse-overlayfs)
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `6f85183` "DB load" (2026-02-06), `3a26c70` "Load filestore" (2026-02-06)
+**Key code today:** `docker_ops/system_ops.py` (template build/import/reload/list), `docker_ops/env_ops.py` (`_mount_filestore`, `remount_template_overlays`), `settings.overlay_threshold_mb`, `naming.get_template_db_name`
+
+## Context
+
+An environment ([[0001-mcp-orchestrated-ephemeral-per-branch-environments]]) is
+a PostgreSQL database plus an Odoo filestore. Creating one from a bare
+`-i base` install is slow and gives an empty system — not the realistic,
+module-rich state an agent needs to exercise a branch against. Environments are
+also **ephemeral and recreated often**, so paying the full install cost on every
+create is unacceptable.
+
+Forces at play:
+- Environment creation must be **fast** and start from a known-good DB state
+  (the customer's modules already installed, demo/seed data present).
+- Many environments share the *same* starting point but must not share *mutable*
+  state — one branch's writes must never leak into another's.
+- Filestores range from a few MB to many GB. Copying a multi-GB filestore for
+  every environment wastes disk and time; copying a tiny one is trivial and
+  safer than a fuse mount.
+
+## Decision
+
+Introduce **templates**: reusable, named snapshots of a `(database dump +
+filestore)` that environments clone from at create time. Isolate each
+environment's filestore from the template's with a **size-tiered strategy**:
+plain copy for small templates, **fuse-overlayfs** above a threshold.
+
+- **Template = DB dump + filestore + metadata.** A template lives in the team's
+  data dir as a SQL/`pgdump` dump, a `filestore/` tree, and a `metadata.json`
+  (Odoo image/version, sizes, `use_overlay`). Its database is restored once into
+  a PostgreSQL *template database* (`oduflow_template_{id}_{name}`), and new
+  environment DBs are created from it.
+- **Tiered filestore isolation.** On create, if the template's filestore is
+  below `overlay_threshold_mb` (default 50 MB) it is **copied**; at or above the
+  threshold it is mounted **copy-on-write via fuse-overlayfs** — the template
+  filestore is the read-only *lower* layer, the environment's writes go to its
+  own *upper* layer, and the environment sees the merged view.
+- **Template-less environments are allowed.** Passing no template initialises a
+  fresh Odoo with `-i base`, for cases where a clean slate is wanted.
+
+## How it works (macro)
+
+- **Building a template.** Templates are created by saving an existing
+  environment as a template, or by **importing from a running Odoo** instance
+  (`import_template_from_odoo` / `import-template`): download a backup, extract
+  `dump` + `filestore`, read `manifest.json` to record the Odoo version/image,
+  and load the dump into the template DB.
+- **Metadata-driven, not rescanned.** The `use_overlay` decision is computed once
+  (from filestore size vs threshold) and **stored in template metadata**, so env
+  creation never re-walks a large filestore to decide copy-vs-overlay; old
+  templates without the flag fall back to a size scan.
+- **Cloning at create time.** Creating an environment makes its DB from the
+  template DB and provisions its filestore by the tiered strategy above. Each
+  overlay environment gets its own `upper`/`work`/`merged` dirs, keeping its
+  changes private.
+- **Non-destructive template update.** Because each overlay env keeps its changes
+  in a separate upper layer, the template's read-only lower can be swapped under
+  *live* environments without losing their data. A reusable
+  `remount_template_overlays()` context manager unmounts affected envs (keeping
+  their uppers), lets the caller mutate the template filestore, and remounts them
+  against the new lower. This makes import/save-as-template/reload safe for live
+  envs, and powers a `refresh_template` tool that re-applies a template's current
+  filestore to its running overlay environments.
+
+## Consequences
+
+- Environment creation is **fast and realistic**: a clone of a known-good DB +
+  filestore instead of a from-scratch install, which is what makes the
+  per-branch ephemeral model practical at scale.
+- The copy/overlay split trades a small amount of complexity (a fuse dependency,
+  mount lifecycle) for large disk and time savings on big customer databases,
+  while keeping small templates dependency-free.
+- Templates became the unit of "shared, persistent state" in the system —
+  persistence lives in templates and the per-branch DB, not in long-lived
+  servers — reinforcing the disposable-environment design.
+- The overlay layering enabled later **non-destructive** template operations,
+  but also coupled template mutation to the set of live mounts, requiring the
+  remount dance to avoid yanking the lower out from under running envs.
+
+## History
+
+- `6f85183` (2026-02-06) — load a DB dump into PostgreSQL as the environment's
+  starting state.
+- `3a26c70` (2026-02-06) — load the template filestore alongside the DB.
+- `8b43721` (2026-02-14) — move bundled templates into `src/`, support per-addon
+  branches, and introduce template **metadata**.
+- `ab69289` (2026-02-11) — **template-less** environments (`template_name=None`
+  → `-i base` from scratch).
+- `a6d53fc` (2026-02-15) — `import_template_from_odoo`: build a template from a
+  running Odoo backup, auto-detecting version and DB name from the manifest.
+- `d2fc703` (2026-02-14) — `ODUFLOW_OVERLAY_THRESHOLD_MB`: copy filestore below
+  the threshold, fuse-overlayfs above it.
+- `e393c44` (2026-02-16) — store `use_overlay` in template metadata instead of
+  scanning the filestore on every environment creation.
+- `c3bee0f` (2026-02-20) — rename the template DB prefix to
+  `oduflow_template_{id}_{name}` and make `template_name` required.
+- `1edafff` (2026-06-05) — non-destructive template update for fuse-overlayfs
+  envs: `remount_template_overlays()` context manager + `refresh_template` tool,
+  preserving each environment's filestore delta across template mutation.

--- a/specs/0004-stable-addressing-port-registry-and-traefik.md
+++ b/specs/0004-stable-addressing-port-registry-and-traefik.md
@@ -1,0 +1,67 @@
+# 0004 — Stable environment addressing: persistent port registry + Traefik routing
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `c60eb5f` "Persient port mapping" (2026-02-07), `d9d877e` "Traefik added" (2026-02-07)
+**Key code today:** `port_registry.py` (`ports.json` allocation), `docker_ops/env_ops.py` + `system_ops.py` (Traefik wiring), `naming.py`
+
+## Context
+
+Environments are **ephemeral and frequently recreated** — a container may be
+destroyed and rebuilt many times over a branch's life (rebuild, template reload,
+config change). Two addressing problems followed from that:
+
+1. **Unstable ports.** If the host port were allocated fresh on every
+   `provision`/recreate, the URL an agent or human bookmarked would change out
+   from under them, and concurrent environments could race for the same port.
+2. **No human-friendly URLs.** Raw `host:port` is awkward to share, doesn't do
+   TLS, and doesn't scale to many concurrent environments on one host.
+
+## Decision
+
+Separate **port allocation** (stable, persisted) from **request routing**
+(reverse proxy by hostname).
+
+- **Persistent port registry.** A `ports.json` file (`port_registry.py`) records
+  the host-port assigned to each environment so the same environment keeps the
+  *same* port across recreation, and two environments never collide. Allocation
+  is a read-modify-write under a **per-path thread mutex plus an flock** on a
+  sidecar file, because the registry is shared state mutated by parallel API
+  requests and potentially by more than one Oduflow process on the same data dir.
+- **Traefik reverse proxy.** A Traefik container fronts the environments and
+  routes by hostname to each container, giving stable, TLS-capable URLs instead
+  of bare `host:port`.
+
+## How it works (macro)
+
+- On environment create, the registry returns this environment's stable host
+  port (newly allocated, or the previously-recorded one on recreate); the port is
+  freed back to the pool on delete.
+- Traefik discovers and routes to environments so each gets a predictable URL;
+  the same mechanism later serves the Web dashboard's own routes.
+- Routing config evolved from a single dynamic file to a **watched directory**
+  provider (`--providers.file.directory` + `--providers.file.watch`), so each
+  Oduflow instance/team can register its routes independently **without
+  restarting Traefik** (`8123667`).
+
+## Consequences
+
+- URLs are **durable**: an agent can recreate an environment and the access URL
+  it reported earlier still works — important for an AI workflow that hands a URL
+  back to a human or reuses it across steps.
+- Concurrency-safe allocation was a prerequisite for safely running many
+  environments and bulk operations (e.g. bulk delete) in parallel, reinforcing
+  the per-branch concurrency model.
+- Centralizing ingress in Traefik created the natural seam for later
+  multi-instance / multi-team routing and for hosting the dashboard behind the
+  same proxy.
+
+## History
+
+- `c60eb5f` (2026-02-07) — persistent port mapping: `port_registry.py` + `ports.json`,
+  ports survive recreation.
+- `d9d877e` (2026-02-07) — Traefik added: hostname-based routing to environments.
+- `8123667` (2026-02-12) — multi-instance routing via Traefik **file directory**
+  provider with watch; each instance writes its own `instance-{id}.yml`, no
+  Traefik restart needed.
+- `727448b` — match TLS certresolver name to Traefik's ACME provider.

--- a/specs/0005-web-dashboard-and-rest-api.md
+++ b/specs/0005-web-dashboard-and-rest-api.md
@@ -1,0 +1,117 @@
+# 0005 — Web dashboard + REST API + interactive consoles
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `83054eb` "Web UI and small fixes" (2026-02-07)
+**Key code today:** `web_ui.py` (Starlette app, REST API, auth middleware, WebSocket terminals), `templates/dashboard.html` (single-page UI), `templates/login.html`
+
+## Context
+
+The founding design ([[0001-mcp-orchestrated-ephemeral-per-branch-environments]])
+exposed everything through MCP tools — a machine-first surface aimed at agents.
+But the environments those agents create are real Docker containers with real
+state, and a **human** needs a window into them: is my branch's environment up?
+why did the install fail? what is the host load? which templates and services
+exist? Driving all of that through an agent's tool-use loop is the wrong
+ergonomics for a quick operational glance.
+
+Forces at play:
+- Agents *create* environments; humans mostly *observe* and occasionally
+  *intervene* (stop, delete, rebuild, read logs). The two audiences want
+  different affordances over the same underlying state.
+- The dashboard must reflect **real Docker state**, not a parallel bookkeeping
+  store that can drift from reality.
+- Sometimes the human needs to drop into the running container — an Odoo shell
+  or a `psql` prompt — without leaving the browser or holding SSH access to the
+  host.
+
+## Decision
+
+Ship a **Starlette web application alongside the MCP server**, served by the
+same process and fronted by the same Traefik routing
+([[0004-stable-addressing-port-registry-and-traefik]]). It provides three things:
+
+- **A single-page dashboard** (`dashboard.html`) that visualizes environments,
+  templates, auxiliary services, volumes, extra-addon repos, and git
+  credentials, with the small set of manual lifecycle actions a human needs.
+- **A REST API** under `/api/*` that mirrors the MCP tool operations
+  (list/create/start/stop/restart/recreate/delete environments,
+  service/volume/preset/repo/credential management, stats, logs). The browser
+  talks to this API; it is the same orchestration layer the tools call, so the
+  UI never invents its own view of state.
+- **In-browser interactive consoles** — an Odoo shell and a `psql` prompt —
+  exposed as WebSocket-backed terminals that attach to the running container.
+
+The dashboard is deliberately **visualization-first**: nobody is expected to
+provision environments through it (agents do that over MCP). Creation-flow
+polish, deep linking, and keyboard accelerators are explicit non-goals; the UI
+exists to *show the machine* and allow occasional intervention.
+
+## How it works (macro)
+
+- **One process, two surfaces.** The `/mcp` route serves agents; the dashboard,
+  `/api/*`, and the terminals serve humans. Both ultimately call into the same
+  `docker_ops` orchestration, so a change an agent makes shows up in the UI and
+  vice versa.
+- **Polling, not a parallel store.** The dashboard polls `/api/*` for live
+  status and stats and renders straight from Docker reality (a single polling
+  interval that pauses while the browser tab is hidden).
+- **Interactive consoles over WebSockets.** Opening a Console or SQL terminal
+  upgrades to a WebSocket that bridges an `xterm.js` front-end to a shell
+  (`odoo shell`) or `psql` session running inside the environment's container.
+  This required the auth layer to authenticate WebSocket upgrades, not just
+  ordinary HTTP requests.
+- **Tenancy-aware.** Every dashboard/API call resolves to a team
+  ([[0014-team-based-multi-tenancy]]) and is scoped to that team's resources,
+  the same way tools are.
+
+## Authentication evolution
+
+Auth for the human surface changed shape as the consoles and hosting needs
+matured:
+
+1. **HTTP Basic auth.** The first dashboard gated `/` and `/api/*` behind a
+   `BasicAuthMiddleware` checking the team's `ui_password`. Simple, but it pops
+   the browser's native credential dialog and has no logout.
+2. **WebSocket gap, then cookie fallback.** Browsers cannot send an
+   `Authorization: Basic` header on a WebSocket handshake, so the new Console/SQL
+   terminals were rejected with 403 while REST worked. The fix added a
+   **signed cookie** the middleware validates for both HTTP and WebSocket scopes.
+   An early version keyed the cookie HMAC off the password itself (deterministic,
+   brute-forceable from one leaked cookie); it was promptly replaced with an
+   `itsdangerous` token signed by a **persistent server-side secret** (stored
+   `0600` in the data dir), expiring after 7 days, carrying a password
+   fingerprint so changing `ui_password` revokes outstanding cookies.
+3. **Session-cookie login form.** The Basic-auth dialog was finally replaced by
+   a proper **`/login` page and `/logout`** (`#54`): unauthenticated page loads
+   redirect to `/login`, `/api/*` returns `401 JSON`, WebSocket handshakes close
+   with `1008`. **Basic auth is retained for API/CLI clients** — so scripts keep
+   working while humans get a real login. This is the current model.
+
+## Consequences
+
+- Oduflow became a **two-audience tool**: an agent-facing MCP surface and a
+  human-facing console over one shared orchestration core, neither owning a
+  separate copy of state.
+- Reusing the REST API as the MCP tools' sibling kept the UI honest — it shows
+  what the tools would do, not a hand-maintained mirror.
+- The interactive consoles made the host's Docker reality directly reachable
+  from the browser, which in turn forced WebSocket-aware authentication and the
+  move off Basic auth to signed session cookies.
+- This human surface is where later work landed: the [[0007-auxiliary-services-and-volumes]]
+  management tabs and the [[0022-engineers-console-design-system]] redesign both
+  build on this dashboard + REST + WebSocket foundation.
+
+## History
+
+- `83054eb` (2026-02-07) — first Web UI (dashboard + REST API) alongside the MCP
+  server; `1a50bfa` (2026-02-07) — follow-up UI fixes.
+- `894f1ea` (2026-02-25) — interactive web console (Odoo shell) via `xterm.js` +
+  WebSocket; authenticate WebSocket upgrades in the Basic-auth middleware.
+- `15d0e59` (2026-02-25) — interactive SQL console (`psql`) on the same pattern.
+- `9e24ab2` (2026-06-12, `#54`) — session-cookie auth with a `/login` form and
+  logout; squashes the WebSocket cookie fallback (`a009824`) and the
+  server-secret-signed cookie fix (`7b484f2`), keeping Basic auth for API
+  clients.
+- `b152559` (2026-06-12) — align the login page with the Engineer's Console
+  system (see [[0022-engineers-console-design-system]]).

--- a/specs/0006-git-driven-change-classification.md
+++ b/specs/0006-git-driven-change-classification.md
@@ -1,0 +1,106 @@
+# 0006 — Git-driven change classification → automatic install/upgrade/restart
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `b1c97d0` "Detect module changes fix" (2026-02-08), `3db7cc1` "Detect field changes in .py files to trigger module upgrade" (2026-02-08)
+**Key code today:** `git_analysis.py` (`classify_changes`, `shallow_classify`, `recommend`, `guardrail_warnings`), `git_ops.py` (`pull_repo` → `old_head`), `docker_ops/env_ops.py` (sync/apply orchestration)
+
+## Context
+
+An agent develops by **pushing code to a branch**, then asking the environment
+to apply it ([[0001-mcp-orchestrated-ephemeral-per-branch-environments]]). But
+"apply" in Odoo is not one thing: a Python method edit only needs the worker
+**restarted**; a new or changed field needs the module **upgraded** (`-u`) so
+the DB schema migrates; a brand-new module needs **installing** (`-i`); a pure
+QWeb/JS tweak needs nothing but a hot reload.
+
+Forces at play:
+- Doing the **maximal** action every time (always `-u` everything) is slow and,
+  for a new module, fails outright (`-u` on a module with no DB schema).
+- Doing the **minimal** action (always just restart) silently skips schema
+  migrations, so the agent sees stale behaviour and chases ghosts.
+- The agent shouldn't have to reason about Odoo's load semantics on every push —
+  the system should infer the right, minimal action from *what actually changed*.
+
+## Decision
+
+Add a **change-classification subsystem** that diffs the files changed between
+two git commits and maps them to the single correct Odoo action —
+`install`, `upgrade`, `restart`, `refresh`, or `none` — then drives the
+environment accordingly. The classification reads **content**, not just paths,
+so it can tell a schema change from a cosmetic one.
+
+The rules, refined incrementally from real misfires:
+
+- **Manifest changes** decide install vs upgrade: a `__manifest__.py` with no
+  prior version in git is a **new module → install**; a version bump or a change
+  to a file-list key (`data`, `demo`, `assets`, `qweb`) is an **upgrade**.
+- **Python field changes** force an upgrade: compare `fields.*` definition lines
+  between old and new source; if any field is added/removed/modified the schema
+  may need migrating → **upgrade**. Other `.py` edits → **restart** (reload code,
+  no schema work).
+- **XML** in `security/` or `data/` directories → **upgrade** (it loads into the
+  DB). Other XML is normally a hot **refresh**, *except* when a view's
+  `<tree>`/`<list>`/`<form>` opening-tag attributes change, which also needs an
+  **upgrade**.
+- **JS/other view XML** → hot **refresh** (no restart, no DB work).
+
+## How it works (macro)
+
+- **Pre-pull commit as baseline.** Before applying, the sync step records the
+  environment's current `HEAD` (`pull_repo` returns `old_head`), pulls, then
+  classifies the full range `old_head..new` against that **pre-pull baseline** —
+  not `HEAD~1` — so multi-commit pushes are analysed in full.
+- **Content diffs via git.** `classify_changes` resolves each file to its Odoo
+  module (walking up to the nearest `__manifest__.py`) and, for manifests/fields/
+  view tags, compares the new working-tree content against the `base_ref` content
+  via `git show`. The result is the minimal action plus the exact module lists.
+- **Degraded mode for non-git mounts.** When no `base_ref` is available (a
+  live-mount with no commit to diff), `shallow_classify` does a coarser
+  path-only pass: it can't distinguish a field edit from a method edit (→ restart)
+  or a new module from a changed one (→ upgrade). `recommend()` picks the deep or
+  shallow path automatically.
+- **Guardrails, not gates.** The agent may request its own action; the system
+  computes the recommendation and emits **non-blocking warnings** only when the
+  request looks like an *under*-action (a missing install/upgrade/restart),
+  leaving the agent in charge.
+- **`# KEEP` protection.** A file whose first line is `# KEEP` is never
+  overwritten by `oduflow upgrade`; it is reported as `(kept)` instead. This lets
+  generated/hand-tuned files (e.g. a locally edited `odoo.conf`,
+  `postgresql.conf`) survive a sync.
+- **Trace logging.** `ODUFLOW_TRACE=1` emits a per-file decision trace through
+  the classify/sync pipeline, for debugging why an action was (or wasn't) chosen.
+
+## Consequences
+
+- An agent's push is applied **correctly and minimally**: schema changes migrate,
+  code changes restart, cosmetic changes hot-reload, and new modules install —
+  without the agent encoding Odoo's load model into every request.
+- The rules are deliberately **heuristic and content-aware**; each refinement
+  (fields, data/security XML, view-tag attributes) closed a concrete class of
+  "I changed X but the environment didn't pick it up" bug. They will keep
+  accreting as new edge cases surface.
+- Tying classification to the **pre-pull commit** made the result correct for
+  batched pushes and is now a load-bearing contract of `pull_repo`.
+- The same subsystem feeds both the automatic apply path and the agent-facing
+  guardrail warnings, keeping recommendation logic in one place.
+
+## History
+
+- `b1c97d0` (2026-02-08) — detect module changes to trigger an upgrade.
+- `3db7cc1` (2026-02-08) — detect `fields.*` changes in `.py` files → upgrade;
+  resolve the real module by walking up to `__manifest__.py`; restart after
+  upgrade to load new Python.
+- `f03b8f6` (2026-02-08) — distinguish **install (`-i`)** from **upgrade (`-u`)**;
+  track install/upgrade module sets separately so new modules don't fail on `-u`.
+- `1280c23` (2026-02-14) — XML under `data/` triggers an upgrade.
+- `044ccb9` (2026-02-14) — rename `pull_environment_repository` → `sync_environment`.
+- `af7b9bc` (2026-02-17) — `ODUFLOW_TRACE=1` trace logging for the sync/classify
+  pipeline.
+- `f69bc2f` (2026-03-05) — include `odoo.conf` in upgrade; skip files unchanged
+  from the bundled version.
+- `cdc9ea9` (2026-03-10) — use the **pre-pull commit** as the baseline for
+  manifest/field comparison so multi-commit pushes classify correctly (#8).
+- `a834ec9` (2026-03-11) — detect `<tree>`/`<list>`/`<form>` view-tag attribute
+  changes → upgrade instead of hot-reload.
+- `a97e13f` (2026-03-17) — `# KEEP` marker protects files from upgrade overwrite.

--- a/specs/0007-auxiliary-services-and-volumes.md
+++ b/specs/0007-auxiliary-services-and-volumes.md
@@ -1,0 +1,105 @@
+# 0007 — Auxiliary services, presets, and Docker volumes
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `cbab215` "add service container management" (2026-02-11)
+**Key code today:** `docker_ops/service_ops.py` (service CRUD), `docker_ops/service_presets.py` (save/restore named configs), `docker_ops/volume_ops.py` (named Docker volumes), plus MCP tools in `server.py`, CLI, and the dashboard Services/Volumes tabs
+
+## Context
+
+A per-branch Odoo environment ([[0001-mcp-orchestrated-ephemeral-per-branch-environments]])
+is rarely the whole picture. Real Odoo modules talk to **companion services** —
+Redis for caching/queues, Meilisearch for search, and assorted sidecars — and a
+developer needs those running next to the environment to exercise the code. Up
+to this point Oduflow orchestrated only the Odoo + PostgreSQL pair; everything
+else had to be stood up by hand outside the tool, which broke the "the agent
+spins up what it needs" promise and left those containers untracked.
+
+Three follow-on needs surfaced:
+- Service configs are **reused** across environments and survive container
+  recreation, so re-typing image/port/env every time is wasteful and error-prone.
+- Some services hold **persistent data** (a search index, a cache snapshot) that
+  must outlive a container rebuild.
+- Some sidecars (VPN/WireGuard, tun/iptables tooling) need **elevated Docker
+  capabilities or host networking** that an ordinary bridge-attached container
+  cannot get.
+
+## Decision
+
+Make **auxiliary service containers a first-class, managed entity** with full
+CRUD across MCP, CLI, and the dashboard — and give them two supporting
+abstractions: **presets** (reusable named configs) and **named Docker volumes**
+(persistent storage), each likewise managed through all three surfaces.
+
+- **Services.** `create/list/get/update/restart/delete` companion containers,
+  attached to the shared network and routable through Traefik
+  ([[0004-stable-addressing-port-registry-and-traefik]]) by hostname. Containers
+  are tracked purely by **Docker labels** (`oduflow.managed`, `oduflow.team`,
+  `oduflow.service`) scoped per team ([[0014-team-based-multi-tenancy]]) — no
+  separate registry file — so listing/teardown finds exactly the right set.
+- **Presets.** A service config can be **saved as a named preset** and
+  **restored** later. Presets are a single per-team JSON file
+  (`service_presets.json` in the team data dir) holding image, port, env, and
+  the capability options below.
+- **Volumes.** Named Docker volumes with their own CRUD, tracked by labels (no
+  registry file), mountable into services as `volume_name:/path[:ro|rw]`; a
+  volume in use by a service is protected from deletion.
+- **Capability options.** Services can opt into `host_mode` (host networking),
+  `privileged`, and `NET_ADMIN`, plus mounting **external (non-managed)
+  volumes** — all carried in presets and re-applied on `update`/recreate so a
+  pull or rebuild preserves them.
+
+## How it works (macro)
+
+- **Label-tracked, registry-free.** Both services and volumes are discovered by
+  querying Docker for the team's `oduflow.*` labels rather than maintaining a
+  parallel state file. The only persisted file is the presets JSON, because a
+  preset is config that has *no* live container to read it back from.
+- **Recreation preserves intent.** `update_service` recreates the container but
+  reads its full config (env, volumes, capabilities, host mode) forward, so the
+  service comes back the same after an image pull or a settings change. Presets
+  encode the same fields so a restore reproduces a service from scratch.
+- **Traefik routing in both network modes.** Bridge-attached services route
+  normally; a `host_mode` service still gets a Traefik router whose backend
+  points at `host.docker.internal:{port}`, so the addressing model holds either
+  way.
+- **External volumes by name fallback.** Volume resolution first looks for the
+  managed name (`oduflow-vol-{team}-{name}`) and falls back to the raw name, so a
+  service can mount a non-managed volume (e.g. Traefik's ACME store) when needed.
+- **Teardown safety.** `destroy_system` refuses while active service containers
+  exist, and an in-use volume cannot be deleted — manual cleanup stays explicit.
+
+## Consequences
+
+- Environments gained **companions**: an agent (or human) can stand up the Redis
+  or Meilisearch a module depends on through the same MCP/CLI/UI surface as the
+  environment itself, keeping the whole setup inside Oduflow's tracking.
+- **Presets** turned repeated, fiddly service setups into a one-call restore and,
+  crucially, made service config durable across the frequent container
+  recreations the system performs.
+- **Volumes** let stateful sidecars keep their data across rebuilds without
+  leaving Oduflow's label-based bookkeeping.
+- The **capability/host-network options** widened the range of sidecars Oduflow
+  can host (VPN, network tooling) at the cost of granting elevated Docker
+  privileges — a deliberate, opt-in trade-off persisted in presets so it is
+  visible and reproducible rather than a one-off manual `docker run`.
+- Services, presets, and volumes each became a tab in the
+  [[0005-web-dashboard-and-rest-api]] dashboard, reinforcing the
+  visualization-first split: agents wire services up, humans watch and intervene.
+
+## History
+
+- `cbab215` (2026-02-11) — service container management: `service_ops` CRUD, MCP
+  tools, `oduflow list-services` CLI, dashboard Services tab, REST routes;
+  `destroy_system` blocks on active services.
+- `c83d749` (2026-02-12) — service presets (save/restore/list/delete);
+  `ce33ee2` (2026-02-12) — presets support wired into the dashboard UI.
+- `d4609e6` / `73fbee7` (2026-03-14) — `host_mode` (host networking) for
+  services, across tool / REST / presets / restore, with the Traefik
+  `host.docker.internal` backend.
+- `6b05f8a` (2026-03-19, `#11`) — Docker volume management (label-tracked CRUD,
+  `volumes` param on services, in-use delete protection, Volumes tab).
+- `a396583` (2026-03-27) — allow mounting external (non-managed) volumes via a
+  name fallback in volume resolution.
+- `edad2ef` (2026-05-21, `#17`) — `privileged` and `NET_ADMIN` capability
+  options, persisted in presets and re-applied on recreate.

--- a/specs/0008-licensing.md
+++ b/specs/0008-licensing.md
@@ -1,0 +1,101 @@
+# 0008 — Licensing: Polyform Noncommercial + in-app license activation
+
+**Status:** Adopted (still in force)
+**Type:** Product / Architecture
+**First introduced:** `317b816` "add Polyform Noncommercial 1.0.0 license" (2026-02-12), `00936c9` "license activation via dashboard UI" (2026-02-13)
+**Key code today:** `licensing.py` (RSA verification, license types, install), `web_ui.py` (`/api/license`, `/api/license/activate`), `templates/dashboard.html` (activation form + banner), `LICENSE`, `docs/licensing.md`
+
+## Context
+
+Oduflow is a real product, not just an open-source side project: it needs a
+commercial model that funds development while staying source-available and
+friendly to individual experimentation. Two questions had to be answered
+together:
+
+1. **Under what terms is the source available?** Fully permissive (MIT/Apache)
+   gives competitors and integrators the right to build a paid business on the
+   code for free; fully closed kills the trust and inspectability that a
+   developer tool needs.
+2. **How does a paying customer prove they hold a commercial license?** The
+   product runs on the customer's own Docker host, often air-gapped or
+   self-hosted, so licensing cannot depend on a phone-home check or a hosted
+   control plane being reachable at runtime.
+
+The forces: keep the code open and auditable (it orchestrates the user's
+private repos and databases — trust matters), but reserve **commercial use** as
+the thing you pay for, and make activation work **offline** on a box the project
+operator does not control.
+
+## Decision
+
+Adopt the **PolyForm Noncommercial License 1.0.0** for the source, and gate
+*commercial* use behind a **signed license key activated in-app**.
+
+- **License terms.** The source is published under PolyForm Noncommercial 1.0.0
+  (`LICENSE`, `pyproject.toml` `PolyForm-Noncommercial-1.0.0`). Anyone may read,
+  run, and modify it for noncommercial purposes; commercial use requires a paid
+  license. This makes "noncommercial-source, paid-commercial" the explicit
+  business model rather than an informal convention.
+- **License key = identity of commercial use.** A license is a short,
+  **RSA-signed** token: a base64 signature plus a JSON payload carrying a
+  `type` (`individual`, `business`, `integrator`) and the licensee `name` /
+  `email`. The signature is verified **offline** against a public key compiled
+  into the package, so no key server is contacted at runtime and tampering is
+  rejected.
+- **In-app activation.** The key is pasted into the dashboard (or installed via
+  file / REST), verified, and stored locally; the running instance then reports
+  itself as licensed and shows who it is licensed to.
+
+## How it works (macro)
+
+- **Verify, then store.** Activation verifies the key's signature and that its
+  `type` is known *before* persisting it. A valid key is written to
+  `license.key` in the instance config dir; an invalid or tampered key is
+  rejected and the instance stays `unlicensed`.
+- **Three entry points, one path.** The dashboard activation form posts the key
+  text to `POST /api/license/activate`; the same effect is available by dropping
+  a `license.key` file in the config dir, or via the REST endpoint directly. All
+  funnel through the same verify-and-install routine in `licensing.py`.
+- **Status is read on demand.** `GET /api/license` re-reads and re-verifies the
+  stored key and returns a `LicenseInfo` (type, name, email, human label). An
+  absent or unverifiable key yields the `unlicensed` state — there is no cached
+  "trusted" flag that could survive a tampered file.
+- **Banner / branding.** The dashboard surfaces license state prominently: an
+  unlicensed instance shows a "NON-COMMERCIAL USE ONLY" banner; a licensed one
+  shows whom it is licensed to. This is the product's honest, visible nudge
+  toward purchasing rather than a hard runtime lock — the tool keeps working,
+  but commercial users are reminded they need a license.
+
+The activation UI is part of the dashboard surface described in
+[[0005-web-dashboard-and-rest-api]]; licensing reuses its Starlette routes and
+Basic-auth boundary rather than adding a separate control plane.
+
+## Consequences
+
+- Established Oduflow's **commercial model** as a first-class, documented thing:
+  source-available for noncommercial use, paid for commercial use, with the
+  license type baked into the key.
+- Offline RSA verification means licensing **never blocks startup** and needs no
+  network — important for self-hosted/air-gapped installs and consistent with
+  the project's bias against runtime dependencies on project-controlled
+  services.
+- Activation deliberately **identifies** rather than **enforces**: the banner and
+  license label inform; the product does not cripple unlicensed use. This keeps
+  the tool trustworthy and the open source honest while still making commercial
+  obligations visible.
+- The public key is shipped in the package, so license *issuance* (signing)
+  stays a private, off-repo capability; only verification is open.
+
+## History
+
+- `317b816` (2026-02-12) — adopt PolyForm Noncommercial 1.0.0 as the source
+  license (`LICENSE`).
+- `00936c9` (2026-02-13) — in-app license activation: paste-a-key dashboard form,
+  signature/type validation, `install_license_from_text`, and the
+  `/api/license` + `/api/license/activate` endpoints.
+- `8e66e8f` (2026-02-17) — fix license load/display in the dashboard.
+- `fe142ec` (2026-06-13) — store/read the key under the resolved instance config
+  dir (config-path fix) so activation and startup agree on `license.key`'s
+  location.
+- `9d532f8` (2026-06-14) — polish the license banner branding; drop redundant
+  footer product attribution.

--- a/specs/0009-agent-guidance-system.md
+++ b/specs/0009-agent-guidance-system.md
@@ -1,0 +1,116 @@
+# 0009 — Agent guidance system: editable MCP instructions + Odoo version dev guides
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `d7016d7` "add Agents Guide — editable MCP instructions with UI tab and versioning" (2026-02-13)
+**Key code today:** `server.py` (`get_agent_instructions`, `get_odoo_development_guide`, `_MCP_INSTRUCTIONS` bootstrap, `create_environment` hint), `web_ui.py` (`/api/agent-guides`), `templates/agent_guides/` (`agent_instructions.md`, `odoo_<N>_guide.md`)
+
+## Context
+
+Oduflow exposes a large, evolving MCP tool surface
+([[0001-mcp-orchestrated-ephemeral-per-branch-environments]]) and a specific,
+non-obvious **workflow**: provision per branch, push or live-mount code, call
+`pull_and_apply`, read the cached errors, fix, retry. A connecting agent does
+not know any of this from its priors. Worse, an agent's "knowledge" of Odoo is a
+blend of versions and community folklore — it will happily write Odoo 12-era
+patterns into an Odoo 19 module, or guess at the right apply action.
+
+Two forces pushed toward shipping guidance *in-band*, from the server to the
+agent, rather than relying on the agent's training:
+
+1. **The workflow is Oduflow-specific and stateful.** The correct sequence,
+   the meaning of each tool, and the *active code delivery mode*
+   ([[0021-code-delivery-modes]]) are facts the server knows and the agent must
+   be told — at connect time, not discovered by trial and error.
+2. **Odoo conventions are version-specific.** What counts as correct (manifest
+   keys, ORM idioms, view syntax, asset bundles) differs by major version. The
+   server knows the target version (from the image/environment); it should hand
+   the agent the matching rulebook before any code is written.
+
+A connected agent is also expensive to re-prompt: fetching a long guide on every
+call wastes context. And the operator running the deployment must be able to
+**tune** what the agent is told without editing Python.
+
+## Decision
+
+Make the server **teach the connecting agent how to work**, through guidance
+delivered over MCP and editable at runtime.
+
+- **Server-level instructions.** The MCP server advertises a short
+  bootstrap (`instructions=` on the FastMCP app) that tells the agent to fetch
+  the full guide first, and exposes `get_agent_instructions` returning the
+  Oduflow workflow guide — including a live-computed "Current Code Delivery
+  Mode" preface so the agent uses the right (git vs live-mount) loop.
+- **Per-version Odoo development guides.** `get_odoo_development_guide(version)`
+  returns version-specific Odoo conventions and constraints. The version is
+  normalized (`"18"` and `"18.0"` both work), and `create_environment` returns
+  an explicit hint to fetch the matching guide *before* writing code.
+- **Editable + versioned, surfaced in the dashboard.** Guides are Markdown files
+  bundled with the package as defaults, copied per team into the data dir on
+  init, and editable through the dashboard. Each guide carries a `Version:`
+  marker so edits and re-pulls are traceable.
+- **Self-caching instruction.** The agent guide tells the agent to save the
+  document locally as a skill/instruction file so it need not re-fetch it over
+  MCP on every session — guidance is pulled once, then cached client-side.
+
+## How it works (macro)
+
+- **Bootstrap → fetch → cache.** On connect the agent sees the short
+  `_MCP_INSTRUCTIONS`, which directs it to call `get_agent_instructions` (and,
+  per target version, `get_odoo_development_guide`). The returned guides instruct
+  it to cache them locally, so steady-state operation costs no extra round-trips.
+- **Layered resolution.** Each guide tool resolves the team's editable copy under
+  the data dir first, then falls back to the bundled default shipped in the
+  package — honoring the no-external-assets rule while letting operators override.
+- **Bundled defaults, editable copies, versions.** `init` seeds the
+  `agent_guides/` folder per team; the dashboard's REST API lists and serves the
+  guides for in-place editing, and the `Version:` field increments so a guide's
+  evolution is visible.
+
+## Consequences
+
+- The server becomes the **source of truth for how to use itself**: new tools or
+  workflow changes are taught to every agent by editing one guide, not by hoping
+  each agent's priors are current. This is why the bootstrap instruction is a
+  hard convention — fetch guidance first.
+- Version-specific guides materially raised code quality: the agent writes to the
+  *actual* target Odoo version's conventions instead of an averaged prior, and
+  the `create_environment` hint makes the fetch automatic rather than optional.
+- Operators can tune agent behavior (house rules, conventions, gotchas) at
+  runtime through the dashboard, without a code release — guidance is data, not
+  Python.
+- A small naming churn was the price of getting the concept right; the resolver
+  reads legacy filenames so old data dirs keep working across renames.
+
+## Evolution
+
+The guidance concept is stable; the tool names converged over a few renames as
+their role sharpened:
+
+- A single editable "Agents Guide" (`get_agents_guide`) →
+- a multi-guide system splitting the workflow guide from per-version Odoo dev
+  guides (`get_agent_guide` + `get_odoo_development_guide`) →
+- `get_agent_guide` → `get_agent_skill` (framing it as an agent *skill* to cache
+  locally) →
+- `get_agent_skill` → **`get_agent_instructions`** (the current name).
+
+The on-disk files followed the same path (`agents_guide.md` → `agent_guide.md` →
+`agent_skill.md` → `agent_instructions.md`); the resolver still accepts the
+legacy names.
+
+## History
+
+- `d7016d7` (2026-02-13) — Agents Guide: bundled default, `get_agents_guide` MCP
+  tool, GET/PUT REST endpoints with auto-incrementing `Version:`, dashboard tab.
+- `8680a18` (2026-02-15) — refactor into multi-guide system: per-version Odoo dev
+  guides + `get_odoo_development_guide(version)`; `create_environment` returns a
+  hint to fetch the matching guide; dashboard becomes a guide list + viewer.
+- `904f6f4` (2026-02-20) — `--update-guides` to refresh bundled guides; container
+  rules added to the guide.
+- `8625790` (2026-02-22) — `get_agent_guide` → `get_agent_skill`; add the
+  **self-caching instruction** ("save this as a local skill, don't refetch").
+- `fbbcf54` (2026-02-24) — `get_agent_skill` → `get_agent_instructions` (part of
+  a broader tool-clarity rename); file renamed `agent_skill.md` →
+  `agent_instructions.md`.
+- `10dda86` (2026-06-15) — server-level MCP bootstrap `instructions` telling the
+  agent to fetch the guide and the version dev guide up front.

--- a/specs/0010-extra-addons-repositories.md
+++ b/specs/0010-extra-addons-repositories.md
@@ -1,0 +1,113 @@
+# 0010 — Extra addons repositories (bare clones + per-environment worktrees)
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `d495dd8` "extra addons repos support" (2026-02-13)
+**Key code today:** `extra_addons.py` (bare clone / worktree lifecycle, fetch summaries), `docker_ops/env_ops.py` (worktree creation + read-only mount, addons_path generation), `server.py` (`add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo`)
+
+## Context
+
+An environment serves the developer's **primary** repository
+([[0001-mcp-orchestrated-ephemeral-per-branch-environments]]), but real Odoo
+modules rarely stand alone. A module under test commonly depends on code that
+lives in *other* repositories — Odoo Enterprise, OCA addon collections, a
+company's shared base modules. Without a way to bring those into the
+environment, the module won't install and tests can't run.
+
+Forces at play:
+- A team has a **small set of shared addon repos** reused across many branches
+  and many environments. Cloning each one fully, per environment, would waste a
+  lot of disk and time, and they recreate often.
+- Different environments may need **different branches** of the same addon repo
+  (e.g. an `18.0` env and a `19.0` env pointing at the same Enterprise repo).
+  The addon checkout therefore must be **pinned per environment**, not global.
+- These repos are usually private, so cloning has to reuse the team's existing
+  git credentials (`git_ops` / `setup_repo_auth`).
+
+## Decision
+
+Manage extra addon repositories as **team-shared bare clones**, and give each
+environment its own **git worktree** of the bare repo, checked out at an
+**explicitly specified branch**. The bare clone is the single on-disk copy of
+the repo's objects; worktrees are cheap, branch-pinned views onto it that are
+bind-mounted **read-only** into the container.
+
+- **Bare clone per repo, shared by the team.** `add_extra_repo(name, repo_url)`
+  does a `git clone --bare` into the team's shared repos directory. There is one
+  object store per addon repo regardless of how many environments use it.
+- **Worktree per environment, pinned to a branch.** On environment create,
+  Oduflow adds a detached worktree at the requested branch and mounts it at
+  `/mnt/extra-addons-<name>`; the generated `odoo.conf` appends that path to
+  `addons_path`. Disk cost per environment is roughly one checkout, not a full
+  clone.
+- **Branch is mandatory and explicit.** Extra addons are requested as
+  `name:branch` (e.g. `enterprise:18.0`). A missing branch is a hard error — no
+  silent fallback to a default branch — because addon repos branch by Odoo
+  version and guessing wrong produces a confusing "module not found".
+- **Protect / unprotect.** A repo can be marked protected (a `.protected`
+  marker), which blocks deletion until it is explicitly unprotected. Deletion is
+  also refused while any environment still depends on the repo.
+- **Fetch with a summary, and propagate to environments.** `update_extra_repo`
+  fetches the bare clone and reports *what changed* (new / deleted / updated
+  branches with commit counts); `pull_and_apply` refreshes an environment's
+  extra-addon worktrees alongside the main repo so addon updates reach running
+  environments through the normal apply path.
+
+## How it works (macro)
+
+- **Add once, reuse everywhere.** The team adds an addon repo once; every
+  environment that lists it gets a worktree, so the shared object store is
+  fetched once and amortised across branches and users.
+- **Branch-pinned, read-only mounts.** Each environment's worktree is detached
+  at its branch tip and mounted read-only — the environment consumes the addon
+  code but never mutates the shared repo. Worktrees are pruned/removed with the
+  environment.
+- **Explicit refspec for bare clones.** `git clone --bare` does not configure a
+  fetch refspec, so a later `git fetch --all` would only move `FETCH_HEAD` and
+  leave `refs/heads/*` stale. Oduflow sets `+refs/heads/*:refs/heads/*`
+  explicitly after clone, and auto-migrates older bare repos that lack it before
+  fetching, so updates actually land on local branches.
+- **Updates flow through `pull_and_apply`.** Fetching the bare repo and resetting
+  an environment's worktree to the new branch tip yields a `changed_files` list,
+  which feeds the same change-classification path
+  ([[0006-git-driven-change-classification]]) used for the primary repo, so an
+  addon update installs/upgrades/restarts as appropriate.
+
+## Consequences
+
+- An environment can faithfully reproduce a **multi-repo** Odoo deployment, which
+  is the common real-world shape — without each environment paying the disk and
+  time cost of independent full clones.
+- The **bare-clone + worktree** split makes "many environments, few repos,
+  different branches" efficient and correct: object storage is shared, branch
+  pinning is per environment.
+- Making **branch explicit** removed a class of silent misconfigurations at the
+  cost of a slightly more verbose request (`name:branch`).
+- The lifecycle gained guardrails — protection markers and dependency checks —
+  because shared repos are long-lived team assets, unlike disposable
+  environments; deleting one out from under live environments would break them.
+
+## Evolution
+
+- An early fix used the **Odoo image version** (e.g. `odoo:18.0` → `18.0`) as a
+  fallback branch when none was given (`ea297fd`), since `default_branch`
+  (`prod`) rarely exists in addon repos. That fallback was later removed in
+  favour of **requiring an explicit branch** (`9254169`) — the current behaviour.
+
+## History
+
+- `d495dd8` (2026-02-13) — extra addons repos support: bare clone, list, delete,
+  and read-only worktree mount into environments.
+- `54bc937` (2026-02-20) — configure `+refs/heads/*:refs/heads/*` fetch refspec
+  on bare clones (and auto-migrate existing ones) so `git fetch` updates
+  branches.
+- `ea297fd` (2026-02-20) — fall back to the `odoo_image` version as the worktree
+  branch when none specified (later superseded).
+- `3c678cc` (2026-02-20) — add the `update_extra_repo` MCP tool.
+- `1245d6c` (2026-02-20) — protect / unprotect extra repos; guard deletion with a
+  `ProtectedError`.
+- `9254169` (2026-02-24) — require explicit `name:branch`; remove the
+  default-branch fallback and the `ODUFLOW_DEFAULT_BRANCH` setting.
+- `a80ba53` (2026-02-27) — `fetch_extra_repo` returns a change summary
+  (new/deleted/updated branches + commit counts); `pull_and_apply` updates
+  extra-addon worktrees alongside the main repo.

--- a/specs/0011-per-user-git-credentials.md
+++ b/specs/0011-per-user-git-credentials.md
@@ -1,0 +1,102 @@
+# 0011 — Per-user git credentials and repository authentication
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `5c28100` "per-user git credentials for repo operations" (2026-02-20), `259164e` "credentials management UI + git auth improvements" (2026-02-20); precursor URL-credential stripping in `b545cb4` (2026-02-11)
+**Key code today:** `git_ops.py` (credential store, `setup_repo_auth`, list/validate/delete, `inject_credential_user`), `server.py` (`setup_repo_auth` tool), `settings.py` (`TeamSettings.git_credentials_file`), `naming.py` (`sanitize_repo_url`), `web_ui.py` (Credentials tab)
+
+## Context
+
+To clone and fetch a user's Odoo addons, Oduflow must authenticate to **private
+git remotes** (GitHub/GitLab/Bitbucket) on the user's behalf. Once Oduflow
+became a remotely hosted, multi-tenant service
+([[0014-team-based-multi-tenancy]]), this raised problems that a single shared
+credential cannot solve:
+
+- **Multi-tenant private repos.** Different teams/users have different private
+  repositories and different personal access tokens; one global token would
+  grant every tenant access to every other tenant's repos, or fail to reach
+  some entirely.
+- **No secret sharing, no SSH prompts.** Tokens must not be passed as tool
+  arguments visible to the agent, and SSH URLs are unusable on a headless server
+  (host-key prompts hang). The practical, scriptable path is **HTTPS + a stored
+  credential**.
+- **Leakage risk.** Authenticated clone URLs (`https://user:TOKEN@host/...`)
+  naturally flow into Docker labels, logs, and dashboard API responses. A token
+  pasted once must not resurface anywhere it can be read.
+
+This is distinct from MCP **client** authentication (who may call the server —
+see [[0020-authentication-oauth]]): this record is about Oduflow authenticating
+**outbound** to upstream git remotes for clone/fetch.
+
+## Decision
+
+Manage git credentials **per team/tenant**, stored via git's own credential
+mechanism in the tenant's private data dir, and **strip credentials from every
+URL** that is logged, labelled, or shown.
+
+- **HTTPS-only, token-based.** SSH and non-HTTPS URLs are rejected early;
+  authentication is always HTTPS with a username + token. This keeps the server
+  non-interactive and the credential format uniform.
+- **Per-tenant credential store.** Each team has its own `.git-credentials` file
+  under its isolated `data_dir` (`TeamSettings.git_credentials_file()`).
+  Credentials are written through git's `credential approve` / `store` helper, so
+  later `git fetch`/`clone` pick them up automatically with no token in the
+  command line. Tenants never share a credential file.
+- **A `setup_repo_auth` flow.** A dedicated MCP tool (and matching dashboard
+  Credentials tab) takes a URL with embedded credentials, **verifies access**
+  with a real `git ls-remote` against the remote, stores the credential on
+  success, and returns only the *clean* (credential-free) URL. After setup,
+  `create_environment` and extra-repo clones use the clean URL and the cached
+  credential.
+- **Credentials never leak into artifacts.** `sanitize_repo_url` removes any
+  embedded `user:password` before a repo URL is logged, stored in a Docker
+  label, or returned by the dashboard API.
+
+## How it works (macro)
+
+- **Cache once, reuse silently.** `setup_repo_auth` parses the
+  `https://user:TOKEN@host/...` URL, stores the credential in the team's file via
+  the git credential helper, and proves it works with `git ls-remote`. Subsequent
+  clone/fetch operations run with a per-team git environment whose
+  `credential.helper` points at that file, so the token is supplied by git itself
+  and never appears as an argument.
+- **Per-user selection at create time.** Environments and extra-repo clones carry
+  a `git_user` (selectable in the Create Environment / Add Extra Repo modals,
+  persisted in the Docker label and template metadata). `inject_credential_user`
+  embeds that username into the clone URL so git matches the correct stored
+  credential when several are present for the same host.
+- **Manage credentials from the dashboard.** The Credentials tab lists stored
+  entries (token masked), validates them against the provider's API
+  (GitHub/GitLab/Bitbucket `user` endpoint), and deletes them — all scoped to the
+  calling team's credential file.
+- **Strip on the way out.** Any path that exposes a repo URL — startup logs, the
+  environment list API, container labels — routes it through `sanitize_repo_url`
+  first, so a token can be entered once but is never readable afterward.
+
+## Consequences
+
+- **Multi-tenant private repos work safely:** each team authenticates to its own
+  remotes with its own tokens, with no cross-tenant access and no shared secret.
+- The "verify before storing" step in `setup_repo_auth` turns a silent
+  misconfiguration (bad token, no access) into an immediate, explicit failure
+  instead of a confusing clone error later.
+- Storing credentials through git's native helper keeps tokens **out of process
+  arguments and out of the agent-visible tool surface**, consistent with the
+  project rule that secrets never appear as tool parameters.
+- Systematic URL sanitization closed the obvious leakage channels (logs, labels,
+  API), making it safe to handle credential-bearing URLs internally.
+- HTTPS-only is a deliberate limitation: it sidesteps SSH host-key prompts on a
+  headless server at the cost of not supporting SSH-key auth.
+
+## History
+
+- `b545cb4` (2026-02-11) — `sanitize_repo_url`; strip credentials from repo URLs
+  in the dashboard API and logs.
+- `5c28100` (2026-02-20) — per-user git credentials: `inject_credential_user`,
+  `git_user` on `create_environment` / extra repos, persisted in Docker labels and
+  template metadata, with a Git Credential picker in the UI.
+- `259164e` (2026-02-20) — credentials management: auth verification via
+  `git ls-remote` (replacing a shallow clone), list/validate/delete API + the
+  dashboard Credentials tab, persistent `.git-credentials` store, and a
+  credential helper configured at startup.

--- a/specs/0012-managed-storage-file-access.md
+++ b/specs/0012-managed-storage-file-access.md
@@ -1,0 +1,90 @@
+# 0012 — Agent file access into managed storage (container files + Docker volumes)
+
+**Status:** Adopted (still in force)
+**Type:** Capability
+**First introduced:** `abcc525` "add read_file_in_odoo MCP tool" (2026-02-24); extended to volumes by `5cabc2c` "Manage files in volumes" (`8dbdc17`, 2026-03-20, `#12`)
+**Key code today:** `docker_ops/odoo_ops.py` (`*_in_odoo` via container exec), `docker_ops/volume_file_ops.py` (`*_in_volume` via helper container), `server.py` (the file tools)
+
+## Context
+
+An AI agent debugging an environment constantly needs to *look at and touch
+files that live inside Oduflow-managed storage* — a generated config inside the
+running Odoo container, an attachment under the filestore, a seed file dropped
+into a service's Docker volume. Two of those stores are awkward to reach:
+
+- **Inside the running container**, files exist but the agent has no shell — its
+  only channels are MCP tool calls. Asking it to script `docker exec` itself
+  defeats the point of a managed, tool-mediated interface.
+- **Inside a Docker volume**, there may be *no running container at all* (a
+  volume can be attached to a stopped service, or to none). The data is opaque:
+  not on the host filesystem in any stable place, not reachable by exec.
+
+The existing surfaces don't cover this. Code delivery
+([[0021-code-delivery-modes]]) moves a repo *into* an environment but says
+nothing about reading arbitrary files back out; volume management
+([[0007-auxiliary-services-and-volumes]]) is lifecycle of the volume *object*
+(create/list/inspect/delete/mount), not its *contents*. And exposing raw shell
+access would blow a hole in the tenant isolation the rest of the system works to
+preserve.
+
+## Decision
+
+Give agents a **first-class, tool-mediated filesystem reach into managed
+storage**, as a small family of MCP tools with consistent semantics and built-in
+safety rails — covering both stores that lack a convenient host path:
+
+- **Container files (`*_in_odoo`)** — `read_file_in_odoo`, `write_file_in_odoo`,
+  `search_in_odoo` operate on the **running Odoo container** via `exec` (`cat` /
+  `sed` ranges / `stat` / `file --mime` / writes), so the agent inspects and
+  edits what Odoo actually sees, without a shell.
+- **Volume files (`*_in_volume`)** — `read_file_in_volume`,
+  `write_file_in_volume`, `search_in_volume`, `delete_file_in_volume` reach into
+  an **opaque Docker volume by mounting it into a short-lived helper container**
+  (`alpine:latest`) at a fixed mount point, running the operation, and discarding
+  the helper. This makes a volume's contents inspectable/editable even when
+  nothing else has it mounted.
+- **Safety is part of the contract, not the caller's job.** Paths are normalised
+  and confined to the mount point (**path-traversal rejected**), reads do
+  **binary detection** and **size/line-range bounds** (the same bounded-output
+  discipline as [[0017-mcp-tool-execution-output-cache]]), and writes stream in
+  via a tar archive rather than shelling out interpolated content.
+
+## How it works (macro)
+
+- **Pick the channel by where the data lives.** If the bytes are inside a live
+  container, exec is the cheapest path and shows exactly the container's view. If
+  they're inside a volume, a disposable helper container is the *only* reliable
+  way to reach them, so the tools spin one up, bind the volume, act, and tear it
+  down — the volume is the durable thing, the helper is throwaway.
+- **One mental model for the agent.** Read / write / search behave the same
+  whether the target is `_in_odoo` or `_in_volume`; the agent thinks "file in
+  managed storage", not "exec vs. mount plumbing".
+- **Confined by construction.** Every path resolves under a single mount root and
+  anything climbing out (`..`) is refused, so a file tool can only touch the
+  storage it was scoped to — preserving the per-tenant boundary the orchestration
+  layer enforces elsewhere.
+
+## Consequences
+
+- Closes the agent's biggest blind spot: it can now *see* generated configs,
+  filestore contents, and volume seed data directly through the tool surface,
+  instead of guessing or driving a raw shell — squarely serving the AI-first goal
+  of [[0001-mcp-orchestrated-ephemeral-per-branch-environments]].
+- The helper-container trick turns **opaque volumes into an inspectable
+  filesystem** without requiring a service to be running, which is what made the
+  volume side worth a distinct capability rather than a footnote on volume
+  management.
+- The safety rails (traversal confinement, binary/size bounds, tar writes) keep a
+  broad new power from becoming an isolation or output-blowup hazard, consistent
+  with the rest of the system's guardrail-first posture.
+
+## History
+
+- `abcc525` (2026-02-24) — `read_file_in_odoo`: first direct file reach into a
+  running container.
+- `44810aa` (2026-03-02) — the MCP tools refinement
+  ([[0017-mcp-tool-execution-output-cache]]) adds `write_file_in_odoo` and
+  `search_in_odoo`, rounding out container-file access.
+- `5cabc2c` / `8dbdc17` (2026-03-20, `#12`) — `read_/write_/search_/delete_file_in_volume`:
+  file access *inside* Docker volumes via a mounted `alpine` helper container,
+  with path-traversal protection, binary detection, and tar-stream writes.

--- a/specs/0013-per-environment-db-credentials-and-sanitization.md
+++ b/specs/0013-per-environment-db-credentials-and-sanitization.md
@@ -1,0 +1,118 @@
+# 0013 — Per-environment PostgreSQL credentials + two-tier database sanitization
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `cd0b9ec` "two-tier database sanitization" (2026-02-24), `e4949b0` "per-environment PostgreSQL credentials" (2026-02-26)
+**Key code today:** `env_credentials.py` (generate / persist / load / delete per-env creds), `sanitizer.py` (two-tier script runner), `docker_ops/env_ops.py` (`_create_pg_role`, post-clone ownership fixup), `docker_ops/system_ops.py` (shared DB, role helpers)
+
+## Context
+
+All environments share **one PostgreSQL server** container, with one database per
+environment. Two data-safety problems followed from how that started out, and
+from where the databases come from.
+
+1. **Shared superuser.** Every environment connected as the same global
+   `odoo`/`odoo` user. That account owns *every* environment's database, so a
+   single leaked or misused credential — or a sloppy script — reaches across all
+   tenants and branches. There was no isolation at the database layer to match
+   the container/filestore isolation already in place.
+2. **Production-derived data.** Templates ([[0003-database-templates-and-filestore-isolation]])
+   are frequently imported from a real production Odoo. A clone of production
+   carries **live mail servers, real customer data, scheduled jobs** — exactly
+   the things that must *not* fire from a throwaway dev environment. An agent
+   spinning up a branch must not be able to email real customers.
+
+A complication sits underneath both: PostgreSQL's `CREATE DATABASE ... TEMPLATE`
+copies objects but leaves them **owned by the original (superuser) role**, so a
+freshly created per-environment role can't run the DDL Odoo needs and can't even
+see some objects in the catalog — which surfaced as confusing "relation already
+exists" / "role cannot be dropped" failures.
+
+## Decision
+
+Two related decisions, both about confining blast radius at the database layer.
+
+- **Per-environment PostgreSQL role.** Each environment gets its **own login role
+  and password**, generated at create time, persisted to
+  `workspace/env_credentials.json`, and used as the **owner** of that
+  environment's database. Odoo connects as this role. The global superuser is
+  retained only for **administrative** operations (CREATE/DROP DATABASE, template
+  loads, GC, orphan cleanup). Old environments without a credentials file fall
+  back to the global user, so the change is backward compatible.
+- **Two-tier sanitization.** After provisioning (default on, `sanitize=True`),
+  Oduflow scrubs the database in two tiers: a **system-wide** baseline owned by
+  the team admin, then **per-repo** rules owned by the developer. Both tiers are
+  directories of `.sql` and `.py` scripts run in alphabetical order, so the
+  baseline is consistent across the fleet while each project can add its own
+  rules.
+
+## How it works (macro)
+
+- **Credential lifecycle.** `create_credentials` derives a role name from the
+  team + environment (`u_<team>_<env>`, capped at PostgreSQL's 63-char limit) and
+  a random password, writes them next to the environment, and `_create_pg_role`
+  creates the role as DB owner. Tests, ad-hoc DB queries, the dashboard SQL
+  terminal, and the sanitizer all `load_credentials` so they connect as the
+  per-env role, not the superuser. On delete/rebuild the role is dropped and the
+  file removed; orphan-role detection cleans up stragglers.
+- **Post-clone ownership fixup.** When a database is created from a template, the
+  fixup transfers ownership of the `public` schema and every table, sequence, and
+  view to the new per-env role (DDL requires ownership; `GRANT ALL` only covers
+  DML), and drops Odoo's signaling sequences carried over from the template so
+  Odoo can recreate them cleanly on first start. This is the load-bearing glue
+  that makes a cloned DB usable under a non-superuser owner.
+- **Sanitization tiers.** `sanitize_environment` runs scripts from the team's
+  `{data_dir}/odoo_sanitize/` first (seeded on `oduflow init` with a bundled
+  `01_disable_mail.sql`), then from the repo's `.odoo_sanitize/` folder. `.sql`
+  runs against the env DB; `.py` runs *inside* the Odoo container using the
+  per-env credentials, so repo rules can use the Odoo ORM. Failures are logged as
+  warnings, not fatal — sanitization is best-effort hardening, not a gate.
+
+## Consequences
+
+- A compromised or misbehaving environment is **confined to its own database**:
+  its login owns only its own data, so the database layer now matches the
+  isolation that containers, ports, and filestores already provide. Tenancy
+  isolation ([[0014-team-based-multi-tenancy]]) gains a real DB-level boundary.
+- Production-derived templates become **safe to clone** for development: mail
+  servers are removed and risky data neutralised before the agent touches the
+  environment, so a dev branch cannot email real customers or trigger live jobs.
+- **Two tiers** put each rule where it belongs — the operator owns the
+  fleet-wide baseline, the developer owns project-specific scrubbing — mirroring
+  the same deployment-vs-repo split as the configuration model
+  ([[0016-configuration-model]]).
+- The non-superuser ownership model is **more correct but more fragile** at the
+  clone boundary: it required a string of fixes (ownership reassignment strategy,
+  role-membership grants, `--no-owner` template restores) because PostgreSQL's
+  template-clone and role-drop semantics interact in non-obvious ways.
+
+## Evolution
+
+The clone-time ownership transfer was reworked several times as edge cases
+surfaced:
+
+- `31df320` (2026-02-26) — iterate tables/sequences and `ALTER ... OWNER TO` the
+  new role after a template clone, so the env role can see them (fixes spurious
+  "relation already exists" on signaling sequences).
+- `c6878e4` (2026-02-27) — replace the per-type loops with a single
+  `REASSIGN OWNED BY` covering all object types.
+- `5c7b737` (2026-02-27) — `REASSIGN OWNED BY` fails on system objects owned by a
+  superuser; instead **grant the env role membership** in the superuser role so it
+  inherits ownership for DDL. (The current code keeps an explicit
+  schema/table/sequence/view `ALTER OWNER` sweep plus a signaling-sequence drop.)
+
+## History
+
+- `cd0b9ec` (2026-02-24) — two-tier sanitization: drop hardcoded built-in queries;
+  bundle `01_disable_mail.sql`; create `/etc/oduflow/odoo_sanitize/` on init; run
+  system-wide then per-repo `.odoo_sanitize/` scripts; add `sanitize` param to
+  `create_environment` (default True).
+- `e4949b0` (2026-02-26) — per-environment PostgreSQL credentials: `env_credentials.py`,
+  `_create_pg_role`/`_drop_pg_role`, env role as DB owner, global user kept for
+  admin ops; tests/queries/sanitizer/SQL terminal use per-env creds; orphan-role
+  cleanup; backward-compatible fallback.
+- `31df320`, `c6878e4`, `5c7b737` (2026-02-26 → 02-27) — clone-time ownership
+  fixups so a non-superuser env role owns the cloned DB (see Evolution).
+- `4f729b1` (2026-03-02) — **delete** mail servers (`fetchmail_server`,
+  `ir_mail_server`) instead of merely disabling them; disabling still let Odoo
+  send in some cases.

--- a/specs/0014-team-based-multi-tenancy.md
+++ b/specs/0014-team-based-multi-tenancy.md
@@ -1,0 +1,102 @@
+# 0014 — Team-based multi-tenancy (replacing instance-based isolation)
+
+**Status:** Adopted (current tenancy model). Supersedes the tenancy mechanism in [[0002-remote-multi-user-mcp-access]]
+**Type:** Architecture
+**First introduced:** `ad3b382` "replace instance-based isolation with team-based multi-tenancy" (2026-03-01), finished in `14503a0` (2026-03-01)
+**Key code today:** `settings.py` (`Settings.from_toml`, `[team.*]` → `TeamSettings`, per-team `data_dir` / ports / credentials), `locking.py` (per-team locks), `server.py` (`_resolve_team`)
+
+## Context
+
+How Oduflow isolates one user's work from another's went through three shapes.
+This record captures *why* it landed on **teams**.
+
+1. **Per-user token hashing** (the original [[0002-remote-multi-user-mcp-access]]
+   model). Identity came from the HTTP header token, hashed into a short
+   `user_id` that was stamped onto every Docker resource and host path. One
+   process, many users, all sharing the same data dir and database, separated
+   only by a label/prefix. This was lightweight but fragile: isolation depended
+   entirely on getting the per-user filtering right everywhere, and everyone
+   shared one blast radius.
+
+2. **Separate instances** (`0a8ceab`, 2026-02-12). To get real operational
+   separation, Oduflow gained an `ODUFLOW_INSTANCE_ID`: databases were prefixed
+   (`oduflow_{instance}_{branch}`), containers carried an `oduflow.instance`
+   label, and each instance got its own data directory, while still sharing the
+   Docker network, PostgreSQL and Traefik. `52224cb` (2026-02-24) reworked the
+   data layout to `ODUFLOW_DATA_DIR` with auto-created `instance_{ID}`
+   subdirectories so a single volume could hold all instances. This isolated
+   instances cleanly — but at the cost of **env-var-driven configuration** and,
+   in practice, running/initializing each instance as its own thing
+   (`init-instance`, `run-instance`).
+
+3. **Teams** (`ad3b382` / `14503a0`, 2026-03-01). The instance model was the
+   right *isolation* but the wrong *ergonomics*: a hosted deployment serving
+   several teams shouldn't require N processes or a spray of env vars. The
+   decision was to make tenancy a **first-class, declarative concept** in one
+   config file, served by one process.
+
+## Decision
+
+Model tenancy as **teams declared as `[team.*]` sections in `oduflow.toml`**, and
+replace both per-user hashing and per-instance env vars with this single
+TOML-driven model.
+
+- Each `[team.N]` carries its own `auth_token`, `ui_password`, `hostname`, and
+  `port_range`, and gets its own per-team data directory (`team_{id}`) holding
+  workspaces, templates, credentials, and a private `ports.json`.
+- One Oduflow process loads all teams from config and **resolves the caller's
+  team per request** (auth token → Host header → single-team fallback), then
+  scopes every operation to that team's directories, ports, and database
+  namespace.
+- Tenancy plugs into the granular lock model
+  ([[0015-granular-locking]]): each team has its own **per-team lock**, so
+  team-wide operations never block another team.
+
+This supersedes the token-hash tenancy described in
+[[0002-remote-multi-user-mcp-access]] (whose *transport* decision — HTTP for
+remote, stdio default — still stands) and retires the instance model entirely.
+
+## How it works (macro)
+
+- `Settings.from_toml` requires at least one `[team.*]` section and builds a
+  `TeamSettings` per team, deriving `team_{id}` data paths under the shared
+  `data_dir` and a per-team port range / registry.
+- At request time the server resolves which team a call belongs to and passes
+  that `TeamSettings` to the orchestration layer, which reads/writes only that
+  team's workspaces, templates, credentials, and ports.
+- Routing reuses the Traefik seam from
+  [[0004-stable-addressing-port-registry-and-traefik]]: each team has its own
+  `hostname`, and per-team routers are generated so requests land on the right
+  team without restarting the proxy.
+- Per-team auth tokens and UI passwords are validated for uniqueness, so a token
+  unambiguously identifies one team.
+
+## Consequences
+
+- A single hosted Oduflow can serve multiple teams with **real isolation**
+  (separate data dirs, port ranges, credentials, DB namespaces) but **without**
+  running multiple processes — simpler to deploy and operate than the instance
+  model it replaced.
+- Configuration consolidated from scattered env vars / `.env` into one
+  declarative `oduflow.toml`, matching the project's lean, config-first
+  direction; `init-instance` / `run-instance` and the instance env vars were
+  removed.
+- Tenancy, locking, and routing now share one notion of "team," keeping
+  per-tenant concurrency and addressing consistent.
+- The removed `MULTI_INSTANCE.md` (deleted in `0aafefb`) documents the
+  superseded instance model for historical reference only.
+
+## History
+
+- `0a8ceab` (2026-02-12) — multi-instance support: `ODUFLOW_INSTANCE_ID`,
+  DB-name and container-label prefixing, per-instance data dir; shared
+  network/PostgreSQL/Traefik. (`MULTI_INSTANCE.md` added.)
+- `52224cb` (2026-02-24) — `ODUFLOW_HOME` → `ODUFLOW_DATA_DIR` with auto-created
+  `instance_{ID}` subdirectories for a single-volume layout.
+- `0aafefb` (2026-02-24) — `MULTI_INSTANCE.md` removed.
+- `ad3b382` (2026-03-01) — team-based multi-tenancy (#5): TOML `[team.*]`
+  settings with per-team workspaces / templates / credentials / port ranges /
+  hostnames; adds `locking.py` (per-team locks) and per-team team resolution;
+  retires instance-based isolation and env-var config.
+- `14503a0` (2026-03-01) — follow-up (#6): cleanup (TRACE flag, `stateless_http`,
+  removed `.env.example`) completing the migration.

--- a/specs/0015-granular-locking.md
+++ b/specs/0015-granular-locking.md
@@ -1,0 +1,91 @@
+# 0015 — Granular locking: per-branch / per-team / system locks
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** global mutex `3a26c70` "Load filestore" (2026-02-06); replaced by the granular `LockManager` in `ad3b382` "team-based multi-tenancy" (2026-03-01)
+**Key code today:** `locking.py` (`LockManager`, `BusyError`), `server.py` (`with_env_lock` / `with_team_lock` decorators, `acquire_system`)
+
+## Context
+
+Oduflow mutates heavy, stateful resources — Docker containers, PostgreSQL
+databases, filestores, a shared port registry. Two concurrent operations that
+touch the *same* environment (e.g. an install and a rebuild on the same branch)
+can corrupt each other, so mutating tools must be serialized.
+
+The first cut took the blunt approach: a **single process-wide mutex**
+(`_busy = threading.Lock()`, applied via a `with_mutex` decorator) guarded
+*every* mutating tool. If any operation was running, a second tool call failed
+fast with `BusyError` rather than queuing or racing.
+
+That was correct but far too coarse. The whole point of the founding design
+([[0001-mcp-orchestrated-ephemeral-per-branch-environments]]) is that the branch
+name is the unit of isolation and work on different branches is independent — and
+once the server became multi-user and then multi-team
+([[0002-remote-multi-user-mcp-access]]), a global lock meant **one tenant's slow
+operation blocked everyone else's**. Installing modules on branch A should never
+make `create_environment` on branch B (let alone another team's branch) bounce
+with "busy". A global mutex threw away exactly the parallelism the architecture
+was built to exploit.
+
+## Decision
+
+Replace the single global mutex with a **`LockManager` that locks at the finest
+safe granularity**, choosing the lock scope to match what an operation actually
+touches:
+
+- **Per-environment (per-branch) lock** — for operations scoped to one
+  environment (install/upgrade/test/restart/exec/rebuild/delete). Two operations
+  on the *same* branch serialize; operations on *different* branches run fully in
+  parallel.
+- **Per-team lock** — for operations that touch team-wide shared state rather
+  than a single environment (e.g. credentials, extra-addon repos, template and
+  service-preset management). Teams never block each other.
+- **System lock** — a single lock for truly global operations (init / destroy of
+  the shared infrastructure) that must exclude everything else.
+
+Contention is still surfaced to the agent as a fast-failing **`BusyError`**
+(non-blocking `acquire`): the caller is told another operation on that specific
+resource is in progress and to retry, instead of the request hanging.
+
+## How it works (macro)
+
+- `LockManager` holds lazily-created `threading.Lock` objects keyed by
+  environment name and by team id, plus one system lock; a small map-guard lock
+  protects the dictionaries themselves.
+- Tools opt into a scope by decorator in `server.py`: `with_env_lock` derives the
+  branch/env name from the call and takes that environment's lock;
+  `with_team_lock` resolves the caller's team and takes that team's lock;
+  global lifecycle paths take the system lock directly.
+- Acquisition is **non-blocking** — a busy lock raises `BusyError` immediately,
+  which `@handle_errors` turns into a clean MCP `ToolError`. The agent retries
+  rather than blocking a worker thread.
+- Because sync tools already run in a thread pool for HTTP concurrency
+  (see [[0002-remote-multi-user-mcp-access]]), independent locks genuinely run in
+  parallel across threads.
+
+## Consequences
+
+- Parallel, conflict-free work across branches and across teams became the
+  default, not the exception — the locking granularity finally matches the
+  branch-as-key and team-as-tenant models.
+- A slow or stuck operation only blocks its own environment (or its own team),
+  containing the blast radius of contention to the smallest meaningful unit.
+- Each new mutating tool must pick the *right* scope; mis-scoping (env lock where
+  a team-shared resource is touched, or vice versa) reintroduces races or
+  over-serialization. The `BusyError` retry contract keeps the failure mode
+  uniform and agent-friendly regardless of scope.
+- Locks are in-process only: they serialize within one Oduflow process, while
+  cross-process safety on shared files (e.g. the port registry) is handled
+  separately with an flock (see [[0004-stable-addressing-port-registry-and-traefik]]).
+
+## History
+
+- `3a26c70` (2026-02-06) — global mutex introduced: `_busy = threading.Lock()` +
+  `with_mutex` decorator guarding all mutating tools, failing fast with
+  `BusyError`.
+- `ad3b382` (2026-03-01) — granular `LockManager` added (`locking.py`) as part of
+  the team-tenancy refactor; the global `with_mutex` is replaced by per-branch
+  (`with_env_lock`) and per-team (`with_team_lock`) decorators plus a system lock.
+- `18b18b1` (2026-03-02) — documentation and tool tables renamed "Mutex" →
+  "Lock" / "Locking" to reflect the per-branch/per-team model; fixed a missing
+  lock indicator on `delete_service_preset`.

--- a/specs/0016-configuration-model.md
+++ b/specs/0016-configuration-model.md
@@ -1,0 +1,103 @@
+# 0016 — Configuration model: `oduflow.toml` + repo-level `.oduflow/` config
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `ad3b382` "replace instance-based isolation with team-based multi-tenancy" (2026-03-01)
+**Key code today:** `settings.py` (`Settings`/`TeamSettings` dataclasses, `Settings.from_toml`), `docker_ops/env_ops.py` (repo-level `.oduflow/` resolution), `pg_tune.py` (auto-tuned `postgresql.conf`)
+
+## Context
+
+Early Oduflow was configured by a sprawl of `ODUFLOW_*` **environment
+variables** (`ODUFLOW_HOME`, `ODUFLOW_OVERLAY_THRESHOLD_MB`,
+`ODUFLOW_ETC_DIR`, `ODUFLOW_DEFAULT_TEMPLATE`, …) read ad hoc at module load.
+That worked for one local instance but did not express **structure**: there was
+no clean way to describe several tenants, each with its own hostname, token,
+port range and data dir. The shift to team-based multi-tenancy
+([[0002-remote-multi-user-mcp-access]]) needed a config format that could carry
+repeated, nested sections — env vars can't.
+
+A second need was **per-repository** configuration. How an environment runs
+(Odoo settings, OS/Python dependencies) is a property of the *user's code*, not
+of the Oduflow deployment, so it belongs in the repo — but without littering the
+repo root with Oduflow-specific files.
+
+Running through both: a project preference for **lean, auto-generated sensible
+defaults over many config knobs**. The right number of options is the smallest
+one that still works on a stranger's machine.
+
+## Decision
+
+Adopt a **typed `Settings` dataclass loaded from `oduflow.toml`** as the single
+configuration source, with **multi-team `[team.*]` sections**; and a
+**repo-level `.oduflow/` directory** for per-repository config. Default
+aggressively rather than expose knobs.
+
+- **`oduflow.toml` + typed Settings.** A frozen `Settings` dataclass (global
+  options) holds a map of frozen `TeamSettings` (per-team: `hostname`,
+  `auth_token`, `ui_password`, `port_range_*`, `data_dir`). `Settings.from_toml`
+  parses the TOML (via `tomllib`), with every field carrying a default so a
+  minimal config just works. The old `.env`/`ODUFLOW_*` mechanism and
+  `.env.example` were removed.
+- **Bootstrap on first run.** `oduflow init` copies a bundled default
+  `oduflow.toml` into place when none exists, so first-run setup needs no manual
+  config authoring.
+- **Repo-level `.oduflow/`.** Per-repo settings live under `<repo>/.oduflow/`:
+  `odoo.conf` (base Odoo config), `apt_packages.txt` (OS packages),
+  `requirements.txt` (Python deps). Keeping them in a dedicated directory leaves
+  the repo root clean; `requirements.txt` also falls back to the repo root for
+  compatibility with conventions used elsewhere (e.g. odoo.sh).
+- **Auto-generate, don't ask.** Where a good value can be *derived*, derive it
+  instead of adding a setting — e.g. the shared `postgresql.conf` is tuned from
+  the host's detected CPU/RAM on first init rather than shipped as a static file
+  or exposed as TOML tunables.
+
+## How it works (macro)
+
+- **Load once, pass explicitly.** `from_toml` builds the `Settings` object at
+  startup; it is threaded through the orchestration layer rather than re-read
+  from the environment, so configuration is a value, not ambient global state.
+  Per-request team resolution then selects the right `TeamSettings` (by auth
+  token, Host header, or single-team fallback).
+- **Defaults everywhere.** Storage threshold, lifecycle reaper hours, image
+  tags, Docker resource/label names, port ranges — all have in-code defaults; a
+  team section can be as small as a name. This keeps the config a stranger has
+  to write minimal.
+- **Repo config resolved at env build.** When creating/rebuilding an
+  environment, Oduflow looks for `<repo>/.oduflow/odoo.conf` (falling back to the
+  team/bundled conf), and installs `.oduflow/apt_packages.txt` and
+  `.oduflow/requirements.txt` (latter falling back to repo root) into the
+  container. The user controls *how their Odoo runs* from inside their own repo.
+- **Tuned PostgreSQL on init.** `pg_tune.detect_resources()` reads CPU/RAM from
+  `docker info` (correcting for the Docker Desktop VM, with host-stat and
+  conservative fallbacks, never raising), and `generate_postgresql_conf()`
+  produces a lean, SSD-oriented config sized for "one host running many
+  lightweight single-user Odoo envs". The generated file is written with a
+  `# KEEP` marker so [[0006-git-driven-change-classification]]'s upgrade never
+  overwrites a hand-edited copy. No new TOML settings were added for it.
+
+## Consequences
+
+- Configuration gained **structure**: multi-team tenancy is expressible as
+  repeated `[team.*]` sections, which the env-var model could not represent — this
+  is what made team-based multi-tenancy practical.
+- A **typed, frozen dataclass** makes settings discoverable, defaultable, and
+  safe to pass around, and gives `mypy` something to check, versus stringly-typed
+  `os.getenv` calls scattered across modules.
+- Splitting **deployment config** (`oduflow.toml`) from **repo config**
+  (`.oduflow/`) put each decision where it belongs: the operator owns the fleet,
+  the developer owns how their module builds and runs.
+- The "derive, don't ask" stance keeps the surface small as the system grows —
+  but it puts the burden on the heuristics (e.g. resource detection) to be robust
+  and to fail safe to sensible defaults rather than erroring.
+
+## History
+
+- `ad3b382` (2026-03-01) — migrate `.env`/`ODUFLOW_*` → `oduflow.toml`; introduce
+  `Settings.from_toml`, `[team.*]` sections, per-team isolation; bootstrap a
+  default config on `init`; delete `.env.example` (#5).
+- `48eea3e` (2026-04-22) — read repo-level `odoo.conf` from `<repo>/.oduflow/`
+  instead of the repo root (#15).
+- `7f8d654` (2026-06-04) — resolve `apt_packages.txt` and `requirements.txt`
+  under `.oduflow/` (requirements falls back to repo root) (#25).
+- `e112ac9` (2026-06-16) — auto-generate a tuned `postgresql.conf` on first init
+  via `pg_tune.py` from detected host resources; no new TOML knobs (#67).

--- a/specs/0017-mcp-tool-execution-output-cache.md
+++ b/specs/0017-mcp-tool-execution-output-cache.md
@@ -1,0 +1,100 @@
+# 0017 — MCP tool execution model: server-side output cache + `read_output` for long operations
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `44810aa` "implement MCP tools refinement spec — output cache, 7 new tools, 3 enhancements" (2026-03-02)
+**Key code today:** `output_cache.py` (`OutputCache`, `CachedOutput`), `server.py` (`_make_summary`, `_maybe_cache`, `read_output`, integration in install/upgrade/test/pull_and_apply/run_odoo_command/run_db_query)
+
+## Context
+
+The founding design ([[0001-mcp-orchestrated-ephemeral-per-branch-environments]])
+gives the agent a closed feedback loop: install/upgrade a module, run tests, read
+the errors, fix, retry. The value of that loop is entirely in the agent *seeing
+the output*. But Odoo's install/upgrade/test runs emit tens of thousands of lines
+of INFO logs — a typical `upgrade_odoo_modules` is 68K+ characters — and **MCP
+responses are bounded**. When a tool result exceeds the client's limit, clients
+like Claude Code spill it to a file the agent never reads:
+
+```
+upgrade_odoo_modules (...) ⎿ Error: result (68,449 characters) exceeds maximum allowed tokens.
+   Output has been saved to .../tool-results/mcp-....txt
+```
+
+At that point the agent has **lost the feedback** — it cannot tell whether the
+run succeeded or what failed. This was a blocking problem for the core workflow,
+not a polish item: the very tools that produce the most important diagnostics
+(`install_odoo_modules`, `upgrade_odoo_modules`, `run_odoo_tests`,
+`pull_and_apply`, arbitrary `run_odoo_command`, unbounded `run_db_query`) are the
+ones most likely to overflow.
+
+A naive "just truncate" loses exactly the error buried in the middle of the log;
+a "return everything" overflows. The agent needs a *small* response that always
+contains the errors, plus a way to *page into* the full output on demand.
+
+## Decision
+
+Introduce a **server-side output cache** plus a retrieval tool, so any tool with
+potentially large output returns a bounded smart summary while the full output
+stays addressable on the server. This refinement was specified up front
+(`mcp-ref.md`) and then implemented.
+
+- **Cache full output, return a summary.** Outputs above a threshold
+  (5K chars) are stored in an in-memory `OutputCache` keyed by a short
+  `output_id`. The tool returns a **smart summary** — head + every error/warning
+  with context + tail + metadata (total lines/chars, error count, the
+  `output_id`) — which fits in one MCP response and always surfaces the failure.
+  Smaller outputs pass through unchanged, so the change is transparent and
+  backward-compatible.
+- **`read_output` for interactive drill-down.** A new tool pages into the cached
+  buffer by `output_id`: line ranges, `errors`-only with context, case-insensitive
+  `grep`, `tail`, and `info` (metadata). The big log effectively becomes a
+  `less`-with-search buffer the agent can explore without re-running anything.
+- **Bounded, ephemeral cache.** In-memory only, ~1h TTL, capped entries with
+  oldest-out eviction, error lines pre-indexed at store time. Yesterday's upgrade
+  log is worthless; the cache exists only to bridge one MCP response limit, not to
+  be durable storage.
+- **Tighten the surrounding tool surface.** The same refinement renamed
+  `exec_in_odoo` → `run_odoo_command` (pairing with the new `run_odoo_shell`),
+  added a `max_rows` guard to `run_db_query`, added `grep`/`level` filtering to
+  log retrieval, and shipped the other tools the spec called for (file write,
+  ORM shell, HTTP-to-Odoo, module listing, in-container search, readiness waits).
+
+## How it works (macro)
+
+- **Transparent caching at the tool boundary.** Tools that can produce large
+  output route their result through one helper: under threshold, return as-is;
+  over threshold, store in the cache and return `header + smart summary`. The
+  agent needs no new parameter — caching is invisible until the output is big.
+- **Two tiers of consumption.** A summary-only agent still sees head, the
+  extracted errors with context, and tail — enough for the common case. A
+  drill-down-capable agent uses `read_output(output_id, mode=...)` to grep, read
+  ranges, or fetch errors with more context.
+- **Self-describing responses.** Every summary footer states the `output_id` and
+  exactly how to call `read_output`, so the retrieval path is discoverable from
+  the response itself rather than from out-of-band docs.
+
+## Consequences
+
+- The **core feedback loop survives long operations**: the agent reliably sees
+  whether an install/upgrade/test failed and why, even when the raw log is far
+  larger than any MCP response could hold — without spilling to an unread file.
+- The summary's "head + errors + tail" shape encodes a debugging heuristic into
+  the protocol layer: the response is short *and* the signal (errors,
+  tracebacks) is never the thing that gets truncated away.
+- Keeping the cache in-memory/TTL'd avoided a persistence/cleanup subsystem; the
+  cost is that outputs vanish on restart or after an hour, which matches their
+  short useful life.
+- This refinement also rationalized tool **naming and scope** (notably
+  `exec_in_odoo` → `run_odoo_command`), and the threshold was tuned down from
+  15K to 5K during the spec phase so the safety net engages well before any
+  client limit.
+
+## History
+
+- `87edd27` (2026-03-02) — author the MCP tools refinement spec (`mcp-ref.md`):
+  output cache as the P0 blocking fix, plus new tools and enhancements.
+- `417eba7` (2026-03-02) — refine the spec: `exec_in_odoo` → `run_odoo_command`,
+  lower the cache threshold 15K → 5K, drop deferred snapshot tools.
+- `44810aa` (2026-03-02) — implement it: `output_cache.py`, `_make_summary`,
+  `_maybe_cache`, `read_output`; caching wired into 6 existing tools; `max_rows`
+  on `run_db_query`; plus the new core tools and log-filter enhancements.

--- a/specs/0018-onboarding-stdio-default-auto-init.md
+++ b/specs/0018-onboarding-stdio-default-auto-init.md
@@ -1,0 +1,92 @@
+# 0018 — Onboarding: stdio default transport + auto-init on startup
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `f33dfe6` "auto-init on startup, add stdio transport (default)" (2026-03-04)
+**Key code today:** `server.py` (`main`, `--transport` default `stdio`, `_ensure_initialized`, `_start_stdio`/`_start_http`)
+
+## Context
+
+By this point Oduflow could run remotely over HTTP for many users
+([[0002-remote-multi-user-mcp-access]]) and had grown real infrastructure to set
+up: shared Docker networking, the Traefik proxy
+([[0004-stable-addressing-port-registry-and-traefik]]), per-team directories,
+bundled configs, sanitize scripts, and agent guides ([[0009-agent-guidance-system]]).
+All of that was provisioned by a mandatory `oduflow init` step the user had to
+run before the server would work, and the server's default transport assumed the
+remote, networked case.
+
+That order of operations is backwards for the **most common use**: a single
+developer running Oduflow locally so one local agent can drive Odoo. For that
+person there is no network to configure and no second tenant — yet they had to
+(1) pick and configure a transport and (2) remember a separate init command
+before anything worked, and hit "Run init_system first" errors if they didn't.
+Every required step before "it just works" is friction that loses the simple
+single-local-agent case to confusion.
+
+The tension: HTTP/remote is a real and important path, so the simplification
+must not break it — it must only stop *forcing* network setup on people who don't
+need it.
+
+## Decision
+
+Make the zero-config local case the default, and remove the manual init step
+entirely.
+
+- **stdio is the default transport.** With no flags, `oduflow` starts over
+  **stdio** — the right transport for a single local agent, requiring no port,
+  no host, no auth. `--transport http` opts into the remote/multi-user server
+  ([[0002-remote-multi-user-mcp-access]]); container and systemd deployments set
+  that explicitly. The default serves the common case; remote is one flag away.
+- **Auto-initialize on startup.** The mandatory `oduflow init` command is
+  replaced by `_ensure_initialized()`, run automatically every time the server
+  starts. It is **idempotent**: it creates shared infrastructure, copies bundled
+  configs and agent guides, and sets up per-team directories only if missing, so
+  running it on every boot is safe and cheap. There is no separate init step to
+  forget; "System not initialized" becomes "restart the server."
+- **Config bootstraps itself too.** First start writes a default config if none
+  exists (searching the same fallback path the server actually writes to), so the
+  tool starts with **zero configuration** — install, run, connect an agent.
+
+## How it works (macro)
+
+- **One entry point, mode by flag.** `main()` parses `--transport` (default
+  `stdio`), ensures the system is initialized, records the active transport, then
+  dispatches to `_start_stdio()` or `_start_http()`. The same binary covers local
+  and remote; only the flag (and what gets initialized/served) differs.
+- **Idempotent init as a startup phase, not a command.** `_ensure_initialized`
+  brings up shared infra and, per configured team, creates directories and seeds
+  bundled artifacts (configs, sanitize scripts, agent guides) only where absent.
+  Because every step is "create if missing," the server can run it unconditionally
+  at boot.
+- **Self-seeding config.** On first run the config file is created at the
+  resolved data/etc dir if absent, removing the previously mandatory "configure"
+  step from the onboarding path.
+
+## Consequences
+
+- The local onboarding collapses to **install → run → connect** — no init
+  command, no transport choice, no config file to write first. This makes the
+  default experience match the most common intent (one developer, one local
+  agent) and removes a whole class of "did you run init?" failures.
+- Auto-init being idempotent means startup is self-healing: a half-set-up data
+  dir is completed on the next boot rather than requiring a remembered command,
+  which also simplified upgrades and container restarts.
+- The remote path is preserved but now **explicit**: HTTP, auth
+  ([[0020-authentication-oauth]]), and multi-tenancy are opt-in via
+  `--transport http`, keeping the dangerous-by-default surface (open network,
+  shared tenants) out of the local case. Dockerfile/systemd set the flag so
+  hosted deployments are unaffected.
+- Making stdio the default also set up the later **live-mount** fast path, which
+  is gated specifically to the stdio transport ([[0021-code-delivery-modes]]).
+
+## History
+
+- `f33dfe6` (2026-03-04) — replace `oduflow init` with idempotent
+  `_ensure_initialized()` at startup; add `--transport` (stdio default, http for
+  remote); `_start_stdio` via FastMCP `run_stdio_async`; bootstrap config copy on
+  every start.
+- `34e42fa` (2026-03-09) — ship the simplification: docs drop `oduflow init` as a
+  required step, document `--transport`, default Dockerfile/systemd to
+  `--transport http`; auto-create config on first start; fix the config search
+  path so zero-config startup works (#7).

--- a/specs/0019-telemetry.md
+++ b/specs/0019-telemetry.md
@@ -1,0 +1,86 @@
+# 0019 — Anonymous usage telemetry
+
+**Status:** Adopted (still in force)
+**Type:** Product
+**First introduced:** `2fc92c8` "release: v1.20.1 — telemetry, ..." (2026-03-11)
+**Key code today:** `telemetry.py` (event sending), `server.py` (startup + `env_created` hooks), `settings.py` (`disable_telemetry`)
+
+## Context
+
+Oduflow is self-hosted and runs on the user's own Docker host, so the project
+has **no inherent visibility** into whether anyone is using it, which versions
+are deployed, or whether installs convert into real use. Product decisions
+(what to build, which versions to support, whether the tool is being adopted at
+all) were being made blind.
+
+The forces:
+
+- The maintainers need a basic adoption signal — *roughly how many instances
+  exist and whether they create environments* — to steer the product.
+- The tool handles private repos and databases; telemetry must be obviously
+  **non-invasive** and trivially auditable, or it will (rightly) erode trust.
+- It must never affect the running tool: no added dependency, no blocking call,
+  no failure mode that touches the user's workflow if the network is down.
+
+## Decision
+
+Ship **anonymous, fire-and-forget usage telemetry**, on by default but easily
+disabled, that reports only coarse lifecycle events to the project backend.
+
+- **What is sent (and only this):** an event name (`first_run` or
+  `env_created`), the Oduflow `version`, and a random per-instance UUID
+  (`instance_id`). No repo URLs, branch names, database contents, user
+  identities, IP-derived data, or any environment specifics are included.
+- **Anonymous by construction.** The `instance_id` is a locally generated random
+  UUID persisted in the config dir; it correlates events from the *same install*
+  over time but is not derived from and cannot be reversed to any user, host, or
+  account.
+- **Opt-out, not opt-in, but loud about it.** Telemetry is on by default to get a
+  representative signal, controlled by a single `disable_telemetry` flag in
+  `oduflow.toml`; the entire module is stdlib-only and open source, so anyone can
+  read exactly what leaves the box.
+- **Never load-bearing.** Sending runs in a daemon thread with a short timeout
+  and swallows all errors. If the endpoint is unreachable, nothing in the tool
+  changes.
+
+## How it works (macro)
+
+- **Two events, minimal payload.** On startup, a first-ever run emits `first_run`
+  (the UUID is created and stored on that first run); creating an environment
+  emits `env_created`. Each is a single JSON POST to the project's usage
+  endpoint, sent and forgotten.
+- **Backend receives, not the tool.** Events are POSTed to the oduflow.dev usage
+  endpoint, where the project's website backend stores them as anonymous usage
+  records for aggregate adoption metrics. The client knows nothing about that
+  storage; it only fires the event. Described here at macro level only — the
+  backend lives in a separate repo.
+- **Edge-friendly marker.** Requests carry a branded `User-Agent`
+  (`oduflow/<version>`) and a shared `X-Oduflow-Telemetry` marker header. The
+  branded UA exists because the default `Python-urllib` signature was being
+  blocked by the backend's edge bot-protection (Cloudflare error 1010), which
+  silently dropped all events; the marker lets the endpoint cheaply discard
+  traffic that does not carry it. The marker is a **speed bump against random
+  scanners, not authentication** — the value is in the open-source client.
+
+## Consequences
+
+- The project gains a **basic, honest adoption signal** (install count via
+  `first_run`, activity via `env_created`, version spread) without instrumenting
+  anything sensitive.
+- The privacy stance is defensible and auditable: the payload is three
+  non-identifying fields, the code is short and dependency-free, and a single
+  config flag turns it off entirely.
+- Telemetry is decoupled from the product's reliability — it can fail, be
+  blocked, or be disabled with zero functional impact, which keeps it from ever
+  becoming a runtime liability.
+- It ties Oduflow to the **oduflow.dev backend** as the metrics sink, but only as
+  a write-only event target; the tool does not depend on that backend to run.
+
+## History
+
+- `2fc92c8` (2026-03-11) — introduce `telemetry.py`: anonymous `first_run` /
+  `env_created` events with version + per-instance UUID, `disable_telemetry`
+  flag, daemon-thread fire-and-forget.
+- `16b9158` (2026-06-15) — send a branded `User-Agent` (to bypass edge
+  bot-protection that was dropping every event) and an `X-Oduflow-Telemetry`
+  marker header; no change to the privacy contract or the opt-out flag.

--- a/specs/0020-authentication-oauth.md
+++ b/specs/0020-authentication-oauth.md
@@ -1,0 +1,97 @@
+# 0020 — Authentication for MCP HTTP transport: GitHub OAuth → self-hosted OAuth Authorization Server
+
+**Status:** Adopted (self-hosted AS is current; static Bearer tokens retained)
+**Type:** Architecture
+**First introduced:** `97c3fc8` "add GitHub OAuth support for MCP HTTP transport" (2026-03-13)
+**Key code today:** `server.py` (`_build_auth`, transport/auth wiring), `oauth_provider.py` (`OduflowOAuthProvider`), `settings.py` (`oauth_base_url`, per-team `auth_token`)
+
+## Context
+
+Remote, multi-user access ([[0002-remote-multi-user-mcp-access]]) established two
+invariants: the server can run over HTTP for callers that aren't the local
+process, and **identity is carried out-of-band in the transport, never as a tool
+parameter**. The first authenticated form of that identity was a raw **static
+Bearer token** per team (introduced with team-based multi-tenancy,
+[[0014-team-based-multi-tenancy]]): the caller sets an `Authorization` header,
+the server maps the token to a team and scopes every resource accordingly.
+
+A static header token is fine for `curl`, CLI clients, and IDEs that let you
+paste a header. But the most important MCP clients — claude.ai, MCP Inspector —
+expect to authenticate via **OAuth**, not a hand-pasted Bearer token. To be a
+first-class, hostable MCP service, Oduflow had to speak the auth protocol those
+clients actually use, while keeping the "no token in tool args" rule intact.
+
+The first answer leaned on GitHub as the identity provider. That worked but
+created a hard dependency: every deployment needed a registered GitHub OAuth app
+(`oauth_client_id`/`secret`), access control was a per-team `github_users`
+whitelist, and the trust root was a third party. For a tool whose whole point is
+self-contained, single-binary deployment, depending on an external IdP to log in
+to your *own* environments was the wrong trade.
+
+## Decision
+
+Harden MCP HTTP auth in two steps, ending at a **self-hosted OAuth 2.1
+Authorization Server** that issues and validates tokens itself, with static
+Bearer tokens retained as the simple fallback.
+
+- **Step 1 — GitHub OAuth (proxy).** Add OAuth 2.1 via GitHub alongside static
+  tokens, auto-detected from config: setting `oauth_client_id`/`secret`/
+  `base_url` enables the GitHub flow; `auth_token` keeps static tokens; both can
+  coexist. Team resolution and access control move to GitHub login
+  (`github_users` whitelist). This made claude.ai/Inspector connect with a real
+  OAuth dance — but tied Oduflow to GitHub.
+- **Step 2 — self-hosted Authorization Server.** Replace the GitHub proxy with a
+  built-in OAuth 2.1 AS so MCP clients authenticate **without any external
+  identity provider**. Oduflow exposes `/authorize`, `/token`, and
+  `/.well-known/oauth-authorization-server`. Each team's existing `auth_token`
+  *doubles as* `client_id`, `client_secret`, and the issued access token — so the
+  plain Bearer-token path is unchanged and there is exactly one secret per team
+  to manage. `oauth_base_url` (the instance's public URL) toggles the mode; the
+  GitHub-specific config and `github_users` are removed.
+
+The interface invariant from [[0002-remote-multi-user-mcp-access]] is preserved
+throughout: auth never appears in a tool signature; identity is resolved from the
+request context and threaded into per-team scoping.
+
+## How it works (macro)
+
+- **Auto-detected auth mode.** At startup `_build_auth` inspects settings: if
+  `oauth_base_url` is set, Oduflow serves the self-hosted Authorization Server;
+  otherwise it falls back to validating static Bearer tokens directly from the
+  `Authorization` header. Both reduce to the same per-team `auth_token`.
+- **One secret, three roles.** Because a team's `auth_token` is preregistered as
+  an OAuth client where `client_id == client_secret == auth_token` and the access
+  token equals it too, an OAuth client and a raw-curl client end up presenting
+  the *same* credential. After the OAuth dance the team resolves exactly as it
+  does for direct Bearer calls — no second identity system.
+- **Scoping unchanged.** Once a request is authenticated to a team, the existing
+  per-team resource scoping and locking apply; OAuth only changes *how the team
+  is proven*, not what it can see.
+
+## Consequences
+
+- Oduflow can be **hosted as a real MCP service** that claude.ai and Inspector
+  connect to via standard OAuth, with no tokens in tool arguments and no external
+  IdP in the trust path — the operator controls token issuance and revocation
+  (rotate `auth_token`).
+- Collapsing client credentials and the issued token into the team's single
+  `auth_token` kept the model tiny: no separate client registry, and the static
+  Bearer path (curl/CLI/IDEs) keeps working with zero OAuth machinery.
+- Dropping GitHub was a **breaking config change** (`oauth_client_id`,
+  `oauth_client_secret`, per-team `github_users` removed; `oauth_base_url`
+  added), traded for self-containment and operator control.
+- Per-user **git** credentials for repo operations are a separate concern from
+  MCP auth and are covered in [[0011-per-user-git-credentials]]; this record is
+  only about authenticating the MCP transport.
+
+## History
+
+- `97c3fc8` (2026-03-13) — GitHub OAuth 2.1 for MCP HTTP transport alongside
+  static Bearer tokens; auto-detected mode; per-team `github_users` whitelist;
+  GitHub login in MCP context (#9).
+- `5f32f58` (2026-05-25) — replace the GitHub proxy with a **self-hosted OAuth
+  Authorization Server**; `auth_token` doubles as client_id/secret/access token;
+  remove `oauth_client_id`/`secret`/`github_users`; `oauth_base_url` toggles
+  OAuth vs static tokens (breaking) (#19).
+- `73aa9b9` (2026-06-10) — document self-hosted OAuth in the config reference,
+  quick start, and llms docs (#33).

--- a/specs/0021-code-delivery-modes.md
+++ b/specs/0021-code-delivery-modes.md
@@ -1,0 +1,101 @@
+# 0021 — Code delivery modes: `repo_url` (git push) vs `local_path` live-mount, with an explicit `pull_and_apply` guardrail
+
+**Status:** Adopted (still in force)
+**Type:** Architecture
+**First introduced:** `aca9445` "Stdio live-mount + explicit pull_and_apply guardrail" (2026-06-12)
+**Key code today:** `server.py` (`create_environment` `local_path`/`repo_url`, `pull_and_apply`, `get_agent_instructions`), `settings.py` (`TRANSPORT`, `allow_local_path`), `docker_ops/env_ops.py` (bind-mount vs clone, `pull_environment`), `git_analysis.py` (guardrail)
+
+## Context
+
+There are two very different ways an agent works, and the original design assumed
+only one. In the founding model
+([[0001-mcp-orchestrated-ephemeral-per-branch-environments]]) the agent develops
+by **pushing code to a branch** and asking the environment to pull and apply it
+([[0006-git-driven-change-classification]]). That is exactly right for a
+**remote, multi-user** deployment ([[0002-remote-multi-user-mcp-access]]): the
+server runs elsewhere, code can only reach it over git, and pushing is the audit
+trail.
+
+But for a developer running Oduflow **locally over stdio**, the git round-trip is
+pure friction. The agent already has the checkout open on the same host as the
+Docker daemon; making it commit and push to GitHub just so Oduflow can pull the
+change back onto the same disk is a slow, noisy dev loop for what is conceptually
+"edit a file and reload".
+
+A second force: when the agent *authored* the edits, it already knows what they
+are. Forcing every change through pure auto-classification is both unnecessary
+(the agent can just say "upgrade this module") and risky (auto-detection is
+heuristic). Yet leaving the agent fully in charge invites the classic mistake of
+"I only restarted, but I changed a field" — stale schema, ghost-chasing.
+
+## Decision
+
+Support **two code-delivery modes**, chosen per environment, and make applying
+changes an **explicit, classified step** in both.
+
+- **`repo_url` (git mode) — default, the only mode for remote/HTTP.** The agent
+  pushes to its branch; `create_environment(repo_url=...)` clones it; later
+  `pull_and_apply` pulls the branch into the managed clone and applies the right
+  Odoo action. This is the multi-user CI path and stays the default.
+- **`local_path` (live-mount) — local fast-path, stdio only.**
+  `create_environment(local_path=<abs path>)` **bind-mounts the agent's own
+  checkout** straight into the container instead of cloning. Edits are visible
+  inside Odoo instantly; there is no push, no pull, no second copy on disk. It is
+  **gated to the stdio transport** (recorded in `settings.TRANSPORT`) and to an
+  `allow_local_path` setting, and is **rejected over HTTP** — a remote tenant
+  must never be able to mount an arbitrary host path.
+- **`pull_and_apply` as an explicit guardrail, not implicit auto-sync.** Applying
+  is always a deliberate tool call, never a hidden file-watcher. The tool is
+  transport-agnostic and parameterised: the agent passes explicit
+  `install` / `upgrade` / `restart` because it authored the edits. A guardrail
+  reuses change classification ([[0006-git-driven-change-classification]]) to
+  cross-check the *requested* action against the *detected* diff and appends
+  **non-blocking warnings** when an action looks missing (`strict=True` refuses
+  instead). Leaving the args empty falls back to full auto-classification —
+  useful when pulling commits the agent did not author.
+- **The active mode is advertised to the agent.** `get_agent_instructions`
+  inspects the environments and emits a "Current Code Delivery Mode" preface, so
+  the agent uses the live-mount workflow (edit + apply, git optional) or the
+  git workflow (commit + push + apply) appropriately, without guessing.
+
+## How it works (macro)
+
+- **Mode picked at create time, recorded on the environment.** Passing
+  `local_path` selects live-mount; passing `repo_url` (or a template that carries
+  one) selects git mode. In live-mount mode the "pull" inside `pull_and_apply` is
+  a no-op — the files are already live — while git mode still fetches and resets
+  the managed clone. The same tool, the same apply semantics, regardless of mode.
+- **Change detection adapts to the source.** Git mode diffs commits; live-mount
+  mode reads the checkout's own working tree, with an mtime-snapshot fallback for
+  non-git directories. Either way the guardrail and the classifier see a
+  `changed_files` set and recommend the minimal correct action.
+- **Safety boundary on the live-mount.** Live-mount is the fast path *because* it
+  trusts the caller's host — so it is confined to stdio, where caller and host
+  are the same trust domain. The HTTP transport never exposes it.
+
+## Consequences
+
+- The dev loop collapses for local work: **edit → `pull_and_apply` → see it**,
+  with no GitHub round-trip — while remote multi-user CI keeps the push-based,
+  auditable git path. One system serves both audiences without compromising
+  either.
+- Making apply an **explicit guardrailed step** (rather than auto-syncing on
+  file change) keeps the agent in control and the action correct: it states what
+  it changed, and the system catches under-actions before they cause stale-schema
+  confusion. It also keeps recommendation logic in one place, shared with the git
+  path.
+- The two modes share almost all machinery (`pull_and_apply`, classification,
+  the environment lifecycle); the difference is localized to *clone vs
+  bind-mount* and a transport gate, keeping the surface small.
+- Templates had to learn about the mode too: a template saved from a
+  live-mounted environment carries a `local_path` instead of a `repo_url` and
+  recreates the live-mount on use (when `allow_local_path` is enabled).
+
+## History
+
+- `044ccb9` (2026-02-14) — rename `pull_environment_repository` → `sync_environment`
+  (the apply entry point that `pull_and_apply` later generalised).
+- `aca9445` (2026-06-12) — stdio **live-mount** (`local_path` bind-mount, gated to
+  stdio) + **explicit `pull_and_apply`** with a classification-backed guardrail
+  (warn by default, `strict=True` to block); mode-aware `create_environment`
+  errors; apply rules documented in the agent instructions (#36).

--- a/specs/0022-engineers-console-design-system.md
+++ b/specs/0022-engineers-console-design-system.md
@@ -1,0 +1,134 @@
+# 0022 — The Engineer's Console: dashboard design system + lifecycle automation
+
+**Status:** Adopted (still in force)
+**Type:** Architecture / Design
+**First introduced:** `e992971` "Engineer's Console dashboard redesign + environment lifecycle automation" (2026-06-12, `#55`)
+**Key docs:** `PRODUCT.md`, `DESIGN.md`
+**Key code today:** `templates/dashboard.html`, `web_ui.py`, `reaper.py` (background sweeper), `activity.py` (per-team activity log), `settings.py` (`[lifecycle]`)
+
+## Context
+
+The dashboard ([[0005-web-dashboard-and-rest-api]]) had grown organically and
+read like a borrowed identity — the palette was GitHub's dark theme verbatim,
+assets were pulled from CDNs, and status leaned on color alone. Two problems
+needed solving together in one change:
+
+1. **No design discipline.** Oduflow's marketing site (oduflow.dev) had a
+   coherent brand — "The Engineer's Console" — but the working dashboard, *the
+   machine the site only demonstrates*, didn't practice it. There was no
+   normative source of truth a human or an agent could design against, so every
+   UI tweak risked drift (random hexes, ad-hoc components, emoji as
+   affordances, an external font request that breaks air-gapped installs).
+
+2. **Environments accumulate.** Agents create per-branch environments faster
+   than anyone cleans them up. Left alone, a host fills with idle and abandoned
+   environments, and the dashboard's "show real fleet state" promise turns into
+   "show a graveyard."
+
+## Decision
+
+Adopt a **normative visual system, codified in `PRODUCT.md` + `DESIGN.md`**, and
+add **environment lifecycle automation** so the fleet self-prunes — shipped as
+one change because the design system's job is to show fleet state honestly and
+the automation is what keeps that state worth showing.
+
+**The design system ("The Engineer's Console", shared with oduflow.dev):**
+
+- `PRODUCT.md` captures the register (product), the user (a terminal-native
+  operator whose agents do the real work), brand personality, anti-references,
+  and design principles — including that the dashboard is **visualization-first**
+  and that creation ergonomics / deep links / keyboard accelerators are
+  **explicit non-goals**.
+- `DESIGN.md` is the normative visual system: OKLCH tokens on a blue-black ramp,
+  Outfit + Geist Mono, a categorical **signal palette**, raised-layer elevation,
+  and named components down to "The Embedded Terminal." `AGENTS.md` points every
+  agent at both docs before touching dashboard UI.
+- **Hard rules** (binding, not suggestions): **no external CDNs** — every asset
+  (xterm.js, fonts, icons) ships with the package and is served from a local
+  `/static` route, so the dashboard works air-gapped; **every `var(--*)` must
+  resolve to a token declared in `:root`** (the Defined Token Rule); **status is
+  never conveyed by color alone** — badges always carry text; **no emoji as UI
+  affordances**; semantic color appears **on intent** (hover/focus), not at rest,
+  so status badges own the resting color story.
+
+**The lifecycle automation:**
+
+- A background **reaper** thread sweeps every few minutes: a running environment
+  idle past `auto_stop_hours` (default 48) is stopped; a stopped environment
+  nobody restarted past `auto_delete_hours` (default 72) is deleted.
+- **Protected** environments are exempt from both — Protect is the "keep for
+  customers" switch, no new flag invented.
+- "Stopped" becomes a **routine state, not an error**: container-level tools and
+  `pull_and_apply` **wake** a stopped environment and prepend a one-line note,
+  while read-only/diagnostic tools never wake anything.
+
+## How it works (macro)
+
+- **Tokens, not hexes.** The dashboard derives every color, font, radius and
+  elevation from the `DESIGN.md` token system declared once in `:root`; JS and
+  inline styles never hardcode hex. A light theme was later added purely as a
+  second token scheme, proving the discipline.
+- **Self-contained assets.** xterm.js and the woff2 fonts are vendored under
+  `templates/static` (lazy-loaded on first console open) and served by the
+  `/static` route — a CDN `<script>` is treated as a bug.
+- **Activity as the lifecycle clock.** `activity.json` per team (written with the
+  same flock + unique-tmp discipline as `ports.json` from
+  [[0004-stable-addressing-port-registry-and-traefik]]) records the last real
+  work on each environment: any env-scoped MCP tool call or dashboard lifecycle
+  action counts; listing/polling does not. The reaper reads this to decide what
+  to stop or delete, takes the same per-env locks as tools
+  ([[0015-granular-locking]]) so busy environments are skipped, and a value of 0
+  disables either behavior.
+- **Wake-on-use.** Tools that physically need the container start it first and
+  tell the agent they did; `get_agent_instructions` explains the auto-stop /
+  auto-delete clocks and Protect as the keep-alive switch, so agents treat a
+  stopped environment as normal.
+- **State honesty in the UI.** Cards show real container state (running /
+  partial / exited), "Active: 2h ago" and "Stopped: 1d ago (auto)", a busy chip
+  during manual interventions, and a transition pulse when state changes — the
+  one celebratory motion the system allows.
+
+## Consequences
+
+- The dashboard gained a **single source of design truth**: changes (by humans or
+  agents) are checked against `PRODUCT.md` / `DESIGN.md`, and the hard rules make
+  whole classes of regressions (CDN dependency, undeclared token, color-only
+  status, emoji affordance) reviewable as bugs. The later light-theme and
+  type-scale work slotted in cleanly because the token system already existed.
+- The brand is now **continuous from marketing site to product**: oduflow.dev and
+  the operator console share one visual language, so the site demonstrates the
+  same machine the user runs.
+- Lifecycle automation made **"visualization-first" sustainable**: the fleet
+  prunes itself, the dashboard keeps reflecting a live working set rather than
+  accumulated cruft, and Protect is the single intentional escape hatch.
+- Treating "stopped" as routine required teaching both the **tools** (wake-on-use
+  + notes) and the **agents** (instructions), tightening the contract between the
+  orchestration layer and the agents that drive it.
+
+## Evolution
+
+- `4676d9f` (2026-06-15, `#63`) — enlarge the type scale via rem tokens; improve
+  the note UX — all within the established token system.
+- `b8c1f28` (2026-06-15, `#65`) — add a **light theme** as a second token scheme
+  (v1.50.5).
+- `0ee3eef` (2026-06-16, `#66`) — STOPPED status surfacing + service env vars in
+  the Info modal.
+
+This record covers the **product dashboard** design system. The separate
+`specs/2026-06-08-mkdocs-material-redesign-design.md` is the related but distinct
+**docs-site** (MkDocs Material) redesign; both share the oduflow.dev blue accent
+but are different surfaces.
+
+## History
+
+- `92be004` (2026-06-12) — add `PRODUCT.md` and `DESIGN.md` design context (the
+  normative system) and point `AGENTS.md` at them. *(Squash-merged into
+  `e992971` on `main`.)*
+- `2e12f6a` (2026-06-12) — Engineer's Console redesign: OKLCH tokens, Outfit +
+  Geist Mono, signal palette, raised-layer elevation, self-contained assets
+  (`/static`), a11y (dialog semantics, tablist, focus rings, reduced motion),
+  responsive layout. *(Squash-merged into `e992971`.)*
+- `e992971` (2026-06-12, `#55`) — the merged change: design system + a11y +
+  semantic-on-intent color + bulk multi-select cleanup + login-page alignment,
+  **and** the lifecycle reaper (`reaper.py`, `activity.py`, `[lifecycle]`
+  settings), wake-on-use for container tools, and agent-instruction updates.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,49 @@
+# Decision records
+
+Macro-level Architecture Decision Records (ADRs) for Oduflow — the *why* behind
+each architectural pillar and major capability, reconstructed from the project's
+history and (going forward) written alongside the change that introduces it. See
+the "Record Architectural Decisions" section in `AGENTS.md` for the convention.
+
+Each record is `NNNN-slug.md`, ADR-style: Context · Decision · How it works
+(macro) · Consequences · (Evolution) · History. Macro altitude — the reasoning a
+future reader needs, not the diff.
+
+**Numbering is chronological** by the date each decision was first made, so the
+catalogue reads as the project's evolution timeline. New records take the next
+number for *their* place in time; the date column below is the defining-decision
+date (a record's own header carries the full commit lineage, including any
+precursors).
+
+## Index (chronological)
+
+| # | First decided | Decision |
+|---|---|----------|
+| [0001](0001-mcp-orchestrated-ephemeral-per-branch-environments.md) | 2026-02-05 | MCP-orchestrated ephemeral per-branch Odoo environments (founding architecture) |
+| [0002](0002-remote-multi-user-mcp-access.md) | 2026-02-05 | Remote, multi-user MCP access over streamable HTTP |
+| [0003](0003-database-templates-and-filestore-isolation.md) | 2026-02-06 | Database templates + filestore isolation (copy vs fuse-overlayfs) |
+| [0004](0004-stable-addressing-port-registry-and-traefik.md) | 2026-02-07 | Stable environment addressing: persistent port registry + Traefik routing |
+| [0005](0005-web-dashboard-and-rest-api.md) | 2026-02-07 | Web dashboard + REST API + interactive consoles |
+| [0006](0006-git-driven-change-classification.md) | 2026-02-08 | Git-driven change classification → automatic install/upgrade/restart |
+| [0007](0007-auxiliary-services-and-volumes.md) | 2026-02-11 | Auxiliary services, presets, and Docker volumes |
+| [0008](0008-licensing.md) | 2026-02-12 | Licensing: Polyform Noncommercial + in-app license activation |
+| [0009](0009-agent-guidance-system.md) | 2026-02-13 | Agent guidance system: editable MCP instructions + Odoo version dev guides |
+| [0010](0010-extra-addons-repositories.md) | 2026-02-13 | Extra addons repositories (bare clones + per-environment worktrees) |
+| [0011](0011-per-user-git-credentials.md) | 2026-02-20 | Per-user git credentials and repository authentication |
+| [0012](0012-managed-storage-file-access.md) | 2026-02-24 | Agent file access into managed storage (container files + Docker volumes) |
+| [0013](0013-per-environment-db-credentials-and-sanitization.md) | 2026-02-24 | Per-environment PostgreSQL credentials + two-tier database sanitization |
+| [0014](0014-team-based-multi-tenancy.md) | 2026-03-01 | Team-based multi-tenancy (replacing instance-based isolation) |
+| [0015](0015-granular-locking.md) | 2026-03-01 | Granular locking: per-branch / per-team / system locks |
+| [0016](0016-configuration-model.md) | 2026-03-01 | Configuration model: `oduflow.toml` + repo-level `.oduflow/` config |
+| [0017](0017-mcp-tool-execution-output-cache.md) | 2026-03-02 | MCP tool execution model: server-side output cache + `read_output` |
+| [0018](0018-onboarding-stdio-default-auto-init.md) | 2026-03-04 | Onboarding: stdio default transport + auto-init on startup |
+| [0019](0019-telemetry.md) | 2026-03-11 | Anonymous usage telemetry |
+| [0020](0020-authentication-oauth.md) | 2026-03-13 | Authentication for MCP HTTP: GitHub OAuth → self-hosted OAuth Authorization Server |
+| [0021](0021-code-delivery-modes.md) | 2026-06-12 | Code delivery modes: `repo_url` git push vs `local_path` live-mount + `pull_and_apply` guardrail |
+| [0022](0022-engineers-console-design-system.md) | 2026-06-12 | The Engineer's Console: dashboard design system + lifecycle automation |
+
+## Design docs
+
+Forward-looking feature design docs also live here, named by date:
+
+- [`2026-06-08-mkdocs-material-redesign-design.md`](2026-06-08-mkdocs-material-redesign-design.md) — docs-site (MkDocs Material) redesign.


### PR DESCRIPTION
## What

Reconstructs the project's macro-level architectural decisions from the full git
history into ADR-style **decision records** under `specs/` (0001–0022), with a
`specs/README.md` timeline index. Adds a **"Record Architectural Decisions"** rule
to `AGENTS.md` so future macro decisions are captured alongside the change that
introduces them.

## How it was produced

- Walked all 304 commits first→last (parallel audit over 6 commit ranges),
  sourcing each decision from the originating change — including the original
  `.zenflow/tasks/*/spec.md`, `mcp-ref.md`, `MULTI_INSTANCE.md`, `PRODUCT.md`,
  `DESIGN.md` — rather than reconstructing from diffs. Every cited commit SHA is
  verified.
- Each record is macro altitude (~1 page): Context · Decision · How it works ·
  Consequences · (Evolution) · History, cross-linked with `[[NNNN-slug]]`.

## Numbering

Records are numbered **chronologically** by first-decided date, so the catalogue
reads as the project's evolution timeline (`specs/README.md` is the index).

## Coverage

22 records spanning the founding MCP/Docker architecture, templates + filestore
isolation, change classification, tenancy + locking, services/volumes, agent
guidance, code-delivery modes, auth/OAuth, telemetry, the Engineer's Console
design system, and more. One capability surfaced by the history audit that was
not yet captured — **agent file access into managed storage** (container +
volume files) — is added as `0012`.

No application code changes; docs/specs only.