### PR TITLE
Auto-generate DB superuser password on first init

### DIFF
--- a/specs/0013-per-environment-db-credentials-and-sanitization.md
+++ b/specs/0013-per-environment-db-credentials-and-sanitization.md
@@ -105,7 +105,7 @@ A later hardening closed the **shared-superuser** gap flagged in Context point 1
 — the part the per-env role decision left untouched, since the superuser is still
 needed for admin operations:
 
-- `29ecd0f` (2026-06-17) — **auto-generate the shared superuser password.** The
+- `#74` (2026-06-17) — **auto-generate the shared superuser password.** The
   bundled `oduflow.toml` no longer ships a hardcoded `password = "odoo"`; on first
   init the bootstrap injects a random `secrets.token_urlsafe(24)` into the
   generated config's `[database]` section, so every install gets a unique
@@ -134,6 +134,6 @@ needed for admin operations:
 - `4f729b1` (2026-03-02) — **delete** mail servers (`fetchmail_server`,
   `ir_mail_server`) instead of merely disabling them; disabling still let Odoo
   send in some cases.
-- `29ecd0f` (2026-06-17) — auto-generate the shared PostgreSQL superuser password
+- `#74` (2026-06-17) — auto-generate the shared PostgreSQL superuser password
   on first init; the bundled `oduflow.toml` ships without a hardcoded password and
   the bootstrap injects a random secret into the generated config (see Evolution).

--- a/specs/0013-per-environment-db-credentials-and-sanitization.md
+++ b/specs/0013-per-environment-db-credentials-and-sanitization.md
@@ -3,7 +3,7 @@
 **Status:** Adopted (still in force)
 **Type:** Architecture
 **First introduced:** `cd0b9ec` "two-tier database sanitization" (2026-02-24), `e4949b0` "per-environment PostgreSQL credentials" (2026-02-26)
-**Key code today:** `env_credentials.py` (generate / persist / load / delete per-env creds), `sanitizer.py` (two-tier script runner), `docker_ops/env_ops.py` (`_create_pg_role`, post-clone ownership fixup), `docker_ops/system_ops.py` (shared DB, role helpers)
+**Key code today:** `env_credentials.py` (generate / persist / load / delete per-env creds), `sanitizer.py` (two-tier script runner), `docker_ops/env_ops.py` (`_create_pg_role`, post-clone ownership fixup), `docker_ops/system_ops.py` (shared DB, role helpers), `server.py` (`_inject_db_password` — bootstrap superuser secret)
 
 ## Context
 
@@ -101,6 +101,24 @@ surfaced:
   inherits ownership for DDL. (The current code keeps an explicit
   schema/table/sequence/view `ALTER OWNER` sweep plus a signaling-sequence drop.)
 
+A later hardening closed the **shared-superuser** gap flagged in Context point 1
+— the part the per-env role decision left untouched, since the superuser is still
+needed for admin operations:
+
+- `29ecd0f` (2026-06-17) — **auto-generate the shared superuser password.** The
+  bundled `oduflow.toml` no longer ships a hardcoded `password = "odoo"`; on first
+  init the bootstrap injects a random `secrets.token_urlsafe(24)` into the
+  generated config's `[database]` section, so every install gets a unique
+  superuser secret instead of a published default. The trade-off chosen was to
+  keep the secret in the instance's own `oduflow.toml`
+  ([[0016-configuration-model]]) rather than a sidecar credentials file — the
+  config is already the single source of truth, loaded each start, and generating
+  at config-creation time means an existing user config is never rewritten. An
+  explicit `[database].password` still overrides, and pre-existing installs (whose
+  volume was initialised under `odoo`) are left untouched, so it is fully backward
+  compatible. The matching admin connections rely on local trust auth inside the
+  container, so they were unaffected by the change.
+
 ## History
 
 - `cd0b9ec` (2026-02-24) — two-tier sanitization: drop hardcoded built-in queries;
@@ -116,3 +134,6 @@ surfaced:
 - `4f729b1` (2026-03-02) — **delete** mail servers (`fetchmail_server`,
   `ir_mail_server`) instead of merely disabling them; disabling still let Odoo
   send in some cases.
+- `29ecd0f` (2026-06-17) — auto-generate the shared PostgreSQL superuser password
+  on first init; the bundled `oduflow.toml` ships without a hardcoded password and
+  the bootstrap injects a random secret into the generated config (see Evolution).

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2712,6 +2712,27 @@ def _copy_bundled_pg_conf(dest) -> None:
             logger.warning("Cannot write %s (permission denied)", dest)
 
 
+def _inject_db_password(toml_text: str, password: str) -> str:
+    """Insert an auto-generated PostgreSQL superuser password into the
+    ``[database]`` section of a freshly bootstrapped oduflow.toml.
+
+    The bundled template ships without a password so each install gets a
+    unique secret. Only used when creating the config from the template —
+    existing user configs are never rewritten.
+    """
+    line = f'password = "{password}"'
+    out: list[str] = []
+    injected = False
+    for raw in toml_text.splitlines():
+        out.append(raw)
+        if not injected and raw.strip() == "[database]":
+            out.append(line)
+            injected = True
+    if not injected:
+        out.extend(["", "[database]", line])
+    return "\n".join(out) + "\n"
+
+
 def _run_reload_template(
     settings: Settings, team: TeamSettings, template_name: str, dump_path: str = ""
 ) -> None:
@@ -3258,12 +3279,13 @@ def main() -> None:
     logging.getLogger("docker").setLevel(logging.WARNING)
     logging.getLogger("docket").setLevel(logging.WARNING)
 
-    # Bootstrap: if no config exists, copy the bundled default
+    # Bootstrap: if no config exists, create it from the bundled default
+    # with an auto-generated PostgreSQL superuser password.
     try:
         find_toml()
     except FileNotFoundError:
         import pathlib
-        import shutil
+        import secrets
 
         from oduflow.settings import _resolve_etc_dir
 
@@ -3271,8 +3293,12 @@ def main() -> None:
         os.makedirs(dest_dir, exist_ok=True)
         bundled = pathlib.Path(__file__).resolve().parent / "templates" / "oduflow.toml"
         dest = os.path.join(dest_dir, "oduflow.toml")
-        shutil.copy2(str(bundled), dest)
-        logger.info("Config created: %s", dest)
+        rendered = _inject_db_password(
+            bundled.read_text(encoding="utf-8"), secrets.token_urlsafe(24)
+        )
+        with open(dest, "w", encoding="utf-8") as f:
+            f.write(rendered)
+        logger.info("Config created: %s (auto-generated DB password)", dest)
 
     global _settings
     _settings = _get_settings()

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -13,7 +13,7 @@ mode = "port"                   # "port" | "traefik"
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"
-password = "odoo"
+# password auto-generated on first init. Set explicitly to override.
 image = "postgres:15"
 
 # ── Storage ───────────────────────────────────────────

--- a/tests/test_bootstrap_db_password.py
+++ b/tests/test_bootstrap_db_password.py
@@ -1,0 +1,64 @@
+import pathlib
+import sys
+
+from oduflow.server import _inject_db_password
+from oduflow.settings import Settings
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+def test_inject_into_database_section():
+    text = '[database]\nuser = "odoo"\nimage = "postgres:15"\n'
+    rendered = _inject_db_password(text, "s3cret-token")
+    data = tomllib.loads(rendered)
+    assert data["database"]["password"] == "s3cret-token"
+    assert data["database"]["user"] == "odoo"
+    assert data["database"]["image"] == "postgres:15"
+
+
+def test_inject_appends_section_when_missing():
+    text = "[server]\nport = 8000\n"
+    rendered = _inject_db_password(text, "abc123")
+    data = tomllib.loads(rendered)
+    assert data["database"]["password"] == "abc123"
+    assert data["server"]["port"] == 8000
+
+
+def test_bundled_template_gets_generated_password():
+    bundled = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "src"
+        / "oduflow"
+        / "templates"
+        / "oduflow.toml"
+    )
+    text = bundled.read_text(encoding="utf-8")
+    # Template must ship without a hardcoded password.
+    assert tomllib.loads(text).get("database", {}).get("password") is None
+
+    rendered = _inject_db_password(text, "generated-pw-xyz")
+    data = tomllib.loads(rendered)
+    assert data["database"]["password"] == "generated-pw-xyz"
+    assert data["database"]["password"] != "odoo"
+
+
+def test_rendered_template_loads_via_settings(tmp_path):
+    bundled = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "src"
+        / "oduflow"
+        / "templates"
+        / "oduflow.toml"
+    )
+    rendered = _inject_db_password(
+        bundled.read_text(encoding="utf-8"), "live-secret-42"
+    )
+    dest = tmp_path / "oduflow.toml"
+    dest.write_text(rendered, encoding="utf-8")
+
+    settings = Settings.from_toml(str(dest))
+    assert settings.db_password == "live-secret-42"
+    assert settings.db_user == "odoo"


### PR DESCRIPTION
## What

On a fresh install the bootstrap now injects a random
`secrets.token_urlsafe(24)` password into the `[database]` section of the
generated `oduflow.toml`, so every install gets a unique PostgreSQL superuser
secret instead of the published `odoo`/`odoo` default. The bundled template
ships without a password (commented).

## Why

The shared `odoo`/`odoo` superuser was a known weak spot of the DB credentials
model (called out in ADR 0013). This closes that gap at the superuser layer,
complementing the per-environment roles that already isolate each branch's DB.

## How

- `server.py` — new pure helper `_inject_db_password(toml_text, password)`;
  bootstrap renders the template with a generated secret instead of `shutil.copy2`.
- `templates/oduflow.toml` — drop `password = "odoo"`, add a comment.
- The config stays the single source of truth (no sidecar file). `from_toml`
  reads the injected password; `init_system` passes it to `POSTGRES_PASSWORD`.

## Backward compatibility

Bootstrap only runs when no config exists. Existing installs (config already has
`password = "odoo"`, volume initialised under it) are untouched.
`[database].password` remains an explicit override.

## Tests & docs

- `tests/test_bootstrap_db_password.py` — injection, fallback section, template
  has no hardcoded password, end-to-end via `Settings.from_toml`.
- ADR 0013 extended (Evolution + History) per AGENTS.md — recorded as an
  incremental refinement of the existing credentials subsystem, not a new ADR.