### PR TITLE
Widen logs modal and add a line-wrap toggle

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -511,9 +511,10 @@
     white-space: pre-wrap; word-break: break-all;
     color: var(--text-dim); font-family: var(--font-mono);
   }
-  #logs-modal .modal { max-width: 80vw; }
+  #logs-modal .modal { width: 80vw; max-width: 80vw; }
   #logs-modal .modal-body { overflow: auto; }
   #logs-modal .modal-body pre { white-space: pre; word-break: normal; }
+  #logs-modal .modal-body pre.wrap { white-space: pre-wrap; word-break: break-all; }
   .log-error { color: var(--red); }
   .log-warning { color: var(--yellow); }
   .logs-toolbar {
@@ -929,7 +930,7 @@
     .env-meta strong, .svc-meta strong, .tpl-meta strong, .preset-meta strong { word-break: break-all; }
     .system-bar { flex-wrap: wrap; gap: 6px 16px; padding: 8px 16px; }
     .modal { width: calc(100vw - 24px); max-height: 88vh; }
-    #logs-modal .modal { max-width: none; }
+    #logs-modal .modal { width: calc(100vw - 24px); max-width: none; }
     .logs-toolbar { flex-wrap: wrap; }
     .toast { left: 16px; right: 16px; max-width: none; }
   }
@@ -1124,6 +1125,7 @@
         <option value="500">500 lines</option>
         <option value="1000">1000 lines</option>
       </select>
+      <button class="logs-btn" id="logs-wrap-btn" onclick="toggleLogsWrap()" title="Toggle line wrapping">↵ Wrap</button>
       <button class="logs-btn" onclick="fetchLogs()" title="Refresh logs">↻ Refresh</button>
       <button class="logs-btn" onclick="copyLogs()" title="Copy displayed log lines to clipboard">⧉ Copy</button>
     </div>
@@ -2290,6 +2292,12 @@ function renderLogs() {
   document.getElementById('logs-content').innerHTML = html;
   var body = document.getElementById('logs-content').parentElement;
   body.scrollTop = body.scrollHeight;
+}
+
+function toggleLogsWrap() {
+  var pre = document.getElementById('logs-content');
+  var on = pre.classList.toggle('wrap');
+  document.getElementById('logs-wrap-btn').classList.toggle('active', on);
 }
 
 function copyLogs() {


### PR DESCRIPTION
## Problem

The logs modal felt too small and forced horizontal scrolling. Root cause: `#logs-modal .modal` only overrode `max-width: 80vw`, but the base `.modal` rule caps `width` at `min(900px, calc(100vw - 32px))`. On a wide monitor `900px < 80vw`, so `max-width` had no effect and the modal rendered at ~900px. Combined with `white-space: pre` (no wrapping), long log lines spilled into horizontal scroll.

## Changes

- **Fix the width bug:** `#logs-modal .modal` now sets `width: 80vw` (not just `max-width`), so the modal actually fills the intended space on wide screens.
- **Preserve mobile behavior:** mirror `width: calc(100vw - 24px)` in the `≤880px` media query so the higher-specificity ID rule doesn't shrink the modal on narrow screens.
- **Add a `↵ Wrap` toggle** to the logs toolbar (reusing the existing `.logs-btn` / `.active` styles). Default is no-wrap (preserves column alignment); toggling on switches the log `<pre>` to `pre-wrap` / `break-all` to eliminate horizontal scrolling for long lines (tracebacks, SQL). State persists across opens within a session.

Applies to both environment **Logs** and **Service Logs** (same modal). Follows `DESIGN.md`: standard modal component, non-emoji glyph, all `var(--*)` already declared in `:root`.

## Verification

Pure HTML/CSS/JS template change (not covered by ruff/mypy/pytest); verify visually: open the dashboard, click **Logs** → modal is ~80vw wide; click **↵ Wrap** → long lines wrap, button turns green, horizontal scroll gone; toggle off restores no-wrap; narrow the window below 880px → modal stays near-full-width.