### PR TITLE
Add Remove button to template cards in dashboard

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2360,6 +2360,27 @@ async function loadTemplates() {
   }
 }
 
+async function doDeleteTemplate(name) {
+  if (!(await confirmDialog({
+    title: 'Remove template',
+    message: 'Permanently remove the template "' + name + '"? This drops its template database and deletes its filestore and SQL dump from disk. Environments already created from it are unaffected.',
+    confirmLabel: 'Remove template',
+    danger: true
+  }))) return;
+  try {
+    var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(name) + '/delete', { method: 'POST' });
+    var data = await r.json();
+    if (data.ok) {
+      showToast('Template "' + name + '" removed');
+      await loadTemplates();
+    } else {
+      showToast(data.error || 'Remove failed', true);
+    }
+  } catch (e) {
+    showToast('Connection error: ' + e.message, true);
+  }
+}
+
 function renderTemplates(templates) {
   var el = document.getElementById('tpl-list');
   if (!templates || templates.length === 0) {
@@ -2403,6 +2424,7 @@ function renderTemplates(templates) {
         '<div class="tpl-head-right">' +
           '<div class="tpl-meta">' + dbTag + sqlTag + fsTag + modeTag + sizeHtml + '</div>' +
           '<button class="btn-create btn-sm" onclick="openCreateFromTemplate(\'' + escAttr(t.template_name) + '\')">+ New Env</button>' +
+          '<button class="btn btn-delete btn-sm" onclick="doDeleteTemplate(\'' + escAttr(t.template_name) + '\')">Remove</button>' +
         '</div>' +
       '</div>' +
       metaHtml +

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -731,6 +731,24 @@ def _build_routes(
             logger.exception("Unexpected error in api_templates")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
+    def api_template_delete(request: Request) -> JSONResponse:
+        name = request.path_params["name"]
+        team = _get_ui_team(request)
+        try:
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            result = system_ops.delete_template(get_settings(), team, name)
+            return JSONResponse({"ok": True, "result": result})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_template_delete")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_team(team.team_id)
+
     def api_services(request: Request) -> JSONResponse:
         try:
             services = service_ops.list_services(get_settings(), _get_ui_team(request))
@@ -1575,6 +1593,9 @@ def _build_routes(
         Route("/api/license", api_license, methods=["GET"]),
         Route("/api/license/activate", api_license_activate, methods=["POST"]),
         Route("/api/templates", api_templates, methods=["GET"]),
+        Route(
+            "/api/templates/{name}/delete", api_template_delete, methods=["POST"]
+        ),
         Route("/api/environments", api_list, methods=["GET"]),
         Route("/api/environments/create", api_create, methods=["POST"]),
         Route("/api/stats", api_stats, methods=["GET"]),


### PR DESCRIPTION
## What

Adds a **Remove** action to each template card in the dashboard's Templates tab, so templates can be deleted from the web UI (previously only possible via the `delete_template` MCP tool).

## Changes

**Backend — `web_ui.py`**
- New `api_template_delete` handler: acquires the team lock, calls the existing `system_ops.delete_template()`, returns JSON. Mirrors the volume-delete handler (lock released in `finally`, `FlowError`/`BusyError` handling).
- Registered route `POST /api/templates/{name}/delete`.

**Frontend — `dashboard.html`**
- `Remove` button next to `+ New Env` on each template card (`btn btn-delete btn-sm` — neutral outline at rest, red on hover/focus).
- `doDeleteTemplate(name)`: danger confirm dialog explaining the consequence (drops the template DB and deletes filestore + SQL dump; existing environments are unaffected), POSTs to the delete endpoint, toasts the result, and reloads the list.

## Notes

- No new MCP tool or backend logic — reuses the existing `delete_template`.
- Not gated by an "in use" check, matching the existing `delete_template` behavior. Overlay environments keep their own filestore copy after creation, so they're unaffected; the template DB is dropped with `FORCE`.
- Design rules respected: existing tokens/classes only, no CDN/emoji, label (not color alone) carries the destructive meaning. `ruff check` passes.