### PR TITLE
Tone down the bright green template badges

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -703,14 +703,16 @@
     display: inline-block;
     padding: 2px 8px;
     border-radius: 12px;
+    border: 1px solid transparent;
     font-size: var(--text-2xs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
     white-space: nowrap;
   }
-  .tag-ok { background: color-mix(in oklab, var(--green) 15%, transparent); color: var(--green); }
-  .tag-missing { background: color-mix(in oklab, var(--red) 15%, transparent); color: var(--red); }
+  .tag-ok      { background: color-mix(in oklab, var(--green) 10%, transparent);    color: var(--green);    border: 1px solid color-mix(in oklab, var(--green) 22%, transparent); }
+  .tag-missing { background: color-mix(in oklab, var(--red) 14%, transparent);      color: var(--red);      border: 1px solid color-mix(in oklab, var(--red) 28%, transparent); }
+  .tag-neutral { background: color-mix(in oklab, var(--text-dim) 12%, transparent); color: var(--text-dim); border: 1px solid color-mix(in oklab, var(--text-dim) 24%, transparent); }
   .form-group select {
     width: 100%;
     padding: 8px 10px;
@@ -2398,8 +2400,8 @@ function renderTemplates(templates) {
       ? '<span class="tag tag-ok" title="Filestore snapshot (attachments) is present">Filestore</span>'
       : '<span class="tag tag-missing" title="No filestore snapshot">No Filestore</span>';
     var modeTag = t.use_overlay
-      ? '<span class="tag tag-ok" title="Filestore cloning mode: copy-on-write via fuse-overlayfs">Overlay</span>'
-      : '<span class="tag tag-ok" title="Filestore cloning mode: plain copy">Copy</span>';
+      ? '<span class="tag tag-neutral" title="Filestore cloning mode: copy-on-write via fuse-overlayfs">Overlay</span>'
+      : '<span class="tag tag-neutral" title="Filestore cloning mode: plain copy">Copy</span>';
     var sizeHtml = '';
     if (t.filestore_size_mb != null || t.dump_size_mb != null) {
       var fmtSize = function(mb) {


### PR DESCRIPTION
## Problem

In the dashboard **Templates** tab, every row stacked four saturated emerald badges (`DB Loaded` / `SQL` / `Filestore` / `Copy`/`Overlay`) at a 15% green tint with solid emerald text — repeated down the list, this created an eye-straining "wall of green". The `Copy`/`Overlay` badge was also rendered with the *success* signal color for both states, i.e. green used purely decoratively (a DESIGN.md Channel-Rule violation — a mode is not a success state).

## Changes (`src/oduflow/templates/dashboard.html`)

- **Calmer `.tag-ok`** — green fill 15% → 10% plus a low-chroma hairline border for definition (mirrors the existing, gentler `.license-individual` treatment). Applies everywhere `.tag-ok` is used, including the credential "✓ Valid" badge.
- **New `.tag-neutral` chip** — a muted-ink gray pill; the `Copy`/`Overlay` mode badge now uses it instead of `tag-ok`.
- **Row alignment** — a transparent base border on `.tpl-meta .tag` keeps bordered and plain badges the same height.

All `var(--*)` used (`--green`, `--red`, `--text-dim`) are declared in `:root` for both themes; every badge keeps its text label (status not by color alone).

## Verification

Rendered the real tokens + badge CSS and screenshotted both **dark** and **light** themes: readiness badges read as a calm muted green, `Copy`/`Overlay` is neutral gray, missing states stay red, heights align.