### PR TITLE
Add 'Created' label to services in dashboard

### DIFF
--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 
@@ -86,6 +87,9 @@ def create_service(
         "oduflow.managed": "true",
         "oduflow.team": team.team_id,
         "oduflow.service": name,
+        "oduflow.created_at": datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat(),
     }
 
     run_kwargs: dict = {
@@ -315,6 +319,8 @@ def _describe_service_container(
         "volumes": svc_volumes,
         "cap_add": svc_cap_add,
         "privileged": svc_privileged,
+        "created_at": container.labels.get("oduflow.created_at", "")
+        or container.attrs.get("Created", ""),
     }
 
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2723,6 +2723,7 @@ function renderServices(services) {
         '<span>Image: <strong>' + esc(svc.image) + '</strong></span>' +
         '<span>Container: <strong>' + esc(svc.container_name) + '</strong>' + containerStatsHtml(svc.container_name) + '</span>' +
         (svc.port ? '<span>Port: <strong>' + svc.port + '</strong></span>' : '') +
+        (svc.created_at ? '<span>Created: <strong>' + formatDate(svc.created_at) + '</strong></span>' : '') +
       '</div>' +
       urlHtml +
       volHtml +


### PR DESCRIPTION
## Summary
Adds a "Created" timestamp label to service cards in the dashboard, mirroring the existing "Created" label on environments.

## Changes
- `service_ops.py`: stamp an `oduflow.created_at` label on the container at `create_service()` time, and expose `created_at` from `_describe_service_container()` (used by both `list_services` and `get_service_info`). Falls back to the Docker container's `Created` attribute, so pre-existing services also show a creation date.
- `dashboard.html`: render `Created: <relative time>` in the service `svc-meta` block via the existing `formatDate()` helper — consistent with environments, no new styles/colors/emoji/CDNs.

## Notes
- `ruff check` passes.
- No pytest environment available in this workspace; existing service tests assert individual label/result keys (not full-dict equality), so the new field/label is non-breaking.