### PR TITLE
Point addons_path at addons/ subdir when present

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -27,7 +27,7 @@ When creating an environment, Oduflow:
 3. **Mounts the filestore overlay** — fuse-overlayfs with the template as lower layer
 4. **Detects UID/GID** — runs `id` in the Odoo image to set correct file ownership
 5. **Installs dependencies** — auto-installs from `.oduflow/apt_packages.txt` and `.oduflow/requirements.txt` (the latter falls back to the repo root) if present
-6. **Configures Odoo** — uses repo's `.oduflow/odoo.conf` if available, otherwise the default template
+6. **Configures Odoo** — uses repo's `.oduflow/odoo.conf` if available, otherwise the default template; if the repo keeps its modules in a top-level `addons/` directory, `addons_path` points there automatically
 7. **Starts the container** — with `--dev=xml` for hot-reloading XML/QWeb changes
 8. **Initializes base** — when `template=none`, runs `odoo -i base --stop-after-init`
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -923,13 +923,16 @@ def create_environment(
 
     odoo_conf_to_copy: str | None = None
     if base_conf_path:
-        from oduflow.extra_addons import generate_odoo_conf
+        from oduflow.extra_addons import generate_odoo_conf, resolve_main_addons_path
 
         generated_conf = os.path.join(workspace_path, "odoo.conf")
         extra_container_paths = (
             [cp for _, cp in extra_mount_paths] if extra_mount_paths else []
         )
-        generate_odoo_conf(base_conf_path, generated_conf, extra_container_paths)
+        main_addons_path = resolve_main_addons_path(repo_path)
+        generate_odoo_conf(
+            base_conf_path, generated_conf, extra_container_paths, main_addons_path
+        )
         odoo_conf_to_copy = generated_conf
 
     if template_name is not None:
@@ -2061,7 +2064,7 @@ def update_environment(
         base_conf_path = None
 
     if base_conf_path:
-        from oduflow.extra_addons import generate_odoo_conf
+        from oduflow.extra_addons import generate_odoo_conf, resolve_main_addons_path
 
         extra_addons_json = labels.get("oduflow.extra_addons", "")
         extra_container_paths: list[str] = []
@@ -2070,7 +2073,10 @@ def update_environment(
             extra_dict = _normalize_extra_addons(parsed)
             extra_container_paths = [f"/mnt/extra-addons-{rn}" for rn in extra_dict]
         generated_conf = os.path.join(workspace_path, "odoo.conf")
-        generate_odoo_conf(base_conf_path, generated_conf, extra_container_paths)
+        main_addons_path = resolve_main_addons_path(repo_path)
+        generate_odoo_conf(
+            base_conf_path, generated_conf, extra_container_paths, main_addons_path
+        )
         _copy_file_to_container(new_container, generated_conf, "/etc/odoo")
 
     # ------------------------------------------------------------------

--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -473,8 +473,23 @@ def pull_extra_worktree(
     return old_head, changed
 
 
+def resolve_main_addons_path(repo_path: str) -> str:
+    """Container addons path for the main repo.
+
+    Odoo scans addons_path non-recursively, so when a repo keeps its modules in
+    a top-level ``addons/`` directory, point Odoo at ``/mnt/extra-addons/addons``
+    instead of the repo root.
+    """
+    if os.path.isdir(os.path.join(repo_path, "addons")):
+        return "/mnt/extra-addons/addons"
+    return "/mnt/extra-addons"
+
+
 def generate_odoo_conf(
-    base_conf_path: str, output_path: str, extra_paths: list[str]
+    base_conf_path: str,
+    output_path: str,
+    extra_paths: list[str],
+    main_addons_path: str = "/mnt/extra-addons",
 ) -> str:
     parser = configparser.RawConfigParser()
     parser.optionxform = str
@@ -482,6 +497,10 @@ def generate_odoo_conf(
 
     existing = parser.get("options", "addons_path", fallback="/mnt/extra-addons")
     parts = [p.strip() for p in existing.split(",") if p.strip()]
+    # Repo keeps modules in addons/ → point at that subdir, not the repo root.
+    parts = [main_addons_path if p == "/mnt/extra-addons" else p for p in parts]
+    if main_addons_path not in parts:
+        parts.insert(0, main_addons_path)
     for p in extra_paths:
         if p not in parts:
             parts.append(p)

--- a/tests/test_extra_addons.py
+++ b/tests/test_extra_addons.py
@@ -1,0 +1,70 @@
+import configparser
+import os
+
+from oduflow.extra_addons import generate_odoo_conf, resolve_main_addons_path
+
+
+def _read_addons_path(conf_path):
+    parser = configparser.RawConfigParser()
+    parser.optionxform = str
+    parser.read(conf_path)
+    return parser.get("options", "addons_path")
+
+
+def _write_base_conf(path, addons_path="/mnt/extra-addons"):
+    path.write_text(f"[options]\naddons_path = {addons_path}\nlist_db = False\n")
+    return str(path)
+
+
+class TestResolveMainAddonsPath:
+    def test_with_addons_subdir(self, tmp_path):
+        os.makedirs(tmp_path / "addons")
+        assert resolve_main_addons_path(str(tmp_path)) == "/mnt/extra-addons/addons"
+
+    def test_without_addons_subdir(self, tmp_path):
+        assert resolve_main_addons_path(str(tmp_path)) == "/mnt/extra-addons"
+
+    def test_addons_is_a_file_not_dir(self, tmp_path):
+        (tmp_path / "addons").write_text("not a directory")
+        assert resolve_main_addons_path(str(tmp_path)) == "/mnt/extra-addons"
+
+
+class TestGenerateOdooConf:
+    def test_replaces_root_with_addons_subdir(self, tmp_path):
+        base = _write_base_conf(tmp_path / "base.conf")
+        out = tmp_path / "odoo.conf"
+        generate_odoo_conf(base, str(out), [], "/mnt/extra-addons/addons")
+
+        assert _read_addons_path(out) == "/mnt/extra-addons/addons"
+
+    def test_default_keeps_root(self, tmp_path):
+        base = _write_base_conf(tmp_path / "base.conf")
+        out = tmp_path / "odoo.conf"
+        generate_odoo_conf(base, str(out), [])
+
+        assert _read_addons_path(out) == "/mnt/extra-addons"
+
+    def test_extra_paths_appended_after_subdir(self, tmp_path):
+        base = _write_base_conf(tmp_path / "base.conf")
+        out = tmp_path / "odoo.conf"
+        generate_odoo_conf(
+            base,
+            str(out),
+            ["/mnt/extra-addons-foo"],
+            "/mnt/extra-addons/addons",
+        )
+
+        parts = _read_addons_path(out).split(",")
+        assert parts == ["/mnt/extra-addons/addons", "/mnt/extra-addons-foo"]
+        assert "/mnt/extra-addons" not in parts
+
+    def test_custom_base_addons_path_untouched(self, tmp_path):
+        # A user-provided conf with a custom path (no exact /mnt/extra-addons
+        # element) is left alone; the detected subdir is prepended.
+        base = _write_base_conf(tmp_path / "base.conf", addons_path="/opt/custom")
+        out = tmp_path / "odoo.conf"
+        generate_odoo_conf(base, str(out), [], "/mnt/extra-addons/addons")
+
+        parts = _read_addons_path(out).split(",")
+        assert "/opt/custom" in parts
+        assert "/mnt/extra-addons/addons" in parts


### PR DESCRIPTION
## What

When generating `odoo.conf`, if the main repo keeps its modules in a top-level `addons/` directory, set `addons_path` to `/mnt/extra-addons/addons` instead of the repo root.

## Why

Odoo scans `addons_path` **non-recursively**, so when modules live under `repo/addons/<module>`, the bare repo-root mount (`/mnt/extra-addons`) never finds them.

## How

- New helper `resolve_main_addons_path(repo_path)` in `extra_addons.py` — detects a top-level `addons/` folder on the host clone.
- `generate_odoo_conf()` gains a `main_addons_path` parameter (default `/mnt/extra-addons`) that replaces the repo-root element in `addons_path`. Custom paths from a user-provided `.oduflow/odoo.conf` are left untouched.
- Wired into both `create_environment` and `update_environment`.
- Falls back to `/mnt/extra-addons` when there is no `addons/` folder — fully backward compatible.

## Tests

New `tests/test_extra_addons.py` (7 unit tests). Full unit suite green: **455 passed**, 14 integration/heavyweight deselected.

## Docs

One line added to `docs/environments.md` (the "Configures Odoo" step).