### PR TITLE
Reconstruct odoo.conf before restart on .oduflow/odoo.conf changes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **Repo `odoo.conf` changes now actually apply** — a changed `.oduflow/odoo.conf` is now reconstructed (merged `addons_path`, stripped `db_*`) and copied into the container before the restart during `pull_and_apply`. Previously (#69) it only triggered a plain restart, which reused the stale `/etc/odoo/odoo.conf` copy and silently ignored the new config; the regeneration only ever ran on a full `update_environment` recreate.
+
 ## v1.51.0
 
 ### Features

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1637,6 +1637,49 @@ def _detect_local_changes(
     return None, changed
 
 
+def _reapply_odoo_conf(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    container: Any,
+) -> bool:
+    """Reconstruct ``/etc/odoo/odoo.conf`` inside *container*.
+
+    Resolves the base config (repo ``.oduflow/odoo.conf`` takes priority over the
+    instance-level conf), regenerates the merged conf with *container*'s current
+    extra-addons paths, and copies it into the container. Returns ``True`` if a
+    conf was applied, ``False`` if no base config exists.
+
+    The container reads ``/etc/odoo/odoo.conf`` as a *copy* made at create/update
+    time — a plain restart reuses the stale copy, so this must run before a
+    restart whenever the source ``odoo.conf`` changed.
+    """
+    repo_path = get_repo_path(env_name, team.workspaces_dir)
+    workspace_path = get_workspace_path(env_name, team.workspaces_dir)
+    repo_odoo_conf = os.path.join(repo_path, ".oduflow", "odoo.conf")
+    if os.path.isfile(repo_odoo_conf):
+        base_conf_path = repo_odoo_conf
+    elif _resolve_instance_conf("odoo.conf", team.data_dir).exists():
+        base_conf_path = str(_resolve_instance_conf("odoo.conf", team.data_dir))
+    else:
+        return False
+
+    from oduflow.extra_addons import generate_odoo_conf, resolve_main_addons_path
+
+    extra_addons_json = (container.labels or {}).get("oduflow.extra_addons", "")
+    extra_container_paths: list[str] = []
+    if extra_addons_json:
+        extra_dict = _normalize_extra_addons(json.loads(extra_addons_json))
+        extra_container_paths = [f"/mnt/extra-addons-{rn}" for rn in extra_dict]
+    generated_conf = os.path.join(workspace_path, "odoo.conf")
+    main_addons_path = resolve_main_addons_path(repo_path)
+    generate_odoo_conf(
+        base_conf_path, generated_conf, extra_container_paths, main_addons_path
+    )
+    _copy_file_to_container(container, generated_conf, "/etc/odoo")
+    return True
+
+
 def _apply_actions(
     client: DockerClient,
     settings: Settings,
@@ -1648,6 +1691,7 @@ def _apply_actions(
     to_upgrade: list[str],
     do_restart: bool,
     changed_files: list[str],
+    config_changed: bool = False,
 ) -> dict[str, Any]:
     """Run install/upgrade/restart and build the result dict (shared by the
     explicit and auto paths of :func:`pull_environment`)."""
@@ -1672,7 +1716,10 @@ def _apply_actions(
             messages.append(f"Upgraded modules: {','.join(to_upgrade)}")
             if res.get("output"):
                 odoo_output_parts.append(res["output"])
-        client.containers.get(odoo_container_name).restart()
+        container = client.containers.get(odoo_container_name)
+        if config_changed and _reapply_odoo_conf(settings, team, env_name, container):
+            messages.append("Reapplied odoo.conf.")
+        container.restart()
         messages.append("Container restarted.")
         logger.info(
             "Container restarted after module update", extra={"env_name": env_name}
@@ -1688,12 +1735,20 @@ def _apply_actions(
         }
 
     if do_restart:
-        client.containers.get(odoo_container_name).restart()
+        container = client.containers.get(odoo_container_name)
+        reapplied = config_changed and _reapply_odoo_conf(
+            settings, team, env_name, container
+        )
+        container.restart()
         logger.info("Container restarted", extra={"env_name": env_name})
         return {
             "action": "restart",
             "changed_files": changed_files,
-            "message": "Container restarted.",
+            "message": (
+                "Reapplied odoo.conf and restarted container."
+                if reapplied
+                else "Container restarted."
+            ),
         }
 
     if changed_files:
@@ -1808,6 +1863,10 @@ def pull_environment(
         if all_changed
         else {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
     )
+    # A changed .oduflow/odoo.conf must be reconstructed and re-copied into the
+    # container before any restart (a plain restart reuses the stale copy).
+    details = recommended.get("details")
+    config_changed = isinstance(details, dict) and bool(details.get("restart_required"))
 
     warnings: list[str] = []
     if explicit:
@@ -1852,6 +1911,7 @@ def pull_environment(
         to_upgrade=to_upgrade,
         do_restart=do_restart,
         changed_files=all_changed,
+        config_changed=config_changed,
     )
     if warnings:
         result["warnings"] = warnings
@@ -2052,32 +2112,10 @@ def update_environment(
 
     new_container = client.containers.run(**run_kwargs)
 
-    # Copy odoo.conf into the container (same resolution logic as create)
+    # Regenerate and copy odoo.conf into the new container (repo .oduflow/ takes
+    # priority over the instance conf; extra-addons paths merged from labels).
     repo_path = get_repo_path(env_name, team.workspaces_dir)
-    workspace_path = get_workspace_path(env_name, team.workspaces_dir)
-    repo_odoo_conf = os.path.join(repo_path, ".oduflow", "odoo.conf")
-    if os.path.isfile(repo_odoo_conf):
-        base_conf_path: str | None = repo_odoo_conf
-    elif _resolve_instance_conf("odoo.conf", team.data_dir).exists():
-        base_conf_path = str(_resolve_instance_conf("odoo.conf", team.data_dir))
-    else:
-        base_conf_path = None
-
-    if base_conf_path:
-        from oduflow.extra_addons import generate_odoo_conf, resolve_main_addons_path
-
-        extra_addons_json = labels.get("oduflow.extra_addons", "")
-        extra_container_paths: list[str] = []
-        if extra_addons_json:
-            parsed = json.loads(extra_addons_json)
-            extra_dict = _normalize_extra_addons(parsed)
-            extra_container_paths = [f"/mnt/extra-addons-{rn}" for rn in extra_dict]
-        generated_conf = os.path.join(workspace_path, "odoo.conf")
-        main_addons_path = resolve_main_addons_path(repo_path)
-        generate_odoo_conf(
-            base_conf_path, generated_conf, extra_container_paths, main_addons_path
-        )
-        _copy_file_to_container(new_container, generated_conf, "/etc/odoo")
+    _reapply_odoo_conf(settings, team, env_name, new_container)
 
     # ------------------------------------------------------------------
     # 5. Re-install apt packages and pip requirements

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -1112,3 +1113,137 @@ class TestGetLogs:
 
         assert "log line 1" in output
         container.logs.assert_called_with(tail=50, stdout=True, stderr=True)
+
+
+class TestApplyActionsConf:
+    """A changed ``.oduflow/odoo.conf`` must be reconstructed before a restart.
+
+    PR #69 only triggered a plain restart, which reuses the stale
+    ``/etc/odoo/odoo.conf`` copy and never picks up the new config.
+    """
+
+    @staticmethod
+    def _client_with_container():
+        client = MagicMock()
+        container = MagicMock()
+        client.containers.get.return_value = container
+        return client, container
+
+    @patch("oduflow.docker_ops.env_ops._reapply_odoo_conf", return_value=True)
+    def test_restart_reapplies_conf_when_config_changed(self, mock_reapply):
+        client, container = self._client_with_container()
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-feature-x-odoo",
+            to_install=[],
+            to_upgrade=[],
+            do_restart=True,
+            changed_files=[".oduflow/odoo.conf"],
+            config_changed=True,
+        )
+        mock_reapply.assert_called_once_with(
+            TEST_SETTINGS, TEST_TEAM, "feature/x", container
+        )
+        container.restart.assert_called_once()
+        assert result["action"] == "restart"
+        assert "odoo.conf" in result["message"]
+
+    @patch("oduflow.docker_ops.env_ops._reapply_odoo_conf")
+    def test_restart_skips_conf_when_only_python(self, mock_reapply):
+        client, container = self._client_with_container()
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-feature-x-odoo",
+            to_install=[],
+            to_upgrade=[],
+            do_restart=True,
+            changed_files=["sale/models/sale.py"],
+            config_changed=False,
+        )
+        mock_reapply.assert_not_called()
+        container.restart.assert_called_once()
+        assert result["message"] == "Container restarted."
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.upgrade_odoo_modules",
+        return_value={"exit_code": 0, "output": "upgraded"},
+    )
+    @patch("oduflow.docker_ops.env_ops._reapply_odoo_conf", return_value=True)
+    def test_upgrade_also_reapplies_conf(self, mock_reapply, mock_upgrade):
+        client, container = self._client_with_container()
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-feature-x-odoo",
+            to_install=[],
+            to_upgrade=["sale"],
+            do_restart=False,
+            changed_files=[".oduflow/odoo.conf", "sale/security/groups.xml"],
+            config_changed=True,
+        )
+        mock_upgrade.assert_called_once()
+        mock_reapply.assert_called_once()
+        container.restart.assert_called_once()
+        assert result["action"] == "upgrade"
+        assert "Reapplied odoo.conf." in result["message"]
+
+
+class TestReapplyOdooConf:
+    @patch("oduflow.docker_ops.env_ops._copy_file_to_container")
+    @patch(
+        "oduflow.extra_addons.generate_odoo_conf",
+        return_value="/tmp/flow-test/workspaces/feature-x/odoo.conf",
+    )
+    @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=True)
+    def test_uses_repo_conf_and_copies(self, mock_isfile, mock_gen, mock_copy):
+        container = MagicMock()
+        container.labels = {}
+        applied = env_ops._reapply_odoo_conf(
+            TEST_SETTINGS, TEST_TEAM, "feature/x", container
+        )
+        assert applied is True
+        base_arg, _generated, extra_arg, main_addons = mock_gen.call_args[0]
+        assert base_arg.endswith("/.oduflow/odoo.conf")
+        assert extra_arg == []
+        assert main_addons == "/mnt/extra-addons"
+        mock_copy.assert_called_once()
+        assert mock_copy.call_args[0][0] is container
+        assert mock_copy.call_args[0][2] == "/etc/odoo"
+
+    @patch("oduflow.docker_ops.env_ops._copy_file_to_container")
+    @patch(
+        "oduflow.extra_addons.generate_odoo_conf",
+        return_value="/tmp/flow-test/workspaces/feature-x/odoo.conf",
+    )
+    @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=True)
+    def test_merges_extra_addons_paths(self, mock_isfile, mock_gen, mock_copy):
+        container = MagicMock()
+        container.labels = {"oduflow.extra_addons": json.dumps({"enterprise": "17.0"})}
+        env_ops._reapply_odoo_conf(TEST_SETTINGS, TEST_TEAM, "feature/x", container)
+        _base, _generated, extra_arg, _main = mock_gen.call_args[0]
+        assert extra_arg == ["/mnt/extra-addons-enterprise"]
+
+    @patch("oduflow.docker_ops.env_ops._copy_file_to_container")
+    @patch("oduflow.docker_ops.env_ops._resolve_instance_conf")
+    @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=False)
+    def test_returns_false_when_no_base_conf(
+        self, mock_isfile, mock_resolve, mock_copy
+    ):
+        inst = MagicMock()
+        inst.exists.return_value = False
+        mock_resolve.return_value = inst
+        container = MagicMock()
+        container.labels = {}
+        applied = env_ops._reapply_odoo_conf(
+            TEST_SETTINGS, TEST_TEAM, "feature/x", container
+        )
+        assert applied is False
+        mock_copy.assert_not_called()


### PR DESCRIPTION
A changed `.oduflow/odoo.conf` was classified as a restart (#69), but a plain restart reuses the stale `/etc/odoo/odoo.conf` copy and never picks up the new config — the merged conf is only ever rebuilt at create/update time. `pull_and_apply` now regenerates the merged conf (addons_path merged, `db_*` stripped, `addons/`-subdir aware via #80's `resolve_main_addons_path`) and copies it into the existing container before restarting, in both the restart and upgrade-then-restart paths. The resolve/generate/copy logic is factored into `_reapply_odoo_conf` and reused by `update_environment`. Adds unit tests and an Unreleased changelog entry.