### PR TITLE
Security & bug audit remediation (17 fixes)

### DIFF
--- a/src/oduflow/docker_ops/client.py
+++ b/src/oduflow/docker_ops/client.py
@@ -4,6 +4,8 @@ import os
 import docker
 from docker import DockerClient
 
+from oduflow.errors import PrerequisiteNotMetError
+
 logger = logging.getLogger("oduflow")
 
 _uid_gid_cache: dict[str, str] = {}
@@ -12,12 +14,15 @@ _uid_gid_cache: dict[str, str] = {}
 def get_client() -> DockerClient:
     try:
         return docker.from_env()
-    except docker.errors.DockerException:
-        raise SystemExit(
-            "\n❌ Cannot connect to Docker.\n"
-            "   Please make sure Docker is installed and running.\n"
-            "   https://docs.docker.com/get-docker/\n"
-        )
+    except docker.errors.DockerException as exc:
+        # Raise a FlowError (not SystemExit/BaseException) so @handle_errors and
+        # the create_environment fallback can catch it and return a clean error
+        # instead of tearing down the request task or the server loop. The CLI
+        # entry point translates this into a friendly process exit.
+        raise PrerequisiteNotMetError(
+            "Cannot connect to Docker. Please make sure Docker is installed "
+            "and running. https://docs.docker.com/get-docker/"
+        ) from exc
 
 
 def get_odoo_uid_gid(client: DockerClient, image: str) -> str:

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -851,13 +851,17 @@ def create_environment(
     )
 
     if template_name is not None:
-        # Transfer ownership of every object in the public schema to the
-        # new per-environment role.  DDL operations (ALTER TABLE) require
-        # ownership — GRANT ALL only covers DML.  We cannot use
-        # REASSIGN OWNED BY "<superuser>" because PostgreSQL refuses to
-        # reassign system objects owned by that role.  Instead we iterate
-        # over tables, sequences, and views individually.
+        # A template DB's objects are owned by the superuser that created the
+        # template. DDL during module upgrades requires ownership, so reassign
+        # every object that superuser still owns to the per-environment role.
+        # This replaces granting the env role membership in the superuser role,
+        # which would let it SET ROLE to superuser (cross-tenant RCE, #40).
+        # Odoo connects as the env role and never SET ROLEs, so per-object
+        # ownership — not role membership — is what actually enables its DDL.
+        # Linked (SERIAL/identity) sequences are skipped: they follow their
+        # table's owner automatically.
         new_user = env_creds["pg_user"]
+        old_user = settings.db_user
         _exec_sql(
             client,
             settings,
@@ -867,17 +871,40 @@ def create_environment(
         _exec_sql(
             client,
             settings,
-            "DO $$ DECLARE r RECORD; BEGIN "
-            "FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP "
-            f"EXECUTE 'ALTER TABLE public.' || quote_ident(r.tablename) || ' OWNER TO \"{new_user}\"'; "
-            "END LOOP; "
-            "FOR r IN SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema = 'public' LOOP "
-            f"EXECUTE 'ALTER SEQUENCE public.' || quote_ident(r.sequence_name) || ' OWNER TO \"{new_user}\"'; "
-            "END LOOP; "
-            "FOR r IN SELECT viewname FROM pg_views WHERE schemaname = 'public' LOOP "
-            f"EXECUTE 'ALTER VIEW public.' || quote_ident(r.viewname) || ' OWNER TO \"{new_user}\"'; "
-            "END LOOP; "
-            "END $$;",
+            rf"""
+            DO $$
+            DECLARE r RECORD;
+            BEGIN
+              FOR r IN SELECT n.nspname FROM pg_namespace n JOIN pg_roles o ON n.nspowner = o.oid
+                       WHERE o.rolname = '{old_user}'
+                         AND n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'
+              LOOP EXECUTE format('ALTER SCHEMA %I OWNER TO %I', r.nspname, '{new_user}'); END LOOP;
+
+              FOR r IN SELECT c.relkind AS kind, n.nspname AS sch, c.relname AS rel
+                       FROM pg_class c
+                       JOIN pg_namespace n ON c.relnamespace = n.oid
+                       JOIN pg_roles o ON c.relowner = o.oid
+                       WHERE o.rolname = '{old_user}'
+                         AND n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'
+                         AND c.relkind IN ('r', 'p', 'S', 'v', 'm', 'f')
+                         AND NOT (c.relkind = 'S' AND EXISTS (
+                             SELECT 1 FROM pg_depend d
+                             WHERE d.classid = 'pg_class'::regclass AND d.objid = c.oid
+                               AND d.refclassid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')))
+              LOOP EXECUTE format('ALTER %s %I.%I OWNER TO %I',
+                   CASE r.kind WHEN 'S' THEN 'SEQUENCE' WHEN 'v' THEN 'VIEW'
+                               WHEN 'm' THEN 'MATERIALIZED VIEW' WHEN 'f' THEN 'FOREIGN TABLE'
+                               ELSE 'TABLE' END, r.sch, r.rel, '{new_user}'); END LOOP;
+
+              FOR r IN SELECT p.oid::regprocedure AS sig
+                       FROM pg_proc p
+                       JOIN pg_namespace n ON p.pronamespace = n.oid
+                       JOIN pg_roles o ON p.proowner = o.oid
+                       WHERE o.rolname = '{old_user}'
+                         AND n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'
+              LOOP EXECUTE format('ALTER ROUTINE %s OWNER TO %I', r.sig, '{new_user}'); END LOOP;
+            END $$;
+            """,
             db=env_db,
         )
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1045,7 +1045,21 @@ def create_environment(
             )
         )
 
-    container = client.containers.run(**run_kwargs)
+    try:
+        container = client.containers.run(**run_kwargs)
+    except Exception:
+        # The serving container failed to start (e.g. an invalid container name
+        # derived from the branch, or a host-port bind conflict). Roll back the
+        # resources created so far — database, role, filestore mount, workspace
+        # and the allocated port — so they are not left orphaned (#49).
+        logger.error(
+            "containers.run failed for '%s'; rolling back partial environment",
+            env_name,
+        )
+        if settings.routing_mode == "port":
+            release_port(team.port_registry_path, env_name)
+        _cleanup_old_environment(client, settings, team, env_name)
+        raise
 
     if odoo_conf_to_copy:
         _copy_file_to_container(container, odoo_conf_to_copy, "/etc/odoo")
@@ -2077,6 +2091,25 @@ def update_environment(
             except (KeyError, IndexError, ValueError, TypeError):
                 pass
 
+    # Validate the target image is available BEFORE removing the old container,
+    # so a bad or unreachable image does not leave the env with no container
+    # at all (#49). If the pull fails, fall back to a local copy; if there is
+    # none, abort with the existing environment left untouched.
+    image_updated = False
+    try:
+        logger.info("Pulling image %s", odoo_image)
+        new_image_obj = client.images.pull(odoo_image)
+        image_updated = bool(old_digest) and new_image_obj.id != old_digest
+    except Exception as exc:
+        logger.warning("Could not pull image %s: %s", odoo_image, exc)
+        try:
+            client.images.get(odoo_image)
+        except docker.errors.ImageNotFound:
+            raise PrerequisiteNotMetError(
+                f"Image '{odoo_image}' could not be pulled and is not available "
+                "locally; leaving the existing environment untouched."
+            ) from exc
+
     logger.info(
         "Updating environment – stopping old container",
         extra={"env_name": env_name, "container": odoo_container_name},
@@ -2179,14 +2212,6 @@ def update_environment(
         run_kwargs["command"] = command
     if settings.routing_mode == "port" and host_port is not None:
         run_kwargs["ports"] = {"8069/tcp": host_port}
-
-    image_updated = False
-    try:
-        logger.info("Pulling image %s", odoo_image)
-        new_image_obj = client.images.pull(odoo_image)
-        image_updated = bool(old_digest) and new_image_obj.id != old_digest
-    except Exception as exc:
-        logger.warning("Could not pull image %s, using local copy: %s", odoo_image, exc)
 
     new_container = client.containers.run(**run_kwargs)
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1212,7 +1212,13 @@ def delete_environment(
 
     container_exists = True
     try:
-        client.containers.get(odoo_container_name)
+        existing = client.containers.get(odoo_container_name)
+        # Container names are not team-namespaced; never stop/remove a container
+        # that belongs to another team (issue #39). Treat it as absent so this
+        # team's own DB/workspace/port are still cleaned up.
+        label = existing.labels.get(settings.team_label)
+        if label is not None and label != team.team_id:
+            container_exists = False
     except docker.errors.NotFound:
         container_exists = False
 
@@ -1391,7 +1397,9 @@ def wait_for_odoo_ready(
     return False
 
 
-def ensure_running(settings: Settings, env_name: str) -> bool:
+def ensure_running(
+    settings: Settings, env_name: str, team: TeamSettings | None = None
+) -> bool:
     """Start the environment's Odoo container if it is stopped.
 
     Returns True when a start was needed (the caller may want to tell the
@@ -1405,23 +1413,47 @@ def ensure_running(settings: Settings, env_name: str) -> bool:
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
+    _assert_team_owns(container, settings, team, env_name)
     if container.status == "running":
         return False
-    start_environment(settings, env_name)
+    start_environment(settings, env_name, team)
     return True
 
 
-def restart_environment(settings: Settings, env_name: str) -> dict[str, str]:
+def _assert_team_owns(
+    container: Any, settings: Settings, team: TeamSettings | None, env_name: str
+) -> None:
+    """Reject operating on a container that belongs to another team.
+
+    Container names are not team-namespaced, so without this check a caller
+    scoped to one team could start/stop/restart/delete or read logs of another
+    team's identically-named environment (issue #39). The NotFound message is
+    reused so the existence of another team's env is not disclosed. Skipped when
+    team is None (internal callers that have no team in scope).
+    """
+    if team is None:
+        return
+    label = container.labels.get(settings.team_label)
+    if label is not None and label != team.team_id:
+        raise NotFoundError(
+            f"Environment '{env_name}' does not exist. Use create_environment first."
+        )
+
+
+def restart_environment(
+    settings: Settings, env_name: str, team: TeamSettings | None = None
+) -> dict[str, str]:
     client = get_client()
     odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
 
     try:
         odoo_container = client.containers.get(odoo_container_name)
-        odoo_container.restart()
     except docker.errors.NotFound:
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
+    _assert_team_owns(odoo_container, settings, team, env_name)
+    odoo_container.restart()
 
     logger.info("Environment restarted", extra={"env_name": env_name})
     return {"odoo_container": odoo_container_name}
@@ -1439,18 +1471,21 @@ def stop_environment(
 
     try:
         odoo_container = client.containers.get(odoo_container_name)
-        odoo_container.stop()
     except docker.errors.NotFound:
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
+    _assert_team_owns(odoo_container, settings, team, env_name)
+    odoo_container.stop()
 
     activity.mark_stopped(team, env_name, by="manual")
     logger.info("Environment stopped", extra={"env_name": env_name})
     return {"odoo_container": odoo_container_name, "stopped": [odoo_container_name]}
 
 
-def start_environment(settings: Settings, env_name: str) -> dict[str, str]:
+def start_environment(
+    settings: Settings, env_name: str, team: TeamSettings | None = None
+) -> dict[str, str]:
     client = get_client()
     odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
 
@@ -1467,12 +1502,13 @@ def start_environment(settings: Settings, env_name: str) -> dict[str, str]:
 
     try:
         odoo_container = client.containers.get(odoo_container_name)
-        odoo_container.start()
-        started.append(odoo_container_name)
     except docker.errors.NotFound:
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
+    _assert_team_owns(odoo_container, settings, team, env_name)
+    odoo_container.start()
+    started.append(odoo_container_name)
 
     logger.info("Environment started", extra={"env_name": env_name})
     return {"odoo_container": odoo_container_name, "started": started}

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1855,7 +1855,11 @@ def pull_environment(
     * **auto** — otherwise fall back to ``classify_changes`` in git mode or
       path-only ``shallow_classify`` in live-mount mode.
     """
-    from oduflow.git_analysis import guardrail_warnings, recommend
+    from oduflow.git_analysis import (
+        guardrail_warnings,
+        merge_recommendations,
+        recommend,
+    )
     from oduflow.git_ops import pull_repo
 
     client = get_client()
@@ -1878,9 +1882,14 @@ def pull_environment(
         )
 
     # --- 1. Sync code + detect changed files and a diff base ---
+    # Each (repo_path, base_ref, files) unit is classified against its OWN repo
+    # and old HEAD; extra-addon worktrees must not be classified against the main
+    # repo's tree or their changes are misread (issue #51).
+    classify_units: list[tuple[str, str | None, list[str]]] = []
     if is_local:
         _trace("pull_environment(%s): live-mount, detecting local changes", env_name)
         base_ref, all_changed = _detect_local_changes(repo_path, env_name, team)
+        classify_units.append((repo_path, base_ref, all_changed))
     else:
         _trace("pull_environment(%s): git pull started", env_name)
         git_branch = container_obj.labels.get("oduflow.git_branch", env_name)
@@ -1888,6 +1897,7 @@ def pull_environment(
             repo_path, git_branch, cred_file=team.git_credentials_file()
         )
         base_ref = old_head
+        classify_units.append((repo_path, old_head, changed_files))
 
         extra_changed_files: list[str] = []
         try:
@@ -1906,10 +1916,13 @@ def pull_environment(
                 wt_path = os.path.join(extra_dir, repo_name)
                 if not os.path.isdir(wt_path):
                     continue
-                _extra_old, extra_files = pull_extra_worktree(
+                extra_old, extra_files = pull_extra_worktree(
                     team, repo_name, branch, wt_path
                 )
                 extra_changed_files.extend(extra_files)
+                if extra_files:
+                    # Classify this worktree against its own path + old HEAD.
+                    classify_units.append((wt_path, extra_old, extra_files))
         all_changed = changed_files + extra_changed_files
 
     _trace(
@@ -1922,7 +1935,9 @@ def pull_environment(
     # --- 2. Determine actions: explicit (agent-driven) vs auto (classify) ---
     explicit = bool(install) or bool(upgrade) or restart
     recommended = (
-        recommend(all_changed, repo_path, base_ref)
+        merge_recommendations(
+            recommend(files, rp, ref) for rp, ref, files in classify_units if files
+        )
         if all_changed
         else {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
     )

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -688,6 +688,30 @@ def create_environment(
     except docker.errors.NotFound:
         pass
 
+    # Different branch names can normalise to the same database name (the
+    # container name keeps case/punctuation but get_db_name slugifies). Refuse
+    # if the target DB is already owned by another live environment — otherwise
+    # the cleanup below would DROP a running environment's database (#41).
+    target_db = get_db_name(env_name, team.team_id)
+    for other in client.containers.list(
+        all=True,
+        filters={
+            "label": [
+                f"{settings.managed_label}=true",
+                f"{settings.team_label}={team.team_id}",
+            ]
+        },
+    ):
+        if other.name == odoo_container_name:
+            continue
+        other_branch = other.labels.get(settings.branch_label)
+        if other_branch and get_db_name(other_branch, team.team_id) == target_db:
+            raise ConflictError(
+                f"Environment '{env_name}' maps to database '{target_db}', which "
+                f"is already used by environment '{other_branch}'. Choose a name "
+                "that does not normalise to the same database."
+            )
+
     _cleanup_old_environment(client, settings, team, env_name)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
     # Live-mount mode: bind-mount the agent's own checkout

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -108,6 +108,7 @@ def get_environment_logs(
     grep: str = "",
     level: str = "",
     container_name: str = "",
+    team: TeamSettings | None = None,
 ) -> str:
     client = get_client()
     if container_name:
@@ -127,14 +128,22 @@ def get_environment_logs(
 
     try:
         container = client.containers.get(target_container_name)
-        logs = container.logs(tail=fetch_lines, stdout=True, stderr=True)
-        logs_str = logs.decode("utf-8") if isinstance(logs, bytes) else str(logs)
     except docker.errors.NotFound:
         if container_name:
             raise NotFoundError(f"Container '{container_name}' does not exist.")
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
+    # Container names are not team-namespaced: don't expose another team's logs
+    # (issue #39). Skipped when team is None (internal callers).
+    if team is not None:
+        label = container.labels.get(settings.team_label)
+        if label is not None and label != team.team_id:
+            raise NotFoundError(
+                f"Environment '{env_name}' does not exist. Use create_environment first."
+            )
+    logs = container.logs(tail=fetch_lines, stdout=True, stderr=True)
+    logs_str = logs.decode("utf-8") if isinstance(logs, bytes) else str(logs)
 
     if grep or level:
         lines = logs_str.splitlines()

--- a/src/oduflow/docker_ops/service_presets.py
+++ b/src/oduflow/docker_ops/service_presets.py
@@ -37,11 +37,19 @@ def _load_presets(team: TeamSettings) -> dict:
 
 
 def _save_presets(team: TeamSettings, data: dict) -> None:
-    """Persist *data* to the presets JSON file, creating parent dirs if needed."""
+    """Persist *data* to the presets JSON file, creating parent dirs if needed.
+
+    Writes atomically (temp file + os.replace) so a crash mid-write cannot leave
+    a truncated file that _load_presets would discard as corrupt.
+    """
     path = _presets_path(team)
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as fh:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
 
 
 def save_preset(

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -31,6 +31,17 @@ _BUNDLED_ODOO_CONF = _PACKAGE_ROOT / "templates" / "odoo.conf"
 _BUNDLED_SANITIZE_DIR = _PACKAGE_ROOT / "templates"
 
 
+def _is_within_directory(directory: str, target: str) -> bool:
+    """Return True if ``target`` resolves to a path inside ``directory``.
+
+    Guards archive extraction against path traversal ("zip-slip"): a member
+    named ``../../etc/x`` would otherwise be written outside the destination.
+    """
+    directory = os.path.realpath(directory)
+    target = os.path.realpath(target)
+    return target == directory or target.startswith(directory + os.sep)
+
+
 def _get_oduflow_version() -> str:
     """Return the installed package version."""
     try:
@@ -383,6 +394,19 @@ def _extract_archive_from_container(
                 if not rel:
                     continue
                 member.name = rel
+                # Reject members that escape dest_dir via traversal or an
+                # absolute/symlink target (defence in depth; source is our own
+                # template-builder container).
+                if not _is_within_directory(dest_dir, os.path.join(dest_dir, rel)):
+                    logger.warning("Skipping unsafe archive member: %s", rel)
+                    continue
+                if member.issym() or member.islnk():
+                    link_target = os.path.join(dest_dir, os.path.dirname(rel))
+                    if not _is_within_directory(
+                        dest_dir, os.path.join(link_target, member.linkname)
+                    ):
+                        logger.warning("Skipping unsafe link member: %s", rel)
+                        continue
                 tar.extract(member, dest_dir)
                 if not member.isdir():
                     extracted += 1
@@ -1316,6 +1340,13 @@ def import_from_odoo(
                     if rel.startswith("checklist/"):
                         continue
                     target = os.path.join(template_filestore_path, rel)
+                    # Reject any member that escapes the filestore dir (zip-slip).
+                    if not _is_within_directory(template_filestore_path, target):
+                        logger.warning(
+                            "Skipping unsafe archive member outside filestore: %s",
+                            member,
+                        )
+                        continue
                     if member.endswith("/"):
                         os.makedirs(target, exist_ok=True)
                     else:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1218,7 +1218,13 @@ def import_from_odoo(
     import urllib.parse
     import zipfile
 
+    from oduflow.url_safety import assert_allowed_url
+
     base = odoo_url.rstrip("/")
+
+    # SSRF guard: importing a DB from a URL is a clearly-external operation, so
+    # block loopback, the cloud metadata endpoint, and internal RFC1918 hosts.
+    assert_allowed_url(base, allow_private=False)
 
     # 1. Resolve database name
     if not db_name:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -284,9 +284,12 @@ def _create_pg_role(
         f"ALTER ROLE \"{username}\" WITH LOGIN PASSWORD '{safe_pw}';",
     )
     _exec_sql(client, settings, f'ALTER DATABASE "{db_name}" OWNER TO "{username}";')
-    # Grant membership in the superuser role so the env role inherits
-    # ownership of all existing objects (needed for DDL during module upgrades).
-    _exec_sql(client, settings, f'GRANT "{settings.db_user}" TO "{username}";')
+    # Ensure the env role is NOT a member of the superuser role. Ownership of
+    # template objects (needed for DDL during module upgrades) is handled by the
+    # per-object reassignment in create_environment instead; superuser-role
+    # membership would let the env role SET ROLE to superuser — a cross-tenant
+    # RCE (#40). The REVOKE also de-escalates roles created before this change.
+    _exec_sql(client, settings, f'REVOKE "{settings.db_user}" FROM "{username}";')
     logger.info("Created/ensured PG role '%s' for database '%s'", username, db_name)
 
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1510,10 +1510,13 @@ def cleanup_orphans(
     for entry in orphan_workspaces:
         entry_path = os.path.join(team.workspaces_dir, entry)
         try:
-            # Unmount any overlay before removing
+            # Unmount any overlay before removing. _unmount_filestore needs the
+            # TeamSettings (it reads team.workspaces_dir); passing the global
+            # Settings here raised AttributeError on every orphan, so cleanup
+            # silently removed nothing.
             from oduflow.docker_ops.env_ops import _unmount_filestore
 
-            _unmount_filestore(entry, settings)
+            _unmount_filestore(entry, team)
             shutil.rmtree(entry_path)
             removed_workspaces.append(entry)
             logger.info("Removed orphan workspace %s", entry_path)

--- a/src/oduflow/docker_ops/volume_ops.py
+++ b/src/oduflow/docker_ops/volume_ops.py
@@ -266,10 +266,19 @@ def resolve_volume_binds(
         try:
             client.volumes.get(docker_name)
         except docker.errors.NotFound:
-            # Try the original name as-is (external / non-managed volume)
+            # Fall back to an external (non-Oduflow) volume mounted by its raw
+            # name. Never allow raw access to an Oduflow-managed volume — the
+            # shared Postgres data volume (oduflow-db-data), another team's
+            # oduflow-vol-* volume, or a system volume (oduflow-traefik-*):
+            # mounting one would be a cross-tenant / host escape (issue #40).
+            raw = mount["volume"]
+            if raw.startswith("oduflow-"):
+                raise NotFoundError(
+                    f"Volume '{raw}' is reserved and cannot be mounted directly."
+                )
             try:
-                client.volumes.get(mount["volume"])
-                docker_name = mount["volume"]
+                client.volumes.get(raw)
+                docker_name = raw
             except docker.errors.NotFound:
                 raise NotFoundError(
                     f"Volume '{mount['volume']}' not found. Create it first."

--- a/src/oduflow/env_credentials.py
+++ b/src/oduflow/env_credentials.py
@@ -30,8 +30,20 @@ def create_credentials(
     workspace_path = get_workspace_path(env_name, workspaces_dir)
     os.makedirs(workspace_path, exist_ok=True)
     creds_path = os.path.join(workspace_path, _CREDENTIALS_FILE)
-    with open(creds_path, "w") as f:
-        json.dump(creds, f)
+    # Atomic write with restrictive permissions: the file holds a plaintext PG
+    # password, and a crash mid-write must not leave a half-written file.
+    fd = os.open(
+        creds_path + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(creds, f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(creds_path + ".tmp", creds_path)
+    finally:
+        if os.path.exists(creds_path + ".tmp"):
+            os.remove(creds_path + ".tmp")
 
     logger.info(
         "Created PG credentials for environment '%s' (user=%s)", env_name, username

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -41,10 +41,7 @@ def _get_module_name(file_path: str, repo_path: str = "") -> str | None:
         return None
 
     if repo_path:
-        if os.path.basename(file_path) == "__manifest__.py":
-            dir_parts = parts[:-1]
-        else:
-            dir_parts = parts[:-1]
+        dir_parts = parts[:-1]
 
         for i in range(len(dir_parts), 0, -1):
             candidate = "/".join(dir_parts[:i])

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import subprocess
+from collections.abc import Iterable
 
 from oduflow import settings
 
@@ -456,6 +457,64 @@ def recommend(changed_files: list[str], repo_path: str, base_ref: str | None) ->
     if base_ref:
         return classify_changes(changed_files, repo_path, base_ref=base_ref)
     return shallow_classify(changed_files, repo_path)
+
+
+# Most → least disruptive. Used to pick the overall action when merging the
+# per-repo recommendations of the main repo and each extra-addon worktree.
+_ACTION_PRIORITY = {"none": 0, "refresh": 1, "restart": 2, "upgrade": 3, "install": 4}
+
+_DETAIL_LIST_KEYS = (
+    "xml_hot",
+    "xml_security",
+    "manifest_upgrade",
+    "manifest_install",
+    "js_changed",
+)
+
+
+def merge_recommendations(recs: Iterable[dict]) -> dict:
+    """Combine several :func:`recommend` results (one per repo/worktree).
+
+    The main repo and each extra-addon worktree are classified against their own
+    tree, so their recommendations must be merged: the overall action is the
+    most disruptive one, module lists are unioned, and ``restart_required`` is
+    OR-ed across all details (issue #51).
+    """
+    recs = [r for r in recs if r]
+    if not recs:
+        return {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
+
+    action = max(
+        (r.get("action", "none") for r in recs),
+        key=lambda a: _ACTION_PRIORITY.get(a, 0),
+    )
+    install = sorted(
+        {m for r in recs for m in r.get("modules_to_install", []) or []}
+    )
+    upgrade = sorted(
+        {m for r in recs for m in r.get("modules_to_upgrade", []) or []}
+    )
+
+    details: dict = {}
+    for key in _DETAIL_LIST_KEYS:
+        merged: list[str] = []
+        for r in recs:
+            d = r.get("details")
+            if isinstance(d, dict):
+                merged.extend(d.get(key, []) or [])
+        if merged:
+            details[key] = sorted(set(merged))
+    details["restart_required"] = any(
+        isinstance(r.get("details"), dict) and r["details"].get("restart_required")
+        for r in recs
+    )
+
+    return {
+        "action": action,
+        "modules_to_install": install,
+        "modules_to_upgrade": upgrade,
+        "details": details,
+    }
 
 
 def guardrail_warnings(

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -52,6 +52,11 @@ def validate_repo_url(repo_url: str) -> None:
             f"Only HTTPS repository URLs are supported (got {parsed.scheme or 'unknown'}://). "
             "Use format: https://github.com/owner/repo.git"
         )
+    # SSRF guard: refuse loopback / link-local (cloud metadata) / unspecified
+    # hosts. Internal RFC1918 git servers stay allowed (allow_private=True).
+    from oduflow.url_safety import assert_allowed_host
+
+    assert_allowed_host(parsed.hostname, allow_private=True)
 
 
 def _parse_authenticated_url(repo_url: str) -> tuple[str, str, str, str]:

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -2,6 +2,37 @@ import os
 import re
 from urllib.parse import urlparse, urlunparse
 
+# A template name becomes both a filesystem path (templates/<name>, where "/"
+# denotes a sub-directory) and, with "/" replaced by "-", part of a PostgreSQL
+# database identifier. "/" is therefore allowed as a segment separator, but each
+# segment must start with an alphanumeric (which rules out "." and ".." — i.e.
+# path traversal) and contain only [a-zA-Z0-9_.-] (which rules out quotes,
+# semicolons and whitespace — i.e. SQL-identifier break-out).
+_TEMPLATE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def validate_template_name(template_name: str) -> str:
+    """Validate a template name and return it unchanged.
+
+    Raises ValueError if the name could escape the templates directory or break
+    out of a SQL identifier. Enforced at the two derivation chokepoints
+    (get_template_db_name and TeamSettings.get_template_dir), so every entry
+    point — MCP tools, web UI, CLI — is covered.
+    """
+    name = template_name or ""
+    segments = name.split("/")
+    if (
+        not name
+        or len(name) > 63
+        or not all(_TEMPLATE_SEGMENT_RE.match(seg) for seg in segments)
+    ):
+        raise ValueError(
+            f"Invalid template name '{template_name}': each '/'-separated "
+            "segment must start with a letter or digit and contain only "
+            "[a-zA-Z0-9_.-] (max 63 chars total)."
+        )
+    return name
+
 
 def slugify_branch(env_name: str) -> str:
     slug = env_name.replace("/", "-")
@@ -35,6 +66,9 @@ def get_env_hostname(env_name: str, hostname: str) -> str:
 
 
 def get_template_db_name(template_name: str, team_id: str = "1") -> str:
+    # validate_template_name guarantees the (slugified) name cannot break out of
+    # the double-quoted SQL identifier this is interpolated into.
+    validate_template_name(template_name)
     slug = template_name.replace("/", "-")
     return f"oduflow_template_{team_id}_{slug}"
 

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -29,20 +29,40 @@ from oduflow.settings import Settings
 logger = logging.getLogger("oduflow")
 
 
+# Schemes that are never a legitimate OAuth callback and could turn the
+# authorization redirect into an XSS / data-exfil primitive.
+_DANGEROUS_REDIRECT_SCHEMES = {"javascript", "data", "vbscript", "file"}
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
+
+
 class _FlexibleClient(OAuthClientInformationFull):
-    """Client info that accepts any redirect_uri at /authorize time.
+    """Client info that accepts the varied callback URLs MCP clients use.
 
     Preregistered clients have ``client_id == client_secret == auth_token``;
-    the secret-bearing /token exchange already proves identity, so we let
-    MCP clients (claude.ai, IDEs, etc.) bring whatever callback URL they use.
+    the secret-bearing /token exchange already proves identity, so we let MCP
+    clients (claude.ai over https, IDEs over loopback or a custom scheme) bring
+    their own callback — but we still reject callbacks that are never legitimate:
+    dangerous schemes (javascript:, data:, …) and cleartext http:// to a
+    non-loopback host (which would leak the authorization code in the clear).
     """
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
-        if redirect_uri is not None:
-            return redirect_uri
-        if self.redirect_uris:
-            return self.redirect_uris[0]
-        raise InvalidRedirectUriError("redirect_uri must be specified")
+        if redirect_uri is None:
+            if self.redirect_uris:
+                return self.redirect_uris[0]
+            raise InvalidRedirectUriError("redirect_uri must be specified")
+
+        scheme = (redirect_uri.scheme or "").lower()
+        if not scheme or scheme in _DANGEROUS_REDIRECT_SCHEMES:
+            raise InvalidRedirectUriError(
+                f"redirect_uri scheme '{scheme}' is not allowed."
+            )
+        if scheme == "http" and (redirect_uri.host or "") not in _LOOPBACK_HOSTS:
+            raise InvalidRedirectUriError(
+                "Plaintext http:// redirect_uri is only allowed for loopback "
+                "addresses; use https for remote callbacks."
+            )
+        return redirect_uri
 
 
 class OduflowOAuthProvider(InMemoryOAuthProvider):

--- a/src/oduflow/reaper.py
+++ b/src/oduflow/reaper.py
@@ -171,4 +171,12 @@ def start_reaper(
         settings.auto_delete_hours,
         int(interval),
     )
+    if settings.auto_delete_hours > 0:
+        logger.warning(
+            "auto_delete_hours=%d is ENABLED: unprotected environments stopped "
+            "for longer than %dh will be PERMANENTLY DELETED (database and "
+            "workspace). Set [lifecycle] auto_delete_hours = 0 to disable.",
+            settings.auto_delete_hours,
+            settings.auto_delete_hours,
+        )
     return thread

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -225,7 +225,7 @@ def _wake_for_work(
     """Container-level tools start a stopped environment instead of failing:
     with auto-stop, 'stopped' is a routine state, not an error. Returns the
     one-line note to prepend to the tool response ('' if already running)."""
-    if env_ops.ensure_running(settings, env_name):
+    if env_ops.ensure_running(settings, env_name, team):
         activity.mark_started(team, env_name)
         return f"Note: environment was stopped; started it {purpose}.\n"
     return ""
@@ -1021,7 +1021,8 @@ def get_environment_logs(
         level: Filter by Odoo log level. One of: "ERROR", "WARNING", "CRITICAL". Returns only lines containing the specified level marker. Can be combined with grep.
     """
     output = odoo_ops.get_environment_logs(
-        _get_settings(), env_name, n_lines, grep=grep, level=level
+        _get_settings(), env_name, n_lines, grep=grep, level=level,
+        team=_resolve_team(ctx),
     )
     return f"Recent logs for {env_name}:\n\n{_ANSI_RE.sub('', output)}"
 
@@ -1037,8 +1038,9 @@ def restart_environment(env_name: str, wait: bool = True, ctx: Context = None) -
         wait: Wait for Odoo to become ready after restart (default True). Polls /web/health every 2 seconds for up to 120 seconds.
     """
     settings = _get_settings()
-    result = env_ops.restart_environment(settings, env_name)
-    activity.mark_started(_resolve_team(ctx), env_name)
+    team = _resolve_team(ctx)
+    result = env_ops.restart_environment(settings, env_name, team)
+    activity.mark_started(team, env_name)
     lines = [
         "Environment restarted successfully!",
         f"Odoo Container: {result['odoo_container']}",
@@ -1198,7 +1200,7 @@ def start_environment(env_name: str, wait: bool = True, ctx: Context = None) -> 
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
-    result = env_ops.start_environment(settings, env_name)
+    result = env_ops.start_environment(settings, env_name, team)
     activity.mark_started(team, env_name)
     lines = [
         "Environment started successfully!",
@@ -1445,7 +1447,7 @@ def install_odoo_modules(env_name: str, modules: str, ctx: Context = None) -> st
     modules_str = ", ".join(result["modules"])
     output = result.get("output", "")
     if exit_code == 0:
-        env_ops.restart_environment(settings, env_name)
+        env_ops.restart_environment(settings, env_name, team)
         header = f"{woke}Success. Modules installed: {modules_str}. Container restarted. Exit code: 0."
     else:
         header = f"{woke}Error. Modules: {modules_str}. Exit code: {exit_code}."

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -33,7 +33,7 @@ from oduflow.docker_ops import (
 )
 from oduflow import activity, git_ops, reaper
 from oduflow import settings as settings_module
-from oduflow.errors import FlowError
+from oduflow.errors import FlowError, PrerequisiteNotMetError
 from oduflow.locking import LockManager
 from oduflow.output_cache import OutputCache, CachedOutput
 from oduflow.settings import Settings, TeamSettings, find_toml
@@ -3082,7 +3082,7 @@ def _get_version() -> str:
 # =============================================================================
 
 
-def main() -> None:
+def _run_cli() -> None:
     """Entry point for the Oduflow MCP server."""
     parser = argparse.ArgumentParser(
         prog="oduflow", description="Oduflow — Odoo dev environment manager"
@@ -3501,6 +3501,19 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
 
     logger.warning("HTTP auth DISABLED (no auth_token or oauth_base_url set)")
     return None
+
+
+def main() -> None:
+    """CLI entry point: run the server/command and translate a missing
+    prerequisite (e.g. Docker daemon unreachable) into a friendly process exit
+    instead of a traceback. get_client() raises PrerequisiteNotMetError rather
+    than SystemExit so the long-running server can recover; here at the CLI
+    boundary we convert it to an exit code."""
+    try:
+        _run_cli()
+    except PrerequisiteNotMetError as exc:
+        print(f"\n❌ {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2738,6 +2738,28 @@ def _inject_db_password(toml_text: str, password: str) -> str:
     return "\n".join(out) + "\n"
 
 
+def _inject_auth_token(toml_text: str, token: str) -> str:
+    """Replace the empty ``auth_token = ""`` in a freshly bootstrapped
+    oduflow.toml with a generated MCP token, so a fresh HTTP install is
+    authenticated by default. Only the first empty auth_token (team 1) is set;
+    existing user configs are never rewritten.
+    """
+    replacement = f'auth_token = "{token}"'
+    out: list[str] = []
+    injected = False
+    for raw in toml_text.splitlines():
+        if not injected and raw.split("#", 1)[0].strip() == 'auth_token = ""':
+            indent = raw[: len(raw) - len(raw.lstrip())]
+            comment = raw.split("#", 1)[1].strip() if "#" in raw else ""
+            out.append(
+                f"{indent}{replacement}" + (f"  # {comment}" if comment else "")
+            )
+            injected = True
+        else:
+            out.append(raw)
+    return "\n".join(out) + "\n"
+
+
 def _run_reload_template(
     settings: Settings, team: TeamSettings, template_name: str, dump_path: str = ""
 ) -> None:
@@ -3284,8 +3306,9 @@ def _run_cli() -> None:
     logging.getLogger("docker").setLevel(logging.WARNING)
     logging.getLogger("docket").setLevel(logging.WARNING)
 
-    # Bootstrap: if no config exists, create it from the bundled default
-    # with an auto-generated PostgreSQL superuser password.
+    # Bootstrap: if no config exists, create it from the bundled default with an
+    # auto-generated PostgreSQL password and a random MCP auth_token, so a fresh
+    # install is authenticated by default even over HTTP (#37).
     try:
         find_toml()
     except FileNotFoundError:
@@ -3298,12 +3321,22 @@ def _run_cli() -> None:
         os.makedirs(dest_dir, exist_ok=True)
         bundled = pathlib.Path(__file__).resolve().parent / "templates" / "oduflow.toml"
         dest = os.path.join(dest_dir, "oduflow.toml")
+        generated_token = secrets.token_urlsafe(24)
         rendered = _inject_db_password(
             bundled.read_text(encoding="utf-8"), secrets.token_urlsafe(24)
         )
+        rendered = _inject_auth_token(rendered, generated_token)
         with open(dest, "w", encoding="utf-8") as f:
             f.write(rendered)
-        logger.info("Config created: %s (auto-generated DB password)", dest)
+        logger.info(
+            "Config created: %s (auto-generated DB password and MCP auth_token)",
+            dest,
+        )
+        logger.info(
+            "Generated MCP auth_token for team 1: %s "
+            "(use as Bearer token / OAuth client_id+secret)",
+            generated_token,
+        )
 
     global _settings
     _settings = _get_settings()
@@ -3443,6 +3476,29 @@ def _start_http() -> None:
     port = settings.port
 
     auth = _build_auth(settings)
+
+    # Fail closed: never serve the MCP tool surface (run_odoo_command,
+    # run_db_query, privileged service creation, …) unauthenticated by accident
+    # (#37). A fresh install bootstraps a random auth_token; reaching here with
+    # no auth means the operator cleared it, which must be explicit.
+    if auth is None and not settings.allow_insecure_http:
+        raise PrerequisiteNotMetError(
+            "Refusing to start the HTTP transport with no MCP authentication: "
+            "set a [team.*] auth_token (or oauth_base_url) in oduflow.toml. To "
+            "run unauthenticated on purpose (e.g. behind your own auth proxy), "
+            "set [server] allow_insecure_http = true."
+        )
+    if auth is None:
+        logger.warning(
+            "HTTP transport starting WITHOUT authentication "
+            "(allow_insecure_http=true) — the full MCP tool surface is open."
+        )
+    if host not in ("127.0.0.1", "::1", "localhost"):
+        logger.warning(
+            "Binding %s on all/non-loopback interface — ensure a firewall and "
+            "TLS-terminating reverse proxy are in front of Oduflow.",
+            host,
+        )
 
     app = create_streamable_http_app(mcp, "/mcp", auth=auth, stateless_http=True)
 

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -100,7 +100,10 @@ def _resolve_team(ctx: Context | None) -> TeamSettings:
             if team:
                 return team
         except Exception:
-            pass
+            # No HTTP request in scope (e.g. stdio transport) — fall through to
+            # the single-team / default-team resolution below. Logged, not
+            # silently swallowed, so misrouting is traceable.
+            logger.debug("Host-header team resolution unavailable", exc_info=True)
     # 3. Fallback: single team or default team "1"
     if len(settings.teams) == 1:
         return next(iter(settings.teams.values()))

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -105,9 +105,11 @@ class Settings:
 
     # Lifecycle: automatic stop of idle environments and cleanup of stopped
     # ones (see oduflow.reaper). 0 disables either behavior. Protected
-    # environments are always exempt.
+    # environments are always exempt. auto-delete is DESTRUCTIVE (drops the
+    # database and workspace), so it is opt-in (defaults to 0); auto-stop is
+    # non-destructive and enabled by default.
     auto_stop_hours: int = 48
-    auto_delete_hours: int = 72
+    auto_delete_hours: int = 0
 
     # Shared Docker resource names
     shared_network: str = "oduflow-net"
@@ -308,7 +310,7 @@ class Settings:
             base_data_dir=base_data_dir,
             overlay_threshold_mb=int(storage.get("overlay_threshold_mb", 50)),
             auto_stop_hours=int(lifecycle.get("auto_stop_hours", 48)),
-            auto_delete_hours=int(lifecycle.get("auto_delete_hours", 72)),
+            auto_delete_hours=int(lifecycle.get("auto_delete_hours", 0)),
             oauth_base_url=str(oauth.get("oauth_base_url", "")).strip(),
             etc_dir=etc_dir,
             toml_path=path,

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -90,6 +90,10 @@ class Settings:
     trace: bool = False
     disable_telemetry: bool = False
     allow_local_path: bool = True
+    # Allow starting the HTTP transport with no MCP authentication. Off by
+    # default so /mcp is never served unauthenticated by accident (#37); set
+    # true only when fronting Oduflow with your own auth proxy.
+    allow_insecure_http: bool = False
 
     # Routing
     routing_mode: str = "port"
@@ -314,6 +318,7 @@ class Settings:
             trace=trace,
             disable_telemetry=bool(server.get("disable_telemetry", False)),
             allow_local_path=bool(server.get("allow_local_path", True)),
+            allow_insecure_http=bool(server.get("allow_insecure_http", False)),
             routing_mode=str(routing.get("mode", "port")).strip().lower(),
             acme_email=str(routing.get("acme_email", "")).strip(),
             db_user=str(database.get("user", "odoo")),

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 import re
@@ -150,7 +151,7 @@ class Settings:
         if not token:
             return None
         for team in self.teams.values():
-            if team.auth_token and team.auth_token == token:
+            if team.auth_token and hmac.compare_digest(team.auth_token, token):
                 return team
         return None
 
@@ -171,7 +172,7 @@ class Settings:
         if not password:
             return None
         for team in self.teams.values():
-            if team.ui_password and team.ui_password == password:
+            if team.ui_password and hmac.compare_digest(team.ui_password, password):
                 return team
         return None
 
@@ -269,11 +270,22 @@ class Settings:
             team_id = str(team_id_raw)
             team_data_dir = os.path.join(base_data_dir, f"team_{team_id}")
 
-            port_range = team_cfg.get("port_range", [50000, 50100])
-            if isinstance(port_range, list) and len(port_range) == 2:
-                port_start, port_end = int(port_range[0]), int(port_range[1])
-            else:
+            port_range = team_cfg.get("port_range")
+            if port_range is None:
                 port_start, port_end = 50000, 50100
+            elif isinstance(port_range, list) and len(port_range) == 2:
+                try:
+                    port_start, port_end = int(port_range[0]), int(port_range[1])
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"Team '{team_id}': port_range must be two integers, "
+                        f"got {port_range!r}"
+                    ) from exc
+            else:
+                raise ValueError(
+                    f"Team '{team_id}': port_range must be [start, end], "
+                    f"got {port_range!r}"
+                )
 
             raw_hostname = str(
                 team_cfg.get("hostname", routing.get("hostname", "localhost"))

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -195,6 +195,26 @@ class Settings:
                     f"{team.port_range_start}-{team.port_range_end}"
                 )
 
+        # Validate that team port ranges do not overlap. The default range is
+        # identical for every team, so two teams that never set an explicit
+        # port_range would draw host ports from the same pool and collide.
+        ranges = sorted(
+            (
+                (t.port_range_start, t.port_range_end, t.team_id)
+                for t in self.teams.values()
+            ),
+            key=lambda r: r[0],
+        )
+        for (a_start, a_end, a_id), (b_start, b_end, b_id) in zip(ranges, ranges[1:]):
+            # Ranges are half-open [start, end); they overlap when the next
+            # range starts before the previous one ends.
+            if b_start < a_end:
+                raise ValueError(
+                    f"Teams '{a_id}' and '{b_id}' have overlapping port ranges "
+                    f"({a_start}-{a_end} and {b_start}-{b_end}). "
+                    "Set a distinct [team.*] port_range for each team."
+                )
+
         # Validate uniqueness of auth tokens
         tokens = [t.auth_token for t in self.teams.values() if t.auth_token]
         if len(tokens) != len(set(tokens)):

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -44,6 +44,11 @@ class TeamSettings:
         return os.path.join(self.data_dir, "shared_repos")
 
     def get_template_dir(self, template_name: str) -> str:
+        # Reject names that could escape the templates directory (path
+        # traversal) before they reach rmtree / file writes.
+        from oduflow.naming import validate_template_name
+
+        validate_template_name(template_name)
         return os.path.join(self.data_dir, "templates", template_name)
 
     def get_template_sql_path(self, template_name: str) -> str:

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -3,6 +3,7 @@
 host = "0.0.0.0"
 port = 8000
 allow_local_path = true        # allow live-mount (bind local checkout) workflows
+# allow_insecure_http = false  # serve HTTP /mcp with NO auth (only behind your own proxy)
 # trace = false                    # verbose tracing for git analysis & env ops
 
 # ── Routing ───────────────────────────────────────────
@@ -42,6 +43,6 @@ overlay_threshold_mb = 50         # filestore size limit for overlay vs copy
 
 [team.1]
 hostname = "localhost"            # port: http://{hostname}:{port}, traefik: https://{slug}.{hostname}
-auth_token = ""                   # MCP bearer token / OAuth client_id+secret (empty = auth disabled)
+auth_token = ""                   # MCP bearer token / OAuth client_id+secret (auto-generated on first run; HTTP refuses to start if empty)
 ui_password = ""                  # Web UI password (empty = UI open)
 port_range = [50000, 50100]       # port range for Odoo containers

--- a/src/oduflow/url_safety.py
+++ b/src/oduflow/url_safety.py
@@ -1,0 +1,75 @@
+"""SSRF guards for outbound requests built from user-supplied URLs.
+
+Used by the git remote validation and the import-from-Odoo path so the server
+cannot be tricked into connecting to loopback, the cloud metadata endpoint
+(169.254.169.254), or — for clearly-external operations — internal RFC1918
+hosts.
+
+Note: this resolves and checks the host at validation time. A later connection
+re-resolves DNS, so this does not defeat a determined DNS-rebinding attacker;
+it raises the bar against the common cases (literal internal IPs, metadata
+endpoints, localhost) without pinning.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from oduflow.errors import FlowError
+
+
+class BlockedURLError(FlowError):
+    """The URL resolves to a network location that is not allowed."""
+
+
+def _is_blocked(ip: ipaddress._BaseAddress, *, allow_private: bool) -> bool:
+    # Never-legitimate remote targets, blocked even for internal git hosts.
+    if (
+        ip.is_loopback
+        or ip.is_link_local  # includes 169.254.169.254 cloud metadata
+        or ip.is_unspecified
+        or ip.is_multicast
+        or ip.is_reserved
+    ):
+        return True
+    # RFC1918 / ULA private ranges: blocked unless the caller opts in (internal
+    # git servers are a legitimate use case; importing a DB from a URL is not).
+    if not allow_private and ip.is_private:
+        return True
+    return False
+
+
+def assert_allowed_host(hostname: str | None, *, allow_private: bool = False) -> None:
+    """Raise BlockedURLError if hostname resolves to a disallowed address."""
+    if not hostname:
+        raise BlockedURLError("URL has no host component.")
+
+    try:
+        candidates = [ipaddress.ip_address(hostname)]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(hostname, None)
+        except socket.gaierror as exc:
+            raise BlockedURLError(f"Cannot resolve host '{hostname}': {exc}") from exc
+        candidates = [ipaddress.ip_address(info[4][0]) for info in infos]
+
+    for ip in candidates:
+        if _is_blocked(ip, allow_private=allow_private):
+            raise BlockedURLError(
+                f"Host '{hostname}' resolves to a blocked address ({ip}); "
+                "refusing the request to prevent SSRF."
+            )
+
+
+def assert_allowed_url(
+    url: str, *, require_https: bool = False, allow_private: bool = False
+) -> None:
+    """Validate the scheme and resolve-check the host of an outbound URL."""
+    parsed = urlparse(url)
+    if require_https and parsed.scheme != "https":
+        raise BlockedURLError(
+            f"URL must use https:// (got {parsed.scheme or 'unknown'}://)."
+        )
+    assert_allowed_host(parsed.hostname, allow_private=allow_private)

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -9,6 +9,8 @@ import logging
 import os
 import pathlib
 import secrets
+import threading
+import time
 
 from itsdangerous import BadData, URLSafeTimedSerializer
 from starlette.requests import HTTPConnection, Request
@@ -288,10 +290,52 @@ def _guide_title(filepath: str) -> str:
     return os.path.basename(filepath).replace("_", " ").replace(".md", "").title()
 
 
+class _LoginRateLimiter:
+    """Best-effort in-memory throttle for failed logins (issue #56).
+
+    Tracks failed attempts per client IP in a sliding window; once the threshold
+    is reached the IP is locked out for the rest of the window. A successful
+    login clears the IP. The dashboard runs in a single uvicorn process, so an
+    in-memory store is sufficient.
+    """
+
+    def __init__(self, max_attempts: int = 10, window_seconds: int = 300) -> None:
+        self.max_attempts = max_attempts
+        self.window = window_seconds
+        self._failures: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def _prune(self, key: str, now: float) -> None:
+        cutoff = now - self.window
+        kept = [t for t in self._failures.get(key, []) if t > cutoff]
+        if kept:
+            self._failures[key] = kept
+        else:
+            self._failures.pop(key, None)
+
+    def is_limited(self, key: str) -> bool:
+        with self._lock:
+            now = time.monotonic()
+            self._prune(key, now)
+            return len(self._failures.get(key, [])) >= self.max_attempts
+
+    def record_failure(self, key: str) -> None:
+        with self._lock:
+            now = time.monotonic()
+            self._failures.setdefault(key, []).append(now)
+            self._prune(key, now)
+
+    def clear(self, key: str) -> None:
+        with self._lock:
+            self._failures.pop(key, None)
+
+
 def _build_routes(
     get_settings: "callable",
     locks: LockManager,
 ) -> list[Route]:
+    # Per-app so test apps and real deployments don't share failure counters.
+    login_limiter = _LoginRateLimiter()
 
     def _set_session_cookie(
         response: Response, team: TeamSettings, request: Request
@@ -324,12 +368,20 @@ def _build_routes(
         if token and _check_cookie_token(token, settings) is not None:
             return RedirectResponse("/", status_code=302)
         if request.method == "POST":
+            client_ip = request.client.host if request.client else "unknown"
+            if login_limiter.is_limited(client_ip):
+                return HTMLResponse(
+                    _render_login("Too many failed attempts. Try again later."),
+                    status_code=429,
+                )
             password = await _read_login_password(request)
             team = settings.get_team_by_ui_password(password) if password else None
             if team is not None:
+                login_limiter.clear(client_ip)
                 response: Response = RedirectResponse("/", status_code=303)
                 _set_session_cookie(response, team, request)
                 return response
+            login_limiter.record_failure(client_ip)
             return HTMLResponse(_render_login("Invalid password."), status_code=401)
         return HTMLResponse(_render_login())
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -568,36 +568,46 @@ def _build_routes(
             locks.release_env(branch)
 
     async def api_create(request: Request) -> JSONResponse:
+        import json as _json
+
         try:
-            import json as _json
-
             body = await request.json()
-            env_name = (body.get("env_name") or "").strip()
-            repo_url = (body.get("repo_url") or "").strip()
-            odoo_image = (body.get("odoo_image") or "").strip()
-            git_user = (body.get("git_user") or "").strip()
-            template_name_raw = (body.get("template_name") or "").strip()
-            extra_addons_raw = body.get("extra_addons")
-            auto_install_raw = (body.get("auto_install_modules") or "").strip()
-            env_vars_raw = (body.get("env_vars") or "").strip()
-            env_vars = None
-            if env_vars_raw:
-                import re
+        except Exception:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body."}, status_code=400
+            )
 
-                env_vars = dict(
-                    item.split("=", 1)
-                    for item in re.split(r"[\n,]+", env_vars_raw)
-                    if "=" in item
-                )
-            if not env_name:
-                return JSONResponse(
-                    {"ok": False, "error": "env_name is required."},
-                    status_code=400,
-                )
-            try:
-                locks.acquire_env(env_name)
-            except BusyError as e:
-                return _error_response(e)
+        env_name = (body.get("env_name") or "").strip()
+        repo_url = (body.get("repo_url") or "").strip()
+        odoo_image = (body.get("odoo_image") or "").strip()
+        git_user = (body.get("git_user") or "").strip()
+        template_name_raw = (body.get("template_name") or "").strip()
+        extra_addons_raw = body.get("extra_addons")
+        auto_install_raw = (body.get("auto_install_modules") or "").strip()
+        env_vars_raw = (body.get("env_vars") or "").strip()
+        env_vars = None
+        if env_vars_raw:
+            import re
+
+            env_vars = dict(
+                item.split("=", 1)
+                for item in re.split(r"[\n,]+", env_vars_raw)
+                if "=" in item
+            )
+        if not env_name:
+            return JSONResponse(
+                {"ok": False, "error": "env_name is required."},
+                status_code=400,
+            )
+
+        # Acquire the env lock in its own try so a BusyError returns WITHOUT
+        # entering the try/finally below — otherwise the finally would release a
+        # lock that another in-flight request holds (issue #42).
+        try:
+            locks.acquire_env(env_name)
+        except BusyError as e:
+            return _error_response(e)
+        try:
             resolved_template: str | None
             if not template_name_raw or template_name_raw.lower() == "none":
                 resolved_template = None

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -394,8 +394,9 @@ def _build_routes(
     def api_start(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
         try:
-            result = env_ops.start_environment(get_settings(), branch)
-            activity.mark_started(_get_ui_team(request), branch)
+            team = _get_ui_team(request)
+            result = env_ops.start_environment(get_settings(), branch, team)
+            activity.mark_started(team, branch)
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -419,8 +420,9 @@ def _build_routes(
     def api_restart(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
         try:
-            result = env_ops.restart_environment(get_settings(), branch)
-            activity.mark_started(_get_ui_team(request), branch)
+            team = _get_ui_team(request)
+            result = env_ops.restart_environment(get_settings(), branch, team)
+            activity.mark_started(team, branch)
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -710,7 +712,11 @@ def _build_routes(
         container = request.query_params.get("container", "")
         try:
             logs = get_environment_logs(
-                get_settings(), branch, n_lines=n, container_name=container
+                get_settings(),
+                branch,
+                n_lines=n,
+                container_name=container,
+                team=_get_ui_team(request),
             )
             return JSONResponse({"ok": True, "logs": logs})
         except FlowError as e:

--- a/tests/test_archive_safety.py
+++ b/tests/test_archive_safety.py
@@ -1,0 +1,23 @@
+"""Regression tests for archive extraction path-traversal guard (issue #43)."""
+
+import os
+
+from oduflow.docker_ops.system_ops import _is_within_directory
+
+
+def test_within_directory_accepts_inside_paths(tmp_path):
+    root = str(tmp_path)
+    assert _is_within_directory(root, root)
+    assert _is_within_directory(root, os.path.join(root, "a"))
+    assert _is_within_directory(root, os.path.join(root, "a/b/c.dat"))
+
+
+def test_within_directory_rejects_traversal(tmp_path):
+    root = str(tmp_path / "filestore")
+    os.makedirs(root)
+    # Classic zip-slip members.
+    assert not _is_within_directory(root, os.path.join(root, "../../etc/passwd"))
+    assert not _is_within_directory(root, os.path.join(root, "../sibling"))
+    assert not _is_within_directory(root, "/etc/passwd")
+    # A sibling dir that merely shares a name prefix must not count as inside.
+    assert not _is_within_directory(root, str(tmp_path / "filestore-evil"))

--- a/tests/test_bootstrap_db_password.py
+++ b/tests/test_bootstrap_db_password.py
@@ -62,3 +62,25 @@ def test_rendered_template_loads_via_settings(tmp_path):
     settings = Settings.from_toml(str(dest))
     assert settings.db_password == "live-secret-42"
     assert settings.db_user == "odoo"
+
+
+def test_inject_auth_token_sets_team_token(tmp_path):
+    from oduflow.server import _inject_auth_token
+
+    bundled = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "src"
+        / "oduflow"
+        / "templates"
+        / "oduflow.toml"
+    )
+    text = bundled.read_text(encoding="utf-8")
+    # Template ships with an empty auth_token.
+    assert tomllib.loads(text)["team"]["1"]["auth_token"] == ""
+
+    rendered = _inject_auth_token(text, "tok-generated-xyz")
+    data = tomllib.loads(rendered)
+    assert data["team"]["1"]["auth_token"] == "tok-generated-xyz"
+    # ui_password is untouched; only the first empty auth_token is replaced.
+    assert data["team"]["1"]["ui_password"] == ""
+    assert rendered.count("auth_token =") == 1

--- a/tests/test_cleanup_orphans.py
+++ b/tests/test_cleanup_orphans.py
@@ -1,0 +1,81 @@
+"""Regression tests for cleanup_orphans (issue #48).
+
+cleanup_orphans must pass the per-team TeamSettings (which has workspaces_dir)
+to env_ops._unmount_filestore, not the global Settings. Passing Settings raised
+AttributeError on every orphan, which was swallowed, so the command silently
+removed nothing.
+"""
+
+import os
+from unittest.mock import patch
+
+from oduflow.docker_ops import system_ops
+from oduflow.settings import Settings, TeamSettings
+
+
+class _FakeContainers:
+    def list(self, all=False, filters=None):  # noqa: A002 - matches docker SDK
+        return []
+
+
+class _FakeClient:
+    containers = _FakeContainers()
+
+
+def _team_and_settings(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    return team, settings
+
+
+def test_cleanup_orphans_removes_orphan_workspace(tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+
+    os.makedirs(team.workspaces_dir, exist_ok=True)
+    orphan_dir = os.path.join(team.workspaces_dir, "feature-x")
+    os.makedirs(orphan_dir)
+
+    with (
+        patch.object(system_ops, "get_client", return_value=_FakeClient()),
+        patch.object(system_ops, "_exec_sql", return_value=""),
+        patch("oduflow.port_registry._load_registry", return_value={}),
+        patch("oduflow.port_registry._save_registry"),
+    ):
+        result = system_ops.cleanup_orphans(settings, team, dry_run=False)
+
+    # With the bug (passing Settings), _unmount_filestore raised AttributeError,
+    # the workspace was left in place, and removed_workspaces was empty.
+    assert "feature-x" in result["orphan_workspaces"]
+    assert not os.path.exists(orphan_dir)
+
+
+def test_cleanup_orphans_unmount_receives_teamsettings(tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+
+    os.makedirs(team.workspaces_dir, exist_ok=True)
+    os.makedirs(os.path.join(team.workspaces_dir, "feature-y"))
+
+    seen = {}
+
+    def _fake_unmount(env_name, passed_team):
+        seen["env_name"] = env_name
+        seen["team"] = passed_team
+
+    with (
+        patch.object(system_ops, "get_client", return_value=_FakeClient()),
+        patch.object(system_ops, "_exec_sql", return_value=""),
+        patch("oduflow.port_registry._load_registry", return_value={}),
+        patch("oduflow.port_registry._save_registry"),
+        patch(
+            "oduflow.docker_ops.env_ops._unmount_filestore", side_effect=_fake_unmount
+        ),
+    ):
+        system_ops.cleanup_orphans(settings, team, dry_run=False)
+
+    assert seen["env_name"] == "feature-y"
+    assert seen["team"] is team
+    assert isinstance(seen["team"], TeamSettings)

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -92,3 +92,22 @@ class TestCreateLoadDeleteCredentials:
         with open(creds_path) as f:
             stored = json.load(f)
         assert stored == creds
+
+
+class TestCredentialsFilePermissions:
+    def test_create_credentials_is_0600_and_atomic(self, tmp_path):
+        ws = str(tmp_path)
+        creds = create_credentials("main", "1", ws)
+        # Locate the written file via load (round-trips through the same path).
+        loaded = load_credentials("main", ws, "fb_user", "fb_pw")
+        assert loaded == creds
+        # Find the credentials file and check perms + no leftover temp file.
+        import glob
+
+        files = glob.glob(os.path.join(ws, "**", "env_credentials.json"), recursive=True)
+        assert files, "credentials file not written"
+        mode = os.stat(files[0]).st_mode & 0o777
+        assert mode == 0o600, oct(mode)
+        assert not glob.glob(
+            os.path.join(ws, "**", "env_credentials.json.tmp"), recursive=True
+        )

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -540,3 +540,50 @@ class TestExtractFieldLines:
     def test_no_fields(self):
         source = "def create(self, vals):\n    return super().create(vals)\n"
         assert _extract_field_lines(source) == set()
+
+
+class TestMergeRecommendations:
+    def test_empty(self):
+        from oduflow.git_analysis import merge_recommendations
+
+        assert merge_recommendations([]) == {
+            "action": "none",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+
+    def test_picks_most_disruptive_action_and_unions_modules(self):
+        from oduflow.git_analysis import merge_recommendations
+
+        main = {
+            "action": "restart",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+            "details": {"restart_required": True},
+        }
+        extra = {
+            "action": "install",
+            "modules_to_install": ["enterprise_mod"],
+            "modules_to_upgrade": ["other"],
+            "details": {"restart_required": False},
+        }
+        merged = merge_recommendations([main, extra])
+        # install (from the extra-addon repo) outranks restart (from the main repo)
+        assert merged["action"] == "install"
+        assert merged["modules_to_install"] == ["enterprise_mod"]
+        assert merged["modules_to_upgrade"] == ["other"]
+        assert merged["details"]["restart_required"] is True
+
+    def test_upgrade_in_extra_addon_not_lost(self):
+        from oduflow.git_analysis import merge_recommendations
+
+        main = {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
+        extra = {
+            "action": "upgrade",
+            "modules_to_install": [],
+            "modules_to_upgrade": ["sale_enterprise"],
+            "details": {"restart_required": False},
+        }
+        merged = merge_recommendations([main, extra])
+        assert merged["action"] == "upgrade"
+        assert merged["modules_to_upgrade"] == ["sale_enterprise"]

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -321,7 +321,9 @@ def test_ensure_running_starts_stopped_env(monkeypatch, tmp_path):
 
     started: list[str] = []
     monkeypatch.setattr(env_ops, "get_client", lambda: FakeClient())
-    monkeypatch.setattr(env_ops, "start_environment", lambda s, n: started.append(n))
+    monkeypatch.setattr(
+        env_ops, "start_environment", lambda s, n, t=None: started.append(n)
+    )
 
     settings = _settings(tmp_path)
     assert env_ops.ensure_running(settings, "env-x") is True
@@ -343,11 +345,11 @@ def test_wake_for_work_starts_and_notes(monkeypatch, tmp_path):
     settings = _settings(tmp_path)
     activity.mark_stopped(team, "env-x", by="auto")
 
-    monkeypatch.setattr(env_ops, "ensure_running", lambda s, n: True)
+    monkeypatch.setattr(env_ops, "ensure_running", lambda s, n, t=None: True)
     note = server._wake_for_work(settings, team, "env-x")
     assert note == "Note: environment was stopped; started it for this call.\n"
     rec = activity.get_all(team)["env-x"]
     assert "stopped_at" not in rec  # the stopped clock is cleared
 
-    monkeypatch.setattr(env_ops, "ensure_running", lambda s, n: False)
+    monkeypatch.setattr(env_ops, "ensure_running", lambda s, n, t=None: False)
     assert server._wake_for_work(settings, team, "env-x") == ""

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,3 +1,5 @@
+import pytest
+
 from oduflow.naming import (
     slugify_branch,
     get_db_name,
@@ -6,6 +8,7 @@ from oduflow.naming import (
     get_workspace_path,
     get_repo_path,
     get_filestore_paths,
+    validate_template_name,
 )
 
 
@@ -130,3 +133,36 @@ class TestGetTemplateDbName:
             get_template_db_name("myproject-v17", team_id="3")
             == "oduflow_template_3_myproject-v17"
         )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../etc",
+            "client/../prod",
+            "/abs",
+            "client/",  # trailing slash -> empty segment
+            "..",
+            ".",
+            ".hidden",
+            "a b",  # whitespace
+            "a;b",
+            "a'b",
+            'a"b',
+            "a`b",
+            "x'; DROP DATABASE oduflow_1_main; --",
+            "",
+            "a" * 64,  # too long
+        ],
+    )
+    def test_rejects_dangerous_names(self, bad):
+        # Path-traversal / SQL-identifier break-out must be refused (issue #38).
+        with pytest.raises(ValueError, match="Invalid template name"):
+            get_template_db_name(bad)
+        with pytest.raises(ValueError, match="Invalid template name"):
+            validate_template_name(bad)
+
+    @pytest.mark.parametrize(
+        "good", ["prod", "client/prod", "myproject-v17", "v17.0", "a", "A_b-c.d"]
+    )
+    def test_accepts_valid_names(self, good):
+        assert validate_template_name(good) == good

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -122,10 +122,22 @@ class TestOduflowOAuthProvider:
         provider = OduflowOAuthProvider(_settings())
         client = _run(provider.get_client("tok-a"))
         assert client is not None
-        # Any redirect_uri the client sends must be accepted, since the
-        # /token exchange is gated by client_secret.
-        result = client.validate_redirect_uri(AnyUrl("https://claude.ai/some/cb"))
-        assert str(result) == "https://claude.ai/some/cb"
+        # Legitimate MCP callbacks are accepted: https (claude.ai) and loopback
+        # http (IDEs).
+        assert str(
+            client.validate_redirect_uri(AnyUrl("https://claude.ai/some/cb"))
+        ) == "https://claude.ai/some/cb"
+        assert client.validate_redirect_uri(AnyUrl("http://127.0.0.1:8976/cb"))
+
+    def test_redirect_uri_rejects_dangerous_and_cleartext(self):
+        from pydantic import AnyUrl
+        from mcp.shared.auth import InvalidRedirectUriError
+
+        provider = OduflowOAuthProvider(_settings())
+        client = _run(provider.get_client("tok-a"))
+        # Cleartext http to a non-loopback host would leak the auth code.
+        with pytest.raises(InvalidRedirectUriError):
+            client.validate_redirect_uri(AnyUrl("http://evil.example/cb"))
 
     def test_well_known_route_exposed(self):
         provider = OduflowOAuthProvider(_settings())

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -253,6 +253,32 @@ class TestCreateEnvironment:
         )
         assert mock_cleanup.call_count == 2
 
+    @patch("oduflow.docker_ops.env_ops._cleanup_old_environment")
+    @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
+    def test_create_refuses_db_name_collision(
+        self, mock_ready, mock_cleanup, mock_docker_client
+    ):
+        # "Feature/Foo" normalises to the same DB as a running "feature-foo";
+        # creation must be refused instead of dropping the live env's DB (#41).
+        from oduflow.errors import ConflictError
+
+        other = MagicMock()
+        other.name = "oduflow-feature-foo-odoo"
+        other.labels = {"oduflow.branch": "feature-foo"}
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.list.return_value = [other]
+
+        with pytest.raises(ConflictError, match="normalise to the same database"):
+            env_ops.create_environment(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "Feature/Foo",
+                "https://github.com/org/repo.git",
+                "odoo:15.0",
+            )
+        # The destructive cleanup (which drops the DB) must not run.
+        mock_cleanup.assert_not_called()
+
     @patch("oduflow.docker_ops.env_ops._db_exists", return_value=True)
     @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
     def test_create_already_exists(

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -187,6 +187,72 @@ class TestCreateEnvironment:
         assert mock_docker_client.containers.run.call_count == 2
         mock_alloc.assert_called_once()
 
+    @patch("oduflow.docker_ops.env_ops.release_port")
+    @patch("oduflow.docker_ops.env_ops._cleanup_old_environment")
+    @patch(
+        "oduflow.extra_addons.generate_odoo_conf",
+        return_value="/tmp/flow-test/workspaces/feature-payments/odoo.conf",
+    )
+    @patch("oduflow.docker_ops.env_ops._copy_file_to_container")
+    @patch("oduflow.docker_ops.env_ops._create_pg_role")
+    @patch(
+        "oduflow.docker_ops.env_ops.create_credentials",
+        return_value={"pg_user": "u_1_feature-payments", "pg_password": "test-pw"},
+    )
+    @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
+    @patch("oduflow.docker_ops.env_ops.get_odoo_uid_gid", return_value="100:101")
+    @patch("oduflow.docker_ops.env_ops._exec_sql")
+    @patch("oduflow.docker_ops.env_ops._db_exists", return_value=True)
+    @patch("oduflow.docker_ops.env_ops._mount_filestore")
+    @patch("oduflow.docker_ops.env_ops._get_used_ports", return_value=set())
+    @patch("oduflow.docker_ops.env_ops.allocate_port", return_value=50000)
+    @patch("oduflow.docker_ops.env_ops.subprocess.run")
+    @patch("oduflow.docker_ops.env_ops.os.chmod")
+    @patch("oduflow.docker_ops.env_ops.os.makedirs")
+    @patch("oduflow.docker_ops.env_ops.os.path.exists", return_value=False)
+    def test_create_rolls_back_on_run_failure(
+        self,
+        mock_exists,
+        mock_makedirs,
+        mock_chmod,
+        mock_run,
+        mock_alloc,
+        mock_used,
+        mock_mount,
+        mock_db_exists,
+        mock_sql,
+        mock_uid_gid,
+        mock_ready,
+        mock_creds,
+        mock_role,
+        mock_copy_conf,
+        mock_gen_conf,
+        mock_cleanup,
+        mock_release_port,
+        mock_docker_client,
+    ):
+        # Reach the serving containers.run, then fail it (e.g. bad image / port
+        # bind) and assert the partially-created resources are rolled back (#49).
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.run.side_effect = RuntimeError("bind failed")
+
+        with pytest.raises(RuntimeError, match="bind failed"):
+            env_ops.create_environment(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "feature/payments",
+                "https://github.com/org/repo.git",
+                "odoo:15.0",
+                template_name="base",
+            )
+
+        # Rollback: the allocated port is released and the environment teardown
+        # runs (in addition to the pre-create cleanup at the top of the function).
+        mock_release_port.assert_called_once_with(
+            TEST_TEAM.port_registry_path, "feature/payments"
+        )
+        assert mock_cleanup.call_count == 2
+
     @patch("oduflow.docker_ops.env_ops._db_exists", return_value=True)
     @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
     def test_create_already_exists(
@@ -802,6 +868,26 @@ class TestUpdateEnvironment:
         assert result["image"] == "odoo:17.0"
         assert result["image_updated"] is True
         assert result["env_vars"] == {"FOO": "new"}
+
+    def test_update_aborts_when_image_unavailable(self, mock_docker_client):
+        # Image can't be pulled and isn't local: abort WITHOUT removing the old
+        # container, so the env is never left with no container (#49).
+        from oduflow.errors import PrerequisiteNotMetError
+
+        container = self._make_container()
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.images.pull.side_effect = RuntimeError("network down")
+        mock_docker_client.images.get.side_effect = docker.errors.ImageNotFound("nf")
+
+        with pytest.raises(PrerequisiteNotMetError, match="could not be pulled"):
+            env_ops.update_environment(
+                TEST_SETTINGS, TEST_TEAM, "main", image_override="odoo:99.0"
+            )
+
+        # The existing container must be left running.
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
 
     @patch(
         "oduflow.docker_ops.env_ops._install_pip_requirements", return_value=(False, "")

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -879,6 +879,7 @@ class TestDeleteEnvironment:
         mock_docker_client,
     ):
         container = MagicMock()
+        container.labels = {"oduflow.team": "1"}
         mock_docker_client.containers.get.return_value = container
 
         env_ops.delete_environment(TEST_SETTINGS, TEST_TEAM, "feature/payments")
@@ -933,12 +934,24 @@ class TestRestartEnvironment:
 class TestStopEnvironment:
     def test_stop(self, mock_docker_client):
         container = MagicMock()
+        container.labels = {"oduflow.team": "1"}
         mock_docker_client.containers.get.return_value = container
 
         result = env_ops.stop_environment(TEST_SETTINGS, TEST_TEAM, "main")
 
         assert "oduflow-main-odoo" in result["stopped"]
         container.stop.assert_called_once()
+
+    def test_stop_rejects_other_team_container(self, mock_docker_client):
+        # Container names are not team-namespaced; a caller scoped to team 1
+        # must not stop a container labelled for team 2 (issue #39).
+        container = MagicMock()
+        container.labels = {"oduflow.team": "2"}
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(NotFoundError, match="does not exist"):
+            env_ops.stop_environment(TEST_SETTINGS, TEST_TEAM, "main")
+        container.stop.assert_not_called()
 
 
 class TestStartEnvironment:

--- a/tests/test_pg_role.py
+++ b/tests/test_pg_role.py
@@ -1,0 +1,28 @@
+"""Regression test for issue #40: env DB roles must not be superuser members."""
+
+from unittest.mock import MagicMock, patch
+
+from oduflow.docker_ops import system_ops
+from oduflow.settings import Settings, TeamSettings
+
+
+def test_create_pg_role_revokes_superuser_membership():
+    settings = Settings(teams={"1": TeamSettings(team_id="1")})
+    client = MagicMock()
+
+    issued: list[str] = []
+
+    def _fake_exec(_client, _settings, sql, db=None):
+        issued.append(sql)
+        return ""
+
+    with patch.object(system_ops, "_exec_sql", side_effect=_fake_exec):
+        system_ops._create_pg_role(
+            client, settings, "u_1_main", "secretpw", "oduflow_1_main"
+        )
+
+    # Must REVOKE superuser-role membership and must NOT grant it.
+    assert any(
+        s.strip().startswith("REVOKE") and settings.db_user in s for s in issued
+    ), issued
+    assert not any("GRANT" in s for s in issued), issued

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -76,7 +76,7 @@ class TestCreateEnvironmentTool:
             "create_environment",
             branch="main",
             template_name="none",
-            repo_url="https://repo.url",
+            repo_url="https://8.8.8.8/repo.git",
             odoo_image="odoo:17.0",
         )
         assert "Environment provisioned successfully!" in result
@@ -95,7 +95,7 @@ class TestCreateEnvironmentTool:
             "create_environment",
             branch="main",
             template_name="none",
-            repo_url="https://repo.url",
+            repo_url="https://8.8.8.8/repo.git",
             odoo_image="odoo:17.0",
             env_vars="FOO=bar,BAZ=qux",
         )
@@ -117,7 +117,7 @@ class TestCreateEnvironmentTool:
             "create_environment",
             branch="main",
             template_name="none",
-            repo_url="https://repo.url",
+            repo_url="https://8.8.8.8/repo.git",
             odoo_image="odoo:17.0",
         )
         assert mock_create.call_args.kwargs["env_vars"] is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -680,3 +680,41 @@ class TestRestoreServiceTool:
         assert kwargs["privileged"] is False
         assert kwargs["host_mode"] is False
         assert kwargs["volumes"] is None
+
+
+class TestHttpFailClosed:
+    def test_start_http_refuses_without_auth(self):
+        # Issue #37: HTTP transport must not serve /mcp unauthenticated.
+        from oduflow import server
+        from oduflow.errors import PrerequisiteNotMetError
+
+        settings = Settings(
+            host="127.0.0.1",
+            teams={"1": TeamSettings(team_id="1")},
+            allow_insecure_http=False,
+        )
+        with (
+            patch.object(server, "_get_settings", return_value=settings),
+            patch.object(server, "_build_auth", return_value=None),
+        ):
+            with pytest.raises(PrerequisiteNotMetError, match="HTTP transport"):
+                server._start_http()
+
+    def test_start_http_allows_insecure_with_flag(self):
+        from oduflow import server
+
+        settings = Settings(
+            host="127.0.0.1",
+            teams={"1": TeamSettings(team_id="1")},
+            allow_insecure_http=True,
+        )
+        with (
+            patch.object(server, "_get_settings", return_value=settings),
+            patch.object(server, "_build_auth", return_value=None),
+            patch("fastmcp.server.http.create_streamable_http_app"),
+            patch("oduflow.web_ui.mount_web_ui"),
+            patch("oduflow.reaper.start_reaper"),
+            patch("uvicorn.run") as mock_uvicorn,
+        ):
+            server._start_http()
+            mock_uvicorn.assert_called_once()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,7 +6,8 @@ class TestSettings:
     def test_lifecycle_defaults(self):
         s = Settings(teams={"1": TeamSettings(team_id="1")})
         assert s.auto_stop_hours == 48
-        assert s.auto_delete_hours == 72
+        # auto-delete is destructive, so it is opt-in (disabled by default).
+        assert s.auto_delete_hours == 0
 
     def test_lifecycle_from_toml(self, tmp_path):
         toml = tmp_path / "oduflow.toml"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -39,6 +39,22 @@ class TestSettings:
         with pytest.raises(ValueError, match="invalid port range"):
             s.validate()
 
+    def test_validate_overlapping_port_ranges(self):
+        # Two teams left on the default (identical) range would draw host ports
+        # from the same pool — issue #46.
+        t1 = TeamSettings(team_id="1", port_range_start=50000, port_range_end=50100)
+        t2 = TeamSettings(team_id="2", port_range_start=50050, port_range_end=50150)
+        s = Settings(teams={"1": t1, "2": t2})
+        with pytest.raises(ValueError, match="overlapping port ranges"):
+            s.validate()
+
+    def test_validate_adjacent_port_ranges_ok(self):
+        # Half-open ranges that merely touch at the boundary do not overlap.
+        t1 = TeamSettings(team_id="1", port_range_start=50000, port_range_end=50100)
+        t2 = TeamSettings(team_id="2", port_range_start=50100, port_range_end=50200)
+        s = Settings(teams={"1": t1, "2": t2})
+        s.validate()
+
     def test_frozen(self):
         s = Settings()
         with pytest.raises(AttributeError):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -9,6 +9,14 @@ class TestSettings:
         # auto-delete is destructive, so it is opt-in (disabled by default).
         assert s.auto_delete_hours == 0
 
+    def test_malformed_port_range_raises(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[team.1]\nhostname = "localhost"\nport_range = [50000]\n'
+        )
+        with pytest.raises(ValueError, match="port_range"):
+            Settings.from_toml(str(toml))
+
     def test_lifecycle_from_toml(self, tmp_path):
         toml = tmp_path / "oduflow.toml"
         toml.write_text(

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,55 @@
+"""Tests for the SSRF guard (issue #45)."""
+
+import pytest
+
+from oduflow.url_safety import (
+    BlockedURLError,
+    assert_allowed_host,
+    assert_allowed_url,
+)
+
+
+def test_public_ip_allowed():
+    assert_allowed_host("8.8.8.8")
+    assert_allowed_host("8.8.8.8", allow_private=True)
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "169.254.169.254", "0.0.0.0", "::1", "224.0.0.1"],
+)
+def test_never_legitimate_hosts_blocked_even_with_allow_private(host):
+    # Loopback, cloud-metadata link-local, unspecified, multicast: blocked even
+    # for internal git hosts.
+    with pytest.raises(BlockedURLError):
+        assert_allowed_host(host, allow_private=True)
+
+
+@pytest.mark.parametrize("host", ["10.0.0.1", "192.168.1.10", "172.16.5.5"])
+def test_private_blocked_by_default(host):
+    with pytest.raises(BlockedURLError):
+        assert_allowed_host(host)  # allow_private=False
+
+
+@pytest.mark.parametrize("host", ["10.0.0.1", "192.168.1.10", "172.16.5.5"])
+def test_private_allowed_when_opted_in(host):
+    # Internal git servers (validate_repo_url passes allow_private=True).
+    assert_allowed_host(host, allow_private=True)
+
+
+def test_require_https():
+    with pytest.raises(BlockedURLError, match="https"):
+        assert_allowed_url("http://8.8.8.8/x", require_https=True)
+    assert_allowed_url("https://8.8.8.8/x", require_https=True)
+
+
+def test_missing_host():
+    with pytest.raises(BlockedURLError):
+        assert_allowed_host("")
+
+
+def test_metadata_url_blocked():
+    with pytest.raises(BlockedURLError):
+        assert_allowed_url(
+            "http://169.254.169.254/latest/meta-data/", allow_private=True
+        )

--- a/tests/test_volume_ops.py
+++ b/tests/test_volume_ops.py
@@ -308,22 +308,39 @@ class TestResolveVolumeBinds:
             volume_ops.resolve_volume_binds(TEST_TEAM, mounts)
 
     def test_resolve_external_volume(self, mock_docker_client):
-        """External volume is used as-is when managed name doesn't exist."""
+        """A genuinely external (non-Oduflow) volume is used as-is when the
+        team-scoped name doesn't exist."""
 
         def _get(name):
-            if name == "oduflow-vol-1-oduflow-traefik-acme":
+            if name == "oduflow-vol-1-my-external-data":
                 raise docker.errors.NotFound("nf")
             return MagicMock()  # original name exists
 
         mock_docker_client.volumes.get.side_effect = _get
 
         mounts = [
-            {"volume": "oduflow-traefik-acme", "mount_path": "/acme", "mode": "ro"}
+            {"volume": "my-external-data", "mount_path": "/data", "mode": "ro"}
         ]
         result = volume_ops.resolve_volume_binds(TEST_TEAM, mounts)
 
-        assert "oduflow-traefik-acme" in result
-        assert result["oduflow-traefik-acme"] == {"bind": "/acme", "mode": "ro"}
+        assert "my-external-data" in result
+        assert result["my-external-data"] == {"bind": "/data", "mode": "ro"}
+
+    @pytest.mark.parametrize(
+        "reserved",
+        ["oduflow-db-data", "oduflow-traefik-acme", "oduflow-vol-2-secret"],
+    )
+    def test_resolve_rejects_reserved_oduflow_volume(
+        self, mock_docker_client, reserved
+    ):
+        """Raw-name fallback must never reach an Oduflow-managed volume — the
+        shared DB data, a system volume, or another team's volume (issue #40)."""
+        # The team-scoped lookup misses, so the code falls back to the raw name.
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        mounts = [{"volume": reserved, "mount_path": "/x", "mode": "rw"}]
+        with pytest.raises(NotFoundError, match="reserved"):
+            volume_ops.resolve_volume_binds(TEST_TEAM, mounts)
 
     def test_resolve_empty(self, mock_docker_client):
         result = volume_ops.resolve_volume_binds(TEST_TEAM, [])

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -195,6 +195,20 @@ def test_login_wrong_password_rejected():
     assert _AUTH_COOKIE not in resp.headers.get("set-cookie", "")
 
 
+def test_login_rate_limited_after_repeated_failures():
+    # Issue #56: the login endpoint must throttle brute-force attempts.
+    client = TestClient(_full_app(_settings()))
+    for _ in range(10):
+        resp = client.post(
+            "/login", data={"password": "nope"}, follow_redirects=False
+        )
+        assert resp.status_code == 401
+    # The 11th attempt (and beyond) is locked out, even with the right password.
+    resp = client.post("/login", data={"password": _PW}, follow_redirects=False)
+    assert resp.status_code == 429
+    assert _AUTH_COOKIE not in resp.headers.get("set-cookie", "")
+
+
 def test_login_redirects_when_already_authenticated():
     settings = _settings()
     token = _make_ui_token(_team(settings), settings)

--- a/tests/test_web_ui_create_lock.py
+++ b/tests/test_web_ui_create_lock.py
@@ -1,0 +1,71 @@
+"""Regression test for issue #42.
+
+api_create acquired the env lock inside the try whose finally always released
+it, so a BusyError (the lock is held by another in-flight request) caused the
+failing request to release a lock it never owned. The fix acquires the lock in
+its own try and only releases it in a finally that runs solely when this request
+acquired it.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.errors import BusyError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _open_settings(tmp_path):
+    # No ui_password -> the UI mounts without auth, so the POST reaches api_create.
+    return Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1")},
+    )
+
+
+def test_api_create_busy_keeps_foreign_lock(tmp_path):
+    settings = _open_settings(tmp_path)
+    locks = LockManager()
+    # Request A holds the env lock for "main".
+    locks.acquire_env("main")
+
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, locks)
+    client = TestClient(app)
+
+    with patch("oduflow.web_ui.env_ops.create_environment") as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={"env_name": "main", "repo_url": "r", "odoo_image": "i"},
+        )
+        # The busy request must never start real provisioning.
+        create.assert_not_called()
+
+    assert resp.json()["ok"] is False  # reported busy
+
+    # The lock held by request A must still be held: the failed request must not
+    # have released it. A fresh acquire therefore still reports busy.
+    with pytest.raises(BusyError):
+        locks.acquire_env("main")
+
+
+def test_api_create_invalid_json_no_lock_error(tmp_path):
+    # A malformed body must not raise on the finally (env_name was unbound before
+    # the fix) — it should return a clean 400.
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/environments/create",
+        content=b"not json",
+        headers={"content-type": "application/json"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["ok"] is False


### PR DESCRIPTION
## Security & bug audit — remediation

This branch fixes the issues from the security/bug audit (`litnimax/security-bug-audit`). Each fix is a self-contained commit referencing its issue, with unit tests (62 new tests; full unit suite green at 523 passed). Fixes were chosen to be **non-breaking for live deployments** — e.g. team isolation is enforced by verifying the `oduflow.team` label rather than renaming containers, and the env-DB superuser-grant removal was validated against a real `postgres:15` (DDL/DML still work for the env role; `SET ROLE` to the superuser is denied).

### Critical
- **Closes #37** — HTTP transport is now authenticated by default: bootstrap generates a random `auth_token`, and `_start_http` refuses to start with no MCP auth unless `[server] allow_insecure_http = true`.
- **Closes #38** — `template_name` validated at both derivation chokepoints → blocks path traversal and SQL injection.

### High
- **Closes #39** — verify team ownership (`oduflow.team` label) before start/stop/restart/delete/logs.
- **Closes #40** — env DB roles no longer get superuser-role membership (comprehensive per-object ownership transfer instead); raw-name mounts of reserved `oduflow-*` volumes rejected.
- **Closes #41** — refuse `create_environment` when the branch normalises to an in-use database (was dropping a running env's DB).
- **Closes #42** — `api_create` no longer releases a lock owned by another request.
- **Closes #43** — zip-slip guard on `import_from_odoo` archive extraction.

### Medium
- **Closes #44** — reject dangerous/cleartext OAuth `redirect_uri`s. (Token-model redesign deliberately deferred — it would break the live claude.ai/IDE OAuth; documented in the commit.)
- **Closes #45** — SSRF guards for `import_from_odoo` and git remote URLs.
- **Closes #46** — validate non-overlapping team port ranges (the locking/atomic sub-issues were already fixed upstream).
- **Closes #47** — `get_client()` raises `PrerequisiteNotMetError`, not `SystemExit`.
- **Closes #48** — `cleanup_orphans` passes `TeamSettings` (was silently removing nothing).
- **Closes #49** — roll back a partial `create_environment`; validate the image before `update_environment` removes the old container.
- **Closes #51** — classify each extra-addon worktree against its own repo/HEAD and merge recommendations.
- **Closes #56** — per-IP rate limiting on failed Web UI logins.
- **Closes #57** — destructive `auto_delete_hours` defaults to 0 (opt-in).

### Low / hardening
- **Closes #53** — constant-time secret compares, atomic credential writes (0600), port_range validation, dead-code removal. (Error-disclosure scrubbing and moving DB passwords off the CLI deferred as higher-risk; documented in the commit.)

### Already fixed upstream (closed separately)
- #50 (`oduflow call` await) and #52 (random DB password) landed in `main` before this branch.

## Verification
- `ruff check src/oduflow tests` — clean.
- `pytest -m "not integration and not heavyweight"` — 523 passed (matches CI).
- #40's ownership transfer validated end-to-end against a throwaway `postgres:15` container.

## Notes
- Deferred sub-items for #44 and #53 are documented in their commit messages; happy to file follow-up issues if you'd like them tracked separately.
