### PR TITLE
Import templates from Odoo.sh (push-based, resumable)

### DIFF
--- a/specs/0023-import-from-odoo-sh.md
+++ b/specs/0023-import-from-odoo-sh.md
@@ -1,0 +1,98 @@
+# 0023 — Import a template from Odoo.sh via a push-based, resumable shell client
+
+**Status:** Adopted (still in force)
+**Type:** Architecture / Capability
+**First introduced:** `import-from-odoosh` branch (2026-07-02)
+**Key code today:** `import_tokens.py` (short-lived upload tokens), `web_ui.py` (`/import-odoo.sh` + `/api/templates/import/*` ingest endpoints, `import-token` mint), `docker_ops/system_ops.py` (`finalize_imported_template`, `extract_filestore_tar`, reusing `reload_template`), `templates/import-odoo.sh` (the client), dashboard "Import from Odoo.sh" button
+
+## Context
+
+Oduflow could already seed a template from a *running* Odoo via
+[[0003-database-templates-and-filestore-isolation]]: `import_from_odoo` pulls a
+`.zip` from `/web/database/backup` (SQL dump + filestore + manifest). That path
+does not work against **Odoo.sh**, which is where many real customer databases
+live. Investigation of a live Odoo.sh instance established the constraints:
+
+- The SSH tenant role is deliberately restricted — no `pg_roles`, `pg_settings`,
+  or `pg_authid` — so `pg_dump` fails at startup on **every** client version. A
+  shell cannot produce its own logical dump.
+- The Odoo web workers are not reachable from the SSH container (no local
+  `:8069`), and `/web/database/manager` is disabled on the public URL, so the
+  existing pull-based importer has nothing to talk to.
+- However, on **production** builds the platform writes a ready-made daily
+  backup under `~/backup.daily/<db>_daily.{sql.gz,json,/}` — a plain-SQL dump
+  (already `psql`-restorable), a manifest, and the filestore tree — created by
+  privileged infrastructure. This is the only complete, restorable artifact a
+  shell can reach.
+- The filestore is ~10 GB while free disk is often less, so no full intermediate
+  archive can be staged locally: the transfer must stream.
+
+So the direction of transport has to invert. Oduflow cannot reach *in*; the
+Odoo.sh shell must push *out*.
+
+## Decision
+
+Add a **push-based import**: a one-line client script, fetched from the Oduflow
+server and run inside the Odoo.sh shell, locates the latest daily backup and
+streams it to Oduflow, which lays it out as a template and restores it through
+the **existing** template machinery. Authorization is a **short-lived,
+single-purpose token** minted by a dashboard button, not the UI password.
+
+## How it works (macro)
+
+- **Token.** The dashboard "Import from Odoo.sh" button calls a UI-authed
+  endpoint that mints a random token (15 min TTL) bound to the target template
+  name and returns a ready-to-paste command. The token is one JSON file per
+  team carrying only auth + the target template; it is deleted on finalize or
+  expiry. A stale token left in terminal scrollback is inert.
+- **Resume is disk-derived, not token-derived.** `status` reports what is
+  actually staged in the template directory (metadata written → manifest done;
+  `dump.sql.gz` present → dump done; each hash-dir present → that chunk done,
+  since a chunk dir only appears after its tar was received in full and
+  extracted). Keeping resume state on disk rather than in the token means a
+  fresh token minted for the same template — e.g. after the first expired
+  mid-upload — still continues from what already landed.
+- **Client (`import-odoo.sh`).** Served unauthenticated from `/import-odoo.sh`.
+  It reads `$PGDATABASE`, finds `~/backup.daily/<db>_daily.*` (erroring cleanly
+  if absent — daily backups exist only on production builds), asks the server
+  what it already has, and uploads only the missing pieces. Nothing large hits
+  disk: the filestore is `tar`-streamed **per top-level hash directory** (256
+  dirs + `checklist`) straight into the upload. It prints an aggregate
+  percentage computed from per-chunk sizes.
+- **Ingest endpoints.** `/api/templates/import/{status,manifest,dump,filestore,
+  finalize}` authenticate by token (a `Bearer` header), so they bypass Basic
+  auth while the mint endpoint stays behind the UI login. `manifest` writes
+  `metadata.json` (Odoo image from `odoo_branch`, module list); `dump` streams
+  `dump.sql.gz`; `filestore?chunk=<hash>` unpacks one tar chunk into the
+  template filestore with a zip-slip guard; `finalize` runs the restore.
+- **Reuse, not reinvention.** By the time `finalize` runs, the template
+  directory already holds exactly what `import_from_odoo` produces
+  (`dump.sql.gz` + `filestore/` + `metadata.json`), so finalize is the shared
+  tail: chown the filestore, remount live overlay envs non-destructively, and
+  call the unchanged `reload_template` (which already handles gzip'd plain-SQL
+  dumps via `gunzip | psql`).
+
+## Consequences
+
+- **Resumable by construction.** Progress is read from the staged files at
+  manifest / dump / per-chunk granularity, so a dropped 10 GB transfer resumes
+  where it stopped instead of restarting; re-running the same command — even
+  with a freshly minted token — is safe and idempotent.
+- **No new dump technology.** The design rides the platform's own backup and
+  Oduflow's own restore path; the only new server logic is streaming ingest +
+  token auth. The restore tolerates the dump's `\restrict`/`OWNER TO` lines the
+  same way it already tolerates external dumps (psql without `ON_ERROR_STOP`).
+- **Production-only source.** Daily backups are kept on production builds; on
+  staging/dev the client reports "backup not found" rather than inventing one.
+  There is no fallback to `_manual`/`_update` backups by design (keep it
+  unambiguous).
+- **New public surface.** Two path families become reachable without the UI
+  password (`/import-odoo.sh`, `/api/templates/import/`); they are gated instead
+  by the expiring token, and the mint endpoint stays authed.
+
+## History
+
+- `import-from-odoosh` (2026-07-02) — push-based Odoo.sh import: `import_tokens`
+  module, `/import-odoo.sh` client + `/api/templates/import/*` ingest endpoints,
+  `finalize_imported_template`/`extract_filestore_tar` reusing `reload_template`,
+  and the dashboard "Import from Odoo.sh" button.

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,6 +41,7 @@ precursors).
 | [0020](0020-authentication-oauth.md) | 2026-03-13 | Authentication for MCP HTTP: GitHub OAuth → self-hosted OAuth Authorization Server |
 | [0021](0021-code-delivery-modes.md) | 2026-06-12 | Code delivery modes: `repo_url` git push vs `local_path` live-mount + `pull_and_apply` guardrail |
 | [0022](0022-engineers-console-design-system.md) | 2026-06-12 | The Engineer's Console: dashboard design system + lifecycle automation |
+| [0023](0023-import-from-odoo-sh.md) | 2026-07-02 | Import a template from Odoo.sh via a push-based, resumable shell client |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1432,6 +1432,92 @@ def import_from_odoo(
     }
 
 
+def extract_filestore_tar(tar_path: str, dest_dir: str) -> int:
+    """Extract a tar stream (one Odoo filestore hash-dir) into ``dest_dir``.
+
+    Used by the push-based Odoo.sh import: the client streams ``tar -C
+    <filestore> -cf - <chunk>`` per top-level hash directory, and this unpacks
+    it into the template's ``filestore/``. Members that would escape the
+    destination (zip-slip) or are not regular files/dirs are skipped. Returns
+    the number of files written.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    written = 0
+    with tarfile.open(tar_path, "r:*") as tf:
+        for member in tf:
+            target = os.path.join(dest_dir, member.name)
+            if not _is_within_directory(dest_dir, target):
+                logger.warning(
+                    "Skipping unsafe tar member outside filestore: %s", member.name
+                )
+                continue
+            if member.isdir():
+                os.makedirs(target, exist_ok=True)
+            elif member.isfile():
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                src = tf.extractfile(member)
+                if src is None:
+                    continue
+                with src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                written += 1
+            # symlinks/devices/etc. are intentionally ignored — Odoo filestores
+            # contain only regular files and directories.
+    return written
+
+
+def finalize_imported_template(
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str,
+    *,
+    major_version: str = "",
+) -> dict[str, object]:
+    """Load an already-staged template (dump + filestore + metadata on disk).
+
+    The push-based Odoo.sh import uploads the pieces incrementally, so by the
+    time this runs the template directory already contains ``dump.sql.gz``,
+    ``filestore/`` and ``metadata.json``. This mirrors the tail of
+    :func:`import_from_odoo`: chown the filestore for the odoo user, remount
+    live overlay envs against the new lower (non-destructive), refresh sizes,
+    then restore the dump into the template DB.
+    """
+    from oduflow.docker_ops import env_ops
+
+    client = get_client()
+    template_filestore_path = team.get_template_filestore_path(template_name)
+
+    with env_ops.remount_template_overlays(
+        client, settings, team, template_name
+    ) as remount:
+        if major_version:
+            try:
+                uid_gid = get_odoo_uid_gid(client, f"odoo:{major_version}")
+                uid_str, gid_str = uid_gid.split(":")
+                chown_recursive(
+                    template_filestore_path,
+                    int(uid_str),
+                    int(gid_str),
+                    client,
+                    f"odoo:{major_version}",
+                )
+                logger.info("Template filestore chowned to %s", uid_gid)
+            except Exception as exc:  # noqa: BLE001 - chown is best-effort
+                logger.warning("Could not chown template filestore: %s", exc)
+
+    _update_template_sizes(team, settings, template_name)
+    result = reload_template(settings, team, template_name=template_name)
+
+    return {
+        "status": "imported",
+        "template_name": template_name,
+        "template_db": result["template_db"],
+        "restore_seconds": result.get("restore_seconds", 0),
+        "affected_envs": remount.affected,
+        "remount_failures": remount.failures,
+    }
+
+
 def cleanup_orphans(
     settings: Settings, team: TeamSettings, dry_run: bool = True
 ) -> dict:

--- a/src/oduflow/import_tokens.py
+++ b/src/oduflow/import_tokens.py
@@ -1,0 +1,137 @@
+"""Short-lived, file-backed tokens for pushing an Odoo.sh backup into a template.
+
+The dashboard mints a token (15 min TTL) bound to a target template name; the
+`import-odoo.sh` client running in the Odoo.sh shell presents that token on every
+ingest call. Because the token expires quickly, a copy left in the terminal
+scrollback is useless afterwards.
+
+Each token is one JSON file under ``<team.data_dir>/import_tokens/<token>.json``.
+The token carries only auth + the target template; it deliberately does NOT
+store upload progress. Resume is instead derived from what is actually staged on
+disk in the template directory (see ``web_ui``), so a re-run — even with a freshly
+minted token after the previous one expired mid-upload — continues where it left
+off instead of restarting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import threading
+import time
+
+from oduflow.errors import NotFoundError, PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+# token_urlsafe(24) yields 32 url-safe chars; accept that shape only so a token
+# taken from the URL/header can never be a path-traversal segment.
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{16,64}$")
+_DEFAULT_TTL_SECONDS = 15 * 60
+_lock = threading.Lock()
+
+
+def _tokens_dir(team: TeamSettings) -> str:
+    return os.path.join(team.data_dir, "import_tokens")
+
+
+def _token_path(team: TeamSettings, token: str) -> str:
+    return os.path.join(_tokens_dir(team), f"{token}.json")
+
+
+def _write(team: TeamSettings, record: dict[str, object]) -> None:
+    path = _token_path(team, str(record["token"]))
+    tmp = f"{path}.tmp"
+    with _lock:
+        os.makedirs(_tokens_dir(team), exist_ok=True)
+        with open(tmp, "w") as f:
+            json.dump(record, f, indent=2)
+        os.replace(tmp, path)
+
+
+def _remove(team: TeamSettings, token: str) -> None:
+    try:
+        os.remove(_token_path(team, token))
+    except OSError:
+        pass
+
+
+def _cleanup_expired(team: TeamSettings, *, now: float) -> None:
+    directory = _tokens_dir(team)
+    if not os.path.isdir(directory):
+        return
+    for name in os.listdir(directory):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(directory, name)
+        try:
+            with open(path) as f:
+                record = json.load(f)
+            expired = float(record.get("expires_at", 0)) < now
+        except (OSError, ValueError):
+            expired = True  # unreadable/garbage token file — drop it
+        if expired:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+def create_token(
+    team: TeamSettings,
+    template_name: str,
+    *,
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+    now: float | None = None,
+) -> dict[str, object]:
+    """Mint a token bound to ``template_name`` and persist it. Also reaps any
+    expired tokens for this team so the directory does not grow unbounded."""
+    from oduflow.naming import validate_template_name
+
+    validate_template_name(template_name)
+    now = time.time() if now is None else now
+    _cleanup_expired(team, now=now)
+    record = {
+        "token": secrets.token_urlsafe(24),
+        "team_id": team.team_id,
+        "template_name": template_name,
+        "created_at": now,
+        "expires_at": now + ttl_seconds,
+    }
+    _write(team, record)
+    return record
+
+
+def load_token(
+    settings: Settings, token: str, *, now: float | None = None
+) -> tuple[TeamSettings, dict[str, object]]:
+    """Resolve a token to ``(team, record)``, searching across all teams.
+
+    Raises NotFoundError for an unknown/malformed token and
+    PrerequisiteNotMetError for an expired one (which is also deleted).
+    """
+    if not token or not _TOKEN_RE.match(token):
+        raise NotFoundError("Invalid or unknown import token.")
+    now = time.time() if now is None else now
+    for team in settings.teams.values():
+        path = _token_path(team, token)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as f:
+                record = json.load(f)
+        except (OSError, ValueError):
+            raise NotFoundError("Invalid or unknown import token.")
+        if float(record.get("expires_at", 0)) < now:
+            _remove(team, token)
+            raise PrerequisiteNotMetError(
+                "Import token has expired. Generate a new one from the dashboard."
+            )
+        return team, record
+    raise NotFoundError("Invalid or unknown import token.")
+
+
+def invalidate(team: TeamSettings, token: str) -> None:
+    """Delete a token (used once the import is finalized)."""
+    _remove(team, token)

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -996,6 +996,9 @@
 </div>
 
 <div id="tab-templates" class="tab-content">
+  <div class="tab-toolbar">
+    <button class="btn-create" onclick="openImportOdooModal()">Import from Odoo.sh</button>
+  </div>
   <div id="tpl-list"></div>
 </div>
 
@@ -1298,6 +1301,36 @@
       <div class="form-actions">
         <button class="btn" onclick="closeCreateVolumeModal()">Cancel</button>
         <button class="btn-create" id="vol-submit" onclick="submitCreateVolume()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal-overlay" id="import-odoo-modal" onclick="closeImportOdooModal(event)">
+  <div class="modal modal-sm">
+    <div class="modal-header">
+      <h2>Import from Odoo.sh</h2>
+      <button class="modal-close" onclick="closeImportOdooModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-error" id="import-odoo-error"></div>
+      <div id="import-odoo-form">
+        <div class="form-group">
+          <label for="import-tpl-name">Template name</label>
+          <input type="text" id="import-tpl-name" placeholder="e.g. zipfit-prod">
+          <div class="hint">Restores an Odoo.sh daily backup (database + filestore) into a new template of this name.</div>
+        </div>
+        <div class="form-actions">
+          <button class="btn" onclick="closeImportOdooModal()">Cancel</button>
+          <button class="btn-create" id="import-odoo-submit" onclick="submitImportOdoo()">Generate command</button>
+        </div>
+      </div>
+      <div id="import-odoo-result" style="display:none;">
+        <div class="hint" style="margin-top:0;">Run this inside your Odoo.sh <strong>production</strong> shell. The token is valid for 15 minutes.</div>
+        <pre id="import-odoo-command"></pre>
+        <div class="form-actions">
+          <button class="btn" onclick="closeImportOdooModal()">Close</button>
+          <button class="btn-create" onclick="copyImportOdooCommand()">Copy command</button>
+        </div>
       </div>
     </div>
   </div>
@@ -2380,6 +2413,65 @@ async function doDeleteTemplate(name) {
     }
   } catch (e) {
     showToast('Connection error: ' + e.message, true);
+  }
+}
+
+function openImportOdooModal() {
+  document.getElementById('import-tpl-name').value = '';
+  var errEl = document.getElementById('import-odoo-error');
+  errEl.style.display = 'none';
+  errEl.textContent = '';
+  document.getElementById('import-odoo-form').style.display = '';
+  document.getElementById('import-odoo-result').style.display = 'none';
+  document.getElementById('import-odoo-command').textContent = '';
+  document.getElementById('import-odoo-submit').disabled = false;
+  document.getElementById('import-odoo-submit').textContent = 'Generate command';
+  showModal('import-odoo-modal');
+  document.getElementById('import-tpl-name').focus();
+}
+
+function closeImportOdooModal(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('import-odoo-modal');
+}
+
+function copyImportOdooCommand() {
+  copyToClipboard(document.getElementById('import-odoo-command').textContent, 'Command copied');
+}
+
+async function submitImportOdoo() {
+  var name = document.getElementById('import-tpl-name').value.trim();
+  var errEl = document.getElementById('import-odoo-error');
+  if (!name) {
+    errEl.textContent = 'Template name is required.';
+    errEl.style.display = 'block';
+    return;
+  }
+  errEl.style.display = 'none';
+  var btn = document.getElementById('import-odoo-submit');
+  btn.disabled = true;
+  btn.textContent = 'Generating...';
+  try {
+    var r = await fetch(API_TEMPLATES + '/import-token', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ template_name: name })
+    });
+    var data = await r.json();
+    if (data.ok) {
+      document.getElementById('import-odoo-command').textContent = data.command;
+      document.getElementById('import-odoo-form').style.display = 'none';
+      document.getElementById('import-odoo-result').style.display = '';
+    } else {
+      errEl.textContent = data.error || 'Failed to generate command';
+      errEl.style.display = 'block';
+    }
+  } catch (e) {
+    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Generate command';
   }
 }
 

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Oduflow — import an Odoo.sh database into an Oduflow template.
+#
+# Run this INSIDE an Odoo.sh shell (production build). It finds the platform's
+# latest daily backup (dump + filestore), then streams it to your Oduflow
+# server, which restores it as a template. Nothing large is written to disk:
+# the filestore is tarred on the fly and streamed straight to the upload.
+#
+# The upload is resumable: on a re-run it asks the server what it already has
+# and only sends the missing pieces (manifest, dump, or individual filestore
+# hash-directories).
+#
+#   curl -sSf https://YOUR-ODUFLOW/import-odoo.sh | bash -s -- \
+#        --server https://YOUR-ODUFLOW --token <TOKEN>
+#
+# The --token is minted by the "Import from Odoo.sh" button in the Oduflow
+# dashboard and is valid for 15 minutes.
+set -euo pipefail
+
+SERVER=""
+TOKEN=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --server) SERVER="${2:-}"; shift 2 ;;
+        --server=*) SERVER="${1#*=}"; shift ;;
+        --token) TOKEN="${2:-}"; shift 2 ;;
+        --token=*) TOKEN="${1#*=}"; shift ;;
+        -h|--help)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -n 20
+            exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$SERVER" ] || { echo "ERROR: --server is required" >&2; exit 2; }
+[ -n "$TOKEN" ]  || { echo "ERROR: --token is required" >&2; exit 2; }
+SERVER="${SERVER%/}"
+
+DB="${PGDATABASE:-}"
+[ -n "$DB" ] || {
+    echo "ERROR: PGDATABASE is not set — run this inside the Odoo.sh shell." >&2
+    exit 2
+}
+
+BK="$HOME/backup.daily/${DB}_daily"
+SQL_GZ="${BK}.sql.gz"
+MANIFEST="${BK}.json"
+FS="${BK}/home/odoo/data/filestore/${DB}"
+
+if [ ! -f "$SQL_GZ" ] || [ ! -f "$MANIFEST" ]; then
+    echo "ERROR: daily backup not found for database '$DB'." >&2
+    echo "       Expected:" >&2
+    echo "         $SQL_GZ" >&2
+    echo "         $MANIFEST" >&2
+    echo "       Daily backups are kept on production builds. If it is missing," >&2
+    echo "       trigger a backup from the Odoo.sh dashboard and try again." >&2
+    exit 3
+fi
+if [ ! -d "$FS" ]; then
+    echo "ERROR: filestore directory not found: $FS" >&2
+    exit 3
+fi
+
+AUTH="Authorization: Bearer ${TOKEN}"
+API="${SERVER}/api/templates/import"
+
+# ---- helpers ---------------------------------------------------------------
+
+human() {  # bytes -> human readable
+    awk -v b="${1:-0}" 'BEGIN{
+        split("B KB MB GB TB", u, " "); i=1;
+        while (b>=1024 && i<5){ b/=1024; i++ }
+        if (i==1) printf "%d%s", b, u[i]; else printf "%.1f%s", b, u[i]
+    }'
+}
+
+json_field() {  # file expr  (expr is python on obj `d`)
+    python3 -c 'import sys,json
+d=json.load(open(sys.argv[1]))
+print('"$2"')' "$1" 2>/dev/null || true
+}
+
+# ---- status (drives resume) ------------------------------------------------
+
+echo ">> Importing '$DB' into Oduflow at $SERVER"
+
+STATUS_FILE="$(mktemp)"
+trap 'rm -f "$STATUS_FILE"' EXIT
+if ! curl -fsS -H "$AUTH" "${API}/status" -o "$STATUS_FILE" 2>/dev/null; then
+    echo "ERROR: could not reach $SERVER or token is invalid/expired." >&2
+    echo "       Generate a fresh token from the dashboard and retry." >&2
+    exit 4
+fi
+
+have_manifest="$(json_field "$STATUS_FILE" 'd.get("progress",{}).get("manifest") and 1 or ""')"
+have_dump="$(json_field "$STATUS_FILE" 'd.get("progress",{}).get("dump") and 1 or ""')"
+done_chunks=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("filestore_chunks",[]))') "
+
+# ---- manifest --------------------------------------------------------------
+
+if [ -z "$have_manifest" ]; then
+    echo ">> uploading manifest"
+    curl -fsS -H "$AUTH" -H "Content-Type: application/json" \
+        --data-binary @"$MANIFEST" -X POST "${API}/manifest" >/dev/null
+else
+    echo ">> manifest already uploaded, skipping"
+fi
+
+# ---- dump ------------------------------------------------------------------
+
+if [ -z "$have_dump" ]; then
+    echo ">> uploading SQL dump ($(human "$(wc -c < "$SQL_GZ")"))"
+    curl -fsS -H "$AUTH" -H "Content-Type: application/gzip" \
+        --data-binary @"$SQL_GZ" -X POST "${API}/dump" >/dev/null
+else
+    echo ">> SQL dump already uploaded, skipping"
+fi
+
+# ---- filestore (chunked by top-level hash directory) -----------------------
+
+dir_bytes() {  # exact on GNU coreutils (du -sb); KB-approx fallback elsewhere
+    local b
+    if b="$(du -sb "$1" 2>/dev/null | cut -f1)"; then
+        printf '%s' "$b"
+    else
+        b="$(du -sk "$1" | cut -f1)"
+        printf '%s' "$((b * 1024))"
+    fi
+}
+
+chunks=()
+total_bytes=0
+for path in "$FS"/*; do
+    [ -d "$path" ] || continue
+    name="$(basename "$path")"
+    if [[ "$name" =~ ^[0-9a-f]{2}$ ]] || [ "$name" = "checklist" ]; then
+        chunks+=("$name")
+        total_bytes=$((total_bytes + $(dir_bytes "$path")))
+    fi
+done
+
+done_bytes=0
+remaining=()
+for c in "${chunks[@]}"; do
+    if [[ "$done_chunks" == *" $c "* ]]; then
+        done_bytes=$((done_bytes + $(dir_bytes "$FS/$c")))
+    else
+        remaining+=("$c")
+    fi
+done
+
+progress() {  # done total label
+    local pct=0
+    [ "$2" -gt 0 ] && pct=$(( $1 * 100 / $2 ))
+    printf '\r>> filestore [%3d%%] %s / %s  %-14s\033[K' \
+        "$pct" "$(human "$1")" "$(human "$2")" "$3" >&2
+}
+
+upload_chunk() {  # name
+    local c="$1" tries=0
+    while :; do
+        if tar -C "$FS" -cf - "$c" \
+            | curl -fsS -H "$AUTH" -H "Content-Type: application/x-tar" \
+                   --data-binary @- -X POST "${API}/filestore?chunk=${c}" >/dev/null; then
+            return 0
+        fi
+        tries=$((tries + 1))
+        [ "$tries" -ge 3 ] && return 1
+        sleep 2
+    done
+}
+
+echo ">> filestore: $(human "$total_bytes") in ${#chunks[@]} chunks (${#remaining[@]} to upload)"
+for c in "${remaining[@]}"; do
+    progress "$done_bytes" "$total_bytes" "uploading $c"
+    if ! upload_chunk "$c"; then
+        echo >&2
+        echo "ERROR: failed to upload filestore chunk '$c' after retries." >&2
+        echo "       Re-run the same command to resume from here." >&2
+        exit 5
+    fi
+    done_bytes=$((done_bytes + $(dir_bytes "$FS/$c")))
+    progress "$done_bytes" "$total_bytes" "done $c"
+done
+progress "$total_bytes" "$total_bytes" "complete"
+echo >&2
+
+# ---- finalize --------------------------------------------------------------
+
+echo ">> finalizing (restoring database — this can take a few minutes)…"
+RESULT_FILE="$(mktemp)"
+trap 'rm -f "$STATUS_FILE" "$RESULT_FILE"' EXIT
+if ! curl -fsS -H "$AUTH" -X POST "${API}/finalize" -o "$RESULT_FILE"; then
+    echo "ERROR: finalize request failed:" >&2
+    cat "$RESULT_FILE" >&2 || true
+    exit 6
+fi
+
+python3 -c 'import sys,json
+d=json.load(open(sys.argv[1]))
+if not d.get("ok"):
+    print(">> ERROR:", d.get("error","unknown error")); sys.exit(1)
+r=d.get("result",{})
+print(">> Done — template ready:", r.get("template_name"))
+print("   DB:", r.get("template_db"), " restore:", r.get("restore_seconds"), "s")' "$RESULT_FILE"

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import secrets
 import threading
 import time
@@ -32,6 +33,7 @@ from oduflow.docker_ops import (
     volume_ops,
 )
 from oduflow import activity
+from oduflow import import_tokens
 from oduflow.docker_ops.odoo_ops import get_environment_logs
 from oduflow.docker_ops.stats import get_container_stats, get_system_stats
 from oduflow.errors import BusyError, FlowError, NotFoundError
@@ -46,8 +48,14 @@ _AUTH_COOKIE = "oduflow_ui_auth"
 # Reachable without authentication: the login flow and static brand assets
 # (so the login page can render its logo/favicon/fonts). /static/ serves only
 # vetted extensions from the packaged assets dir (fonts, icons, xterm).
-_PUBLIC_PATHS = frozenset({"/login", "/logout", "/favicon.ico", "/logo.png"})
-_PUBLIC_PREFIXES = ("/static/",)
+# /import-odoo.sh (the Odoo.sh client script) and the /api/templates/import/*
+# ingest endpoints authenticate with a short-lived import token, not the UI
+# password, so they bypass Basic auth. NOTE: /api/templates/import-token (which
+# mints the token) is deliberately NOT public — it stays behind the UI login.
+_PUBLIC_PATHS = frozenset(
+    {"/login", "/logout", "/favicon.ico", "/logo.png", "/import-odoo.sh"}
+)
+_PUBLIC_PREFIXES = ("/static/", "/api/templates/import/")
 _SESSION_SALT = "oduflow.ui-auth.v1"
 _SESSION_MAX_AGE = 7 * 24 * 3600  # 7 days
 _SECRET_FILENAME = ".ui_session_secret"
@@ -813,6 +821,253 @@ def _build_routes(
             return _error_response(e)
         except Exception as e:
             logger.exception("Unexpected error in api_template_delete")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_team(team.team_id)
+
+    # --- Import from Odoo.sh (push-based template ingest) ------------------
+
+    def _import_token_value(request: Request) -> str:
+        """Read the import token from an Authorization: Bearer header (preferred,
+        keeps it out of URLs/logs) or a ?token= query param as a fallback."""
+        auth = request.headers.get("authorization", "")
+        if auth.startswith("Bearer "):
+            return auth[len("Bearer ") :].strip()
+        return request.query_params.get("token", "").strip()
+
+    def _resolve_import_token(
+        request: Request,
+    ) -> tuple[TeamSettings, dict[str, object]]:
+        return import_tokens.load_token(get_settings(), _import_token_value(request))
+
+    def _import_progress(team: TeamSettings, template_name: str) -> dict[str, object]:
+        """Derive upload progress from what is staged on disk, not from the
+        token — so a re-run (even with a fresh token after the old one expired)
+        resumes from what already landed instead of restarting."""
+        tpl_dir = team.get_template_dir(template_name)  # validates the name
+        manifest = os.path.isfile(team.get_template_metadata_path(template_name))
+        dump = os.path.isfile(os.path.join(tpl_dir, "dump.sql.gz"))
+        fs_dir = team.get_template_filestore_path(template_name)
+        chunks: list[str] = []
+        if os.path.isdir(fs_dir):
+            # A chunk directory exists only after its tar was received in full
+            # and extracted, so its presence means that chunk is complete.
+            for entry in os.listdir(fs_dir):
+                if (
+                    re.fullmatch(r"[0-9a-f]{2}", entry) or entry == "checklist"
+                ) and os.path.isdir(os.path.join(fs_dir, entry)):
+                    chunks.append(entry)
+        return {
+            "manifest": manifest,
+            "dump": dump,
+            "filestore_chunks": sorted(chunks),
+        }
+
+    def import_odoo_script(request: Request) -> Response:
+        script = (_TEMPLATE_DIR / "import-odoo.sh").read_text(encoding="utf-8")
+        return Response(
+            script,
+            media_type="text/x-shellscript; charset=utf-8",
+            headers={"Cache-Control": "no-store"},
+        )
+
+    async def api_import_token(request: Request) -> JSONResponse:
+        """Mint a short-lived import token for a target template (UI-authed)."""
+        team = _get_ui_team(request)
+        try:
+            body = await request.body()
+            data = json.loads(body or b"{}")
+            template_name = str((data or {}).get("template_name") or "").strip()
+            if not template_name:
+                return JSONResponse(
+                    {"ok": False, "error": "template_name is required"},
+                    status_code=400,
+                )
+            from oduflow.naming import validate_template_name
+
+            validate_template_name(template_name)
+            record = import_tokens.create_token(team, template_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except Exception as e:
+            logger.exception("Unexpected error in api_import_token")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+        base = str(request.base_url).rstrip("/")
+        command = (
+            f"curl -sSf {base}/import-odoo.sh | bash -s -- "
+            f"--server {base} --token {record['token']}"
+        )
+        return JSONResponse(
+            {
+                "ok": True,
+                "token": record["token"],
+                "template_name": template_name,
+                "expires_at": record["expires_at"],
+                "command": command,
+            }
+        )
+
+    def api_import_status(request: Request) -> JSONResponse:
+        try:
+            team, record = _resolve_import_token(request)
+            progress = _import_progress(team, str(record["template_name"]))
+        except FlowError as e:
+            return _error_response(e)
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        return JSONResponse(
+            {
+                "ok": True,
+                "template_name": record["template_name"],
+                "progress": progress,
+                "expires_at": record["expires_at"],
+            }
+        )
+
+    async def api_import_manifest(request: Request) -> JSONResponse:
+        try:
+            team, record = _resolve_import_token(request)
+        except FlowError as e:
+            return _error_response(e)
+        body = await request.body()
+        try:
+            manifest = json.loads(body or b"{}")
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid manifest JSON"}, status_code=400
+            )
+
+        template_name = str(record["template_name"])
+        branch = str(manifest.get("odoo_branch") or "").strip()  # e.g. "18.0"
+        metadata = {
+            "odoo_image": f"odoo:{branch}" if branch else "",
+            "repo_url": "",
+            "source": "odoo.sh",
+            "source_db": manifest.get("name", ""),
+            "source_revision": manifest.get("revision", ""),
+            "source_repository": manifest.get("repository", ""),
+            "odoo_version": branch,
+            "modules": manifest.get("installed_modules", {}),
+            "backup_datetime_utc": manifest.get("backup_datetime_utc", ""),
+        }
+        try:
+            tpl_dir = team.get_template_dir(template_name)
+            os.makedirs(tpl_dir, exist_ok=True)
+            with open(team.get_template_metadata_path(template_name), "w") as f:
+                json.dump(metadata, f, indent=2)
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        return JSONResponse({"ok": True})
+
+    async def api_import_dump(request: Request) -> JSONResponse:
+        try:
+            team, record = _resolve_import_token(request)
+        except FlowError as e:
+            return _error_response(e)
+        template_name = str(record["template_name"])
+        try:
+            tpl_dir = team.get_template_dir(template_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        os.makedirs(tpl_dir, exist_ok=True)
+        # Drop any stale dump under other names so get_template_sql_path resolves
+        # to the gzip'd SQL dump we are about to write.
+        for stale in ("dump.pgdump", "dump.sql", "dump.pgdump.gz"):
+            stale_path = os.path.join(tpl_dir, stale)
+            if os.path.isfile(stale_path):
+                os.remove(stale_path)
+        dest = os.path.join(tpl_dir, "dump.sql.gz")
+        tmp = f"{dest}.part"
+        try:
+            with open(tmp, "wb") as f:
+                async for chunk in request.stream():
+                    f.write(chunk)
+            os.replace(tmp, dest)
+        except Exception as e:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            logger.exception("Failed to receive dump for template %s", template_name)
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        return JSONResponse({"ok": True})
+
+    async def api_import_filestore(request: Request) -> JSONResponse:
+        try:
+            team, record = _resolve_import_token(request)
+        except FlowError as e:
+            return _error_response(e)
+        chunk = request.query_params.get("chunk", "").strip()
+        if not re.fullmatch(r"[0-9a-f]{2}|checklist", chunk):
+            return JSONResponse(
+                {"ok": False, "error": f"Invalid filestore chunk '{chunk}'"},
+                status_code=400,
+            )
+        template_name = str(record["template_name"])
+        try:
+            tpl_dir = team.get_template_dir(template_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        fs_dir = team.get_template_filestore_path(template_name)
+        os.makedirs(tpl_dir, exist_ok=True)
+        tmp_tar = os.path.join(tpl_dir, f".chunk_{chunk}.tar")
+        try:
+            with open(tmp_tar, "wb") as f:
+                async for data in request.stream():
+                    f.write(data)
+            system_ops.extract_filestore_tar(tmp_tar, fs_dir)
+        except Exception as e:
+            logger.exception(
+                "Failed to receive filestore chunk %s for %s", chunk, template_name
+            )
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            if os.path.exists(tmp_tar):
+                os.remove(tmp_tar)
+        return JSONResponse({"ok": True})
+
+    def api_import_finalize(request: Request) -> JSONResponse:
+        try:
+            team, record = _resolve_import_token(request)
+        except FlowError as e:
+            return _error_response(e)
+        template_name = str(record["template_name"])
+        try:
+            progress = _import_progress(team, template_name)
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        if not progress["manifest"] or not progress["dump"]:
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "Manifest and SQL dump must be uploaded before finalize.",
+                },
+                status_code=400,
+            )
+        # The Odoo image major (e.g. "18.0") drives the filestore chown; read it
+        # from the staged metadata so finalize does not depend on token state.
+        major_version = ""
+        try:
+            with open(team.get_template_metadata_path(template_name)) as f:
+                major_version = str(json.load(f).get("odoo_version") or "")
+        except (OSError, ValueError):
+            pass
+        try:
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            result = system_ops.finalize_imported_template(
+                get_settings(),
+                team,
+                template_name,
+                major_version=major_version,
+            )
+            import_tokens.invalidate(team, str(record["token"]))
+            return JSONResponse({"ok": True, "result": result})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_import_finalize")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
         finally:
             locks.release_team(team.team_id)
@@ -1661,9 +1916,16 @@ def _build_routes(
         Route("/api/license", api_license, methods=["GET"]),
         Route("/api/license/activate", api_license_activate, methods=["POST"]),
         Route("/api/templates", api_templates, methods=["GET"]),
+        Route("/import-odoo.sh", import_odoo_script, methods=["GET"]),
+        Route("/api/templates/import-token", api_import_token, methods=["POST"]),
+        Route("/api/templates/import/status", api_import_status, methods=["GET"]),
+        Route("/api/templates/import/manifest", api_import_manifest, methods=["POST"]),
+        Route("/api/templates/import/dump", api_import_dump, methods=["POST"]),
         Route(
-            "/api/templates/{name}/delete", api_template_delete, methods=["POST"]
+            "/api/templates/import/filestore", api_import_filestore, methods=["POST"]
         ),
+        Route("/api/templates/import/finalize", api_import_finalize, methods=["POST"]),
+        Route("/api/templates/{name}/delete", api_template_delete, methods=["POST"]),
         Route("/api/environments", api_list, methods=["GET"]),
         Route("/api/environments/create", api_create, methods=["POST"]),
         Route("/api/stats", api_stats, methods=["GET"]),

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -1,0 +1,227 @@
+"""End-to-end tests for the push-based Odoo.sh template import endpoints."""
+
+import io
+import json
+import os
+import tarfile
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.docker_ops import system_ops
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path):
+    # No ui_password -> UI mounts without auth, so token endpoints are reachable.
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team1"))
+    settings = Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": team},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app), settings, team
+
+
+def _mint(client, template_name="zipfit"):
+    r = client.post(
+        "/api/templates/import-token", json={"template_name": template_name}
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["ok"] is True
+    return data["token"], data
+
+
+def _tar_bytes(members):
+    """Build an in-memory tar. `members` maps arcname -> file content (bytes)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def test_import_script_served(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    r = client.get("/import-odoo.sh")
+    assert r.status_code == 200
+    assert "PGDATABASE" in r.text
+    assert "backup.daily" in r.text
+    assert "finalize" in r.text
+
+
+def test_token_command_contains_server_and_token(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, data = _mint(client)
+    assert token in data["command"]
+    assert "/import-odoo.sh" in data["command"]
+    assert data["template_name"] == "zipfit"
+
+
+def test_full_push_flow(tmp_path):
+    client, _settings, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    # status: nothing done yet
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["manifest"] is False
+    assert st["progress"]["filestore_chunks"] == []
+
+    # manifest
+    manifest = {
+        "name": "zipfit-odoo-main-7950600",
+        "odoo_branch": "18.0",
+        "revision": "deadbeef",
+        "repository": "git@github.com:zipfit/odoo.git",
+        "installed_modules": {"standard": "base,web", "custom": "zipfit_x"},
+        "backup_datetime_utc": "2026-07-02 02:09:47",
+    }
+    r = client.post(
+        "/api/templates/import/manifest",
+        headers=hdr,
+        content=json.dumps(manifest).encode(),
+    )
+    assert r.status_code == 200 and r.json()["ok"] is True
+    meta_path = team.get_template_metadata_path("zipfit")
+    meta = json.loads(open(meta_path).read())
+    assert meta["odoo_image"] == "odoo:18.0"
+    assert meta["source"] == "odoo.sh"
+    assert meta["source_db"] == "zipfit-odoo-main-7950600"
+
+    # dump (gzip bytes, contents irrelevant here)
+    r = client.post(
+        "/api/templates/import/dump", headers=hdr, content=b"\x1f\x8bFAKEGZIP"
+    )
+    assert r.status_code == 200 and r.json()["ok"] is True
+    dump_path = os.path.join(team.get_template_dir("zipfit"), "dump.sql.gz")
+    assert os.path.isfile(dump_path)
+
+    # filestore chunk "ab"
+    tar = _tar_bytes({"ab/abcdef0123": b"BLOBDATA"})
+    r = client.post(
+        "/api/templates/import/filestore?chunk=ab", headers=hdr, content=tar
+    )
+    assert r.status_code == 200 and r.json()["ok"] is True
+    extracted = os.path.join(
+        team.get_template_filestore_path("zipfit"), "ab", "abcdef0123"
+    )
+    assert open(extracted, "rb").read() == b"BLOBDATA"
+
+    # status reflects progress
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["manifest"] is True
+    assert st["progress"]["dump"] is True
+    assert st["progress"]["filestore_chunks"] == ["ab"]
+
+    # re-uploading the same chunk does not duplicate it (resume idempotency)
+    client.post("/api/templates/import/filestore?chunk=ab", headers=hdr, content=tar)
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["filestore_chunks"] == ["ab"]
+
+    # finalize (mock the heavy DB restore)
+    with patch.object(
+        system_ops,
+        "finalize_imported_template",
+        return_value={
+            "status": "imported",
+            "template_name": "zipfit",
+            "template_db": "oduflow_template_1_zipfit",
+            "restore_seconds": 1.2,
+            "affected_envs": [],
+            "remount_failures": [],
+        },
+    ) as fin:
+        r = client.post("/api/templates/import/finalize", headers=hdr)
+    assert r.status_code == 200 and r.json()["ok"] is True
+    fin.assert_called_once()
+    assert r.json()["result"]["template_db"] == "oduflow_template_1_zipfit"
+
+    # token invalidated after finalize
+    st = client.get("/api/templates/import/status", headers=hdr)
+    assert st.json()["ok"] is False
+
+
+def test_resume_survives_a_fresh_token(tmp_path):
+    """Progress is derived from disk, so a brand-new token (minted after the
+    previous one expired mid-upload) sees what already landed."""
+    client, _s, _t = _client(tmp_path)
+    token_a, _ = _mint(client, "zipfit")
+    hdr_a = {"Authorization": f"Bearer {token_a}"}
+    manifest = {"name": "db", "odoo_branch": "18.0", "installed_modules": {}}
+    client.post(
+        "/api/templates/import/manifest",
+        headers=hdr_a,
+        content=json.dumps(manifest).encode(),
+    )
+    client.post("/api/templates/import/dump", headers=hdr_a, content=b"gz")
+    client.post(
+        "/api/templates/import/filestore?chunk=00",
+        headers=hdr_a,
+        content=_tar_bytes({"00/x": b"y"}),
+    )
+
+    # A different token for the same template still reports the staged progress.
+    token_b, _ = _mint(client, "zipfit")
+    st = client.get(
+        "/api/templates/import/status",
+        headers={"Authorization": f"Bearer {token_b}"},
+    ).json()
+    assert st["progress"]["manifest"] is True
+    assert st["progress"]["dump"] is True
+    assert st["progress"]["filestore_chunks"] == ["00"]
+
+
+def test_finalize_requires_manifest_and_dump(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, _ = _mint(client)
+    hdr = {"Authorization": f"Bearer {token}"}
+    r = client.post("/api/templates/import/finalize", headers=hdr)
+    assert r.status_code == 400
+    assert r.json()["ok"] is False
+
+
+def test_invalid_chunk_rejected(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, _ = _mint(client)
+    hdr = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/api/templates/import/filestore?chunk=../evil", headers=hdr, content=b"x"
+    )
+    assert r.status_code == 400
+
+
+def test_bad_token_rejected(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    r = client.get(
+        "/api/templates/import/status",
+        headers={"Authorization": "Bearer not-a-real-token"},
+    )
+    assert r.json()["ok"] is False
+
+
+def test_filestore_tar_zip_slip_is_skipped(tmp_path):
+    dest = tmp_path / "fs"
+    dest.mkdir()
+    tar_path = tmp_path / "evil.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        data = b"pwn"
+        info = tarfile.TarInfo(name="../escape")
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+        good = b"ok"
+        info2 = tarfile.TarInfo(name="ab/file")
+        info2.size = len(good)
+        tf.addfile(info2, io.BytesIO(good))
+    written = system_ops.extract_filestore_tar(str(tar_path), str(dest))
+    assert written == 1
+    assert (dest / "ab" / "file").read_bytes() == b"ok"
+    assert not (tmp_path / "escape").exists()

--- a/tests/test_import_tokens.py
+++ b/tests/test_import_tokens.py
@@ -1,0 +1,73 @@
+"""Unit tests for the short-lived Odoo.sh import tokens."""
+
+import os
+
+import pytest
+
+from oduflow import import_tokens
+from oduflow.errors import NotFoundError, PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+
+def _team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _settings(team):
+    return Settings(teams={team.team_id: team})
+
+
+def test_create_and_load_roundtrip(tmp_path):
+    team = _team(tmp_path)
+    settings = _settings(team)
+    rec = import_tokens.create_token(team, "zipfit")
+    assert rec["template_name"] == "zipfit"
+    team2, rec2 = import_tokens.load_token(settings, rec["token"])
+    assert team2.team_id == "1"
+    assert rec2["token"] == rec["token"]
+    assert rec2["template_name"] == "zipfit"
+
+
+def test_malformed_and_unknown_tokens_raise_not_found(tmp_path):
+    settings = _settings(_team(tmp_path))
+    with pytest.raises(NotFoundError):
+        import_tokens.load_token(settings, "")
+    with pytest.raises(NotFoundError):
+        import_tokens.load_token(settings, "has spaces!")
+    # Well-formed shape but never issued.
+    with pytest.raises(NotFoundError):
+        import_tokens.load_token(settings, "a" * 24)
+
+
+def test_expired_token_is_rejected_and_removed(tmp_path):
+    team = _team(tmp_path)
+    settings = _settings(team)
+    rec = import_tokens.create_token(team, "tpl", ttl_seconds=1, now=1000.0)
+    with pytest.raises(PrerequisiteNotMetError):
+        import_tokens.load_token(settings, rec["token"], now=1002.0)
+    # The expired token file is deleted, so a second look is a plain NotFound.
+    with pytest.raises(NotFoundError):
+        import_tokens.load_token(settings, rec["token"], now=1002.0)
+
+
+def test_invalidate_deletes_token(tmp_path):
+    team = _team(tmp_path)
+    settings = _settings(team)
+    rec = import_tokens.create_token(team, "tpl")
+    import_tokens.invalidate(team, rec["token"])
+    with pytest.raises(NotFoundError):
+        import_tokens.load_token(settings, rec["token"])
+
+
+def test_create_reaps_expired_tokens(tmp_path):
+    team = _team(tmp_path)
+    old = import_tokens.create_token(team, "old", ttl_seconds=1, now=1000.0)
+    # A later mint triggers cleanup of the now-expired token file.
+    import_tokens.create_token(team, "new", now=5000.0)
+    assert not os.path.exists(import_tokens._token_path(team, old["token"]))
+
+
+def test_invalid_template_name_rejected(tmp_path):
+    team = _team(tmp_path)
+    with pytest.raises(ValueError):
+        import_tokens.create_token(team, "../escape")


### PR DESCRIPTION
Adds a push-based import of Odoo.sh databases into Oduflow templates: since the Odoo.sh tenant PG role blocks `pg_dump` and the DB manager is disabled, a client script (`curl <server>/import-odoo.sh | bash`) runs inside the Odoo.sh shell and streams the platform's own daily backup (SQL dump + filestore, tar'd per hash-directory with no intermediate archive on disk) to new token-authenticated `/api/templates/import/*` endpoints.

The dashboard Templates tab gains an "Import from Odoo.sh" button that mints a short-lived (15 min) token and a ready-to-paste command; resume state is derived from what is already staged on disk, so re-running the command — even with a fresh token — only uploads the missing pieces. Finalize reuses the existing `reload_template` + overlay-remount machinery via a new `finalize_imported_template`, with zip-slip-guarded tar extraction. Includes decision record `specs/0023-import-from-odoo-sh.md` and 14 new unit tests (537 total passing).