### PR TITLE
Make dashboard create buttons neutral with blue hover border

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -139,9 +139,10 @@ A near-monochrome blue-black field carrying one saturated brand blue, with a
 tight categorical signal palette for environment and service state.
 
 ### Primary
-- **Console Blue** (`oklch(0.6 0.2 260)`): The single accent. Primary action
-  buttons, active tab indicator, focus rings, links, selected state. Carries
-  ≤15% of any screen; its rarity is what makes it read as confident.
+- **Console Blue** (`oklch(0.6 0.2 260)`): The single accent. Active tab
+  indicator, focus rings, links, selected state, and the hover/focus reveal on
+  primary and Sync/Logs actions — not a resting button fill. Carries ≤15% of any
+  screen; its rarity is what makes it read as confident.
 
 ### Secondary (Signal palette)
 Categorical state and channel colors. Each names one meaning; they never mix
@@ -184,7 +185,9 @@ decoratively within an element.
 
 ### Named Rules
 **The One Light Rule.** Console Blue is the only brand accent that carries
-weight; ≤15% of any screen. Do not introduce a second "primary".
+weight; ≤15% of any screen. Do not introduce a second "primary". Even the
+primary action is neutral at rest and reveals the blue only on intent
+(hover/focus), so the accent stays scarce and confident.
 
 **The Channel Rule.** Signal colors are categorical. A color may mark a state
 or a capability channel; a surface never gets a signal color "for variety".
@@ -302,8 +305,13 @@ be traced against a dimmed page, it is missing one of the two.
 ### Buttons
 - **Shape:** Gently rounded (`0.425rem`, the `md` radius), compact
   (`0.3125rem 0.875rem` padding), label weight 600.
-- **Primary:** Console Blue fill, near-white text. One per view/modal (Create,
-  Activate). Hover deepens the fill; no glow at dashboard density.
+- **Primary (Create / Activate):** the quiet primary — neutral at rest like the
+  outline action (Surface fill, hairline border, Ink text), set apart only by
+  its heavier weight (600) and the larger `lg` radius, not by a resting fill. It
+  reveals its intent on hover/focus: Console Blue border + text + 10% Console
+  Blue tint, same as Sync/Logs. One per view/modal. The destructive confirm is
+  the sole exception — it keeps a solid Alert Red fill so the moment of choice
+  stays loud.
 - **Outline (default action):** Transparent fill, hairline border, Ink text.
   Hover: border and text shift to the action's semantic color.
 - **Semantic on intent:** action buttons are neutral at rest (hairline

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -428,17 +428,33 @@
   .btn-logs:hover, .btn-logs:focus-visible { border-color: var(--accent); color: var(--accent); background: color-mix(in oklab, var(--accent) 10%, transparent); }
   .btn-protect:hover, .btn-protect:focus-visible { border-color: var(--yellow); color: var(--yellow); background: color-mix(in oklab, var(--yellow) 10%, transparent); }
   .btn-create {
-    background: var(--accent);
-    color: var(--accent-fg);
-    border: 1px solid var(--accent);
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
     padding: 6px 14px;
     border-radius: var(--radius);
     cursor: pointer;
     font-size: var(--text-sm);
     font-weight: 600;
+    transition: border-color 0.15s, color 0.15s, background 0.15s;
   }
-  .btn-create.danger { background: var(--red); border-color: var(--red); }
-  .btn-create:hover { opacity: 0.85; }
+  .btn-create:hover, .btn-create:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: color-mix(in oklab, var(--accent) 10%, transparent);
+  }
+  /* Destructive confirm keeps a solid red fill — the moment of choice stays loud. */
+  .btn-create.danger {
+    background: var(--red);
+    border-color: var(--red);
+    color: var(--accent-fg);
+  }
+  .btn-create.danger:hover, .btn-create.danger:focus-visible {
+    opacity: 0.85;
+    background: var(--red);
+    border-color: var(--red);
+    color: var(--accent-fg);
+  }
   .btn-create:disabled { opacity: 0.4; cursor: not-allowed; }
   .btn.danger { color: var(--red); }
   .btn.danger:hover, .btn.danger:focus-visible { border-color: var(--red); background: color-mix(in oklab, var(--red) 10%, transparent); }


### PR DESCRIPTION
The dashboard's primary `.btn-create` buttons (toolbar create actions across every tab and modal submit buttons) used a solid Console Blue fill, which read as heavy and inconsistent next to the neutral outline actions. This restyles them to the outline treatment — surface fill, hairline border, ink text at rest — that reveals a Console Blue border + text + 10% tint on hover/focus, matching the existing Sync/Logs buttons. Weight 600 and the larger radius keep the primary action distinguishable without a resting fill, and the destructive confirm button keeps its solid red fill so the moment of choice stays loud. `DESIGN.md` is updated to match (Primary button spec, the Console Blue usage list, and The One Light Rule). The change is a single CSS class override plus doc edits — no HTML/JS touched — and was verified visually in both dark and light themes.