### PR TITLE
Auto-publish Docker image to Docker Hub on GitHub Release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: oduist/oduflow
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,9 +167,21 @@ When preparing a new release, update the product version before creating the tag
 
 Do not create or move a release tag until the version bump and changelog commit is already on `main`: the publish workflow builds from the tagged commit, so its `pyproject.toml` version must already be correct. Remember that publishing is gated on the GitHub Release (step 5) — a tag alone does not publish.
 
+Publishing the GitHub Release also triggers the **Docker image** workflow (`.github/workflows/docker.yml`, same `release: [published]` event), which builds and pushes `oduist/oduflow:<VERSION>` and `oduist/oduflow:latest` to Docker Hub automatically. No separate manual `docker push` is required — see the next section.
+
 ## Publishing Docker Image
 
-When asked to publish a Docker image, build and push to Docker Hub:
+The Docker image is published **automatically** by `.github/workflows/docker.yml`
+on every published GitHub Release (`release: [published]` — the same trigger as
+the PyPI publish). It uses `docker/build-push-action` with Buildx/QEMU to build
+`linux/amd64` + `linux/arm64` and pushes `oduist/oduflow:<VERSION>` (version from
+the release git tag) plus `oduist/oduflow:latest` (skipped for pre-releases) to
+Docker Hub. This requires the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo
+secrets (a Docker Hub access token with Read & Write scope, not the account
+password).
+
+So a normal release needs no manual Docker step. The manual build/push below is a
+**fallback** for re-publishing an image out of band (or building locally):
 
 ```bash
 # Read version from pyproject.toml, then:


### PR DESCRIPTION
Adds `.github/workflows/docker.yml` that builds and pushes the `oduist/oduflow` image to Docker Hub automatically on every published GitHub Release (`release: [published]` — the same trigger as the PyPI publish), so the image no longer drifts from the released version. It uses `docker/build-push-action` with Buildx/QEMU to build `linux/amd64` + `linux/arm64`, tags `<VERSION>` from the release git tag plus `latest` (skipped for pre-releases), and caches layers via GitHub Actions. `AGENTS.md` is updated to document the automated flow and demote the manual `docker build/push` to a fallback.

Requires the repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (a Docker Hub access token with Read & Write scope) to be configured before the first release.