### PR TITLE
Relicense to Business Source License 1.1 with three commercial tiers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,131 +1,144 @@
-# PolyForm Noncommercial License 1.0.0
+Business Source License 1.1
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+Parameters
 
-## Acceptance
+Licensor:             Oduist
 
-In order to get any license under these terms, you must agree
-to them as both strict obligations and conditions to all
-your licenses.
+Licensed Work:        Oduflow
+                      The Licensed Work is (c) 2026 Oduist.
 
-## Copyright License
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided such use is for a Non-Commercial Purpose.
 
-The licensor grants you a copyright license for the
-software to do everything you might do with the software
-that would otherwise infringe the licensor's copyright
-in it for any permitted purpose.  However, you may
-only distribute the software according to [Distribution
-License](#distribution-license) and make changes or new works
-based on the software according to [Changes and New Works
-License](#changes-and-new-works-license).
+                      A "Non-Commercial Purpose" means any of the following,
+                      in each case only where the use is not intended for or
+                      directed toward commercial advantage or monetary
+                      compensation:
 
-## Distribution License
+                      (a) evaluating or trialing the Licensed Work, including
+                          to decide whether to purchase a commercial license;
+                      (b) education, teaching, and academic research;
+                      (c) personal or hobby projects; and
+                      (d) use by charitable organizations, educational
+                          institutions, public research organizations, or
+                          government institutions.
 
-The licensor grants you an additional copyright license
-to distribute copies of the software.  Your license
-to distribute covers distributing the software with
-changes and new works permitted by [Changes and New Works
-License](#changes-and-new-works-license).
+                      Any other production use of the Licensed Work is use
+                      for a "Commercial Purpose" and is not permitted under
+                      this Additional Use Grant; it requires a commercial
+                      license purchased from the Licensor. Commercial
+                      licenses are offered in three tiers:
 
-## Notices
+                      1. Individual License -- for one named natural person,
+                         such as a freelancer or sole developer, who uses
+                         the Licensed Work for a Commercial Purpose on their
+                         own account.
 
-You must ensure that anyone who gets a copy of any part of
-the software from you also gets a copy of these terms or the
-URL for them above, as well as copies of any plain-text lines
-beginning with `Required Notice:` that the licensor provided
-with the software.  For example:
+                      2. Business License -- for a legal entity that uses
+                         the Licensed Work internally, for its own needs:
+                         developing, testing, maintaining, and operating
+                         Odoo systems that are used by that entity itself
+                         and its affiliates under common control.
 
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+                      3. Integrator License -- for a person or entity that
+                         uses the Licensed Work to provide services to third
+                         parties, such as Odoo implementation, integration,
+                         custom development, migration, maintenance,
+                         support, or hosting. The difference from a Business
+                         License is whose Odoo systems the Licensed Work is
+                         used for: if they belong to, or are used by, your
+                         clients rather than your own organization, you need
+                         an Integrator License, regardless of the size of
+                         your organization.
 
-## Changes and New Works License
+                      The tiers are identified here for convenience; their
+                      terms and pricing are set out in the applicable
+                      commercial license agreement, available at
+                      https://oduflow.dev.
 
-The licensor grants you an additional copyright license to
-make changes and new works based on the software for any
-permitted purpose.
+Change Date:          Four years from the date the Licensed Work is published.
 
-## Patent License
+Change License:       MPL 2.0
 
-The licensor grants you a patent license for the software that
-covers patent claims the licensor can license, or becomes able
-to license, that you would infringe by using the software.
+For information about alternative licensing arrangements for the Licensed
+Work, please visit https://oduflow.dev.
 
-## Noncommercial Purposes
+Notice
 
-Any noncommercial purpose is a permitted purpose.
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.
 
-## Personal Uses
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-Personal use for research, experiment, and testing for
-the benefit of public knowledge, personal study, private
-entertainment, hobby projects, amateur pursuits, or religious
-observance, without any anticipated commercial application,
-is use for a permitted purpose.
+-----------------------------------------------------------------------------
 
-## Noncommercial Organizations
+Business Source License 1.1
 
-Use by any charitable organization, educational institution,
-public research organization, public safety or health
-organization, environmental protection organization,
-or government institution is use for a permitted purpose
-regardless of the source of funding or obligations resulting
-from the funding.
+Terms
 
-## Fair Use
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
 
-You may have "fair use" rights for the software under the
-law. These terms do not limit them.
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-## No Other Rights
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-These terms do not allow you to sublicense or transfer any of
-your licenses to anyone else, or prevent the licensor from
-granting licenses to anyone else.  These terms do not imply
-any other licenses.
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-## Patent Defense
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
 
-If you make any written claim that the software infringes or
-contributes to infringement of any patent, your patent license
-for the software granted under these terms ends immediately. If
-your company makes such a claim, your patent license ends
-immediately for work on behalf of your company.
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
 
-## Violations
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
 
-The first time you are notified in writing that you have
-violated any of these terms, or done anything with the software
-not covered by your licenses, your licenses can nonetheless
-continue if you come into full compliance with these terms,
-and take practical steps to correct past violations, within
-32 days of receiving notice.  Otherwise, all your licenses
-end immediately.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
 
-## No Liability
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
 
-***As far as the law allows, the software comes as is, without
-any warranty or condition, and the licensor will not be liable
-to you for any damages arising out of these terms or the use
-or nature of the software, under any kind of legal claim.***
+Covenants of Licensor
 
-## Definitions
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
 
-The **licensor** is the individual or entity offering these
-terms, and the **software** is the software the licensor makes
-available under these terms.
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
 
-**You** refers to the individual or entity agreeing to these
-terms.
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
 
-**Your company** is any legal entity, sole proprietorship,
-or other kind of organization that you work for, plus all
-organizations that have control over, are under the control of,
-or are under common control with that organization.  **Control**
-means ownership of substantially all the assets of an entity,
-or the power to direct its management and policies by vote,
-contract, or otherwise.  Control can be direct or indirect.
+3. To specify a Change Date.
 
-**Your licenses** are all the licenses granted to you for the
-software under these terms.
-
-**Use** means anything you do with the software requiring one
-of your licenses.
+4. Not to modify this License in any other way.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img src="https://img.shields.io/badge/Python-3.10+-blue?logo=python&logoColor=white" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/Docker-Required-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://img.shields.io/badge/Protocol-MCP-green" alt="MCP">
-  <img src="https://img.shields.io/badge/License-Polyform%20NC-yellow" alt="Polyform Noncommercial License">
+  <img src="https://img.shields.io/badge/License-BUSL--1.1-yellow" alt="Business Source License 1.1">
   <img src="https://img.shields.io/badge/Odoo-15.0--19.0-714B67?logo=odoo&logoColor=white" alt="Odoo">
 </p>
 
@@ -121,4 +121,4 @@ Oduflow collects anonymous usage telemetry (first startup and environment creati
 
 ## Licensing
 
-Oduflow is source-available under the [Polyform Noncommercial License 1.0.0](LICENSE). Commercial use requires a license — visit [oduflow.dev](https://oduflow.dev).
+Oduflow is source-available under the [Business Source License 1.1](LICENSE). Evaluation, educational, and other non-commercial use is free forever. Commercial use requires a paid license in one of three tiers — Individual (solo developers), Business (internal company use), or Integrator (Odoo service providers) — visit [oduflow.dev](https://oduflow.dev). Each release converts to the open-source MPL 2.0 four years after publication.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,15 +1,23 @@
 # Licensing
 
-Oduflow is source-available under the [Polyform Noncommercial License 1.0.0](https://github.com/oduist/oduflow/blob/main/LICENSE). Commercial use requires a license.
+Oduflow is source-available under the [Business Source License 1.1](https://github.com/oduist/oduflow/blob/main/LICENSE) (BUSL-1.1).
+
+- **Free forever for non-commercial use**: evaluation, education, academic research, personal and hobby projects, non-profits.
+- **Commercial use requires a paid license** in one of three tiers (below).
+- Standard BUSL mechanics: each release converts to the open-source **MPL 2.0** four years after publication.
 
 ## License Types
 
-| Type | Label | Description |
+| Type | Label | Who needs it |
 |---|---|---|
-| `unlicensed` | UNLICENSED — NON-COMMERCIAL USE ONLY | Default when no license key is installed |
-| `individual` | Licensed to individual | Personal commercial license |
-| `business` | Licensed to company (internal use only) | Company license for internal use |
-| `integrator` | Licensed to Odoo integrator | License for Odoo integrators and consultancies |
+| `unlicensed` | UNLICENSED — NON-COMMERCIAL USE ONLY | Default when no license key is installed; fine for evaluation, education, and other non-commercial use |
+| `individual` | Licensed to individual | One natural person (freelancer, sole developer) using Oduflow commercially on their own account |
+| `business` | Licensed to company (internal use only) | A company using Oduflow internally, for its own Odoo systems |
+| `integrator` | Licensed to Odoo integrator | A person or company using Oduflow to deliver Odoo services (implementation, development, support, hosting) to clients |
+
+### Business vs. Integrator
+
+The test is whose Odoo systems you point Oduflow at. If the environments you develop, test, and operate serve your own organization, a Business license covers you. If they belong to, or are used by, your clients — you are an integrator and need an Integrator license, regardless of company size.
 
 ## Installing a License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Oduist" }
 ]
 readme = "README.md"
-license = { text = "PolyForm-Noncommercial-1.0.0" }
+license = { text = "BUSL-1.1" }
 requires-python = ">=3.10"
 keywords = ["odoo", "mcp", "docker", "development", "ci"]
 dependencies = [

--- a/specs/0008-licensing.md
+++ b/specs/0008-licensing.md
@@ -1,6 +1,6 @@
 # 0008 — Licensing: Polyform Noncommercial + in-app license activation
 
-**Status:** Adopted (still in force)
+**Status:** Adopted; license terms superseded by [[0024-business-source-license]] (BUSL-1.1) — the in-app activation model remains in force
 **Type:** Product / Architecture
 **First introduced:** `317b816` "add Polyform Noncommercial 1.0.0 license" (2026-02-12), `00936c9` "license activation via dashboard UI" (2026-02-13)
 **Key code today:** `licensing.py` (RSA verification, license types, install), `web_ui.py` (`/api/license`, `/api/license/activate`), `templates/dashboard.html` (activation form + banner), `LICENSE`, `docs/licensing.md`

--- a/specs/0024-business-source-license.md
+++ b/specs/0024-business-source-license.md
@@ -1,0 +1,72 @@
+# 0024 — Relicense to Business Source License 1.1 with three commercial tiers
+
+**Status:** Adopted
+**Type:** Product / Legal
+**First introduced:** 2026-07-02 (this change)
+**Key code today:** `LICENSE`, `pyproject.toml` (`BUSL-1.1`), `docs/licensing.md`, `README.md`; activation machinery unchanged in `licensing.py`
+
+## Context
+
+[[0008-licensing]] adopted PolyForm Noncommercial 1.0.0: source-available,
+free for noncommercial use, paid for commercial use, with RSA-signed keys
+carrying a `type` of `individual` / `business` / `integrator`. Two gaps grew
+over time:
+
+1. **The tiers had no legal counterpart.** The three license types existed in
+   the activation machinery and on the pricing page, but the license text
+   itself knew only "noncommercial vs commercial". A prospective customer
+   reading `LICENSE` couldn't tell *which* license they needed — in
+   particular, the business-vs-integrator boundary (using Oduflow for your
+   own Odoo vs using it to serve clients) was undefined anywhere binding.
+2. **PolyForm is a niche license.** Business Source License 1.1 (MariaDB,
+   HashiCorp, and others) is the recognized industry standard for
+   source-available-with-paid-production-use, with well-understood mechanics
+   and an SPDX identifier — less friction for legal review at customers.
+
+## Decision
+
+Replace PolyForm Noncommercial 1.0.0 with **Business Source License 1.1**,
+using the canonical MariaDB text and encoding the commercial model in the
+parameters:
+
+- **Additional Use Grant** permits production use for *Non-Commercial
+  Purposes* — evaluation/trial, education and academic research, personal or
+  hobby projects, and non-profit/government use — perpetually and free of
+  charge. (BUSL's base grant already covers copying, modification,
+  redistribution, and non-production use.)
+- Any other production use is a *Commercial Purpose* and requires one of
+  **three commercial tiers**, defined in the grant text and matching the key
+  types verified by `licensing.py`:
+  - **Individual** — one natural person (freelancer, sole developer) using
+    Oduflow commercially on their own account;
+  - **Business** — a legal entity using Oduflow internally, for Odoo systems
+    used by the entity itself and its affiliates;
+  - **Integrator** — a person or entity using Oduflow to provide Odoo
+    services (implementation, integration, development, migration,
+    maintenance, support, hosting) to third parties. The business/integrator
+    test is *whose Odoo systems Oduflow is used for*: your own → Business;
+    your clients' → Integrator, regardless of organization size.
+- **Change Date / Change License:** four years after each version is
+  published, that version converts to **MPL 2.0**. A change date and a
+  GPL-compatible change license are mandatory under MariaDB's Covenants of
+  Licensor — eventual open-sourcing of each release is inherent to adopting
+  BSL, not an optional extra.
+
+## Consequences
+
+- The commercial taxonomy is now part of the legal terms rather than only
+  activation UX; `LICENSE`, `pyproject.toml`, `README.md`, and
+  `docs/licensing.md` all state BUSL-1.1 consistently.
+- Each release becomes open source (MPL 2.0) four years after publication —
+  the deliberate trade-off of using standard BSL instead of a bespoke
+  perpetual-proprietary license. The current release is always under the
+  commercial terms.
+- The activation model from [[0008-licensing]] is unchanged: offline RSA
+  verification of signed keys typed `individual` / `business` / `integrator`,
+  banner-based nudging, no runtime enforcement.
+
+## History
+
+- 2026-07-02 — relicense `LICENSE` to BUSL-1.1; update `pyproject.toml`,
+  `README.md`, `docs/licensing.md`; supersedes the license-terms half of
+  [[0008-licensing]].

--- a/specs/README.md
+++ b/specs/README.md
@@ -42,6 +42,7 @@ precursors).
 | [0021](0021-code-delivery-modes.md) | 2026-06-12 | Code delivery modes: `repo_url` git push vs `local_path` live-mount + `pull_and_apply` guardrail |
 | [0022](0022-engineers-console-design-system.md) | 2026-06-12 | The Engineer's Console: dashboard design system + lifecycle automation |
 | [0023](0023-import-from-odoo-sh.md) | 2026-07-02 | Import a template from Odoo.sh via a push-based, resumable shell client |
+| [0024](0024-business-source-license.md) | 2026-07-02 | Relicense to Business Source License 1.1 with three commercial tiers |
 
 ## Design docs
 


### PR DESCRIPTION
Replaces PolyForm Noncommercial 1.0.0 with the canonical Business Source License 1.1 (MariaDB text). The Additional Use Grant keeps production use free forever for non-commercial purposes (evaluation, education, personal projects, non-profits) and defines the three commercial tiers matching the existing license key types: Individual (solo developers), Business (internal company use), and Integrator (Odoo services to third parties), with an explicit whose-Odoo-systems test distinguishing the last two. Per standard BSL mechanics, each release converts to MPL 2.0 four years after publication. Also updates the `pyproject.toml` license field, README badge and Licensing section, and `docs/licensing.md`. Records the decision as ADR 0024 and marks the license-terms half of ADR 0008 as superseded.