### PR TITLE
Multi-tenant hosting: hard tenant isolation, startup migrations, quotas, usage stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ MCP Clients (Cursor, Claude, etc.)
         │         └── LockManager (per-branch / per-team / system) → BusyError
         ├── web_ui.py ── Starlette dashboard + REST API + Basic auth
         ├── settings.py ── @dataclass Settings, loads from oduflow.toml (TOML)
+        ├── migrations.py ── Startup data migrations (Odoo-style, applied automatically on server start)
         ├── locking.py ── LockManager with per-branch, per-team, system locks
         ├── git_ops.py ── Clone, credentials, manifest parsing
         ├── git_analysis.py ── Classify changed files → action (install/upgrade/restart/nothing)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ MCP Clients (Cursor, Claude, etc.)
         ├── web_ui.py ── Starlette dashboard + REST API + Basic auth
         ├── settings.py ── @dataclass Settings, loads from oduflow.toml (TOML)
         ├── migrations.py ── Startup data migrations (Odoo-style, applied automatically on server start)
+        ├── quotas.py ── Per-team disk quotas (XFS project quotas)
         ├── locking.py ── LockManager with per-branch, per-team, system locks
         ├── git_ops.py ── Clone, credentials, manifest parsing
         ├── git_analysis.py ── Classify changed files → action (install/upgrade/restart/nothing)

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -1,6 +1,6 @@
 # Multi-Team Support
 
-Oduflow supports running **multiple isolated teams** within a single server instance. Each team has its own environments, templates, services, credentials, and port registry, while sharing the Docker network and PostgreSQL container.
+Oduflow supports running **multiple isolated teams** within a single server instance. Each team has its own environments, templates, services, credentials, port registry, Docker network, and PostgreSQL tablespace; the PostgreSQL and Traefik containers are the only shared infrastructure.
 
 ## Configuration
 
@@ -72,11 +72,15 @@ disk_quota_gb = 0     # default: 0 (off)
   (`pg_database_size()`), so there is no per-file scanning in the hot path.
   Replacement operations (refresh/reload of an existing template) are not
   gated, so a team at its quota can still shrink or refresh what it has.
-- `disk_quota_gb` is **reserved**: it will cap the team's data dir
-  (workspaces, filestores, template dumps) via filesystem project quotas,
-  which requires the data dir to live on XFS mounted with `prjquota`.
-  Enforcement is not wired up yet; setting a non-zero value only logs a
-  warning today.
+- `disk_quota_gb` caps the team's disk usage — its data dir (workspaces,
+  filestores, template dumps) **plus** its PostgreSQL tablespace — enforced
+  by the kernel via XFS project quotas. Requirements: Linux, `xfsprogs`
+  installed, and the data dir on an XFS filesystem mounted with `prjquota`.
+  Both directory trees get the same project ID, so one `bhard` limit covers
+  files and databases together; writes beyond it fail with ENOSPC while the
+  rest of the machine is unaffected. On filesystems without project-quota
+  support the limit is not enforced (one warning at startup) and usage stays
+  visible via the dashboard and `/api/usage`.
 
 ## Per-Team PostgreSQL Tablespaces
 
@@ -103,8 +107,10 @@ database size.
 
 | Resource | Scope |
 |---|---|
-| Docker network (`oduflow-net`) | Shared |
+| Infra Docker network (`oduflow-net`) | Shared (PostgreSQL, Traefik) |
+| Team Docker network (`oduflow-{team}-net`) | Per-team — env/service containers join only their team's network; shared infra is attached to every team network |
 | PostgreSQL container (`oduflow-db`) | Shared |
+| PostgreSQL tablespace (`oduflow_team_{id}`) | Per-team |
 | Traefik container (`oduflow-traefik`) | Shared |
 | Environments (workspaces, containers) | Per-team |
 | Templates (DB snapshots, filestores) | Per-team |

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -49,6 +49,35 @@ When an MCP tool is called, Oduflow resolves the team using the following priori
 3. **Single team** — if only one team is configured, uses it automatically
 4. **Default** — falls back to team `"1"`
 
+Steps 3–4 apply to the stdio transport (implicit local single user) only. In
+HTTP mode a request that matches no token and no hostname is rejected, so it
+can never land in another team's context — unless `allow_insecure_http = true`
+explicitly opts out (e.g. behind your own auth proxy). HTTP mode with multiple
+teams also requires a non-empty `auth_token` for every team at startup.
+
+## Quotas
+
+Each team can carry resource quotas (`0` disables a quota):
+
+```toml
+[team.1]
+db_quota_gb = 50      # default: 50
+disk_quota_gb = 0     # default: 0 (off)
+```
+
+- `db_quota_gb` caps the combined size of the team's PostgreSQL databases —
+  environments plus templates. It is checked before operations that create a
+  *new* database (`create_environment`, `save_as_template` of a new template,
+  `import_template_from_odoo`) with a single catalog query
+  (`pg_database_size()`), so there is no per-file scanning in the hot path.
+  Replacement operations (refresh/reload of an existing template) are not
+  gated, so a team at its quota can still shrink or refresh what it has.
+- `disk_quota_gb` is **reserved**: it will cap the team's data dir
+  (workspaces, filestores, template dumps) via filesystem project quotas,
+  which requires the data dir to live on XFS mounted with `prjquota`.
+  Enforcement is not wired up yet; setting a non-zero value only logs a
+  warning today.
+
 ## Shared vs. Per-Team Resources
 
 | Resource | Scope |

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -78,6 +78,27 @@ disk_quota_gb = 0     # default: 0 (off)
   Enforcement is not wired up yet; setting a non-zero value only logs a
   warning today.
 
+## Per-Team PostgreSQL Tablespaces
+
+Each team's databases (environments and templates) live in a dedicated
+PostgreSQL tablespace, `oduflow_team_{id}`, whose files sit under
+`{data_dir}/pg_tablespaces/team_{id}/` on the host. Only that
+`pg_tablespaces/` directory is mounted into the PostgreSQL container — never
+the rest of the data dir.
+
+This makes a team's disk consumption one visible number: assign
+`team_{id}/` and `pg_tablespaces/team_{id}/` the same XFS project ID and a
+single project quota covers the team's files *and* its databases. WAL stays
+in the shared `PGDATA`, so a team hitting its quota gets aborted
+transactions, not a server-wide outage.
+
+Existing installs are converted automatically on server start (startup
+migration `0002-team-pg-tablespaces`): the PostgreSQL container is recreated
+once with the new mount (its data volume persists), then each team database
+is physically moved with `ALTER DATABASE ... SET TABLESPACE`. Expect the
+first start after the upgrade to take time proportional to the total
+database size.
+
 ## Shared vs. Per-Team Resources
 
 | Resource | Scope |

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -92,14 +92,20 @@ disk_quota_gb = 0     # default: 0 (off)
 | Port assignments | Per-team |
 | Git credentials | Per-team |
 
-## Database Naming
+## Resource Naming
 
-Databases are namespaced by team ID:
+Databases and containers are namespaced by team ID:
 
 - Environment DB: `oduflow_{team_id}_{slugified_branch}` (e.g. `oduflow_1_feature-login`)
 - Template DB: `oduflow_template_{team_id}_{template_name}` (e.g. `oduflow_template_1_default`)
+- Environment containers: `oduflow-{team_id}-{env}-{type}` (e.g. `oduflow-1-feature-login-odoo`)
+- Service containers: `oduflow-{team_id}-svc-{name}` (e.g. `oduflow-1-svc-redis`)
 
-Containers are labeled with `oduflow.team={team_id}` for filtering.
+Containers are additionally labeled with `oduflow.team={team_id}`; listing and
+filtering are label-based, and container names are team-scoped so two teams
+can use the same branch name without colliding. Containers created by older
+versions are renamed to this scheme automatically on server start (startup
+migration `0001-team-scoped-container-names`).
 
 ## CLI Team Selection
 

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -39,6 +39,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | `GET` | `/api/environments/{branch}/logs?n=200` | Get environment logs |
 | `POST` | `/api/environments/{branch}/protect` | Protect environment from deletion |
 | `POST` | `/api/environments/{branch}/unprotect` | Remove protection from environment |
+| `POST` | `/api/environments/{branch}/storage/refresh` | Recompute the environment's DB size and workspace disk size (cached; served via `/api/stats` and `/api/usage`) |
 | `WebSocket` | `/api/environments/{branch}/terminal` | Interactive Odoo Python shell via WebSocket (used by the Web Dashboard terminal) |
 
 ### Services
@@ -64,7 +65,9 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/stats` | Container CPU/RAM stats + system metrics |
+| `GET` | `/api/stats` | Container CPU/RAM stats + system metrics + cached per-environment DB/disk sizes |
+| `GET` | `/api/usage` | Cached team storage usage (per environment + team totals) and the team's quotas — the read side for external billing/quota tooling |
+| `POST` | `/api/usage/refresh` | Recompute storage for every environment plus team totals (heavy: walks every workspace); returns the same payload as `GET /api/usage` |
 | `GET` | `/api/templates` | List available template profiles |
 
 ### Extra Addons

--- a/specs/0023-startup-data-migrations.md
+++ b/specs/0023-startup-data-migrations.md
@@ -1,0 +1,71 @@
+# 0023 — Startup data migrations (Odoo-style upgrade steps)
+
+**Status:** Adopted
+**Type:** Architecture
+**First introduced:** this change (2026-07-02), branch `litnimax/multi-tenant-hosting-design`
+**Key code today:** `migrations.py` (`Migration`, `MIGRATIONS`, `run_pending`), `server.py` (hook in the server-start path, before `_ensure_initialized`)
+
+## Context
+
+Oduflow manages long-lived state outside its own process: Docker containers,
+networks and volumes, per-team data directories, `ports.json`, Traefik dynamic
+config. Until now every release had to be shape-compatible with whatever a
+previous version left on the machine — there was no mechanism to change that
+shape. The multi-tenant hardening work is the first to need one: moving to
+team-scoped container names (`oduflow-{team}-{env}-{type}`) requires renaming
+the containers of every existing environment, or they become visible but
+inoperable "zombies" (listing is label-based, operations are name-based).
+
+Ad-hoc "detect and fix at startup" code scattered per feature would run on
+every start forever and accumulate. The prior art we already live with daily
+is Odoo's own migration model: versioned one-shot scripts that run exactly
+once, when an existing install upgrades past them — and never on a fresh
+install.
+
+## Decision
+
+Add a **startup migrations subsystem** modeled on Odoo's:
+
+- The code ships an ordered, **append-only registry** of one-shot steps
+  (`MIGRATIONS` in `migrations.py`), each with a stable sequence id
+  (`"0001-team-scoped-container-names"`) and an `apply(settings)` function.
+- The data dir records applied ids in `base_data_dir/migrations.json`. On
+  server start, before shared-infrastructure init, Oduflow diffs registry vs
+  state and applies only the missing steps, oldest first.
+- A **fresh install is stamped** as fully applied without running anything —
+  current code lays down current-shape data, so historical steps have nothing
+  to act on (exactly Odoo's fresh-install behavior). Freshness = no state file
+  and no `team_*` directories yet.
+- State is persisted **after each successful step** (atomic replace, under an
+  flock), so a crash resumes at the failed step. A failing step aborts startup
+  with a `PrerequisiteNotMetError` naming the migration — a half-migrated
+  fleet must be noticed by the operator, not served.
+
+## How it works (macro)
+
+- `run_pending(settings)` is called once in the server-start path
+  (`args.command is None`), *before* `_ensure_initialized`, so each step sees
+  the data dir and Docker resources exactly as the previous version left them
+  (and before init creates fresh per-team directories, which would defeat
+  fresh-install detection).
+- Steps run with full `Settings` and may touch anything Oduflow owns: rename
+  containers, rewrite registries, regenerate Traefik files. They must be
+  idempotent where possible, since a crashed step re-runs on the next start.
+- CLI subcommands do not trigger migrations; only serving does. A machine that
+  only ever runs one-off CLI commands keeps its state until the server next
+  starts.
+
+## Consequences
+
+- Releases can now change the on-disk/Docker shape of existing deployments —
+  the prerequisite for team-scoped resource naming, per-team networks, and
+  the rest of the multi-tenant hardening plan.
+- Upgrade cost at start is one JSON read once migrated; the registry is
+  append-only, so entries are never re-run, reordered, or renamed.
+- The registry ships empty in this change; the first real entry lands together
+  with the naming-v2 work.
+
+## History
+
+- Introduced together with the multi-tenant hosting design discussion
+  ([[0014-team-based-multi-tenancy]] is the tenancy model this hardens).

--- a/specs/0023-startup-data-migrations.md
+++ b/specs/0023-startup-data-migrations.md
@@ -62,8 +62,9 @@ Add a **startup migrations subsystem** modeled on Odoo's:
   the rest of the multi-tenant hardening plan.
 - Upgrade cost at start is one JSON read once migrated; the registry is
   append-only, so entries are never re-run, reordered, or renamed.
-- The registry ships empty in this change; the first real entry lands together
-  with the naming-v2 work.
+- The first entry is `0001-team-scoped-container-names`: renaming every
+  managed container to the team-scoped scheme, which fixes the cross-team
+  branch-name collision the label-based listing masked.
 
 ## History
 

--- a/specs/0024-per-team-pg-tablespaces.md
+++ b/specs/0024-per-team-pg-tablespaces.md
@@ -1,0 +1,71 @@
+# 0024 — Per-team PostgreSQL tablespaces
+
+**Status:** Adopted
+**Type:** Architecture
+**First introduced:** this change (2026-07-02), branch `litnimax/multi-tenant-hosting-design`
+**Key code today:** `docker_ops/system_ops.py` (`_ensure_pg_container`, `ensure_team_tablespace`), `naming.py` (`get_tablespace_name`), `migrations.py` (`0002-team-pg-tablespaces`), `CREATE DATABASE ... TABLESPACE` call sites in `env_ops.py` / `system_ops.py`
+
+## Context
+
+Hosting mutually-untrusting clients on one machine ([[0014-team-based-multi-tenancy]]
+hardened for that case) needs a per-client disk quota that is *complete*. A
+filesystem project quota on `team_{id}/` covers workspaces, filestores, and
+template dumps — but not PostgreSQL: all databases lived in one `PGDATA`
+inside the shared PG container's volume, invisible to any per-team quota, and
+"how much disk does this client use" required adding up numbers from two
+different worlds.
+
+Mounting the whole data dir into the PG container to co-locate database files
+with team files was rejected outright: PostgreSQL has no business seeing
+other teams' workspaces or credential files.
+
+## Decision
+
+Give every team its **own PostgreSQL tablespace**, with its files under a
+**dedicated** `base_data_dir/pg_tablespaces/team_{id}/` directory:
+
+- The PG container mounts **only** `pg_tablespaces/` (as `/tablespaces`) —
+  one mount, created once. Adding a team is `mkdir` + `CREATE TABLESPACE`
+  inside the existing mount; the container is never recreated again.
+- Every `CREATE DATABASE` (environments, templates) goes through
+  `ensure_team_tablespace()` (idempotent, one catalog query) and carries
+  `TABLESPACE "oduflow_team_{id}"`.
+- For quotas, hosting setups assign `team_{id}/` and
+  `pg_tablespaces/team_{id}/` the **same XFS project ID** — project quotas
+  attach to the ID, not to a single subtree — so one `disk_quota_gb` covers
+  the client's files *and* databases.
+- WAL stays in the shared `PGDATA`, deliberately: a team hitting its quota
+  gets aborted transactions (ENOSPC on data files is safe), never a
+  server-wide PANIC — the noisy neighbor stays isolated.
+
+## How it works (macro)
+
+- `_ensure_pg_container` (extracted from the two duplicated PG-bootstrap
+  blocks) creates the PG container with the `/tablespaces` mount.
+- `ensure_team_tablespace` creates the host dir, fixes ownership to the
+  `postgres` OS user inside the container, and issues `CREATE TABLESPACE`.
+- Startup migration `0002-team-pg-tablespaces` ([[0023-startup-data-migrations]])
+  converts existing installs: recreates the PG container once if the mount is
+  missing (data volume persists; seconds of downtime at startup), then
+  `ALTER DATABASE ... SET TABLESPACE` per team database — blocking reconnects
+  via `ALLOW_CONNECTIONS false` + `pg_terminate_backend` so the move cannot
+  race Odoo's reconnect loop. Move time is proportional to database size;
+  already-moved databases are skipped, so a partial run resumes cleanly.
+
+## Consequences
+
+- A client's disk consumption is one number and one enforcement point; the
+  external billing/usage API (`/api/usage`) and `du`/`xfs_quota` now agree on
+  what "the client's disk" means.
+- Databases become visible per team on the host filesystem — useful for
+  ops even without quotas.
+- Operators using `pg_basebackup`-style physical backups must be aware
+  tablespaces exist; the built-in template flow (`pg_dump`) is unaffected.
+- One-time upgrade cost on existing installs: a PG container recreate plus a
+  physical copy of every database at first startup.
+
+## History
+
+- Follows the naming-v2 hardening (`0001-team-scoped-container-names`) in the
+  multi-tenant hosting pass; see [[0014-team-based-multi-tenancy]] and
+  [[0023-startup-data-migrations]].

--- a/specs/0025-hard-tenant-isolation.md
+++ b/specs/0025-hard-tenant-isolation.md
@@ -1,0 +1,77 @@
+# 0025 — Hard tenant isolation: per-team networks, resource limits, disk quotas
+
+**Status:** Adopted
+**Type:** Architecture
+**First introduced:** this change (2026-07-02), branch `litnimax/multi-tenant-hosting-design`
+**Key code today:** `system_ops.py` (`ensure_team_network`), `naming.py` (`get_team_network_name`), `stats.py` (`default_env_limits`), `quotas.py`, `migrations.py` (`0003-per-team-networks`, `0004-env-resource-limits`)
+
+## Context
+
+Team-based multi-tenancy ([[0014-team-based-multi-tenancy]]) isolated teams'
+*data* — directories, databases, ports, credentials — but all containers still
+shared one Docker network and ran without resource limits. For teams inside
+one organization that was acceptable; for **mutually-untrusting clients** it
+is not, because environment containers execute arbitrary client code (their
+addons): client A's module could reach client B's Odoo over the shared
+network (XML-RPC, default admin passwords), hit B's Redis/Meilisearch
+(typically unauthenticated), or simply OOM the whole machine with one heavy
+test run. Disk quotas (`disk_quota_gb`, reserved since the quota work) had no
+enforcement.
+
+## Decision
+
+Make the container, network, and filesystem layers enforce the team boundary:
+
+- **Per-team networks.** Each team gets `oduflow-{team}-net`; environment and
+  service containers join *only* their team's network. The shared PostgreSQL
+  container and Traefik are attached to every team network — they are the
+  only cross-team surface, and both are credential/route protected. Traefik
+  backend selection moves from a global `--providers.docker.network` to the
+  per-container `traefik.docker.network` label.
+- **Default resource limits** on environment containers, auto-derived from
+  host size (no config knobs): memory = host RAM / 4 clamped to [2 GB, 8 GB],
+  plus a pids ceiling (fork bombs). CPU is deliberately uncapped — it is
+  compressible and the kernel scheduler already arbitrates contention.
+- **Disk quota enforcement** for `disk_quota_gb` via XFS project quotas
+  (`quotas.py`): the team dir and its PG tablespace ([[0024-per-team-pg-tablespaces]])
+  share one project ID, so a single kernel-enforced `bhard` limit covers the
+  client's files and databases. On filesystems without project-quota support
+  enforcement is off with one startup warning — usage stays visible via the
+  dashboard and `/api/usage`.
+
+## How it works (macro)
+
+- `ensure_team_network` is idempotent and called from system init and every
+  environment/service creation; it creates the network and attaches infra.
+- Startup migrations ([[0023-startup-data-migrations]]) convert existing
+  installs live: `0003-per-team-networks` connects each managed container to
+  its team network and disconnects it from the shared one (no restarts;
+  established DB connections re-establish over the team network), removing a
+  Traefik container that still pins the old backend network so init recreates
+  it. `0004-env-resource-limits` retrofits limits onto running environment
+  containers via `docker update`, best-effort.
+- `quotas.apply_all` runs on every server start after init: detects
+  Linux + xfsprogs + XFS with `prjquota`, allocates stable numeric project
+  IDs per team (`quota_projects.json`), stamps both directory trees, and sets
+  the hard limit.
+
+## Consequences
+
+- Lateral movement between clients is gone at the network layer; a client's
+  addon code can reach only its own containers plus the password-protected
+  shared PG and Traefik.
+- One client can no longer take the machine down by memory exhaustion or a
+  fork bomb, and — on a properly provisioned host (XFS + `prjquota`) — cannot
+  exceed its disk allotment at all.
+- The recommended hosting layout gains one requirement: put the data dir on
+  an XFS filesystem mounted with `prjquota` for quota enforcement.
+- Residual trust surface: the shared PostgreSQL and Traefik containers, and
+  the oduflow process itself (Docker socket) — application-level bugs remain
+  the tenant boundary there, which is why the strict HTTP team resolution and
+  input-validation audits stay load-bearing.
+
+## History
+
+- Completes the multi-tenant hosting pass started with DB quotas / strict
+  HTTP resolution, naming v2 (`0001`, `0002` migrations), and
+  [[0024-per-team-pg-tablespaces]].

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,6 +41,7 @@ precursors).
 | [0020](0020-authentication-oauth.md) | 2026-03-13 | Authentication for MCP HTTP: GitHub OAuth → self-hosted OAuth Authorization Server |
 | [0021](0021-code-delivery-modes.md) | 2026-06-12 | Code delivery modes: `repo_url` git push vs `local_path` live-mount + `pull_and_apply` guardrail |
 | [0022](0022-engineers-console-design-system.md) | 2026-06-12 | The Engineer's Console: dashboard design system + lifecycle automation |
+| [0023](0023-startup-data-migrations.md) | 2026-07-02 | Startup data migrations (Odoo-style upgrade steps) |
 
 ## Design docs
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -43,6 +43,7 @@ precursors).
 | [0022](0022-engineers-console-design-system.md) | 2026-06-12 | The Engineer's Console: dashboard design system + lifecycle automation |
 | [0023](0023-startup-data-migrations.md) | 2026-07-02 | Startup data migrations (Odoo-style upgrade steps) |
 | [0024](0024-per-team-pg-tablespaces.md) | 2026-07-02 | Per-team PostgreSQL tablespaces |
+| [0025](0025-hard-tenant-isolation.md) | 2026-07-02 | Hard tenant isolation: per-team networks, resource limits, disk quotas |
 
 ## Design docs
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -42,6 +42,7 @@ precursors).
 | [0021](0021-code-delivery-modes.md) | 2026-06-12 | Code delivery modes: `repo_url` git push vs `local_path` live-mount + `pull_and_apply` guardrail |
 | [0022](0022-engineers-console-design-system.md) | 2026-06-12 | The Engineer's Console: dashboard design system + lifecycle automation |
 | [0023](0023-startup-data-migrations.md) | 2026-07-02 | Startup data migrations (Odoo-style upgrade steps) |
+| [0024](0024-per-team-pg-tablespaces.md) | 2026-07-02 | Per-team PostgreSQL tablespaces |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -23,6 +23,7 @@ from oduflow.docker_ops.system_ops import (
     _drop_pg_role,
     _exec_sql,
     _resolve_instance_conf,
+    check_db_quota,
 )
 from oduflow.env_credentials import create_credentials, load_credentials
 from oduflow.errors import (
@@ -711,6 +712,8 @@ def create_environment(
                 f"is already used by environment '{other_branch}'. Choose a name "
                 "that does not normalise to the same database."
             )
+
+    check_db_quota(client, settings, team)
 
     _cleanup_old_environment(client, settings, team, env_name)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -352,7 +352,9 @@ def remount_template_overlays(
         if not os.path.ismount(merged):
             continue
 
-        container_name = get_resource_name(env_name, "odoo", settings.prefix)
+        container_name = get_resource_name(
+            env_name, "odoo", settings.prefix, team.team_id
+        )
         image = env.get("odoo_image") or "odoo:19.0"
         was_running = False
         try:
@@ -534,7 +536,9 @@ def _cleanup_old_environment(
     team: TeamSettings,
     env_name: str,
 ) -> None:
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     try:
         old = client.containers.get(odoo_container_name)
         old.stop()
@@ -576,6 +580,7 @@ def _cleanup_old_environment(
 def _init_empty_database(
     client: DockerClient,
     settings: Settings,
+    team: TeamSettings,
     odoo_image: str,
     env_db: str,
     odoo_env: dict,
@@ -593,7 +598,7 @@ def _init_empty_database(
     the pg catalog). ``-i base`` is explicit, so it works regardless of whether
     the image build auto-initializes an empty DB on plain ``-d``.
     """
-    init_name = get_resource_name(env_name, "odoo-init", settings.prefix)
+    init_name = get_resource_name(env_name, "odoo-init", settings.prefix, team.team_id)
     try:
         client.containers.get(init_name).remove(force=True)
     except docker.errors.NotFound:
@@ -669,7 +674,9 @@ def create_environment(
 
     _ensure_system_ready(client, settings, team, template_name)
 
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     try:
         existing = client.containers.get(odoo_container_name)
         if existing.status == "running":
@@ -757,7 +764,7 @@ def create_environment(
 
     if settings.routing_mode == "traefik":
         slug = slugify_branch(env_name)
-        traefik_router = f"oduflow-{slug}"
+        traefik_router = f"oduflow-{team.team_id}-{slug}"
         traefik_host = get_env_hostname(env_name, team.hostname)
         labels.update(
             {
@@ -1068,7 +1075,14 @@ def create_environment(
         )
         setup_logs.append(
             _init_empty_database(
-                client, settings, odoo_image, env_db, odoo_env, odoo_volumes, env_name
+                client,
+                settings,
+                team,
+                odoo_image,
+                env_db,
+                odoo_env,
+                odoo_volumes,
+                env_name,
             )
         )
 
@@ -1183,7 +1197,7 @@ def protect_environment(
 ) -> dict[str, Any]:
     """Mark environment as protected by creating .protected marker file."""
     client = get_client()
-    container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    container_name = get_resource_name(env_name, "odoo", settings.prefix, team.team_id)
     try:
         client.containers.get(container_name)
     except docker.errors.NotFound:
@@ -1200,7 +1214,7 @@ def unprotect_environment(
 ) -> dict[str, Any]:
     """Remove protection from environment by deleting .protected marker file."""
     client = get_client()
-    container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    container_name = get_resource_name(env_name, "odoo", settings.prefix, team.team_id)
     try:
         client.containers.get(container_name)
     except docker.errors.NotFound:
@@ -1222,7 +1236,7 @@ def set_note(
 ) -> dict[str, Any]:
     """Set or clear a note for an environment."""
     client = get_client()
-    container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    container_name = get_resource_name(env_name, "odoo", settings.prefix, team.team_id)
     try:
         client.containers.get(container_name)
     except docker.errors.NotFound:
@@ -1247,16 +1261,18 @@ def delete_environment(
             f"Environment '{env_name}' is protected. Unprotect it before deleting."
         )
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     env_db = get_db_name(env_name, team.team_id)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
 
     container_exists = True
     try:
         existing = client.containers.get(odoo_container_name)
-        # Container names are not team-namespaced; never stop/remove a container
-        # that belongs to another team (issue #39). Treat it as absent so this
-        # team's own DB/workspace/port are still cleaned up.
+        # Defence in depth on top of team-scoped names: never stop/remove a
+        # container that belongs to another team (issue #39). Treat it as
+        # absent so this team's own DB/workspace/port are still cleaned up.
         label = existing.labels.get(settings.team_label)
         if label is not None and label != team.team_id:
             container_exists = False
@@ -1438,16 +1454,16 @@ def wait_for_odoo_ready(
     return False
 
 
-def ensure_running(
-    settings: Settings, env_name: str, team: TeamSettings | None = None
-) -> bool:
+def ensure_running(settings: Settings, env_name: str, team: TeamSettings) -> bool:
     """Start the environment's Odoo container if it is stopped.
 
     Returns True when a start was needed (the caller may want to tell the
     agent the environment was woken up), False when it was already running.
     """
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     try:
         container = client.containers.get(odoo_container_name)
     except docker.errors.NotFound:
@@ -1466,11 +1482,11 @@ def _assert_team_owns(
 ) -> None:
     """Reject operating on a container that belongs to another team.
 
-    Container names are not team-namespaced, so without this check a caller
-    scoped to one team could start/stop/restart/delete or read logs of another
-    team's identically-named environment (issue #39). The NotFound message is
-    reused so the existence of another team's env is not disclosed. Skipped when
-    team is None (internal callers that have no team in scope).
+    Defence in depth on top of team-scoped container names (issue #39): even
+    if a name unexpectedly resolves across teams, the team label must match.
+    The NotFound message is reused so the existence of another team's env is
+    not disclosed. Skipped when team is None (internal callers that have no
+    team in scope).
     """
     if team is None:
         return
@@ -1482,10 +1498,12 @@ def _assert_team_owns(
 
 
 def restart_environment(
-    settings: Settings, env_name: str, team: TeamSettings | None = None
+    settings: Settings, env_name: str, team: TeamSettings
 ) -> dict[str, str]:
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         odoo_container = client.containers.get(odoo_container_name)
@@ -1508,7 +1526,9 @@ def stop_environment(
             f"Environment '{env_name}' is protected. Unprotect it before stopping."
         )
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         odoo_container = client.containers.get(odoo_container_name)
@@ -1525,10 +1545,12 @@ def stop_environment(
 
 
 def start_environment(
-    settings: Settings, env_name: str, team: TeamSettings | None = None
+    settings: Settings, env_name: str, team: TeamSettings
 ) -> dict[str, str]:
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         db_container = client.containers.get(settings.shared_db_container)
@@ -1561,7 +1583,9 @@ def get_environment_info(
     from oduflow.docker_ops.stats import _get_one_container_stats
 
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     result: dict[str, Any] = {
         "env_name": env_name,
@@ -1681,7 +1705,9 @@ def _local_snapshot_path(env_name: str, team: TeamSettings) -> str:
     )
 
 
-def _load_local_snapshot(env_name: str, team: TeamSettings) -> dict[str, dict[str, int]]:
+def _load_local_snapshot(
+    env_name: str, team: TeamSettings
+) -> dict[str, dict[str, int]]:
     snap_path = _local_snapshot_path(env_name, team)
     if not os.path.isfile(snap_path):
         return {}
@@ -1904,7 +1930,9 @@ def pull_environment(
     from oduflow.git_ops import pull_repo
 
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         container_obj = client.containers.get(odoo_container_name)
@@ -2058,7 +2086,9 @@ def update_environment(
     comes from the image itself.
     """
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     # ------------------------------------------------------------------
     # 1. Look up existing container and extract its configuration

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -25,7 +25,9 @@ from oduflow.docker_ops.system_ops import (
     _resolve_instance_conf,
     check_db_quota,
     ensure_team_tablespace,
+    ensure_team_network,
 )
+from oduflow.docker_ops.stats import default_env_limits
 from oduflow.env_credentials import create_credentials, load_credentials
 from oduflow.errors import (
     ConflictError,
@@ -40,6 +42,7 @@ from oduflow.naming import (
     get_env_hostname,
     get_filestore_paths,
     get_repo_path,
+    get_team_network_name,
     get_resource_name,
     get_template_db_name,
     get_workspace_path,
@@ -609,7 +612,8 @@ def _init_empty_database(
         image=odoo_image,
         name=init_name,
         detach=True,
-        network=settings.shared_network,
+        network=get_team_network_name(team.team_id, settings.prefix),
+        **default_env_limits(),
         environment=odoo_env,
         volumes=odoo_volumes,
         command=f"odoo -d {env_db} -i base --stop-after-init --no-http",
@@ -722,6 +726,7 @@ def create_environment(
             )
 
     check_db_quota(client, settings, team)
+    ensure_team_network(client, settings, team)
 
     _cleanup_old_environment(client, settings, team, env_name)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
@@ -775,6 +780,9 @@ def create_environment(
                 f"traefik.http.routers.{traefik_router}.tls": "true",
                 f"traefik.http.routers.{traefik_router}.tls.certresolver": "letsencrypt",
                 f"traefik.http.services.{traefik_router}.loadbalancer.server.port": "8069",
+                "traefik.docker.network": get_team_network_name(
+                    team.team_id, settings.prefix
+                ),
             }
         )
 
@@ -1047,7 +1055,8 @@ def create_environment(
         image=odoo_image,
         name=odoo_container_name,
         detach=True,
-        network=settings.shared_network,
+        network=get_team_network_name(team.team_id, settings.prefix),
+        **default_env_limits(),
         environment=odoo_env,
         labels=labels,
         volumes=odoo_volumes,
@@ -2261,7 +2270,8 @@ def update_environment(
         image=odoo_image,
         name=odoo_container_name,
         detach=True,
-        network=settings.shared_network,
+        network=get_team_network_name(team.team_id, settings.prefix),
+        **default_env_limits(),
         environment=env_dict,
         labels=labels,
         volumes=volumes,

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -24,6 +24,7 @@ from oduflow.docker_ops.system_ops import (
     _exec_sql,
     _resolve_instance_conf,
     check_db_quota,
+    ensure_team_tablespace,
 )
 from oduflow.env_credentials import create_credentials, load_credentials
 from oduflow.errors import (
@@ -865,18 +866,19 @@ def create_environment(
             container_path = f"/mnt/extra-addons-{repo_name}"
             extra_mount_paths.append((wt_path, container_path))
 
+    ts_name = ensure_team_tablespace(client, settings, team)
     if template_name is not None:
         tpl_db = get_template_db_name(template_name, team.team_id)
         _exec_sql(
             client,
             settings,
-            f'CREATE DATABASE "{env_db}" TEMPLATE "{tpl_db}";',
+            f'CREATE DATABASE "{env_db}" TEMPLATE "{tpl_db}" TABLESPACE "{ts_name}";',
         )
     else:
         _exec_sql(
             client,
             settings,
-            f'CREATE DATABASE "{env_db}";',
+            f'CREATE DATABASE "{env_db}" TABLESPACE "{ts_name}";',
         )
 
     env_creds = create_credentials(env_name, team.team_id, team.workspaces_dir)

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -60,7 +60,9 @@ def run_environment_tests(
     settings: Settings, team: TeamSettings, env_name: str, modules: str
 ) -> str:
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     env_db = get_db_name(env_name, team.team_id)
 
     try:
@@ -108,12 +110,13 @@ def get_environment_logs(
     grep: str = "",
     level: str = "",
     container_name: str = "",
-    team: TeamSettings | None = None,
+    *,
+    team: TeamSettings,
 ) -> str:
     client = get_client()
     if container_name:
         # Only allow containers that belong to this environment.
-        env_prefix = get_resource_name(env_name, "", settings.prefix)
+        env_prefix = get_resource_name(env_name, "", settings.prefix, team.team_id)
         if not container_name.startswith(env_prefix):
             raise NotFoundError(
                 f"Container '{container_name}' does not belong to "
@@ -121,7 +124,9 @@ def get_environment_logs(
             )
         target_container_name = container_name
     else:
-        target_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+        target_container_name = get_resource_name(
+            env_name, "odoo", settings.prefix, team.team_id
+        )
 
     # Fetch more lines when filtering to have meaningful results
     fetch_lines = min(n_lines * 10, 10_000) if (grep or level) else n_lines
@@ -134,8 +139,8 @@ def get_environment_logs(
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
-    # Container names are not team-namespaced: don't expose another team's logs
-    # (issue #39). Skipped when team is None (internal callers).
+    # Defence in depth on top of team-scoped names: never expose another
+    # team's logs even if a name resolves unexpectedly (issue #39).
     if team is not None:
         label = container.labels.get(settings.team_label)
         if label is not None and label != team.team_id:
@@ -166,7 +171,9 @@ def _run_odoo_module_command(
         raise ValueError("At least one module name is required.")
 
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     env_db = get_db_name(env_name, team.team_id)
 
     try:
@@ -211,10 +218,16 @@ _FILE_SIZE_LIMIT = 100 * 1024  # 100KB
 
 
 def read_file_in_environment(
-    settings: Settings, env_name: str, path: str, read_range: str = ""
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    path: str,
+    read_range: str = "",
 ) -> dict[str, Any]:
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         container = client.containers.get(odoo_container_name)
@@ -311,10 +324,16 @@ def read_file_in_environment(
 
 
 def run_command_in_environment(
-    settings: Settings, env_name: str, command: str, user: str = "odoo"
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    command: str,
+    user: str = "odoo",
 ) -> dict[str, Any]:
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         container = client.containers.get(odoo_container_name)
@@ -340,7 +359,9 @@ def reset_admin_password(
     settings: Settings, team: TeamSettings, env_name: str, new_password: str = "test"
 ) -> dict[str, str]:
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     env_db = get_db_name(env_name, team.team_id)
 
     try:
@@ -435,7 +456,12 @@ _WRITE_FILE_LIMIT = 1_000_000  # 1 MB
 
 
 def write_file_in_environment(
-    settings: Settings, env_name: str, path: str, content: str, user: str = "odoo"
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    path: str,
+    content: str,
+    user: str = "odoo",
 ) -> dict[str, Any]:
     """Write a text file inside the Odoo container via tar stream."""
     import io
@@ -447,7 +473,9 @@ def write_file_in_environment(
         )
 
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         container = client.containers.get(odoo_container_name)
@@ -487,7 +515,9 @@ def run_odoo_shell(
     import tarfile
 
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     env_db = get_db_name(env_name, team.team_id)
 
     try:
@@ -538,6 +568,7 @@ def run_odoo_shell(
 
 def search_in_environment(
     settings: Settings,
+    team: TeamSettings,
     env_name: str,
     pattern: str,
     path: str = "/mnt/extra-addons",
@@ -546,7 +577,9 @@ def search_in_environment(
 ) -> dict[str, Any]:
     """Search for a pattern in files inside the Odoo container."""
     client = get_client()
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
 
     try:
         container = client.containers.get(odoo_container_name)

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -10,6 +10,7 @@ from oduflow.docker_ops.client import get_client
 from oduflow.docker_ops import service_presets
 from oduflow.docker_ops import volume_ops
 from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
+from oduflow.naming import get_service_container_name
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -63,7 +64,7 @@ def create_service(
     privileged: bool = False,
 ) -> dict[str, str]:
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     # Check that the shared network exists (not needed for host mode)
     if not host_mode:
@@ -87,9 +88,7 @@ def create_service(
         "oduflow.managed": "true",
         "oduflow.team": team.team_id,
         "oduflow.service": name,
-        "oduflow.created_at": datetime.datetime.now(
-            datetime.timezone.utc
-        ).isoformat(),
+        "oduflow.created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
 
     run_kwargs: dict = {
@@ -176,9 +175,11 @@ def create_service(
     }
 
 
-def restart_service(settings: Settings, name: str) -> dict[str, str]:
+def restart_service(
+    settings: Settings, team: TeamSettings, name: str
+) -> dict[str, str]:
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     try:
         container = client.containers.get(container_name)
@@ -194,9 +195,9 @@ def restart_service(settings: Settings, name: str) -> dict[str, str]:
     }
 
 
-def delete_service(settings: Settings, name: str) -> dict[str, str]:
+def delete_service(settings: Settings, team: TeamSettings, name: str) -> dict[str, str]:
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     try:
         container = client.containers.get(container_name)
@@ -239,22 +240,28 @@ def _describe_service_container(
     is_host_mode = container.labels.get("oduflow.host_mode") == "true"
 
     if settings.routing_mode == "traefik":
-        rule_label = f"traefik.http.routers.oduflow-svc-{svc_name}.rule"
-        rule_value = container.labels.get(rule_label, "")
+        # Router names embed the container name, which changed with naming v2;
+        # containers created before the rename migration still carry labels
+        # with the old name. Match by label suffix instead of exact router name.
+        def _label_by_suffix(suffix: str) -> str:
+            for key, value in container.labels.items():
+                if key.startswith("traefik.http.") and key.endswith(suffix):
+                    return str(value)
+            return ""
+
+        rule_value = _label_by_suffix(".rule")
         match = re.search(r"Host\(`([^`]+)`\)", rule_value)
         if match:
             hostname = match.group(1)
             url = f"https://{hostname}"
 
         if is_host_mode:
-            url_label = f"traefik.http.services.oduflow-svc-{svc_name}.loadbalancer.server.url"
-            url_value = container.labels.get(url_label, "")
+            url_value = _label_by_suffix(".loadbalancer.server.url")
             port_match = re.search(r":(\d+)$", url_value)
             if port_match:
                 port_num = int(port_match.group(1))
         else:
-            port_label = f"traefik.http.services.oduflow-svc-{svc_name}.loadbalancer.server.port"
-            label_port = container.labels.get(port_label)
+            label_port = _label_by_suffix(".loadbalancer.server.port")
             if label_port:
                 port_num = int(label_port)
     else:
@@ -353,7 +360,7 @@ def get_service_info(settings: Settings, team: TeamSettings, name: str) -> dict:
     if the service container is missing.
     """
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     try:
         container = client.containers.get(container_name)
@@ -405,7 +412,7 @@ def update_service(
     even if the image digest has not changed.
     """
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     try:
         container = client.containers.get(container_name)
@@ -459,25 +466,26 @@ def update_service(
         hostname: str | None = None
 
         if settings.routing_mode == "traefik":
-            rule_label = f"traefik.http.routers.{container_name}.rule"
-            rule_value = container.labels.get(rule_label, "")
+            # Suffix-matched: pre-migration containers carry labels keyed by
+            # their old (team-less) container name.
+            def _label_by_suffix(suffix: str) -> str:
+                for key, value in container.labels.items():
+                    if key.startswith("traefik.http.") and key.endswith(suffix):
+                        return str(value)
+                return ""
+
+            rule_value = _label_by_suffix(".rule")
             match = re.search(r"Host\(`([^`]+)`\)", rule_value)
             if match:
                 hostname = match.group(1)
 
             if is_host_mode:
-                url_label = (
-                    f"traefik.http.services.{container_name}.loadbalancer.server.url"
-                )
-                url_value = container.labels.get(url_label, "")
+                url_value = _label_by_suffix(".loadbalancer.server.url")
                 port_match = re.search(r":(\d+)$", url_value)
                 if port_match:
                     port = int(port_match.group(1))
             else:
-                port_label = (
-                    f"traefik.http.services.{container_name}.loadbalancer.server.port"
-                )
-                label_port = container.labels.get(port_label)
+                label_port = _label_by_suffix(".loadbalancer.server.port")
                 if label_port:
                     port = int(label_port)
         else:
@@ -500,7 +508,7 @@ def update_service(
                 vol_docker_name = mount.get("Name", "")
                 prefix = f"oduflow-vol-{team.team_id}-"
                 if vol_docker_name.startswith(prefix):
-                    short_name = vol_docker_name[len(prefix):]
+                    short_name = vol_docker_name[len(prefix) :]
                     vols.append(
                         {
                             "volume": short_name,
@@ -613,9 +621,11 @@ def update_service(
     return result
 
 
-def get_service_logs(settings: Settings, name: str, lines: int = 100) -> str:
+def get_service_logs(
+    settings: Settings, team: TeamSettings, name: str, lines: int = 100
+) -> str:
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     try:
         container = client.containers.get(container_name)
@@ -627,10 +637,10 @@ def get_service_logs(settings: Settings, name: str, lines: int = 100) -> str:
 
 
 def run_command_in_service(
-    settings: Settings, name: str, command: str, user: str = "root"
+    settings: Settings, team: TeamSettings, name: str, command: str, user: str = "root"
 ) -> dict[str, object]:
     client = get_client()
-    container_name = f"oduflow-svc-{name}"
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
     try:
         container = client.containers.get(container_name)

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -9,7 +9,7 @@ import docker
 from oduflow.docker_ops.client import get_client
 from oduflow.docker_ops import service_presets
 from oduflow.docker_ops import volume_ops
-from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
+from oduflow.errors import ConflictError, NotFoundError
 from oduflow.naming import get_service_container_name
 from oduflow.settings import Settings, TeamSettings
 
@@ -66,15 +66,12 @@ def create_service(
     client = get_client()
     container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
-    # Check that the shared network exists (not needed for host mode)
+    # Services join the team's isolated network (not needed for host mode).
+    team_network = ""
     if not host_mode:
-        try:
-            client.networks.get(settings.shared_network)
-        except docker.errors.NotFound:
-            raise PrerequisiteNotMetError(
-                f"Shared network '{settings.shared_network}' not found. "
-                "System not initialized. Restart oduflow."
-            )
+        from oduflow.docker_ops.system_ops import ensure_team_network
+
+        team_network = ensure_team_network(client, settings, team)
 
     # Check for existing container
     try:
@@ -103,7 +100,7 @@ def create_service(
         run_kwargs["network_mode"] = "host"
         labels["oduflow.host_mode"] = "true"
     else:
-        run_kwargs["network"] = settings.shared_network
+        run_kwargs["network"] = team_network
 
     if settings.routing_mode == "traefik":
         if not hostname:
@@ -124,6 +121,7 @@ def create_service(
             labels[
                 f"traefik.http.services.{container_name}.loadbalancer.server.port"
             ] = str(port)
+            labels["traefik.docker.network"] = team_network
         url = f"https://{hostname}"
     else:
         if not host_mode:

--- a/src/oduflow/docker_ops/stats.py
+++ b/src/oduflow/docker_ops/stats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -7,9 +8,11 @@ import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
 from typing import Any
 
 from oduflow.docker_ops.client import get_client
+from oduflow.naming import get_db_name, get_filestore_paths, get_workspace_path
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -283,3 +286,141 @@ def get_system_stats() -> dict[str, Any]:
         )
 
     return result
+
+
+# ── Storage stats: DB + disk usage per environment and per team ──────────────
+#
+# Walking a filestore is far too slow for the dashboard polling loop, so these
+# numbers are computed only on demand (the per-environment refresh button, or
+# the team-wide REST refresh) and cached in team_data_dir/storage_stats.json.
+# The same cache is the data source for external billing/quota tooling: an
+# operator script can POST /api/usage/refresh per team and read the totals
+# without touching Docker or PostgreSQL itself.
+
+_STORAGE_CACHE_FILE = "storage_stats.json"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _storage_cache_path(team: TeamSettings) -> str:
+    return os.path.join(team.data_dir, _STORAGE_CACHE_FILE)
+
+
+def read_storage_cache(team: TeamSettings) -> dict[str, Any]:
+    """Return the cached storage stats: {"envs": {name: entry}, "team": entry|None}."""
+    try:
+        with open(_storage_cache_path(team)) as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return {"envs": data.get("envs", {}), "team": data.get("team")}
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.debug("Unreadable storage stats cache", exc_info=True)
+    return {"envs": {}, "team": None}
+
+
+def _write_storage_cache(team: TeamSettings, cache: dict[str, Any]) -> None:
+    path = _storage_cache_path(team)
+    os.makedirs(team.data_dir, exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(cache, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def _dir_size_bytes(path: str, skip_dirs: set[str] | None = None) -> int:
+    """Sum file sizes under ``path``, pruning any directory in ``skip_dirs``."""
+    skip = skip_dirs or set()
+    total = 0
+    for dirpath, dirnames, filenames in os.walk(path, onerror=lambda e: None):
+        dirnames[:] = [d for d in dirnames if os.path.join(dirpath, d) not in skip]
+        for name in filenames:
+            try:
+                total += os.lstat(os.path.join(dirpath, name)).st_size
+            except OSError:
+                continue
+    return total
+
+
+def _env_merged_filestore_skip(env_name: str, team: TeamSettings) -> set[str]:
+    """The overlay's merged view includes the template's read-only lower layer;
+    only the upper layer is data this environment actually adds, so the merged
+    mountpoint is excluded from disk sizing (it would also double-count the
+    upper layer)."""
+    paths = get_filestore_paths(env_name, team.workspaces_dir)
+    if os.path.isdir(paths["upper"]):
+        return {paths["merged"]}
+    return set()
+
+
+def _env_db_size_bytes(settings: Settings, team: TeamSettings, env_name: str) -> int:
+    from oduflow.docker_ops.system_ops import _exec_sql
+
+    db_name = get_db_name(env_name, team.team_id)
+    out = _exec_sql(
+        get_client(),
+        settings,
+        "SELECT COALESCE((SELECT pg_database_size(datname) FROM pg_database "
+        f"WHERE datname = '{db_name}'), 0);",
+    )
+    return int(out) if out.strip().isdigit() else 0
+
+
+def compute_env_storage(
+    settings: Settings, team: TeamSettings, env_name: str
+) -> dict[str, Any]:
+    """Measure one environment: database size (one catalog query) and workspace
+    disk size (full walk — seconds on large filestores, hence the cache)."""
+    workspace = get_workspace_path(env_name, team.workspaces_dir)
+    disk = 0
+    if os.path.isdir(workspace):
+        disk = _dir_size_bytes(workspace, _env_merged_filestore_skip(env_name, team))
+    return {
+        "db_bytes": _env_db_size_bytes(settings, team, env_name),
+        "disk_bytes": disk,
+        "computed_at": _utcnow_iso(),
+    }
+
+
+def refresh_env_storage(
+    settings: Settings, team: TeamSettings, env_name: str
+) -> dict[str, Any]:
+    """Recompute one environment's storage entry and persist it in the cache."""
+    entry = compute_env_storage(settings, team, env_name)
+    cache = read_storage_cache(team)
+    cache["envs"][env_name] = entry
+    _write_storage_cache(team, cache)
+    return entry
+
+
+def refresh_team_storage(settings: Settings, team: TeamSettings) -> dict[str, Any]:
+    """Recompute storage for every environment plus team totals.
+
+    The team disk total covers the whole team data dir (workspaces, templates,
+    shared repos, dumps) minus overlay merged views; the team DB total is the
+    same single pg_database catalog query the quota check uses. This is the
+    entry point external billing tooling calls per team.
+    """
+    from oduflow.docker_ops import env_ops
+    from oduflow.docker_ops.system_ops import get_team_db_usage_bytes
+
+    env_names = [e["env_name"] for e in env_ops.list_environments(settings, team)]
+    envs = {name: compute_env_storage(settings, team, name) for name in env_names}
+
+    skip: set[str] = set()
+    for name in env_names:
+        skip |= _env_merged_filestore_skip(name, team)
+    cache = {
+        "envs": envs,
+        "team": {
+            "db_bytes": get_team_db_usage_bytes(get_client(), settings, team.team_id),
+            "disk_bytes": _dir_size_bytes(team.data_dir, skip),
+            "computed_at": _utcnow_iso(),
+        },
+    }
+    _write_storage_cache(team, cache)
+    return cache

--- a/src/oduflow/docker_ops/stats.py
+++ b/src/oduflow/docker_ops/stats.py
@@ -424,3 +424,29 @@ def refresh_team_storage(settings: Settings, team: TeamSettings) -> dict[str, An
     }
     _write_storage_cache(team, cache)
     return cache
+
+
+# ── Default resource limits for environment containers ───────────────────────
+
+_GB = 1024**3
+
+
+def default_env_limits() -> dict[str, Any]:
+    """Resource limits applied to every environment container.
+
+    Auto-derived from host size — no config knobs: memory is a quarter of
+    host RAM clamped to [2 GB, 8 GB] (Odoo installs and test runs are
+    memory-hungry; the cap keeps one tenant's environment from taking the
+    machine), plus a pids ceiling against fork bombs. CPU gets no hard
+    quota: it is compressible, the kernel's fair scheduler already splits it
+    evenly under contention, and a cap would only slow work on an idle host.
+    """
+    mem = _read_memory_linux()
+    if mem is None and sys.platform == "darwin":
+        mem = _read_memory_macos()
+    total_bytes = int(mem[0] * 1024 * 1024) if mem else 0
+    if total_bytes:
+        mem_limit = min(8 * _GB, max(2 * _GB, total_bytes // 4))
+    else:
+        mem_limit = 4 * _GB
+    return {"mem_limit": mem_limit, "pids_limit": 4096}

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -15,12 +15,18 @@ import docker
 from docker import DockerClient
 
 from oduflow.docker_ops.client import chown_recursive, get_client, get_odoo_uid_gid
+from oduflow.docker_ops.stats import default_env_limits
 from oduflow.errors import (
     ExternalCommandError,
     NotFoundError,
     PrerequisiteNotMetError,
 )
-from oduflow.naming import get_db_name, get_tablespace_name, get_template_db_name
+from oduflow.naming import (
+    get_db_name,
+    get_tablespace_name,
+    get_team_network_name,
+    get_template_db_name,
+)
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -200,7 +206,6 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
             "--log.level=INFO",
             "--providers.docker=true",
             "--providers.docker.exposedbydefault=false",
-            f"--providers.docker.network={settings.shared_network}",
             "--providers.file.filename=/etc/traefik/dynamic/oduflow.json",
             "--providers.file.watch=true",
             "--entrypoints.web.address=:80",
@@ -566,6 +571,48 @@ def ensure_team_tablespace(
     return ts_name
 
 
+def ensure_team_network(
+    client: DockerClient, settings: Settings, team: TeamSettings
+) -> str:
+    """Ensure the team's isolated network exists and infra is attached to it.
+
+    Environment/service containers join only their team network, so one
+    tenant's code can never reach another tenant's containers. The shared
+    PostgreSQL container (password-protected, per-env roles) and Traefik (in
+    traefik mode) are attached to every team network — they are the only
+    cross-team surface. Idempotent and cheap.
+    """
+    net_name = get_team_network_name(team.team_id, settings.prefix)
+    try:
+        net = client.networks.get(net_name)
+    except docker.errors.NotFound:
+        net = client.networks.create(
+            net_name,
+            labels={
+                settings.managed_label: "true",
+                settings.system_label: "true",
+                settings.team_label: team.team_id,
+            },
+        )
+        logger.info("Created network %s", net_name)
+        _ensure_iptables_accept(client, net_name)
+
+    infra = [settings.shared_db_container]
+    if settings.routing_mode == "traefik":
+        infra.append(settings.traefik_container)
+    for container_name in infra:
+        try:
+            container = client.containers.get(container_name)
+        except docker.errors.NotFound:
+            continue
+        try:
+            net.connect(container)
+        except docker.errors.APIError as exc:
+            if "already exists" not in str(exc).lower():
+                raise
+    return net_name
+
+
 def _ensure_iptables_accept(client: DockerClient, network_name: str) -> None:
     try:
         net = client.networks.get(network_name)
@@ -618,6 +665,9 @@ def init_system(
     _ensure_pg_container(client, settings, system_labels)
 
     _wait_pg_ready(client, settings)
+
+    for team in settings.teams.values():
+        ensure_team_network(client, settings, team)
 
     logger.info("System initialized")
     return {"status": "initialized"}
@@ -866,7 +916,8 @@ def init_template(
         odoo_image,
         name=temp_container_name,
         detach=True,
-        network=settings.shared_network,
+        network=ensure_team_network(client, settings, team),
+        **default_env_limits(),
         environment={
             "HOST": settings.shared_db_container,
             "USER": settings.db_user,
@@ -1293,6 +1344,16 @@ def destroy_system(settings: Settings) -> dict[str, str]:
         pass
 
     try:
+        for extra_net in client.networks.list(
+            filters={"label": f"{settings.managed_label}=true"}
+        ):
+            if extra_net.name == settings.shared_network:
+                continue
+            try:
+                extra_net.remove()
+                removed.append(extra_net.name)
+            except docker.errors.APIError:
+                logger.warning("Could not remove network %s", extra_net.name)
         net = client.networks.get(settings.shared_network)
         net.remove()
         removed.append(settings.shared_network)

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -263,6 +263,55 @@ def _exec_sql(
     return result.strip()
 
 
+def get_team_db_usage_bytes(
+    client: DockerClient, settings: Settings, team_id: str
+) -> int:
+    """Combined on-disk size of the team's PostgreSQL databases (environments
+    and templates).
+
+    One catalog query: ``pg_database_size()`` stats the database's files under
+    PGDATA (each database is one directory there) — it does not scan table
+    contents, so this is milliseconds, not a table walk. Names are filtered in
+    Python to avoid LIKE-pattern escaping of the team id.
+    """
+    rows = _exec_sql(
+        client,
+        settings,
+        "SELECT datname, pg_database_size(datname) FROM pg_database "
+        "WHERE NOT datistemplate;",
+    )
+    prefixes = (f"oduflow_{team_id}_", f"oduflow_template_{team_id}_")
+    total = 0
+    for line in rows.splitlines():
+        name, _, size = line.partition("|")
+        if name.startswith(prefixes) and size.strip().isdigit():
+            total += int(size)
+    return total
+
+
+def check_db_quota(
+    client: DockerClient, settings: Settings, team: TeamSettings
+) -> None:
+    """Raise if the team's PostgreSQL usage is at or over its ``db_quota_gb``.
+
+    Called before operations that create a *new* database (environment or
+    template); replacement operations (refresh/reload) are not gated so a
+    team at its quota can still shrink or refresh what it has. 0 disables
+    the quota.
+    """
+    if team.db_quota_gb <= 0:
+        return
+    used = get_team_db_usage_bytes(client, settings, team.team_id)
+    quota = team.db_quota_gb * 1024**3
+    if used >= quota:
+        raise PrerequisiteNotMetError(
+            f"Team '{team.team_id}' database quota exceeded: "
+            f"{used / 1024**3:.1f} GB of {team.db_quota_gb} GB used "
+            "(db_quota_gb in oduflow.toml). Delete unused environments or "
+            "templates, or raise the quota."
+        )
+
+
 def _create_pg_role(
     client: DockerClient, settings: Settings, username: str, password: str, db_name: str
 ) -> None:
@@ -935,6 +984,11 @@ def publish_env_as_template(
             f"Database '{env_db}' for environment '{env_name}' not found."
         )
 
+    # Republishing an existing template replaces it (no net growth); only a
+    # brand-new template is gated by the quota.
+    if not _db_exists(client, settings, tpl_db):
+        check_db_quota(client, settings, team)
+
     _wait_pg_ready(client, settings)
     db_container = client.containers.get(settings.shared_db_container)
 
@@ -1228,6 +1282,9 @@ def import_from_odoo(
     # SSRF guard: importing a DB from a URL is a clearly-external operation, so
     # block loopback, the cloud metadata endpoint, and internal RFC1918 hosts.
     assert_allowed_url(base, allow_private=False)
+
+    # Gate on the DB quota before downloading a potentially huge backup.
+    check_db_quota(get_client(), settings, team)
 
     # 1. Resolve database name
     if not db_name:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1022,7 +1022,9 @@ def publish_env_as_template(
     env_paths = get_filestore_paths(env_name, team.workspaces_dir)
     branch_merged = env_paths["merged"]
     template_filestore_path = team.get_template_filestore_path(template_name)
-    source_container = get_resource_name(env_name, "odoo", settings.prefix)
+    source_container = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     source_is_overlay = os.path.isdir(branch_merged) and os.path.ismount(branch_merged)
 
     # Snapshot the source env's merged filestore while it is still mounted.

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -20,7 +20,7 @@ from oduflow.errors import (
     NotFoundError,
     PrerequisiteNotMetError,
 )
-from oduflow.naming import get_db_name, get_template_db_name
+from oduflow.naming import get_db_name, get_tablespace_name, get_template_db_name
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -467,6 +467,105 @@ def _extract_archive_from_container(
         os.remove(tmp_path)
 
 
+_PG_TABLESPACES_MOUNT = "/tablespaces"
+
+
+def _pg_tablespaces_host_dir(settings: Settings) -> str:
+    return os.path.join(settings.base_data_dir, "pg_tablespaces")
+
+
+def _ensure_pg_container(
+    client: DockerClient, settings: Settings, system_labels: dict[str, str]
+) -> None:
+    """Start (or create) the shared PostgreSQL container.
+
+    Mounts only the dedicated pg_tablespaces directory into the container —
+    never the whole data dir: PostgreSQL has no business seeing team
+    workspaces or credentials. Per-team tablespace directories are created
+    inside this one mount, so adding a team never requires recreating the
+    container (see ensure_team_tablespace).
+    """
+    try:
+        db_container = client.containers.get(settings.shared_db_container)
+        if db_container.status != "running":
+            db_container.start()
+        return
+    except docker.errors.NotFound:
+        pass
+
+    tablespaces_dir = _pg_tablespaces_host_dir(settings)
+    os.makedirs(tablespaces_dir, exist_ok=True)
+    client.containers.run(
+        settings.postgres_image,
+        name=settings.shared_db_container,
+        detach=True,
+        network=settings.shared_network,
+        volumes={
+            settings.shared_db_volume: {
+                "bind": "/var/lib/postgresql/data",
+                "mode": "rw",
+            },
+            str(_resolve_conf("postgresql.conf")): {
+                "bind": "/etc/postgresql/postgresql.conf",
+                "mode": "ro",
+            },
+            tablespaces_dir: {"bind": _PG_TABLESPACES_MOUNT, "mode": "rw"},
+        },
+        command=["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"],
+        environment={
+            "POSTGRES_USER": settings.db_user,
+            "POSTGRES_PASSWORD": settings.db_password,
+        },
+        labels=system_labels,
+        restart_policy={"Name": "unless-stopped"},
+    )
+    logger.info("Created container %s", settings.shared_db_container)
+
+
+def ensure_team_tablespace(
+    client: DockerClient, settings: Settings, team: TeamSettings
+) -> str:
+    """Ensure the team's PostgreSQL tablespace exists; return its name.
+
+    The tablespace lives in base_data_dir/pg_tablespaces/team_{id} on the
+    host. Hosting setups assign this directory the same XFS project ID as
+    team_{id}/, so one disk quota covers the team's files AND its databases.
+    Idempotent and cheap (one catalog query) — called before every
+    CREATE DATABASE.
+    """
+    ts_name = get_tablespace_name(team.team_id)
+    exists = _exec_sql(
+        client,
+        settings,
+        f"SELECT 1 FROM pg_tablespace WHERE spcname = '{ts_name}';",
+    )
+    if exists.strip() == "1":
+        return ts_name
+
+    host_dir = os.path.join(_pg_tablespaces_host_dir(settings), f"team_{team.team_id}")
+    os.makedirs(host_dir, exist_ok=True)
+    target = f"{_PG_TABLESPACES_MOUNT}/team_{team.team_id}"
+    container = client.containers.get(settings.shared_db_container)
+    # PostgreSQL requires the location to be owned by its OS user (postgres,
+    # regardless of POSTGRES_USER) with private permissions.
+    for cmd in (["chown", "postgres:postgres", target], ["chmod", "700", target]):
+        exit_code, output = container.exec_run(cmd, user="root")
+        if exit_code != 0:
+            out = (
+                output.decode("utf-8", errors="replace")
+                if isinstance(output, bytes)
+                else str(output)
+            )
+            raise ExternalCommandError(cmd[0], exit_code, out)
+    _exec_sql(
+        client,
+        settings,
+        f"CREATE TABLESPACE \"{ts_name}\" LOCATION '{target}';",
+    )
+    logger.info("Created tablespace %s at %s", ts_name, target)
+    return ts_name
+
+
 def _ensure_iptables_accept(client: DockerClient, network_name: str) -> None:
     try:
         net = client.networks.get(network_name)
@@ -516,35 +615,7 @@ def init_system(
         client.volumes.create(settings.shared_db_volume, labels=system_labels)
         logger.info("Created volume %s", settings.shared_db_volume)
 
-    try:
-        db_container = client.containers.get(settings.shared_db_container)
-        if db_container.status != "running":
-            db_container.start()
-    except docker.errors.NotFound:
-        client.containers.run(
-            settings.postgres_image,
-            name=settings.shared_db_container,
-            detach=True,
-            network=settings.shared_network,
-            volumes={
-                settings.shared_db_volume: {
-                    "bind": "/var/lib/postgresql/data",
-                    "mode": "rw",
-                },
-                str(_resolve_conf("postgresql.conf")): {
-                    "bind": "/etc/postgresql/postgresql.conf",
-                    "mode": "ro",
-                },
-            },
-            command=["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"],
-            environment={
-                "POSTGRES_USER": settings.db_user,
-                "POSTGRES_PASSWORD": settings.db_password,
-            },
-            labels=system_labels,
-            restart_policy={"Name": "unless-stopped"},
-        )
-        logger.info("Created container %s", settings.shared_db_container)
+    _ensure_pg_container(client, settings, system_labels)
 
     _wait_pg_ready(client, settings)
 
@@ -579,7 +650,8 @@ def reload_template(
         _exec_sql(client, settings, f'DROP DATABASE "{tpl_db}" WITH (FORCE);')
         logger.info("Dropped template DB %s", tpl_db)
 
-    _exec_sql(client, settings, f'CREATE DATABASE "{tpl_db}";')
+    ts_name = ensure_team_tablespace(client, settings, team)
+    _exec_sql(client, settings, f'CREATE DATABASE "{tpl_db}" TABLESPACE "{ts_name}";')
 
     db_container = client.containers.get(settings.shared_db_container)
     tmp_name = os.path.basename(resolved_dump)
@@ -759,35 +831,7 @@ def init_template(
         client.volumes.create(settings.shared_db_volume, labels=system_labels)
         logger.info("Created volume %s", settings.shared_db_volume)
 
-    try:
-        db_container = client.containers.get(settings.shared_db_container)
-        if db_container.status != "running":
-            db_container.start()
-    except docker.errors.NotFound:
-        client.containers.run(
-            settings.postgres_image,
-            name=settings.shared_db_container,
-            detach=True,
-            network=settings.shared_network,
-            volumes={
-                settings.shared_db_volume: {
-                    "bind": "/var/lib/postgresql/data",
-                    "mode": "rw",
-                },
-                str(_resolve_conf("postgresql.conf")): {
-                    "bind": "/etc/postgresql/postgresql.conf",
-                    "mode": "ro",
-                },
-            },
-            command=["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"],
-            environment={
-                "POSTGRES_USER": settings.db_user,
-                "POSTGRES_PASSWORD": settings.db_password,
-            },
-            labels=system_labels,
-            restart_policy={"Name": "unless-stopped"},
-        )
-        logger.info("Created container %s", settings.shared_db_container)
+    _ensure_pg_container(client, settings, system_labels)
 
     _wait_pg_ready(client, settings)
 

--- a/src/oduflow/env_credentials.py
+++ b/src/oduflow/env_credentials.py
@@ -32,9 +32,7 @@ def create_credentials(
     creds_path = os.path.join(workspace_path, _CREDENTIALS_FILE)
     # Atomic write with restrictive permissions: the file holds a plaintext PG
     # password, and a crash mid-write must not leave a half-written file.
-    fd = os.open(
-        creds_path + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
-    )
+    fd = os.open(creds_path + ".tmp", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         with os.fdopen(fd, "w") as f:
             json.dump(creds, f)

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -253,9 +253,7 @@ def classify_changes(
                     )
                 else:
                     xml_hot.append(f)
-                    _trace(
-                        "  file=%s ext=.xml module=%s -> hot-reload XML", f, module
-                    )
+                    _trace("  file=%s ext=.xml module=%s -> hot-reload XML", f, module)
             continue
 
         if ext == ".js":
@@ -488,12 +486,8 @@ def merge_recommendations(recs: Iterable[dict]) -> dict:
         (r.get("action", "none") for r in recs),
         key=lambda a: _ACTION_PRIORITY.get(a, 0),
     )
-    install = sorted(
-        {m for r in recs for m in r.get("modules_to_install", []) or []}
-    )
-    upgrade = sorted(
-        {m for r in recs for m in r.get("modules_to_upgrade", []) or []}
-    )
+    install = sorted({m for r in recs for m in r.get("modules_to_install", []) or []})
+    upgrade = sorted({m for r in recs for m in r.get("modules_to_upgrade", []) or []})
 
     details: dict = {}
     for key in _DETAIL_LIST_KEYS:

--- a/src/oduflow/licensing.py
+++ b/src/oduflow/licensing.py
@@ -135,9 +135,7 @@ def install_license(source_path: str, etc_dir: str | None = None) -> LicenseInfo
     return info
 
 
-def install_license_from_text(
-    key_text: str, etc_dir: str | None = None
-) -> LicenseInfo:
+def install_license_from_text(key_text: str, etc_dir: str | None = None) -> LicenseInfo:
     info = _verify_license_text(key_text)
     license_path = get_license_path(etc_dir)
     os.makedirs(os.path.dirname(license_path), exist_ok=True)

--- a/src/oduflow/migrations.py
+++ b/src/oduflow/migrations.py
@@ -48,10 +48,79 @@ class Migration:
     apply: Callable[[Settings], None]
 
 
+def _migrate_team_scoped_names(settings: Settings) -> None:
+    """Rename managed containers to the team-scoped naming scheme.
+
+    ``oduflow-{env}-{type}`` → ``oduflow-{team}-{env}-{type}`` and
+    ``oduflow-svc-{name}`` → ``oduflow-{team}-svc-{name}``. Docker rename
+    keeps volumes, network attachment, and restart policy; Traefik routing is
+    label-based (labels are immutable but reference no container names), so
+    nothing else changes. Idempotent: a container whose name no longer
+    matches the old scheme is skipped, so a partially-applied run resumes
+    cleanly.
+    """
+    import docker
+
+    from oduflow.docker_ops.client import get_client
+    from oduflow.naming import get_resource_name, get_service_container_name
+
+    client = get_client()
+    for team_id in settings.teams:
+        containers = client.containers.list(
+            all=True,
+            filters={
+                "label": [
+                    f"{settings.managed_label}=true",
+                    f"{settings.team_label}={team_id}",
+                ]
+            },
+        )
+        for container in containers:
+            name = container.name
+            if not name.startswith(settings.prefix):
+                continue
+            svc_name = container.labels.get("oduflow.service")
+            branch = container.labels.get(settings.branch_label)
+            if svc_name:
+                if not name.startswith(f"{settings.prefix}svc-"):
+                    continue  # already team-scoped
+                new_name = get_service_container_name(
+                    svc_name, settings.prefix, team_id
+                )
+            elif branch:
+                old_prefix = f"{settings.prefix}{branch.replace('/', '-')}-"
+                if not name.startswith(old_prefix):
+                    continue  # already team-scoped
+                resource_type = name[len(old_prefix) :]
+                new_name = get_resource_name(
+                    branch, resource_type, settings.prefix, team_id
+                )
+            else:
+                continue
+            if name == new_name:
+                continue
+            try:
+                container.rename(new_name)
+            except docker.errors.APIError as exc:
+                raise RuntimeError(
+                    f"Failed to rename container {name} -> {new_name}: {exc}"
+                ) from exc
+            logger.info("Renamed container %s -> %s", name, new_name)
+
+
 # Append-only registry, executed in list order. Ids are recorded in
 # migrations.json once applied; reordering or renaming entries would re-run
 # or skip steps on existing installs.
-MIGRATIONS: list[Migration] = []
+MIGRATIONS: list[Migration] = [
+    Migration(
+        id="0001-team-scoped-container-names",
+        description=(
+            "Rename managed containers to team-scoped names "
+            "(oduflow-{team}-{env}-{type}, oduflow-{team}-svc-{name})"
+        ),
+        apply=_migrate_team_scoped_names,
+    ),
+]
 
 
 @contextmanager

--- a/src/oduflow/migrations.py
+++ b/src/oduflow/migrations.py
@@ -202,6 +202,107 @@ def _migrate_team_pg_tablespaces(settings: Settings) -> None:
                 )
 
 
+def _migrate_per_team_networks(settings: Settings) -> None:
+    """Move each team's containers to the team's isolated Docker network.
+
+    Creates ``oduflow-{team}-net`` per team (attaching the shared PostgreSQL
+    container), connects every managed env/service container to it, and
+    disconnects them from the shared network — live, no restarts.
+    Established DB connections over the old network break once; Odoo
+    reconnects via DNS on the team network. A Traefik container still
+    pinning the shared backend network via ``--providers.docker.network`` is
+    removed here and recreated by system init right after migrations (the
+    ACME volume persists); afterwards each backend's network comes from the
+    container itself. Idempotent.
+    """
+    import docker
+
+    from oduflow.docker_ops import system_ops
+    from oduflow.docker_ops.client import get_client
+
+    client = get_client()
+
+    try:
+        traefik = client.containers.get(settings.traefik_container)
+        cmd = traefik.attrs.get("Config", {}).get("Cmd") or []
+        if any(str(arg).startswith("--providers.docker.network=") for arg in cmd):
+            logger.info(
+                "Removing %s (stale --providers.docker.network); system init "
+                "recreates it",
+                settings.traefik_container,
+            )
+            traefik.stop()
+            traefik.remove()
+    except docker.errors.NotFound:
+        pass
+
+    try:
+        shared_net = client.networks.get(settings.shared_network)
+    except docker.errors.NotFound:
+        shared_net = None
+
+    for team in settings.teams.values():
+        net_name = system_ops.ensure_team_network(client, settings, team)
+        net = client.networks.get(net_name)
+        containers = client.containers.list(
+            all=True,
+            filters={
+                "label": [
+                    f"{settings.managed_label}=true",
+                    f"{settings.team_label}={team.team_id}",
+                ]
+            },
+        )
+        for container in containers:
+            if container.labels.get(settings.system_label) == "true":
+                continue  # shared infra stays on the shared network
+            if container.attrs.get("HostConfig", {}).get("NetworkMode") == "host":
+                continue
+            networks = container.attrs.get("NetworkSettings", {}).get("Networks") or {}
+            if net_name not in networks:
+                net.connect(container)
+            if shared_net is not None and settings.shared_network in networks:
+                shared_net.disconnect(container)
+            logger.info("Moved container %s to %s", container.name, net_name)
+
+
+def _migrate_env_resource_limits(settings: Settings) -> None:
+    """Apply the default memory/pids limits to existing environment containers.
+
+    New containers get limits at creation; ``docker update`` retrofits the
+    running fleet without restarts. Best-effort per container: a failure is
+    logged and skipped (the next Update/Recreate applies limits anyway).
+    """
+    from oduflow.docker_ops.client import get_client
+    from oduflow.docker_ops.stats import default_env_limits
+
+    client = get_client()
+    limits = default_env_limits()
+    for team_id in settings.teams:
+        containers = client.containers.list(
+            all=True,
+            filters={
+                "label": [
+                    f"{settings.managed_label}=true",
+                    f"{settings.team_label}={team_id}",
+                ]
+            },
+        )
+        for container in containers:
+            # Environments only: services are operator-sized, infra is shared.
+            if not container.labels.get(settings.branch_label):
+                continue
+            try:
+                container.update(**limits)
+                logger.info("Applied resource limits to %s", container.name)
+            except Exception as exc:
+                logger.warning(
+                    "Could not apply resource limits to %s: %s",
+                    container.name,
+                    exc,
+                )
+
+
 # Append-only registry, executed in list order. Ids are recorded in
 # migrations.json once applied; reordering or renaming entries would re-run
 # or skip steps on existing installs.
@@ -221,6 +322,22 @@ MIGRATIONS: list[Migration] = [
             "under base_data_dir/pg_tablespaces/team_{id}"
         ),
         apply=_migrate_team_pg_tablespaces,
+    ),
+    Migration(
+        id="0003-per-team-networks",
+        description=(
+            "Move env/service containers to isolated per-team networks "
+            "(oduflow-{team}-net); shared infra attaches to every team network"
+        ),
+        apply=_migrate_per_team_networks,
+    ),
+    Migration(
+        id="0004-env-resource-limits",
+        description=(
+            "Apply default memory/pids limits to existing environment "
+            "containers via docker update"
+        ),
+        apply=_migrate_env_resource_limits,
     ),
 ]
 

--- a/src/oduflow/migrations.py
+++ b/src/oduflow/migrations.py
@@ -108,6 +108,100 @@ def _migrate_team_scoped_names(settings: Settings) -> None:
             logger.info("Renamed container %s -> %s", name, new_name)
 
 
+def _migrate_team_pg_tablespaces(settings: Settings) -> None:
+    """Move every team's databases into a per-team PostgreSQL tablespace.
+
+    Tablespace files live under ``base_data_dir/pg_tablespaces/team_{id}`` on
+    the host, so a filesystem project quota can cover a team's databases
+    together with its data dir. Steps:
+
+    1. If the PG container lacks the ``/tablespaces`` mount, recreate it once
+       (the data volume persists; seconds of downtime at startup).
+    2. Ensure each team's tablespace exists.
+    3. ``ALTER DATABASE ... SET TABLESPACE`` for every team database that is
+       not already there, blocking reconnects during the move
+       (``ALLOW_CONNECTIONS false`` + terminate). Odoo containers reconnect
+       on their own afterwards. Time is proportional to database size.
+
+    Idempotent: already-moved databases are skipped, so a partial run
+    resumes where it stopped.
+    """
+    import docker
+
+    from oduflow.docker_ops import system_ops
+    from oduflow.docker_ops.client import get_client
+    from oduflow.naming import get_tablespace_name
+
+    client = get_client()
+    try:
+        pg = client.containers.get(settings.shared_db_container)
+    except docker.errors.NotFound:
+        # No PG container: nothing to move. Fresh infrastructure is created
+        # with the mount, and databases are placed on creation.
+        return
+
+    has_mount = any(
+        m.get("Destination") == system_ops._PG_TABLESPACES_MOUNT
+        for m in pg.attrs.get("Mounts", [])
+    )
+    if not has_mount:
+        logger.info(
+            "Recreating %s with the tablespaces mount (data volume persists)",
+            settings.shared_db_container,
+        )
+        pg.stop()
+        pg.remove()
+        system_labels = {
+            settings.managed_label: "true",
+            settings.system_label: "true",
+        }
+        system_ops._ensure_pg_container(client, settings, system_labels)
+    system_ops._wait_pg_ready(client, settings)
+
+    rows = system_ops._exec_sql(
+        client,
+        settings,
+        "SELECT d.datname, COALESCE(t.spcname, '') FROM pg_database d "
+        "LEFT JOIN pg_tablespace t ON d.dattablespace = t.oid "
+        "WHERE NOT d.datistemplate;",
+    )
+    db_tablespaces = {}
+    for line in rows.splitlines():
+        name, _, spc = line.partition("|")
+        if name:
+            db_tablespaces[name] = spc
+
+    for team_id, team in settings.teams.items():
+        ts_name = get_tablespace_name(team_id)
+        system_ops.ensure_team_tablespace(client, settings, team)
+        prefixes = (f"oduflow_{team_id}_", f"oduflow_template_{team_id}_")
+        for db, current in sorted(db_tablespaces.items()):
+            if not db.startswith(prefixes) or current == ts_name:
+                continue
+            logger.info("Moving database %s to tablespace %s", db, ts_name)
+            system_ops._exec_sql(
+                client, settings, f'ALTER DATABASE "{db}" WITH ALLOW_CONNECTIONS false;'
+            )
+            system_ops._exec_sql(
+                client,
+                settings,
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{db}';",
+            )
+            try:
+                system_ops._exec_sql(
+                    client,
+                    settings,
+                    f'ALTER DATABASE "{db}" SET TABLESPACE "{ts_name}";',
+                )
+            finally:
+                system_ops._exec_sql(
+                    client,
+                    settings,
+                    f'ALTER DATABASE "{db}" WITH ALLOW_CONNECTIONS true;',
+                )
+
+
 # Append-only registry, executed in list order. Ids are recorded in
 # migrations.json once applied; reordering or renaming entries would re-run
 # or skip steps on existing installs.
@@ -119,6 +213,14 @@ MIGRATIONS: list[Migration] = [
             "(oduflow-{team}-{env}-{type}, oduflow-{team}-svc-{name})"
         ),
         apply=_migrate_team_scoped_names,
+    ),
+    Migration(
+        id="0002-team-pg-tablespaces",
+        description=(
+            "Move each team's databases into a per-team PostgreSQL tablespace "
+            "under base_data_dir/pg_tablespaces/team_{id}"
+        ),
+        apply=_migrate_team_pg_tablespaces,
     ),
 ]
 

--- a/src/oduflow/migrations.py
+++ b/src/oduflow/migrations.py
@@ -1,0 +1,149 @@
+"""Startup data migrations.
+
+Odoo-style upgrade mechanism for the on-disk/Docker state Oduflow manages:
+the code ships an ordered, append-only registry of one-shot migration steps,
+and the data directory records which steps were already applied
+(``migrations.json`` under ``base_data_dir``). On server start Oduflow diffs
+the registry against the recorded state and applies only the missing steps,
+oldest first.
+
+A fresh install (no state file and no ``team_*`` data yet) is stamped as
+fully applied without running anything — the same way Odoo skips migration
+scripts when a module is installed from scratch rather than upgraded.
+
+Adding a migration:
+
+- append a :class:`Migration` to ``MIGRATIONS`` with the next sequence number
+  in its id (``"0001-team-scoped-container-names"``);
+- never reorder, rename, or remove existing entries — recorded ids are what
+  keeps reruns idempotent on existing installs;
+- make the step itself idempotent where possible: state is persisted after
+  each successful step, so a step that crashed halfway is retried on the next
+  start.
+"""
+
+import fcntl
+import glob
+import json
+import logging
+import os
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings
+
+logger = logging.getLogger("oduflow")
+
+_STATE_FILENAME = "migrations.json"
+
+
+@dataclass(frozen=True)
+class Migration:
+    """One irreversible upgrade step, identified by a stable sequence id."""
+
+    id: str
+    description: str
+    apply: Callable[[Settings], None]
+
+
+# Append-only registry, executed in list order. Ids are recorded in
+# migrations.json once applied; reordering or renaming entries would re-run
+# or skip steps on existing installs.
+MIGRATIONS: list[Migration] = []
+
+
+@contextmanager
+def _state_lock(state_path: str) -> Iterator[None]:
+    """Serialize state read-modify-write across processes (and threads:
+    flock on two separate fds of the same file contends within one process
+    too)."""
+    fd = os.open(state_path + ".lock", os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _load_state(state_path: str) -> list[str] | None:
+    """Return the applied-id list, or None if no state was ever recorded."""
+    if not os.path.isfile(state_path):
+        return None
+    with open(state_path) as f:
+        data = json.load(f)
+    applied = data.get("applied", [])
+    return [str(mig_id) for mig_id in applied]
+
+
+def _write_state(state_path: str, applied: list[str]) -> None:
+    tmp_path = state_path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump({"applied": applied}, f, indent=2)
+        f.write("\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, state_path)
+
+
+def _is_fresh_install(settings: Settings) -> bool:
+    """No prior per-team data means there is nothing to migrate."""
+    pattern = os.path.join(settings.base_data_dir, "team_*")
+    return not any(os.path.isdir(path) for path in glob.glob(pattern))
+
+
+def run_pending(
+    settings: Settings, registry: list[Migration] | None = None
+) -> list[str]:
+    """Apply not-yet-applied migrations, oldest first; return the ids run.
+
+    Called once at server start, *before* shared-infrastructure init, so a
+    migration sees the data dir and Docker resources exactly as the previous
+    version left them. A failing step aborts startup (already-applied steps
+    stay recorded and are not re-run on the next attempt).
+    """
+    migs = MIGRATIONS if registry is None else registry
+    ids = [mig.id for mig in migs]
+    if len(set(ids)) != len(ids):
+        raise ValueError(f"Duplicate migration ids in registry: {ids}")
+
+    os.makedirs(settings.base_data_dir, exist_ok=True)
+    state_path = os.path.join(settings.base_data_dir, _STATE_FILENAME)
+    ran: list[str] = []
+    with _state_lock(state_path):
+        applied = _load_state(state_path)
+        if applied is None:
+            if _is_fresh_install(settings):
+                # Fresh install: current code lays down current-shape data,
+                # so historical steps have nothing to act on.
+                _write_state(state_path, ids)
+                if ids:
+                    logger.info(
+                        "Fresh install: stamped %d migration(s) as applied",
+                        len(ids),
+                    )
+                return []
+            applied = []  # pre-migrations-era install: everything is pending
+
+        for mig in migs:
+            if mig.id in applied:
+                continue
+            logger.info("Applying migration %s: %s", mig.id, mig.description)
+            try:
+                mig.apply(settings)
+            except Exception as exc:
+                raise PrerequisiteNotMetError(
+                    f"Startup migration '{mig.id}' failed: {exc}. Fix the "
+                    "cause and restart — already-applied steps will not "
+                    "re-run."
+                ) from exc
+            applied.append(mig.id)
+            # Persist after every step so a crash resumes at the failed one.
+            _write_state(state_path, applied)
+            ran.append(mig.id)
+
+    if ran:
+        logger.info("Applied %d migration(s): %s", len(ran), ", ".join(ran))
+    return ran

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -78,6 +78,12 @@ def get_env_hostname(env_name: str, hostname: str) -> str:
     return f"{slug}.{hostname}"
 
 
+def get_tablespace_name(team_id: str) -> str:
+    """PostgreSQL tablespace holding all of the team's databases (its files
+    live under base_data_dir/pg_tablespaces/team_{id} on the host)."""
+    return f"oduflow_team_{team_id}"
+
+
 def get_template_db_name(template_name: str, team_id: str = "1") -> str:
     # validate_template_name guarantees the (slugified) name cannot break out of
     # the double-quoted SQL identifier this is interpolated into.

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -78,6 +78,14 @@ def get_env_hostname(env_name: str, hostname: str) -> str:
     return f"{slug}.{hostname}"
 
 
+def get_team_network_name(team_id: str, prefix: str = "oduflow-") -> str:
+    """The team's isolated Docker network. Environment and service containers
+    join only this network; shared infrastructure (PostgreSQL, Traefik) is
+    additionally attached to every team network, so tenants can reach the
+    infra but never each other."""
+    return f"{prefix}{team_id}-net"
+
+
 def get_tablespace_name(team_id: str) -> str:
     """PostgreSQL tablespace holding all of the team's databases (its files
     live under base_data_dir/pg_tablespaces/team_{id} on the host)."""

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -46,9 +46,22 @@ def get_db_name(env_name: str, team_id: str = "1") -> str:
 
 
 def get_resource_name(
-    env_name: str, resource_type: str, prefix: str = "oduflow-"
+    env_name: str, resource_type: str, prefix: str, team_id: str
 ) -> str:
-    return f"{prefix}{env_name.replace('/', '-')}-{resource_type}"
+    """Docker container name for an environment resource.
+
+    Team-scoped (naming v2): two teams using the same branch name must never
+    collide on — or worse, operate on — each other's containers. Existing
+    containers are renamed to this scheme by startup migration
+    0001-team-scoped-container-names.
+    """
+    return f"{prefix}{team_id}-{env_name.replace('/', '-')}-{resource_type}"
+
+
+def get_service_container_name(name: str, prefix: str, team_id: str) -> str:
+    """Docker container name for an auxiliary service (team-scoped, see
+    get_resource_name)."""
+    return f"{prefix}{team_id}-svc-{name}"
 
 
 def get_workspace_path(env_name: str, workspaces_dir: str) -> str:

--- a/src/oduflow/quotas.py
+++ b/src/oduflow/quotas.py
@@ -1,0 +1,166 @@
+"""Per-team disk quota enforcement via XFS project quotas.
+
+A team's disk quota (``[team.*] disk_quota_gb``) is enforced by the kernel,
+not by walking directories: when ``base_data_dir`` lives on an XFS filesystem
+mounted with ``prjquota``, each team gets a filesystem *project* spanning its
+two directory trees — ``team_{id}/`` (workspaces, filestores, template dumps)
+and ``pg_tablespaces/team_{id}/`` (its PostgreSQL databases, see ADR 0024).
+Project quotas attach to the project ID rather than a single subtree, so one
+``bhard`` limit covers the client's files and databases together, and writes
+beyond it fail instantly with ENOSPC.
+
+When the filesystem does not support project quotas (macOS, ext4 without
+project quota, XFS without ``prjquota``), enforcement is simply off and the
+reason is logged once at startup — usage stays visible via the dashboard and
+``/api/usage``. Numeric project IDs are allocated per team in
+``base_data_dir/quota_projects.json``.
+
+Applied idempotently on every server start (``apply_all``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+from oduflow.settings import Settings, TeamSettings
+
+logger = logging.getLogger("oduflow")
+
+_PROJECTS_FILE = "quota_projects.json"
+_FIRST_PROJECT_ID = 1001
+
+
+def _read_mounts() -> list[tuple[str, str, str]]:
+    """Return (mountpoint, fstype, options) for every mounted filesystem."""
+    mounts: list[tuple[str, str, str]] = []
+    try:
+        with open("/proc/mounts") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 4:
+                    mounts.append((parts[1], parts[2], parts[3]))
+    except OSError:
+        pass
+    return mounts
+
+
+def _find_mount(path: str) -> tuple[str, str, str] | None:
+    """The mount entry holding ``path`` (longest matching mountpoint)."""
+    real = os.path.realpath(path)
+    best: tuple[str, str, str] | None = None
+    for mountpoint, fstype, options in _read_mounts():
+        if real == mountpoint or real.startswith(mountpoint.rstrip("/") + "/"):
+            if best is None or len(mountpoint) > len(best[0]):
+                best = (mountpoint, fstype, options)
+    return best
+
+
+def quota_support(settings: Settings) -> tuple[bool, str]:
+    """Whether project-quota enforcement is available for the data dir."""
+    if not sys.platform.startswith("linux"):
+        return False, f"platform is {sys.platform}, not linux"
+    if shutil.which("xfs_quota") is None:
+        return False, "xfs_quota binary not found (install xfsprogs)"
+    mount = _find_mount(settings.base_data_dir)
+    if mount is None:
+        return False, f"no mount found for {settings.base_data_dir}"
+    mountpoint, fstype, options = mount
+    if fstype != "xfs":
+        return False, f"{mountpoint} is {fstype}, not xfs"
+    opts = options.split(",")
+    if not any(opt in ("prjquota", "pquota") for opt in opts):
+        return False, f"{mountpoint} is not mounted with prjquota"
+    return True, mountpoint
+
+
+def _load_project_ids(settings: Settings) -> dict[str, int]:
+    path = os.path.join(settings.base_data_dir, _PROJECTS_FILE)
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return {str(k): int(v) for k, v in data.items()}
+    except (OSError, ValueError):
+        return {}
+
+
+def _project_id_for(settings: Settings, team_id: str) -> int:
+    """Stable numeric project ID for a team (allocated once, persisted)."""
+    ids = _load_project_ids(settings)
+    if team_id in ids:
+        return ids[team_id]
+    new_id = max(ids.values(), default=_FIRST_PROJECT_ID - 1) + 1
+    ids[team_id] = new_id
+    path = os.path.join(settings.base_data_dir, _PROJECTS_FILE)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(ids, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+    return new_id
+
+
+def _xfs_quota(mountpoint: str, command: str) -> None:
+    result = subprocess.run(
+        ["xfs_quota", "-x", "-c", command, mountpoint],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"xfs_quota -c '{command}' failed: {result.stderr.strip()}")
+
+
+def apply_team_disk_quota(
+    settings: Settings, team: TeamSettings, mountpoint: str
+) -> None:
+    """Attach the team's directories to its project and set the hard limit."""
+    project_id = _project_id_for(settings, team.team_id)
+    trees = [
+        team.data_dir,
+        os.path.join(settings.base_data_dir, "pg_tablespaces", f"team_{team.team_id}"),
+    ]
+    for tree in trees:
+        os.makedirs(tree, exist_ok=True)
+        # -s: set up the project (recursively stamps the project ID).
+        _xfs_quota(mountpoint, f"project -s -p {tree} {project_id}")
+    _xfs_quota(mountpoint, f"limit -p bhard={team.disk_quota_gb}g {project_id}")
+    logger.info(
+        "Disk quota for team '%s': %d GB (project %d)",
+        team.team_id,
+        team.disk_quota_gb,
+        project_id,
+    )
+
+
+def apply_all(settings: Settings) -> None:
+    """Apply disk quotas for every team with disk_quota_gb > 0 (idempotent).
+
+    Called on server start. Unsupported filesystems log one warning and skip;
+    a failure for one team does not block the others or the startup.
+    """
+    teams = [t for t in settings.teams.values() if t.disk_quota_gb > 0]
+    if not teams:
+        return
+    supported, detail = quota_support(settings)
+    if not supported:
+        logger.warning(
+            "disk_quota_gb is set but filesystem quota enforcement is "
+            "unavailable: %s. Usage stays visible on the dashboard; the "
+            "limit is not enforced.",
+            detail,
+        )
+        return
+    for team in teams:
+        try:
+            apply_team_disk_quota(settings, team, detail)
+        except Exception as exc:
+            logger.error(
+                "Failed to apply disk quota for team '%s': %s",
+                team.team_id,
+                exc,
+            )

--- a/src/oduflow/sanitizer.py
+++ b/src/oduflow/sanitizer.py
@@ -52,7 +52,9 @@ def _run_scripts_from_dir(
 
     import docker as _docker
 
-    odoo_container_name = get_resource_name(env_name, "odoo", settings.prefix)
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
     try:
         container = client.containers.get(odoo_container_name)
     except _docker.errors.NotFound:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -827,8 +827,8 @@ def get_agent_instructions(ctx: Context = None) -> str:
                 "Use the local live-mount workflow for these environments:\n"
                 "1. Edit files directly in the mounted local folder; no git push is required.\n"
                 "2. Call `pull_and_apply` after edits. Prefer explicit actions when you authored the changes.\n"
-                "3. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade=\"module\")`.\n"
-                "4. If you add a new module, call `pull_and_apply(..., install=\"module\")`.\n"
+                '3. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`.\n'
+                '4. If you add a new module, call `pull_and_apply(..., install="module")`.\n'
                 "5. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.\n"
                 "6. Git commits are optional in live-mount mode and are not used by Oduflow to detect applied changes.\n\n"
                 "---\n\n"
@@ -1029,7 +1029,11 @@ def get_environment_logs(
         level: Filter by Odoo log level. One of: "ERROR", "WARNING", "CRITICAL". Returns only lines containing the specified level marker. Can be combined with grep.
     """
     output = odoo_ops.get_environment_logs(
-        _get_settings(), env_name, n_lines, grep=grep, level=level,
+        _get_settings(),
+        env_name,
+        n_lines,
+        grep=grep,
+        level=level,
         team=_resolve_team(ctx),
     )
     return f"Recent logs for {env_name}:\n\n{_ANSI_RE.sub('', output)}"
@@ -1527,8 +1531,11 @@ def read_file_in_odoo(
                     If omitted, returns the entire file (up to 100KB).
     """
     settings = _get_settings()
-    woke = _wake_for_work(settings, _resolve_team(ctx), env_name)
-    result = odoo_ops.read_file_in_environment(settings, env_name, path, read_range)
+    team = _resolve_team(ctx)
+    woke = _wake_for_work(settings, team, env_name)
+    result = odoo_ops.read_file_in_environment(
+        settings, team, env_name, path, read_range
+    )
     if "error" in result:
         return f"{woke}Error: {result['error']}"
     return woke + result["output"]
@@ -1567,8 +1574,11 @@ def write_file_in_odoo(
         user: OS user to own the file (default "odoo"). Use "root" for system paths.
     """
     settings = _get_settings()
-    woke = _wake_for_work(settings, _resolve_team(ctx), env_name)
-    result = odoo_ops.write_file_in_environment(settings, env_name, path, content, user)
+    team = _resolve_team(ctx)
+    woke = _wake_for_work(settings, team, env_name)
+    result = odoo_ops.write_file_in_environment(
+        settings, team, env_name, path, content, user
+    )
     return f"{woke}File written: {result['path']} ({result['size']} bytes)"
 
 
@@ -1703,9 +1713,10 @@ def search_in_odoo(
         max_results: Maximum number of matching lines to return (default 50).
     """
     settings = _get_settings()
-    woke = _wake_for_work(settings, _resolve_team(ctx), env_name)
+    team = _resolve_team(ctx)
+    woke = _wake_for_work(settings, team, env_name)
     result = odoo_ops.search_in_environment(
-        settings, env_name, pattern, path, glob, max_results
+        settings, team, env_name, pattern, path, glob, max_results
     )
     output = result["output"]
     if not output:
@@ -1775,8 +1786,11 @@ def run_odoo_command(
         user: The OS user to run the command as (default "odoo"). Use "root" for privileged operations.
     """
     settings = _get_settings()
-    woke = _wake_for_work(settings, _resolve_team(ctx), env_name)
-    result = odoo_ops.run_command_in_environment(settings, env_name, command, user)
+    team = _resolve_team(ctx)
+    woke = _wake_for_work(settings, team, env_name)
+    result = odoo_ops.run_command_in_environment(
+        settings, team, env_name, command, user
+    )
     exit_code = result["exit_code"]
     output = result.get("output", "")
     status = "Success" if exit_code == 0 else "Error"
@@ -2016,7 +2030,7 @@ def delete_service(name: str, ctx: Context = None) -> str:
     Args:
         name: The name of the service to delete.
     """
-    result = service_ops.delete_service(_get_settings(), name)
+    result = service_ops.delete_service(_get_settings(), _resolve_team(ctx), name)
     return f"Service '{result['name']}' deleted. Container '{result['container_name']}' removed."
 
 
@@ -2029,7 +2043,7 @@ def restart_service(name: str, ctx: Context = None) -> str:
     Args:
         name: The name of the service to restart (e.g. "redis", "meilisearch").
     """
-    result = service_ops.restart_service(_get_settings(), name)
+    result = service_ops.restart_service(_get_settings(), _resolve_team(ctx), name)
     return f"Service '{result['name']}' restarted."
 
 
@@ -2221,7 +2235,9 @@ def get_service_logs(name: str, n_lines: int = 100, ctx: Context = None) -> str:
         name: The name of the service.
         n_lines: Number of recent log lines to retrieve (default 100).
     """
-    output = service_ops.get_service_logs(_get_settings(), name, n_lines)
+    output = service_ops.get_service_logs(
+        _get_settings(), _resolve_team(ctx), name, n_lines
+    )
     return f"Recent logs for service '{name}':\n\n{_ANSI_RE.sub('', output)}"
 
 
@@ -2238,7 +2254,9 @@ def run_service_command(
         command: The shell command to execute (e.g. "redis-cli ping", "ls /data").
         user: The OS user to run the command as (default "root").
     """
-    result = service_ops.run_command_in_service(_get_settings(), name, command, user)
+    result = service_ops.run_command_in_service(
+        _get_settings(), _resolve_team(ctx), name, command, user
+    )
     exit_code = result["exit_code"]
     output = result.get("output", "")
     status = "Success" if exit_code == 0 else "Error"
@@ -2759,9 +2777,7 @@ def _inject_auth_token(toml_text: str, token: str) -> str:
         if not injected and raw.split("#", 1)[0].strip() == 'auth_token = ""':
             indent = raw[: len(raw) - len(raw.lstrip())]
             comment = raw.split("#", 1)[1].strip() if "#" in raw else ""
-            out.append(
-                f"{indent}{replacement}" + (f"  # {comment}" if comment else "")
-            )
+            out.append(f"{indent}{replacement}" + (f"  # {comment}" if comment else ""))
             injected = True
         else:
             out.append(raw)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -31,9 +31,9 @@ from oduflow.docker_ops import (
     volume_file_ops,
     volume_ops,
 )
-from oduflow import activity, git_ops, reaper
+from oduflow import activity, git_ops, migrations, reaper
 from oduflow import settings as settings_module
-from oduflow.errors import FlowError, PrerequisiteNotMetError
+from oduflow.errors import FlowError, NotFoundError, PrerequisiteNotMetError
 from oduflow.locking import LockManager
 from oduflow.output_cache import OutputCache, CachedOutput
 from oduflow.settings import Settings, TeamSettings, find_toml
@@ -104,7 +104,15 @@ def _resolve_team(ctx: Context | None) -> TeamSettings:
             # the single-team / default-team resolution below. Logged, not
             # silently swallowed, so misrouting is traceable.
             logger.debug("Host-header team resolution unavailable", exc_info=True)
-    # 3. Fallback: single team or default team "1"
+    # 3. Fallback: single team or default team "1". Only for stdio (implicit
+    # local single user) and explicitly-unauthenticated HTTP: in a hosted
+    # multi-client deployment a request that matches no token and no hostname
+    # must never silently land in another team's context.
+    if settings_module.TRANSPORT == "http" and not settings.allow_insecure_http:
+        raise NotFoundError(
+            "Cannot resolve a team for this request: no team auth token "
+            "matched and the Host header matches no [team.*] hostname."
+        )
     if len(settings.teams) == 1:
         return next(iter(settings.teams.values()))
     return settings.get_team("1")
@@ -3351,7 +3359,10 @@ def _run_cli() -> None:
     # --- Commands that need Settings --------------------------------
 
     if args.command is None:
-        # No subcommand → start the MCP server
+        # No subcommand → start the MCP server. Migrations run before init so
+        # each step sees the data dir / Docker resources exactly as the
+        # previous version left them.
+        migrations.run_pending(_settings)
         _ensure_initialized(_settings)
         # Record the active transport for informational purposes.
         # local_path is gated by allow_local_path in Settings.
@@ -3493,6 +3504,20 @@ def _start_http() -> None:
             "HTTP transport starting WITHOUT authentication "
             "(allow_insecure_http=true) — the full MCP tool surface is open."
         )
+
+    # With several teams, every team needs its own token: auth rejects a
+    # tokenless team's requests before Host-based routing, so its members
+    # would be locked out — and _resolve_team no longer falls back in HTTP
+    # mode, so misconfiguration must fail here, at startup.
+    if not settings.allow_insecure_http and len(settings.teams) > 1:
+        tokenless = sorted(
+            tid for tid, team in settings.teams.items() if not team.auth_token
+        )
+        if tokenless:
+            raise PrerequisiteNotMetError(
+                "HTTP transport with multiple teams requires an auth_token "
+                f"for every team; missing for: {', '.join(tokenless)}."
+            )
     if host not in ("127.0.0.1", "::1", "localhost"):
         logger.warning(
             "Binding %s on all/non-loopback interface — ensure a firewall and "

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -31,7 +31,7 @@ from oduflow.docker_ops import (
     volume_file_ops,
     volume_ops,
 )
-from oduflow import activity, git_ops, migrations, reaper
+from oduflow import activity, git_ops, migrations, quotas, reaper
 from oduflow import settings as settings_module
 from oduflow.errors import FlowError, NotFoundError, PrerequisiteNotMetError
 from oduflow.locking import LockManager
@@ -3380,6 +3380,7 @@ def _run_cli() -> None:
         # previous version left them.
         migrations.run_pending(_settings)
         _ensure_initialized(_settings)
+        quotas.apply_all(_settings)
         # Record the active transport for informational purposes.
         # local_path is gated by allow_local_path in Settings.
         settings_module.TRANSPORT = args.transport

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -38,9 +38,8 @@ class TeamSettings:
     # Quotas; 0 disables. db_quota_gb caps the combined size of the team's
     # PostgreSQL databases (environments + templates) and is checked before
     # operations that create a new database. disk_quota_gb caps the team's
-    # data dir (workspaces, filestores, template dumps); enforcement requires
-    # filesystem project quotas (XFS prjquota) and is not wired up yet — the
-    # value is reserved and currently informational.
+    # data dir plus its PG tablespace via XFS project quotas (see quotas.py);
+    # on filesystems without project-quota support it stays informational.
     db_quota_gb: int = 50
     disk_quota_gb: int = 0
 
@@ -217,13 +216,6 @@ class Settings:
             if team.db_quota_gb < 0 or team.disk_quota_gb < 0:
                 raise ValueError(
                     f"Team '{team.team_id}': quotas must be >= 0 (0 disables)"
-                )
-            if team.disk_quota_gb > 0:
-                logger.warning(
-                    "Team '%s': disk_quota_gb is set but filesystem quota "
-                    "enforcement is not implemented yet — the value is "
-                    "informational for now.",
-                    team.team_id,
                 )
 
         # Validate that team port ranges do not overlap. The default range is

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -35,6 +35,14 @@ class TeamSettings:
     port_range_end: int = 50100
     data_dir: str = ""
     port_registry_path: str = ""
+    # Quotas; 0 disables. db_quota_gb caps the combined size of the team's
+    # PostgreSQL databases (environments + templates) and is checked before
+    # operations that create a new database. disk_quota_gb caps the team's
+    # data dir (workspaces, filestores, template dumps); enforcement requires
+    # filesystem project quotas (XFS prjquota) and is not wired up yet — the
+    # value is reserved and currently informational.
+    db_quota_gb: int = 50
+    disk_quota_gb: int = 0
 
     @property
     def workspaces_dir(self) -> str:
@@ -206,6 +214,17 @@ class Settings:
                     f"Team '{team.team_id}': invalid port range "
                     f"{team.port_range_start}-{team.port_range_end}"
                 )
+            if team.db_quota_gb < 0 or team.disk_quota_gb < 0:
+                raise ValueError(
+                    f"Team '{team.team_id}': quotas must be >= 0 (0 disables)"
+                )
+            if team.disk_quota_gb > 0:
+                logger.warning(
+                    "Team '%s': disk_quota_gb is set but filesystem quota "
+                    "enforcement is not implemented yet — the value is "
+                    "informational for now.",
+                    team.team_id,
+                )
 
         # Validate that team port ranges do not overlap. The default range is
         # identical for every team, so two teams that never set an explicit
@@ -305,6 +324,8 @@ class Settings:
                 port_range_end=port_end,
                 data_dir=team_data_dir,
                 port_registry_path=os.path.join(team_data_dir, "ports.json"),
+                db_quota_gb=int(team_cfg.get("db_quota_gb", 50)),
+                disk_quota_gb=int(team_cfg.get("disk_quota_gb", 0)),
             )
 
         trace = bool(server.get("trace", False))

--- a/src/oduflow/sync.py
+++ b/src/oduflow/sync.py
@@ -49,9 +49,7 @@ def sync_template_from_source(
         )
 
     # Reload template DB
-    result = system_ops.reload_template(
-        settings, team, template_name=template_name
-    )
+    result = system_ops.reload_template(settings, team, template_name=template_name)
 
     return {
         "sync_source": source,

--- a/src/oduflow/telemetry.py
+++ b/src/oduflow/telemetry.py
@@ -76,9 +76,7 @@ def record_startup(etc_dir: str, version: str, disable_telemetry: bool) -> str:
     return instance_id
 
 
-def record_env_created(
-    instance_id: str, version: str, disable_telemetry: bool
-) -> None:
+def record_env_created(instance_id: str, version: str, disable_telemetry: bool) -> None:
     """Record an env_created event."""
     if disable_telemetry or not instance_id:
         return

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -616,6 +616,18 @@
     color: var(--text-dim);
   }
   .container-stats .stat-val { color: var(--text); font-weight: 500; }
+  .env-storage { margin-left: 0; align-items: center; }
+  .stat-refresh {
+    background: none;
+    border: none;
+    padding: 0;
+    display: inline-flex;
+    color: var(--text-dim);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+  }
+  .stat-refresh svg { width: 13px; height: 13px; }
+  .stat-refresh:hover { color: var(--accent); }
   .system-bar {
     position: fixed;
     bottom: 0;
@@ -1440,6 +1452,10 @@ const MIN_INTERVAL = 5;
 let refreshInterval = 60;
 let refreshTimer = null;
 let containerStatsMap = {};
+// Per-environment DB/disk sizes: cached server-side, recomputed only via the
+// per-card refresh button (walking a filestore is too slow for the poll loop).
+let envStorageMap = {};
+let storageRefreshing = {};
 let cachedTemplates = [];
 let cachedEnvs = [];
 let cachedServices = [];
@@ -1696,6 +1712,17 @@ function _tickBusy() {
   });
 }
 
+function fmtBytes(b) {
+  if (b == null) return '—';
+  if (b >= 1024 * 1024 * 1024) return (b / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+  if (b >= 1024 * 1024) return (b / (1024 * 1024)).toFixed(1) + ' MB';
+  return Math.round(b / 1024) + ' KB';
+}
+
+var REFRESH_SVG =
+  '<svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">' +
+  '<path d="M8 3a5 5 0 104.546 2.914.75.75 0 011.364-.626A6.5 6.5 0 118 1.5v-1a.25.25 0 01.427-.177l2.25 2.25a.25.25 0 010 .354l-2.25 2.25A.25.25 0 018 5V3z"/></svg>';
+
 function applyStats() {
   document.querySelectorAll('[data-stats-for]').forEach(function(el) {
     var s = containerStatsMap[el.getAttribute('data-stats-for')];
@@ -1705,6 +1732,38 @@ function applyStats() {
       '<span>RAM <span class="stat-val">' + s.mem_usage_mb + ' MB</span> ' +
         usageBar(s.mem_percent) + '</span>';
   });
+  document.querySelectorAll('[data-storage-for]').forEach(function(el) {
+    var branch = el.getAttribute('data-storage-for');
+    var s = envStorageMap[branch];
+    var btn = storageRefreshing[branch]
+      ? '<span class="spinner" aria-hidden="true"></span>'
+      : '<button class="stat-refresh" onclick="refreshStorage(\'' + escAttr(branch) + '\')" ' +
+          'title="' + (s ? 'Recompute DB and disk usage (measured ' + escAttr(formatDate(s.computed_at)) + ')' : 'Compute DB and disk usage') + '" ' +
+          'aria-label="Recompute DB and disk usage">' + REFRESH_SVG + '</button>';
+    el.innerHTML =
+      '<span>DB size <span class="stat-val">' + (s ? fmtBytes(s.db_bytes) : '—') + '</span></span>' +
+      '<span>Disk <span class="stat-val">' + (s ? fmtBytes(s.disk_bytes) : '—') + '</span></span>' +
+      btn;
+  });
+}
+
+async function refreshStorage(branch) {
+  if (storageRefreshing[branch]) return;
+  storageRefreshing[branch] = true;
+  applyStats();
+  try {
+    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/storage/refresh', { method: 'POST' });
+    const data = await r.json();
+    if (data.ok) {
+      envStorageMap[branch] = data.storage;
+    } else {
+      showToast(data.error || 'Failed to measure usage', true);
+    }
+  } catch (e) {
+    showToast('Failed to measure usage: ' + e, true);
+  }
+  delete storageRefreshing[branch];
+  applyStats();
 }
 
 function renderEnvironments(envs, force) {
@@ -1831,7 +1890,11 @@ function renderEnvironments(envs, force) {
       urlHtml +
       metaHtml +
       extraHtml +
-      (containerHtml ? '<div class="containers">' + containerHtml + '</div>' : '') +
+      // The storage span renders even when everything is stopped: DB/disk
+      // usage is exactly what you check before cleaning up idle environments.
+      '<div class="containers">' + containerHtml +
+        '<span class="container-stats env-storage" data-storage-for="' + esc(env.branch) + '"></span>' +
+      '</div>' +
     '</div>';
   }).join('');
 
@@ -2082,6 +2145,7 @@ async function loadStats() {
 
     containerStatsMap = {};
     (data.containers || []).forEach(c => { containerStatsMap[c.name] = c; });
+    envStorageMap = (data.storage && data.storage.envs) || {};
 
     const sys = data.system;
     document.getElementById('sys-cpu').innerHTML =

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1738,7 +1738,7 @@ function applyStats() {
     var btn = storageRefreshing[branch]
       ? '<span class="spinner" aria-hidden="true"></span>'
       : '<button class="stat-refresh" onclick="refreshStorage(\'' + escAttr(branch) + '\')" ' +
-          'title="' + (s ? 'Recompute DB and disk usage (measured ' + escAttr(formatDate(s.computed_at)) + ')' : 'Compute DB and disk usage') + '" ' +
+          'title="' + (s ? 'Recompute DB and disk usage (measured ' + esc(relTime(s.computed_at)) + ')' : 'Compute DB and disk usage') + '" ' +
           'aria-label="Recompute DB and disk usage">' + REFRESH_SVG + '</button>';
     el.innerHTML =
       '<span>DB size <span class="stat-val">' + (s ? fmtBytes(s.db_bytes) : '—') + '</span></span>' +
@@ -2045,19 +2045,24 @@ function escAttr(s) {
   return (s || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
+// Plain-text relative time ("just now", "5m ago"). Safe for attribute
+// values (via esc); formatDate below wraps it in markup — never use
+// formatDate inside an attribute.
+function relTime(iso) {
+  var d = new Date(iso);
+  var diff = Date.now() - d.getTime();
+  if (diff < 0 || diff < 60000) return 'just now';
+  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago';
+  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
+  if (diff < 30 * 86400000) return Math.floor(diff / 86400000) + 'd ago';
+  return d.toLocaleDateString();
+}
+
 function formatDate(iso) {
   if (!iso) return '';
   try {
     var d = new Date(iso);
-    var full = d.toLocaleString();
-    var diff = Date.now() - d.getTime();
-    var rel;
-    if (diff < 0 || diff < 60000) rel = 'just now';
-    else if (diff < 3600000) rel = Math.floor(diff / 60000) + 'm ago';
-    else if (diff < 86400000) rel = Math.floor(diff / 3600000) + 'h ago';
-    else if (diff < 30 * 86400000) rel = Math.floor(diff / 86400000) + 'd ago';
-    else rel = d.toLocaleDateString();
-    return '<span title="' + esc(full) + '">' + esc(rel) + '</span>';
+    return '<span title="' + esc(d.toLocaleString()) + '">' + esc(relTime(iso)) + '</span>';
   }
   catch(e) { return esc(iso); }
 }

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -47,4 +47,4 @@ auth_token = ""                   # MCP bearer token / OAuth client_id+secret (a
 ui_password = ""                  # Web UI password (empty = UI open)
 port_range = [50000, 50100]       # port range for Odoo containers
 # db_quota_gb = 50                # combined size cap for the team's PostgreSQL DBs (environments + templates); 0 = off
-# disk_quota_gb = 0               # reserved: data-dir cap via filesystem project quotas (XFS prjquota); not enforced yet
+# disk_quota_gb = 0               # cap on team files + databases via XFS project quotas (needs data dir on XFS with prjquota)

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -46,3 +46,5 @@ hostname = "localhost"            # port: http://{hostname}:{port}, traefik: htt
 auth_token = ""                   # MCP bearer token / OAuth client_id+secret (auto-generated on first run; HTTP refuses to start if empty)
 ui_password = ""                  # Web UI password (empty = UI open)
 port_range = [50000, 50100]       # port range for Odoo containers
+# db_quota_gb = 50                # combined size cap for the team's PostgreSQL DBs (environments + templates); 0 = off
+# disk_quota_gb = 0               # reserved: data-dir cap via filesystem project quotas (XFS prjquota); not enforced yet

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -585,7 +585,7 @@ def _build_routes(
             activity.touch(team, branch)
             client = _get_client()
             odoo_container_name = env_ops.get_resource_name(
-                branch, "odoo", settings.prefix
+                branch, "odoo", settings.prefix, team.team_id
             )
             try:
                 container = client.containers.get(odoo_container_name)
@@ -1030,7 +1030,9 @@ def _build_routes(
     def api_service_restart(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         try:
-            result = service_ops.restart_service(get_settings(), name)
+            result = service_ops.restart_service(
+                get_settings(), _get_ui_team(request), name
+            )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -1046,7 +1048,9 @@ def _build_routes(
         except BusyError as e:
             return _error_response(e)
         try:
-            result = service_ops.delete_service(get_settings(), name)
+            result = service_ops.delete_service(
+                get_settings(), _get_ui_team(request), name
+            )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -1063,7 +1067,9 @@ def _build_routes(
         except (ValueError, TypeError):
             n = 200
         try:
-            logs = service_ops.get_service_logs(get_settings(), name, n)
+            logs = service_ops.get_service_logs(
+                get_settings(), _get_ui_team(request), name, n
+            )
             return JSONResponse({"ok": True, "logs": logs})
         except FlowError as e:
             return _error_response(e)
@@ -1521,7 +1527,9 @@ def _build_routes(
             settings = get_settings()
             team = _get_ui_team(websocket)
             client = _get_client()
-            container_name = get_resource_name(branch, "odoo", settings.prefix)
+            container_name = get_resource_name(
+                branch, "odoo", settings.prefix, team.team_id
+            )
             db_name = get_db_name(branch, team.team_id)
 
             try:

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -24,6 +24,8 @@ from starlette.routing import Route, WebSocketRoute
 from starlette.types import ASGIApp, Receive, Scope, Send
 from starlette.websockets import WebSocket
 
+from collections.abc import Callable
+
 from oduflow.docker_ops import (
     env_ops,
     service_ops,
@@ -33,7 +35,13 @@ from oduflow.docker_ops import (
 )
 from oduflow import activity
 from oduflow.docker_ops.odoo_ops import get_environment_logs
-from oduflow.docker_ops.stats import get_container_stats, get_system_stats
+from oduflow.docker_ops.stats import (
+    get_container_stats,
+    get_system_stats,
+    read_storage_cache,
+    refresh_env_storage,
+    refresh_team_storage,
+)
 from oduflow.errors import BusyError, FlowError, NotFoundError
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
@@ -149,7 +157,7 @@ def _check_cookie_token(token: str, settings: Settings) -> "TeamSettings | None"
 
 
 class BasicAuthMiddleware:
-    def __init__(self, app: ASGIApp, get_settings: "callable") -> None:
+    def __init__(self, app: ASGIApp, get_settings: Callable[[], Settings]) -> None:
         self._app = app
         self._get_settings = get_settings
 
@@ -331,7 +339,7 @@ class _LoginRateLimiter:
 
 
 def _build_routes(
-    get_settings: "callable",
+    get_settings: Callable[[], Settings],
     locks: LockManager,
 ) -> list[Route]:
     # Per-app so test apps and real deployments don't share failure counters.
@@ -780,13 +788,76 @@ def _build_routes(
     def api_stats(request: Request) -> JSONResponse:
         try:
             settings = get_settings()
-            containers = get_container_stats(settings, _get_ui_team(request))
+            team = _get_ui_team(request)
+            containers = get_container_stats(settings, team)
             system = get_system_stats()
+            # Cached only — one small JSON read; recomputing storage is an
+            # explicit action (the refresh button / the refresh endpoints).
+            storage = read_storage_cache(team)
             return JSONResponse(
-                {"ok": True, "containers": containers, "system": system}
+                {
+                    "ok": True,
+                    "containers": containers,
+                    "system": system,
+                    "storage": storage,
+                }
             )
         except Exception as e:
             logger.exception("Unexpected error in api_stats")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+    def api_storage_refresh(request: Request) -> JSONResponse:
+        branch = request.path_params["branch"]
+        try:
+            entry = refresh_env_storage(get_settings(), _get_ui_team(request), branch)
+            return JSONResponse({"ok": True, "storage": entry})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_storage_refresh")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+    def api_usage(request: Request) -> JSONResponse:
+        """Cached per-team usage + quotas — the read side for external
+        billing/quota tooling (see api_usage_refresh for recomputation)."""
+        try:
+            team = _get_ui_team(request)
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "team_id": team.team_id,
+                    "quotas": {
+                        "db_quota_gb": team.db_quota_gb,
+                        "disk_quota_gb": team.disk_quota_gb,
+                    },
+                    "usage": read_storage_cache(team),
+                }
+            )
+        except Exception as e:
+            logger.exception("Unexpected error in api_usage")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
+    def api_usage_refresh(request: Request) -> JSONResponse:
+        """Recompute storage for every environment plus team totals. Heavy
+        (walks every workspace); meant for operator tooling on a schedule."""
+        try:
+            team = _get_ui_team(request)
+            usage = refresh_team_storage(get_settings(), team)
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "team_id": team.team_id,
+                    "quotas": {
+                        "db_quota_gb": team.db_quota_gb,
+                        "disk_quota_gb": team.disk_quota_gb,
+                    },
+                    "usage": usage,
+                }
+            )
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_usage_refresh")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
     def api_templates(request: Request) -> JSONResponse:
@@ -1661,12 +1732,17 @@ def _build_routes(
         Route("/api/license", api_license, methods=["GET"]),
         Route("/api/license/activate", api_license_activate, methods=["POST"]),
         Route("/api/templates", api_templates, methods=["GET"]),
-        Route(
-            "/api/templates/{name}/delete", api_template_delete, methods=["POST"]
-        ),
+        Route("/api/templates/{name}/delete", api_template_delete, methods=["POST"]),
         Route("/api/environments", api_list, methods=["GET"]),
         Route("/api/environments/create", api_create, methods=["POST"]),
         Route("/api/stats", api_stats, methods=["GET"]),
+        Route("/api/usage", api_usage, methods=["GET"]),
+        Route("/api/usage/refresh", api_usage_refresh, methods=["POST"]),
+        Route(
+            "/api/environments/{branch:path}/storage/refresh",
+            api_storage_refresh,
+            methods=["POST"],
+        ),
         Route("/api/agent-guides", api_agent_guides_list, methods=["GET"]),
         Route("/api/agent-guides/{filename}", api_agent_guide_get, methods=["GET"]),
         Route("/api/environments/{branch:path}/start", api_start, methods=["POST"]),
@@ -1725,7 +1801,7 @@ def _build_routes(
 
 def mount_web_ui(
     app,
-    get_settings: "callable",
+    get_settings: Callable[[], Settings],
     locks: LockManager,
 ) -> None:
     from starlette.routing import Router

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,8 +114,7 @@ def _needs_system(scenario: dict) -> bool:
 
 def _needs_main_environment(scenario: dict) -> bool:
     return (
-        scenario.get("needs_env", False)
-        or scenario.get("tool") == "delete_environment"
+        scenario.get("needs_env", False) or scenario.get("tool") == "delete_environment"
     )
 
 

--- a/tests/test_db_quota.py
+++ b/tests/test_db_quota.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import pytest
+
+from oduflow.docker_ops.system_ops import check_db_quota, get_team_db_usage_bytes
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+GB = 1024**3
+
+# pg_database rows as psql -tAc returns them: "datname|size" per line.
+_ROWS = "\n".join(
+    [
+        f"postgres|{10 * 1024}",
+        f"oduflow_1_main|{2 * GB}",
+        f"oduflow_1_feature-x|{1 * GB}",
+        f"oduflow_template_1_prod|{4 * GB}",
+        f"oduflow_2_main|{30 * GB}",  # another team: not counted
+        f"oduflow_template_2_prod|{30 * GB}",
+    ]
+)
+
+
+def _team(quota_gb: int) -> TeamSettings:
+    return TeamSettings(team_id="1", db_quota_gb=quota_gb)
+
+
+def test_usage_sums_only_the_teams_databases():
+    with patch(
+        "oduflow.docker_ops.system_ops._exec_sql", return_value=_ROWS
+    ) as exec_sql:
+        used = get_team_db_usage_bytes(None, Settings(), "1")
+    assert used == 7 * GB  # 2 envs + 1 template, team 2 and postgres excluded
+    assert exec_sql.call_count == 1  # one catalog query, no per-DB roundtrips
+
+
+def test_under_quota_passes():
+    with patch("oduflow.docker_ops.system_ops._exec_sql", return_value=_ROWS):
+        check_db_quota(None, Settings(), _team(quota_gb=8))
+
+
+def test_over_quota_raises():
+    with patch("oduflow.docker_ops.system_ops._exec_sql", return_value=_ROWS):
+        with pytest.raises(PrerequisiteNotMetError, match="database quota exceeded"):
+            check_db_quota(None, Settings(), _team(quota_gb=7))
+
+
+def test_zero_disables_without_querying():
+    with patch("oduflow.docker_ops.system_ops._exec_sql") as exec_sql:
+        check_db_quota(None, Settings(), _team(quota_gb=0))
+    exec_sql.assert_not_called()

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -104,7 +104,9 @@ class TestCredentialsFilePermissions:
         # Find the credentials file and check perms + no leftover temp file.
         import glob
 
-        files = glob.glob(os.path.join(ws, "**", "env_credentials.json"), recursive=True)
+        files = glob.glob(
+            os.path.join(ws, "**", "env_credentials.json"), recursive=True
+        )
         assert files, "credentials file not written"
         mode = os.stat(files[0]).st_mode & 0o777
         assert mode == 0o600, oct(mode)

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -483,9 +483,7 @@ class TestXmlViewAttrUpgrade:
         (tmp_path / "crm" / "__manifest__.py").write_text(
             "{'name': 'CRM', 'version': '17.0.1.0.0'}"
         )
-        (module_dir / "crm_lead.xml").write_text(
-            '<form string="Lead" create="false">'
-        )
+        (module_dir / "crm_lead.xml").write_text('<form string="Lead" create="false">')
 
         from unittest.mock import patch
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -308,6 +308,8 @@ def test_ensure_running_starts_stopped_env(monkeypatch, tmp_path):
     state = {"status": "exited"}
 
     class FakeContainer:
+        labels = {"oduflow.team": "1"}
+
         @property
         def status(self):
             return state["status"]
@@ -326,11 +328,11 @@ def test_ensure_running_starts_stopped_env(monkeypatch, tmp_path):
     )
 
     settings = _settings(tmp_path)
-    assert env_ops.ensure_running(settings, "env-x") is True
+    assert env_ops.ensure_running(settings, "env-x", settings.teams["1"]) is True
     assert started == ["env-x"]
 
     state["status"] = "running"
-    assert env_ops.ensure_running(settings, "env-x") is False
+    assert env_ops.ensure_running(settings, "env-x", settings.teams["1"]) is False
     assert started == ["env-x"]
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -207,3 +207,54 @@ class TestTeamScopedNamesMigration:
 
         assert foreign.renamed_to is None
         assert other_team.renamed_to is None
+
+
+class TestResourceLimitsMigration:
+    def test_updates_env_containers_only(self, monkeypatch):
+        from oduflow.migrations import _migrate_env_resource_limits
+        from oduflow.settings import TeamSettings
+        from unittest.mock import MagicMock
+
+        env = MagicMock()
+        env.labels = {
+            "oduflow.managed": "true",
+            "oduflow.team": "1",
+            "oduflow.branch": "main",
+        }
+        svc = MagicMock()
+        svc.labels = {
+            "oduflow.managed": "true",
+            "oduflow.team": "1",
+            "oduflow.service": "redis",
+        }
+        client = MagicMock()
+        client.containers.list.return_value = [env, svc]
+        monkeypatch.setattr("oduflow.docker_ops.client.get_client", lambda: client)
+        monkeypatch.setattr(
+            "oduflow.docker_ops.stats.default_env_limits",
+            lambda: {"mem_limit": 2**31, "pids_limit": 4096},
+        )
+
+        settings = Settings(teams={"1": TeamSettings(team_id="1")})
+        _migrate_env_resource_limits(settings)
+
+        env.update.assert_called_once_with(mem_limit=2**31, pids_limit=4096)
+        svc.update.assert_not_called()
+
+    def test_update_failure_is_logged_not_fatal(self, monkeypatch):
+        from oduflow.migrations import _migrate_env_resource_limits
+        from oduflow.settings import TeamSettings
+        from unittest.mock import MagicMock
+
+        env = MagicMock()
+        env.labels = {
+            "oduflow.managed": "true",
+            "oduflow.team": "1",
+            "oduflow.branch": "main",
+        }
+        env.update.side_effect = RuntimeError("kernel says no")
+        client = MagicMock()
+        client.containers.list.return_value = [env]
+        monkeypatch.setattr("oduflow.docker_ops.client.get_client", lambda: client)
+
+        _migrate_env_resource_limits(Settings(teams={"1": TeamSettings(team_id="1")}))

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,111 @@
+import json
+import os
+
+import pytest
+
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.migrations import MIGRATIONS, Migration, run_pending
+from oduflow.settings import Settings
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(base_data_dir=str(tmp_path))
+
+
+def _mig(mig_id: str, calls: list[str], fail: bool = False) -> Migration:
+    def apply(settings: Settings) -> None:
+        if fail:
+            raise RuntimeError("boom")
+        calls.append(mig_id)
+
+    return Migration(id=mig_id, description=f"test step {mig_id}", apply=apply)
+
+
+def _state(tmp_path) -> list[str]:
+    with open(os.path.join(str(tmp_path), "migrations.json")) as f:
+        return json.load(f)["applied"]
+
+
+def test_fresh_install_stamps_without_running(tmp_path):
+    calls: list[str] = []
+    registry = [_mig("0001-a", calls), _mig("0002-b", calls)]
+
+    ran = run_pending(_settings(tmp_path), registry)
+
+    assert ran == []
+    assert calls == []
+    assert _state(tmp_path) == ["0001-a", "0002-b"]
+
+    # Second start: still a no-op.
+    assert run_pending(_settings(tmp_path), registry) == []
+    assert calls == []
+
+
+def test_legacy_install_runs_all_in_order(tmp_path):
+    # A pre-migrations-era install is recognized by existing team data.
+    os.makedirs(tmp_path / "team_1")
+    calls: list[str] = []
+    registry = [_mig("0001-a", calls), _mig("0002-b", calls)]
+
+    ran = run_pending(_settings(tmp_path), registry)
+
+    assert ran == ["0001-a", "0002-b"]
+    assert calls == ["0001-a", "0002-b"]
+    assert _state(tmp_path) == ["0001-a", "0002-b"]
+
+
+def test_only_pending_steps_run(tmp_path):
+    os.makedirs(tmp_path / "team_1")
+    calls: list[str] = []
+    registry = [_mig("0001-a", calls)]
+    run_pending(_settings(tmp_path), registry)
+    calls.clear()
+
+    # A new release appends a step: only it runs.
+    registry.append(_mig("0002-b", calls))
+    ran = run_pending(_settings(tmp_path), registry)
+
+    assert ran == ["0002-b"]
+    assert calls == ["0002-b"]
+    assert _state(tmp_path) == ["0001-a", "0002-b"]
+
+
+def test_failure_aborts_and_resumes_at_failed_step(tmp_path):
+    os.makedirs(tmp_path / "team_1")
+    calls: list[str] = []
+    registry = [
+        _mig("0001-a", calls),
+        _mig("0002-b", calls, fail=True),
+        _mig("0003-c", calls),
+    ]
+
+    with pytest.raises(PrerequisiteNotMetError, match="0002-b"):
+        run_pending(_settings(tmp_path), registry)
+
+    # The successful step is recorded; the failed one and its successor are not.
+    assert calls == ["0001-a"]
+    assert _state(tmp_path) == ["0001-a"]
+
+    # Next start (cause fixed): resumes at the failed step, skips 0001-a.
+    fixed = [_mig("0001-a", calls), _mig("0002-b", calls), _mig("0003-c", calls)]
+    ran = run_pending(_settings(tmp_path), fixed)
+
+    assert ran == ["0002-b", "0003-c"]
+    assert calls == ["0001-a", "0002-b", "0003-c"]
+    assert _state(tmp_path) == ["0001-a", "0002-b", "0003-c"]
+
+
+def test_duplicate_ids_rejected(tmp_path):
+    calls: list[str] = []
+    registry = [_mig("0001-a", calls), _mig("0001-a", calls)]
+
+    with pytest.raises(ValueError, match="Duplicate migration ids"):
+        run_pending(_settings(tmp_path), registry)
+
+
+def test_default_registry_ids_unique_and_sorted():
+    # Registry order is execution order; keeping ids sorted keeps the file
+    # readable and reviewable as it grows.
+    ids = [mig.id for mig in MIGRATIONS]
+    assert ids == sorted(ids)
+    assert len(set(ids)) == len(ids)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -109,3 +109,101 @@ def test_default_registry_ids_unique_and_sorted():
     ids = [mig.id for mig in MIGRATIONS]
     assert ids == sorted(ids)
     assert len(set(ids)) == len(ids)
+
+
+class _FakeContainer:
+    def __init__(self, name: str, labels: dict[str, str]):
+        self.name = name
+        self.labels = labels
+        self.renamed_to: str | None = None
+
+    def rename(self, new_name: str) -> None:
+        self.renamed_to = new_name
+        self.name = new_name
+
+
+class _FakeClient:
+    def __init__(self, containers: list[_FakeContainer]):
+        self._containers = containers
+
+        class _Containers:
+            def __init__(self, outer):
+                self._outer = outer
+
+            def list(self, all=True, filters=None):
+                wanted = filters["label"] if filters else []
+                result = []
+                for c in self._outer._containers:
+                    ok = True
+                    for cond in wanted:
+                        key, _, value = cond.partition("=")
+                        if c.labels.get(key) != value:
+                            ok = False
+                            break
+                    if ok:
+                        result.append(c)
+                return result
+
+        self.containers = _Containers(self)
+
+
+class TestTeamScopedNamesMigration:
+    def _run(self, monkeypatch, containers, teams=("1",)):
+        from oduflow.migrations import _migrate_team_scoped_names
+        from oduflow.settings import TeamSettings
+
+        client = _FakeClient(containers)
+        monkeypatch.setattr("oduflow.docker_ops.client.get_client", lambda: client)
+        settings = Settings(teams={t: TeamSettings(team_id=t) for t in teams})
+        _migrate_team_scoped_names(settings)
+
+    def test_renames_env_and_service_containers(self, monkeypatch):
+        env = _FakeContainer(
+            "oduflow-feature-x-odoo",
+            {
+                "oduflow.managed": "true",
+                "oduflow.team": "1",
+                "oduflow.branch": "feature/x",
+            },
+        )
+        svc = _FakeContainer(
+            "oduflow-svc-redis",
+            {
+                "oduflow.managed": "true",
+                "oduflow.team": "1",
+                "oduflow.service": "redis",
+            },
+        )
+        self._run(monkeypatch, [env, svc])
+
+        assert env.name == "oduflow-1-feature-x-odoo"
+        assert svc.name == "oduflow-1-svc-redis"
+
+    def test_idempotent_on_rerun(self, monkeypatch):
+        env = _FakeContainer(
+            "oduflow-1-main-odoo",
+            {"oduflow.managed": "true", "oduflow.team": "1", "oduflow.branch": "main"},
+        )
+        svc = _FakeContainer(
+            "oduflow-1-svc-redis",
+            {
+                "oduflow.managed": "true",
+                "oduflow.team": "1",
+                "oduflow.service": "redis",
+            },
+        )
+        self._run(monkeypatch, [env, svc])
+
+        assert env.renamed_to is None
+        assert svc.renamed_to is None
+
+    def test_unmanaged_and_foreign_containers_untouched(self, monkeypatch):
+        foreign = _FakeContainer("someone-elses-app", {})
+        other_team = _FakeContainer(
+            "oduflow-main-odoo",
+            {"oduflow.managed": "true", "oduflow.team": "2", "oduflow.branch": "main"},
+        )
+        self._run(monkeypatch, [foreign, other_team], teams=("1",))
+
+        assert foreign.renamed_to is None
+        assert other_team.renamed_to is None

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -63,16 +63,18 @@ class TestGetDbName:
 
 class TestGetResourceName:
     def test_odoo(self):
-        assert get_resource_name("main", "odoo") == "oduflow-main-odoo"
+        assert (
+            get_resource_name("main", "odoo", "oduflow-", "1") == "oduflow-1-main-odoo"
+        )
 
     def test_slash_branch(self):
         assert (
-            get_resource_name("feature/payments", "odoo")
-            == "oduflow-feature-payments-odoo"
+            get_resource_name("feature/payments", "odoo", "oduflow-", "1")
+            == "oduflow-1-feature-payments-odoo"
         )
 
     def test_custom_prefix(self):
-        assert get_resource_name("main", "odoo", prefix="test-") == "test-main-odoo"
+        assert get_resource_name("main", "odoo", "test-", "2") == "test-2-main-odoo"
 
 
 class TestGetWorkspacePath:

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -124,9 +124,10 @@ class TestOduflowOAuthProvider:
         assert client is not None
         # Legitimate MCP callbacks are accepted: https (claude.ai) and loopback
         # http (IDEs).
-        assert str(
-            client.validate_redirect_uri(AnyUrl("https://claude.ai/some/cb"))
-        ) == "https://claude.ai/some/cb"
+        assert (
+            str(client.validate_redirect_uri(AnyUrl("https://claude.ai/some/cb")))
+            == "https://claude.ai/some/cb"
+        )
         assert client.validate_redirect_uri(AnyUrl("http://127.0.0.1:8976/cb"))
 
     def test_redirect_uri_rejects_dangerous_and_cleartext(self):

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -95,7 +95,7 @@ class TestDestroySystem:
     def test_destroy_with_active_envs(self, mock_docker_client):
         container = MagicMock()
         container.labels = {"oduflow.branch": "main", "oduflow.managed": "true"}
-        container.name = "oduflow-main-odoo"
+        container.name = "oduflow-1-main-odoo"
         mock_docker_client.containers.list.return_value = [container]
 
         with pytest.raises(ConflictError, match="Active environments"):
@@ -188,7 +188,7 @@ class TestCreateEnvironment:
 
         assert result["url"] == "http://localhost:50000"
         assert result["database"] == "oduflow_1_feature-payments"
-        assert result["odoo_container"] == "oduflow-feature-payments-odoo"
+        assert result["odoo_container"] == "oduflow-1-feature-payments-odoo"
         assert mock_sql.call_count == 2
         mock_creds.assert_called_once()
         mock_role.assert_called_once()
@@ -272,7 +272,7 @@ class TestCreateEnvironment:
         from oduflow.errors import ConflictError
 
         other = MagicMock()
-        other.name = "oduflow-feature-foo-odoo"
+        other.name = "oduflow-1-feature-foo-odoo"
         other.labels = {"oduflow.branch": "feature-foo"}
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
         mock_docker_client.containers.list.return_value = [other]
@@ -1038,18 +1038,19 @@ class TestDeleteEnvironment:
 class TestRestartEnvironment:
     def test_restart(self, mock_docker_client):
         container = MagicMock()
+        container.labels = {"oduflow.team": "1"}
         mock_docker_client.containers.get.return_value = container
 
-        result = env_ops.restart_environment(TEST_SETTINGS, "main")
+        result = env_ops.restart_environment(TEST_SETTINGS, "main", TEST_TEAM)
 
-        assert result["odoo_container"] == "oduflow-main-odoo"
+        assert result["odoo_container"] == "oduflow-1-main-odoo"
         container.restart.assert_called_once()
 
     def test_restart_not_found(self, mock_docker_client):
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
         with pytest.raises(NotFoundError, match="does not exist"):
-            env_ops.restart_environment(TEST_SETTINGS, "main")
+            env_ops.restart_environment(TEST_SETTINGS, "main", TEST_TEAM)
 
 
 class TestStopEnvironment:
@@ -1060,7 +1061,7 @@ class TestStopEnvironment:
 
         result = env_ops.stop_environment(TEST_SETTINGS, TEST_TEAM, "main")
 
-        assert "oduflow-main-odoo" in result["stopped"]
+        assert "oduflow-1-main-odoo" in result["stopped"]
         container.stop.assert_called_once()
 
     def test_stop_rejects_other_team_container(self, mock_docker_client):
@@ -1080,6 +1081,7 @@ class TestStartEnvironment:
         db = MagicMock()
         db.status = "running"
         odoo = MagicMock()
+        odoo.labels = {"oduflow.team": "1"}
 
         def get_container(name):
             if name == "oduflow-db":
@@ -1088,9 +1090,9 @@ class TestStartEnvironment:
 
         mock_docker_client.containers.get.side_effect = get_container
 
-        result = env_ops.start_environment(TEST_SETTINGS, "main")
+        result = env_ops.start_environment(TEST_SETTINGS, "main", TEST_TEAM)
 
-        assert "oduflow-main-odoo" in result["started"]
+        assert "oduflow-1-main-odoo" in result["started"]
         odoo.start.assert_called_once()
 
 
@@ -1240,10 +1242,13 @@ class TestRunEnvironmentTests:
 class TestGetLogs:
     def test_logs(self, mock_docker_client):
         container = MagicMock()
+        container.labels = {"oduflow.team": "1"}
         container.logs.return_value = b"log line 1\nlog line 2"
         mock_docker_client.containers.get.return_value = container
 
-        output = odoo_ops.get_environment_logs(TEST_SETTINGS, "main", 50)
+        output = odoo_ops.get_environment_logs(
+            TEST_SETTINGS, "main", 50, team=TEST_TEAM
+        )
 
         assert "log line 1" in output
         container.logs.assert_called_with(tail=50, stdout=True, stderr=True)
@@ -1271,7 +1276,7 @@ class TestApplyActionsConf:
             TEST_SETTINGS,
             TEST_TEAM,
             "feature/x",
-            "oduflow-feature-x-odoo",
+            "oduflow-1-feature-x-odoo",
             to_install=[],
             to_upgrade=[],
             do_restart=True,
@@ -1293,7 +1298,7 @@ class TestApplyActionsConf:
             TEST_SETTINGS,
             TEST_TEAM,
             "feature/x",
-            "oduflow-feature-x-odoo",
+            "oduflow-1-feature-x-odoo",
             to_install=[],
             to_upgrade=[],
             do_restart=True,
@@ -1316,7 +1321,7 @@ class TestApplyActionsConf:
             TEST_SETTINGS,
             TEST_TEAM,
             "feature/x",
-            "oduflow-feature-x-odoo",
+            "oduflow-1-feature-x-odoo",
             to_install=[],
             to_upgrade=["sale"],
             do_restart=False,

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -77,7 +77,9 @@ class TestInitSystem:
         result = system_ops.init_system(TEST_SETTINGS)
 
         assert result["status"] == "initialized"
-        mock_docker_client.networks.create.assert_called_once()
+        # Shared infra network plus one isolated network per team.
+        created = [c.args[0] for c in mock_docker_client.networks.create.call_args_list]
+        assert created == ["oduflow-net", "oduflow-1-net"]
         mock_docker_client.volumes.create.assert_called_once()
 
     @patch("oduflow.docker_ops.system_ops._db_exists", return_value=True)

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -26,6 +26,15 @@ TEST_SETTINGS = Settings(
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_db_quota(monkeypatch):
+    # Quota enforcement is covered by tests/test_db_quota.py; here it would
+    # only add a psql exec to every mocked create_environment call chain.
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.check_db_quota", lambda *a, **kw: None
+    )
+
+
 @pytest.fixture
 def mock_docker_client():
     with (

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -33,6 +33,11 @@ def _no_db_quota(monkeypatch):
     monkeypatch.setattr(
         "oduflow.docker_ops.env_ops.check_db_quota", lambda *a, **kw: None
     )
+    # Tablespace provisioning is covered by tests/test_tablespaces.py.
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.ensure_team_tablespace",
+        lambda *a, **kw: "oduflow_team_1",
+    )
 
 
 @pytest.fixture

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -1,0 +1,118 @@
+from unittest.mock import call, patch
+
+from oduflow import quotas
+from oduflow.settings import Settings, TeamSettings
+
+
+def _team(tmp_path, quota_gb=10) -> TeamSettings:
+    return TeamSettings(
+        team_id="1", data_dir=str(tmp_path / "team_1"), disk_quota_gb=quota_gb
+    )
+
+
+def _settings(tmp_path, quota_gb=10) -> Settings:
+    return Settings(base_data_dir=str(tmp_path), teams={"1": _team(tmp_path, quota_gb)})
+
+
+class TestQuotaSupport:
+    def test_non_linux(self, monkeypatch):
+        monkeypatch.setattr(quotas.sys, "platform", "darwin")
+        ok, reason = quotas.quota_support(Settings(base_data_dir="/srv"))
+        assert not ok
+        assert "not linux" in reason
+
+    def test_missing_xfs_quota_binary(self, monkeypatch):
+        monkeypatch.setattr(quotas.sys, "platform", "linux")
+        monkeypatch.setattr(quotas.shutil, "which", lambda name: None)
+        ok, reason = quotas.quota_support(Settings(base_data_dir="/srv"))
+        assert not ok
+        assert "xfsprogs" in reason
+
+    def _support(self, monkeypatch, mounts, path="/srv/oduflow"):
+        monkeypatch.setattr(quotas.sys, "platform", "linux")
+        monkeypatch.setattr(quotas.shutil, "which", lambda name: "/usr/sbin/xfs_quota")
+        monkeypatch.setattr(quotas, "_read_mounts", lambda: mounts)
+        return quotas.quota_support(Settings(base_data_dir=path))
+
+    def test_not_xfs(self, monkeypatch):
+        ok, reason = self._support(
+            monkeypatch, [("/", "ext4", "rw,relatime"), ("/srv", "ext4", "rw")]
+        )
+        assert not ok
+        assert "not xfs" in reason
+
+    def test_xfs_without_prjquota(self, monkeypatch):
+        ok, reason = self._support(monkeypatch, [("/srv", "xfs", "rw,relatime")])
+        assert not ok
+        assert "prjquota" in reason
+
+    def test_supported_picks_longest_mount(self, monkeypatch):
+        ok, mountpoint = self._support(
+            monkeypatch,
+            [("/", "ext4", "rw"), ("/srv", "xfs", "rw,prjquota")],
+        )
+        assert ok
+        assert mountpoint == "/srv"
+
+
+class TestProjectIds:
+    def test_sequential_and_stable(self, tmp_path):
+        settings = _settings(tmp_path)
+        first = quotas._project_id_for(settings, "1")
+        second = quotas._project_id_for(settings, "acme")
+        assert (first, second) == (1001, 1002)
+        # Stable across calls (persisted).
+        assert quotas._project_id_for(settings, "1") == 1001
+
+
+class TestApplyAll:
+    def test_disabled_when_no_quota_set(self, tmp_path, monkeypatch):
+        called = []
+        monkeypatch.setattr(quotas, "quota_support", lambda s: called.append(1))
+        quotas.apply_all(_settings(tmp_path, quota_gb=0))
+        assert called == []  # support not even probed
+
+    def test_unsupported_logs_and_skips(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(quotas, "quota_support", lambda s: (False, "no xfs"))
+        with patch.object(quotas, "apply_team_disk_quota") as apply_one:
+            quotas.apply_all(_settings(tmp_path))
+        apply_one.assert_not_called()
+
+    def test_applies_project_and_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(quotas, "quota_support", lambda s: (True, "/srv"))
+        with patch.object(quotas, "_xfs_quota") as xfs:
+            quotas.apply_all(_settings(tmp_path, quota_gb=25))
+
+        team_dir = str(tmp_path / "team_1")
+        pg_dir = str(tmp_path / "pg_tablespaces" / "team_1")
+        assert xfs.call_args_list == [
+            call("/srv", f"project -s -p {team_dir} 1001"),
+            call("/srv", f"project -s -p {pg_dir} 1001"),
+            call("/srv", "limit -p bhard=25g 1001"),
+        ]
+        # Both trees exist (created if missing so the project can be set up).
+        assert (tmp_path / "pg_tablespaces" / "team_1").is_dir()
+
+    def test_one_team_failure_does_not_block_others(self, tmp_path, monkeypatch):
+        t1 = TeamSettings(
+            team_id="1", data_dir=str(tmp_path / "team_1"), disk_quota_gb=5
+        )
+        t2 = TeamSettings(
+            team_id="2",
+            data_dir=str(tmp_path / "team_2"),
+            disk_quota_gb=5,
+            port_range_start=50100,
+            port_range_end=50200,
+        )
+        settings = Settings(base_data_dir=str(tmp_path), teams={"1": t1, "2": t2})
+        monkeypatch.setattr(quotas, "quota_support", lambda s: (True, "/srv"))
+        applied = []
+
+        def apply_one(settings_, team, mountpoint):
+            if team.team_id == "1":
+                raise RuntimeError("boom")
+            applied.append(team.team_id)
+
+        monkeypatch.setattr(quotas, "apply_team_disk_quota", apply_one)
+        quotas.apply_all(settings)
+        assert applied == ["2"]

--- a/tests/test_resolve_team.py
+++ b/tests/test_resolve_team.py
@@ -1,0 +1,64 @@
+"""Team resolution: strict in HTTP mode, permissive fallback in stdio."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import oduflow.server as server
+from oduflow import settings as settings_module
+from oduflow.errors import NotFoundError
+from oduflow.settings import Settings, TeamSettings
+
+
+def _settings(n_teams: int = 2, allow_insecure_http: bool = False) -> Settings:
+    teams = {
+        str(i): TeamSettings(
+            team_id=str(i),
+            hostname=f"team{i}.example.com",
+            auth_token=f"token-{i}",
+            port_range_start=50000 + i * 100,
+            port_range_end=50100 + i * 100,
+        )
+        for i in range(1, n_teams + 1)
+    }
+    return Settings(teams=teams, allow_insecure_http=allow_insecure_http)
+
+
+@pytest.fixture
+def inject(monkeypatch):
+    def _inject(settings: Settings, transport: str) -> None:
+        monkeypatch.setattr(server, "_settings", settings)
+        monkeypatch.setattr(settings_module, "TRANSPORT", transport)
+
+    yield _inject
+    server._settings = None
+
+
+def test_stdio_falls_back_to_default_team(inject):
+    inject(_settings(n_teams=2), "stdio")
+    assert server._resolve_team(None).team_id == "1"
+
+
+def test_http_refuses_unresolved_request(inject):
+    inject(_settings(n_teams=2), "http")
+    with pytest.raises(NotFoundError, match="Cannot resolve a team"):
+        server._resolve_team(None)
+
+
+def test_http_refuses_even_with_single_team(inject):
+    # A hosted single-client server must not serve requests that carry no
+    # resolvable identity either.
+    inject(_settings(n_teams=1), "http")
+    with pytest.raises(NotFoundError, match="Cannot resolve a team"):
+        server._resolve_team(None)
+
+
+def test_http_insecure_optout_keeps_fallback(inject):
+    inject(_settings(n_teams=1, allow_insecure_http=True), "http")
+    assert server._resolve_team(None).team_id == "1"
+
+
+def test_http_token_resolution_still_works(inject):
+    inject(_settings(n_teams=2), "http")
+    ctx = SimpleNamespace(client_id="2")
+    assert server._resolve_team(ctx).team_id == "2"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -256,7 +256,7 @@ class TestAgentInstructionsTool:
 
         assert result.startswith("## Current Code Delivery Mode")
         assert "Live-mount/local_path mode is active" in result
-        assert "upgrade=\"module\"" in result
+        assert 'upgrade="module"' in result
         assert "Git commits are optional" in result
 
     @patch("oduflow.docker_ops.env_ops.list_environments")
@@ -325,7 +325,7 @@ class TestCreateServiceTool:
     def test_create(self, mock_create):
         mock_create.return_value = {
             "name": "redis",
-            "container_name": "oduflow-svc-redis",
+            "container_name": "oduflow-1-svc-redis",
             "url": "http://localhost:6379",
             "image": "redis:7",
         }
@@ -334,14 +334,14 @@ class TestCreateServiceTool:
         )
         assert "Service created successfully!" in result
         assert "redis" in result
-        assert "oduflow-svc-redis" in result
+        assert "oduflow-1-svc-redis" in result
         assert "http://localhost:6379" in result
 
     @patch("oduflow.docker_ops.service_ops.create_service")
     def test_create_with_env_vars_parsing(self, mock_create):
         mock_create.return_value = {
             "name": "meili",
-            "container_name": "oduflow-svc-meili",
+            "container_name": "oduflow-1-svc-meili",
             "url": "http://localhost:7700",
             "image": "getmeili/meilisearch:v1.6",
         }
@@ -359,7 +359,7 @@ class TestCreateServiceTool:
     def test_create_empty_env_vars(self, mock_create):
         mock_create.return_value = {
             "name": "redis",
-            "container_name": "oduflow-svc-redis",
+            "container_name": "oduflow-1-svc-redis",
             "url": "http://localhost:6379",
             "image": "redis:7",
         }
@@ -375,14 +375,14 @@ class TestUpdateServiceTool:
     def test_update(self, mock_update):
         mock_update.return_value = {
             "name": "redis",
-            "container_name": "oduflow-svc-redis",
+            "container_name": "oduflow-1-svc-redis",
             "url": "http://localhost:6379",
             "image": "redis:7",
         }
         result = _get_tool_fn("update_service")(name="redis")
         assert "Service updated successfully!" in result
         assert "redis" in result
-        assert "oduflow-svc-redis" in result
+        assert "oduflow-1-svc-redis" in result
         mock_update.assert_called_once_with(
             TEST_SETTINGS,
             TEST_TEAM,
@@ -401,7 +401,7 @@ class TestUpdateServiceTool:
     def test_update_net_admin_and_privileged_mapping(self, mock_update):
         mock_update.return_value = {
             "name": "vpn",
-            "container_name": "oduflow-svc-vpn",
+            "container_name": "oduflow-1-svc-vpn",
             "url": "http://localhost:1194",
             "image": "vpn:latest",
         }
@@ -414,7 +414,7 @@ class TestUpdateServiceTool:
     def test_update_net_admin_false_clears_cap(self, mock_update):
         mock_update.return_value = {
             "name": "vpn",
-            "container_name": "oduflow-svc-vpn",
+            "container_name": "oduflow-1-svc-vpn",
             "url": "http://localhost:1194",
             "image": "vpn:latest",
         }
@@ -437,12 +437,12 @@ class TestDeleteServiceTool:
     def test_delete(self, mock_delete):
         mock_delete.return_value = {
             "name": "redis",
-            "container_name": "oduflow-svc-redis",
+            "container_name": "oduflow-1-svc-redis",
         }
         result = _get_tool_fn("delete_service")(name="redis")
         assert "deleted" in result
         assert "redis" in result
-        mock_delete.assert_called_once_with(TEST_SETTINGS, "redis")
+        mock_delete.assert_called_once_with(TEST_SETTINGS, TEST_TEAM, "redis")
 
 
 class TestListServicesTool:
@@ -451,7 +451,7 @@ class TestListServicesTool:
         mock_list.return_value = [
             {
                 "name": "redis",
-                "container_name": "oduflow-svc-redis",
+                "container_name": "oduflow-1-svc-redis",
                 "image": "redis:7",
                 "status": "running",
                 "port": 6379,
@@ -461,7 +461,7 @@ class TestListServicesTool:
         ]
         result = _call_tool("list_services")
         assert "redis" in result
-        assert "oduflow-svc-redis" in result
+        assert "oduflow-1-svc-redis" in result
         assert "redis:7" in result
         assert "6379" in result
         assert "REDIS_PASSWORD=secret" in result
@@ -480,7 +480,7 @@ class TestGetServiceLogsTool:
         result = _get_tool_fn("get_service_logs")(name="redis", n_lines=50)
         assert "log line 1" in result
         assert "service 'redis'" in result
-        mock_logs.assert_called_once_with(TEST_SETTINGS, "redis", 50)
+        mock_logs.assert_called_once_with(TEST_SETTINGS, TEST_TEAM, "redis", 50)
 
     @patch("oduflow.docker_ops.service_ops.get_service_logs")
     def test_logs_error(self, mock_logs):
@@ -615,7 +615,7 @@ class TestRestoreServiceTool:
         }
         mock_create.return_value = {
             "name": "wg",
-            "container_name": "oduflow-svc-wg",
+            "container_name": "oduflow-1-svc-wg",
             "image": "linuxserver/wireguard:latest",
             "url": "http://localhost:51820",
         }
@@ -646,7 +646,7 @@ class TestRestoreServiceTool:
         }
         mock_create.return_value = {
             "name": "dind",
-            "container_name": "oduflow-svc-dind",
+            "container_name": "oduflow-1-svc-dind",
             "image": "docker:dind",
             "url": "http://localhost:2375",
         }
@@ -669,7 +669,7 @@ class TestRestoreServiceTool:
         }
         mock_create.return_value = {
             "name": "redis",
-            "container_name": "oduflow-svc-redis",
+            "container_name": "oduflow-1-svc-redis",
             "image": "redis:7",
             "url": "http://localhost:6379",
         }

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -3,7 +3,7 @@ import docker
 from unittest.mock import MagicMock, patch
 
 from oduflow.docker_ops import service_ops, system_ops
-from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
+from oduflow.errors import ConflictError, NotFoundError
 from oduflow.settings import Settings, TeamSettings
 
 TEST_TEAM = TeamSettings(
@@ -20,6 +20,17 @@ TEST_SETTINGS = Settings(
     db_password="odoo",
     teams={"1": TEST_TEAM},
 )
+
+
+@pytest.fixture(autouse=True)
+def _fake_team_network(monkeypatch):
+    # Network provisioning is covered by tests/test_team_networks.py; here it
+    # would only consume the mocked docker client's side_effect iterators.
+    monkeypatch.setattr(
+        "oduflow.docker_ops.system_ops.ensure_team_network",
+        lambda client, settings, team: f"oduflow-{team.team_id}-net",
+    )
+
 
 TRAEFIK_TEAM = TeamSettings(
     team_id="1",
@@ -72,7 +83,7 @@ class TestCreateService:
         run_kwargs = mock_docker_client.containers.run.call_args
         assert run_kwargs[1]["name"] == "oduflow-1-svc-redis"
         assert run_kwargs[1]["image"] == "redis:7"
-        assert run_kwargs[1]["network"] == "oduflow-net"
+        assert run_kwargs[1]["network"] == "oduflow-1-net"
         assert run_kwargs[1]["ports"] == {"6379/tcp": 6379}
         assert run_kwargs[1]["labels"]["oduflow.managed"] == "true"
         assert run_kwargs[1]["labels"]["oduflow.service"] == "redis"
@@ -166,16 +177,6 @@ class TestCreateService:
         mock_docker_client.containers.get.return_value = existing
 
         with pytest.raises(ConflictError, match="already exists"):
-            service_ops.create_service(
-                TEST_SETTINGS, TEST_TEAM, "redis", "redis:7", 6379
-            )
-
-        mock_docker_client.containers.run.assert_not_called()
-
-    def test_create_network_missing(self, mock_docker_client):
-        mock_docker_client.networks.get.side_effect = docker.errors.NotFound("nf")
-
-        with pytest.raises(PrerequisiteNotMetError, match="not initialized"):
             service_ops.create_service(
                 TEST_SETTINGS, TEST_TEAM, "redis", "redis:7", 6379
             )

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -65,12 +65,12 @@ class TestCreateService:
         )
 
         assert result["name"] == "redis"
-        assert result["container_name"] == "oduflow-svc-redis"
+        assert result["container_name"] == "oduflow-1-svc-redis"
         assert result["url"] == "http://localhost:6379"
         assert result["image"] == "redis:7"
 
         run_kwargs = mock_docker_client.containers.run.call_args
-        assert run_kwargs[1]["name"] == "oduflow-svc-redis"
+        assert run_kwargs[1]["name"] == "oduflow-1-svc-redis"
         assert run_kwargs[1]["image"] == "redis:7"
         assert run_kwargs[1]["network"] == "oduflow-net"
         assert run_kwargs[1]["ports"] == {"6379/tcp": 6379}
@@ -98,12 +98,12 @@ class TestCreateService:
         labels = run_kwargs[1]["labels"]
         assert labels["traefik.enable"] == "true"
         assert (
-            labels["traefik.http.routers.oduflow-svc-meilisearch.rule"]
+            labels["traefik.http.routers.oduflow-1-svc-meilisearch.rule"]
             == "Host(`meilisearch.example.com`)"
         )
         assert (
             labels[
-                "traefik.http.services.oduflow-svc-meilisearch.loadbalancer.server.port"
+                "traefik.http.services.oduflow-1-svc-meilisearch.loadbalancer.server.port"
             ]
             == "7700"
         )
@@ -127,7 +127,7 @@ class TestCreateService:
         assert result["url"] == "https://my-redis.example.com"
         labels = mock_docker_client.containers.run.call_args[1]["labels"]
         assert (
-            labels["traefik.http.routers.oduflow-svc-redis.rule"]
+            labels["traefik.http.routers.oduflow-1-svc-redis.rule"]
             == "Host(`my-redis.example.com`)"
         )
 
@@ -188,10 +188,10 @@ class TestDeleteService:
         container = MagicMock()
         mock_docker_client.containers.get.return_value = container
 
-        result = service_ops.delete_service(TEST_SETTINGS, "redis")
+        result = service_ops.delete_service(TEST_SETTINGS, TEST_TEAM, "redis")
 
         assert result["name"] == "redis"
-        assert result["container_name"] == "oduflow-svc-redis"
+        assert result["container_name"] == "oduflow-1-svc-redis"
         container.stop.assert_called_once()
         container.remove.assert_called_once_with(v=True)
 
@@ -199,7 +199,7 @@ class TestDeleteService:
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
         with pytest.raises(NotFoundError, match="Service 'redis' not found"):
-            service_ops.delete_service(TEST_SETTINGS, "redis")
+            service_ops.delete_service(TEST_SETTINGS, TEST_TEAM, "redis")
 
 
 class TestListServices:
@@ -209,7 +209,7 @@ class TestListServices:
             "oduflow.managed": "true",
             "oduflow.service": "redis",
         }
-        container.name = "oduflow-svc-redis"
+        container.name = "oduflow-1-svc-redis"
         container.status = "running"
         container.image.tags = ["redis:7"]
         container.attrs = {
@@ -225,7 +225,7 @@ class TestListServices:
         assert len(result) == 1
         svc = result[0]
         assert svc["name"] == "redis"
-        assert svc["container_name"] == "oduflow-svc-redis"
+        assert svc["container_name"] == "oduflow-1-svc-redis"
         assert svc["image"] == "redis:7"
         assert svc["status"] == "running"
         assert svc["port"] == 6379
@@ -239,10 +239,10 @@ class TestListServices:
             "oduflow.managed": "true",
             "oduflow.service": "meili",
             "traefik.enable": "true",
-            "traefik.http.routers.oduflow-svc-meili.rule": "Host(`meili.example.com`)",
-            "traefik.http.services.oduflow-svc-meili.loadbalancer.server.port": "7700",
+            "traefik.http.routers.oduflow-1-svc-meili.rule": "Host(`meili.example.com`)",
+            "traefik.http.services.oduflow-1-svc-meili.loadbalancer.server.port": "7700",
         }
-        container.name = "oduflow-svc-meili"
+        container.name = "oduflow-1-svc-meili"
         container.status = "running"
         container.image.tags = ["getmeili/meilisearch:v1.6"]
         container.attrs = {"Config": {"Env": []}}
@@ -275,7 +275,7 @@ class TestListServices:
     def test_list_env_var_filtering(self, mock_docker_client):
         container = MagicMock()
         container.labels = {"oduflow.managed": "true", "oduflow.service": "meili"}
-        container.name = "oduflow-svc-meili"
+        container.name = "oduflow-1-svc-meili"
         container.status = "running"
         container.image.tags = ["getmeili/meilisearch:v1.6"]
         container.attrs = {
@@ -307,7 +307,7 @@ class TestListServices:
         """When image.tags is empty, fall back to Config.Image."""
         container = MagicMock()
         container.labels = {"oduflow.managed": "true", "oduflow.service": "redis"}
-        container.name = "oduflow-svc-redis"
+        container.name = "oduflow-1-svc-redis"
         container.status = "running"
         container.image.tags = []
         container.attrs = {
@@ -324,7 +324,7 @@ class TestListServices:
         """Port key exists but no host mappings."""
         container = MagicMock()
         container.labels = {"oduflow.managed": "true", "oduflow.service": "redis"}
-        container.name = "oduflow-svc-redis"
+        container.name = "oduflow-1-svc-redis"
         container.status = "exited"
         container.image.tags = ["redis:7"]
         container.attrs = {
@@ -374,12 +374,15 @@ class TestUpdateService:
             ],
         }
 
-        with patch(
-            "oduflow.docker_ops.service_ops.service_presets.get_preset",
-            return_value=preset,
-        ), patch(
-            "oduflow.docker_ops.service_ops.volume_ops.resolve_volume_binds",
-            return_value={"vol1": {"bind": "/acme", "mode": "ro"}},
+        with (
+            patch(
+                "oduflow.docker_ops.service_ops.service_presets.get_preset",
+                return_value=preset,
+            ),
+            patch(
+                "oduflow.docker_ops.service_ops.volume_ops.resolve_volume_binds",
+                return_value={"vol1": {"bind": "/acme", "mode": "ro"}},
+            ),
         ):
             result = service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
 
@@ -417,13 +420,16 @@ class TestUpdateService:
             "volumes": volumes,
         }
 
-        with patch(
-            "oduflow.docker_ops.service_ops.service_presets.get_preset",
-            return_value=preset,
-        ), patch(
-            "oduflow.docker_ops.service_ops.volume_ops.resolve_volume_binds",
-            return_value={"vol1": {"bind": "/acme", "mode": "ro"}},
-        ) as mock_resolve:
+        with (
+            patch(
+                "oduflow.docker_ops.service_ops.service_presets.get_preset",
+                return_value=preset,
+            ),
+            patch(
+                "oduflow.docker_ops.service_ops.volume_ops.resolve_volume_binds",
+                return_value={"vol1": {"bind": "/acme", "mode": "ro"}},
+            ) as mock_resolve,
+        ):
             service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
             mock_resolve.assert_called_once_with(TEST_TEAM, volumes)
 
@@ -434,9 +440,7 @@ class TestUpdateService:
             labels={"oduflow.managed": "true", "oduflow.service": "redis"},
             attrs={
                 "NetworkSettings": {
-                    "Ports": {
-                        "6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]
-                    }
+                    "Ports": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]}
                 },
                 "Config": {
                     "Env": ["REDIS_PASSWORD=secret", "PATH=/usr/bin", "HOME=/root"]
@@ -475,8 +479,8 @@ class TestUpdateService:
             labels={
                 "oduflow.managed": "true",
                 "oduflow.service": "meili",
-                "traefik.http.routers.oduflow-svc-meili.rule": "Host(`meili.example.com`)",
-                "traefik.http.services.oduflow-svc-meili.loadbalancer.server.port": "7700",
+                "traefik.http.routers.oduflow-1-svc-meili.rule": "Host(`meili.example.com`)",
+                "traefik.http.services.oduflow-1-svc-meili.loadbalancer.server.port": "7700",
             },
             attrs={"Config": {"Env": ["MEILI_MASTER_KEY=abc"]}},
         )
@@ -500,9 +504,7 @@ class TestUpdateService:
             "oduflow.docker_ops.service_ops.service_presets.get_preset",
             return_value=preset,
         ):
-            result = service_ops.update_service(
-                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili"
-            )
+            result = service_ops.update_service(TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili")
 
         assert result["url"] == "https://meili.example.com"
         mock_docker_client.images.pull.assert_any_call("getmeili/meilisearch:v1.6")
@@ -510,7 +512,7 @@ class TestUpdateService:
         run_kwargs = mock_docker_client.containers.run.call_args
         labels = run_kwargs[1]["labels"]
         assert (
-            labels["traefik.http.routers.oduflow-svc-meili.rule"]
+            labels["traefik.http.routers.oduflow-1-svc-meili.rule"]
             == "Host(`meili.example.com`)"
         )
 
@@ -610,9 +612,7 @@ class TestUpdateService:
             "oduflow.docker_ops.service_ops.service_presets.get_preset",
             return_value=preset,
         ):
-            result = service_ops.update_service(
-                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili"
-            )
+            result = service_ops.update_service(TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili")
 
         assert result["image_updated"] is False
         assert result["url"] == "https://meili.example.com"
@@ -1002,7 +1002,7 @@ class TestUpdateService:
 class TestGetServiceInfo:
     def _make_container(self, image_tags, image_id, labels, attrs, status="running"):
         container = MagicMock()
-        container.name = labels.get("__name") or "oduflow-svc-redis"
+        container.name = labels.get("__name") or "oduflow-1-svc-redis"
         container.image.tags = image_tags
         container.image.id = image_id
         container.labels = {k: v for k, v in labels.items() if k != "__name"}
@@ -1015,7 +1015,7 @@ class TestGetServiceInfo:
             image_tags=["redis:7"],
             image_id="sha256:abc123def456",
             labels={
-                "__name": "oduflow-svc-redis",
+                "__name": "oduflow-1-svc-redis",
                 "oduflow.managed": "true",
                 "oduflow.service": "redis",
             },
@@ -1027,9 +1027,7 @@ class TestGetServiceInfo:
                     ]
                 },
                 "NetworkSettings": {
-                    "Ports": {
-                        "6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]
-                    }
+                    "Ports": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]}
                 },
                 "Mounts": [
                     {
@@ -1053,7 +1051,7 @@ class TestGetServiceInfo:
             info = service_ops.get_service_info(TEST_SETTINGS, TEST_TEAM, "redis")
 
         assert info["name"] == "redis"
-        assert info["container_name"] == "oduflow-svc-redis"
+        assert info["container_name"] == "oduflow-1-svc-redis"
         assert info["image"] == "redis:7"
         assert info["image_digest"] == "sha256:abc123def456"
         assert info["status"] == "running"
@@ -1075,11 +1073,11 @@ class TestGetServiceInfo:
             image_tags=["getmeili/meilisearch:v1.6"],
             image_id="sha256:meili123",
             labels={
-                "__name": "oduflow-svc-meili",
+                "__name": "oduflow-1-svc-meili",
                 "oduflow.managed": "true",
                 "oduflow.service": "meili",
-                "traefik.http.routers.oduflow-svc-meili.rule": "Host(`meili.example.com`)",
-                "traefik.http.services.oduflow-svc-meili.loadbalancer.server.port": "7700",
+                "traefik.http.routers.oduflow-1-svc-meili.rule": "Host(`meili.example.com`)",
+                "traefik.http.services.oduflow-1-svc-meili.loadbalancer.server.port": "7700",
             },
             attrs={
                 "Config": {"Env": ["MEILI_MASTER_KEY=abc"]},
@@ -1095,9 +1093,7 @@ class TestGetServiceInfo:
             "oduflow.docker_ops.service_ops.service_presets.get_preset",
             side_effect=NotFoundError("no preset"),
         ):
-            info = service_ops.get_service_info(
-                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili"
-            )
+            info = service_ops.get_service_info(TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili")
 
         assert info["hostname"] == "meili.example.com"
         assert info["url"] == "https://meili.example.com"
@@ -1111,7 +1107,7 @@ class TestGetServiceInfo:
             service_ops.get_service_info(TEST_SETTINGS, TEST_TEAM, "redis")
 
     def test_get_service_info_not_managed(self, mock_docker_client):
-        """A container with name oduflow-svc-X but no oduflow.service label is rejected."""
+        """A container with name oduflow-1-svc-X but no oduflow.service label is rejected."""
         container = self._make_container(
             image_tags=["redis:7"],
             image_id="sha256:abc",
@@ -1137,7 +1133,7 @@ class TestGetServiceLogs:
         )
         mock_docker_client.containers.get.return_value = container
 
-        output = service_ops.get_service_logs(TEST_SETTINGS, "redis", 50)
+        output = service_ops.get_service_logs(TEST_SETTINGS, TEST_TEAM, "redis", 50)
 
         assert "log line 1" in output
         assert "log line 2" in output
@@ -1148,7 +1144,7 @@ class TestGetServiceLogs:
         container.logs.return_value = b"line"
         mock_docker_client.containers.get.return_value = container
 
-        service_ops.get_service_logs(TEST_SETTINGS, "redis")
+        service_ops.get_service_logs(TEST_SETTINGS, TEST_TEAM, "redis")
 
         container.logs.assert_called_with(tail=100, timestamps=True)
 
@@ -1156,14 +1152,14 @@ class TestGetServiceLogs:
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
         with pytest.raises(NotFoundError, match="Service 'redis' not found"):
-            service_ops.get_service_logs(TEST_SETTINGS, "redis")
+            service_ops.get_service_logs(TEST_SETTINGS, TEST_TEAM, "redis")
 
 
 class TestDestroyBlockedByServices:
     def test_destroy_with_active_services(self, mock_docker_client):
         container = MagicMock()
         container.labels = {"oduflow.service": "redis", "oduflow.managed": "true"}
-        container.name = "oduflow-svc-redis"
+        container.name = "oduflow-1-svc-redis"
         mock_docker_client.containers.list.return_value = [container]
 
         with pytest.raises(ConflictError, match="Active environments/services exist"):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -192,3 +192,25 @@ class TestTeamTemplatePaths:
     def test_git_credentials_file(self):
         t = TeamSettings(team_id="1", data_dir="/srv/data")
         assert t.git_credentials_file() == "/srv/data/.git-credentials"
+
+
+class TestQuotas:
+    def test_defaults(self):
+        t = TeamSettings(team_id="1")
+        assert t.db_quota_gb == 50
+        assert t.disk_quota_gb == 0  # off until FS quota enforcement lands
+
+    def test_from_toml(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[team.1]\nhostname = "localhost"\ndb_quota_gb = 10\ndisk_quota_gb = 20\n'
+        )
+        s = Settings.from_toml(str(toml))
+        assert s.teams["1"].db_quota_gb == 10
+        assert s.teams["1"].disk_quota_gb == 20
+
+    def test_negative_quota_rejected(self):
+        team = TeamSettings(team_id="1", db_quota_gb=-1)
+        s = Settings(teams={"1": team})
+        with pytest.raises(ValueError, match="quotas must be >= 0"):
+            s.validate()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,16 +11,14 @@ class TestSettings:
 
     def test_malformed_port_range_raises(self, tmp_path):
         toml = tmp_path / "oduflow.toml"
-        toml.write_text(
-            '[team.1]\nhostname = "localhost"\nport_range = [50000]\n'
-        )
+        toml.write_text('[team.1]\nhostname = "localhost"\nport_range = [50000]\n')
         with pytest.raises(ValueError, match="port_range"):
             Settings.from_toml(str(toml))
 
     def test_lifecycle_from_toml(self, tmp_path):
         toml = tmp_path / "oduflow.toml"
         toml.write_text(
-            '[lifecycle]\nauto_stop_hours = 12\nauto_delete_hours = 0\n'
+            "[lifecycle]\nauto_stop_hours = 12\nauto_delete_hours = 0\n"
             '[team.1]\nhostname = "localhost"\n'
         )
         s = Settings.from_toml(str(toml))

--- a/tests/test_storage_stats.py
+++ b/tests/test_storage_stats.py
@@ -85,3 +85,28 @@ def test_refresh_team_totals(mock_list, mock_sql, mock_team_db, mock_client, tmp
     # measuring, so it is not counted.
     assert cache["team"]["disk_bytes"] == 7000
     assert read_storage_cache(team)["team"] == cache["team"]
+
+
+class TestDefaultEnvLimits:
+    def _limits(self, monkeypatch, total_mb):
+        from oduflow.docker_ops import stats
+
+        monkeypatch.setattr(
+            stats, "_read_memory_linux", lambda: (total_mb, 0.0) if total_mb else None
+        )
+        monkeypatch.setattr(stats, "_read_memory_macos", lambda: None)
+        return stats.default_env_limits()
+
+    def test_quarter_of_host(self, monkeypatch):
+        assert self._limits(monkeypatch, 16 * 1024)["mem_limit"] == 4 * 1024**3
+
+    def test_floor_2gb(self, monkeypatch):
+        assert self._limits(monkeypatch, 4 * 1024)["mem_limit"] == 2 * 1024**3
+
+    def test_cap_8gb(self, monkeypatch):
+        assert self._limits(monkeypatch, 128 * 1024)["mem_limit"] == 8 * 1024**3
+
+    def test_unknown_host_fallback(self, monkeypatch):
+        limits = self._limits(monkeypatch, 0)
+        assert limits["mem_limit"] == 4 * 1024**3
+        assert limits["pids_limit"] == 4096

--- a/tests/test_storage_stats.py
+++ b/tests/test_storage_stats.py
@@ -1,0 +1,87 @@
+import os
+from unittest.mock import patch
+
+from oduflow.docker_ops.stats import (
+    read_storage_cache,
+    refresh_env_storage,
+    refresh_team_storage,
+)
+from oduflow.settings import Settings, TeamSettings
+
+
+def _team(tmp_path) -> TeamSettings:
+    return TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+
+
+def _make_workspace(team: TeamSettings, env: str, overlay: bool) -> str:
+    ws = os.path.join(team.workspaces_dir, env)
+    os.makedirs(os.path.join(ws, "repo"))
+    with open(os.path.join(ws, "repo", "module.py"), "w") as f:
+        f.write("x" * 1000)
+    merged = os.path.join(ws, "filestore")
+    os.makedirs(merged)
+    with open(os.path.join(merged, "blob"), "w") as f:
+        f.write("y" * 50_000)
+    if overlay:
+        upper = os.path.join(ws, "filestore_upper")
+        os.makedirs(upper)
+        with open(os.path.join(upper, "own-blob"), "w") as f:
+            f.write("z" * 2000)
+    return ws
+
+
+def test_read_cache_missing(tmp_path):
+    assert read_storage_cache(_team(tmp_path)) == {"envs": {}, "team": None}
+
+
+@patch("oduflow.docker_ops.stats.get_client", return_value=None)
+@patch("oduflow.docker_ops.system_ops._exec_sql", return_value="12345")
+def test_refresh_env_counts_upper_not_merged(mock_sql, mock_client, tmp_path):
+    team = _team(tmp_path)
+    _make_workspace(team, "main", overlay=True)
+
+    entry = refresh_env_storage(Settings(), team, "main")
+
+    assert entry["db_bytes"] == 12345
+    # repo (1000) + upper (2000); the merged overlay view (50000) holds the
+    # template's lower layer and duplicates upper — excluded.
+    assert entry["disk_bytes"] == 3000
+    assert entry["computed_at"]
+    # Persisted and readable back.
+    assert read_storage_cache(team)["envs"]["main"] == entry
+
+
+@patch("oduflow.docker_ops.stats.get_client", return_value=None)
+@patch("oduflow.docker_ops.system_ops._exec_sql", return_value="500")
+def test_refresh_env_plain_filestore_is_counted(mock_sql, mock_client, tmp_path):
+    team = _team(tmp_path)
+    _make_workspace(team, "plain", overlay=False)
+
+    entry = refresh_env_storage(Settings(), team, "plain")
+
+    # No overlay upper dir → the filestore is a plain copy owned by the env.
+    assert entry["disk_bytes"] == 51_000
+
+
+@patch("oduflow.docker_ops.stats.get_client", return_value=None)
+@patch("oduflow.docker_ops.system_ops.get_team_db_usage_bytes", return_value=777)
+@patch("oduflow.docker_ops.system_ops._exec_sql", return_value="100")
+@patch("oduflow.docker_ops.env_ops.list_environments")
+def test_refresh_team_totals(mock_list, mock_sql, mock_team_db, mock_client, tmp_path):
+    team = _team(tmp_path)
+    _make_workspace(team, "main", overlay=True)
+    os.makedirs(os.path.join(team.data_dir, "templates", "prod"))
+    with open(os.path.join(team.data_dir, "templates", "prod", "dump.sql"), "w") as f:
+        f.write("d" * 4000)
+    mock_list.return_value = [{"env_name": "main"}]
+
+    cache = refresh_team_storage(Settings(), team)
+
+    assert cache["envs"]["main"]["db_bytes"] == 100
+    assert cache["envs"]["main"]["disk_bytes"] == 3000
+    assert cache["team"]["db_bytes"] == 777
+    # Whole team dir minus the merged overlay view: workspace (3000) +
+    # template dump (4000) + the storage cache file itself is written after
+    # measuring, so it is not counted.
+    assert cache["team"]["disk_bytes"] == 7000
+    assert read_storage_cache(team)["team"] == cache["team"]

--- a/tests/test_tablespaces.py
+++ b/tests/test_tablespaces.py
@@ -1,0 +1,113 @@
+from unittest.mock import MagicMock, patch
+
+from oduflow.docker_ops.system_ops import ensure_team_tablespace
+from oduflow.migrations import _migrate_team_pg_tablespaces
+from oduflow.naming import get_tablespace_name
+from oduflow.settings import Settings, TeamSettings
+
+
+def _team(tmp_path) -> TeamSettings:
+    return TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+
+
+def _settings(tmp_path, teams=None) -> Settings:
+    return Settings(
+        base_data_dir=str(tmp_path),
+        teams=teams or {"1": _team(tmp_path)},
+    )
+
+
+def test_tablespace_name():
+    assert get_tablespace_name("1") == "oduflow_team_1"
+
+
+class TestEnsureTeamTablespace:
+    def test_creates_when_missing(self, tmp_path):
+        pg = MagicMock()
+        pg.exec_run.return_value = (0, b"")
+        client = MagicMock()
+        client.containers.get.return_value = pg
+        executed = []
+
+        def fake_sql(client_, settings_, sql, db="postgres"):
+            executed.append(sql)
+            return ""  # not found in pg_tablespace
+
+        with patch("oduflow.docker_ops.system_ops._exec_sql", side_effect=fake_sql):
+            name = ensure_team_tablespace(client, _settings(tmp_path), _team(tmp_path))
+
+        assert name == "oduflow_team_1"
+        # Host directory created inside the single mounted pg_tablespaces dir.
+        assert (tmp_path / "pg_tablespaces" / "team_1").is_dir()
+        # Ownership fixed inside the container, then the tablespace created.
+        pg.exec_run.assert_any_call(
+            ["chown", "postgres:postgres", "/tablespaces/team_1"], user="root"
+        )
+        assert any("CREATE TABLESPACE" in sql for sql in executed)
+
+    def test_noop_when_exists(self, tmp_path):
+        client = MagicMock()
+        with patch("oduflow.docker_ops.system_ops._exec_sql", return_value="1"):
+            name = ensure_team_tablespace(client, _settings(tmp_path), _team(tmp_path))
+
+        assert name == "oduflow_team_1"
+        client.containers.get.assert_not_called()
+
+
+class TestTablespacesMigration:
+    def _run(self, tmp_path, db_rows, has_mount=True):
+        """Run the migration against a fake PG container; return executed SQL."""
+        pg = MagicMock()
+        pg.attrs = {"Mounts": [{"Destination": "/tablespaces"}] if has_mount else []}
+        client = MagicMock()
+        client.containers.get.return_value = pg
+        executed = []
+
+        def fake_sql(client_, settings_, sql, db="postgres"):
+            executed.append(sql)
+            if "FROM pg_database" in sql:
+                return "\n".join(db_rows)
+            if "FROM pg_tablespace" in sql:
+                return "1"  # tablespace already exists
+            return ""
+
+        with (
+            patch("oduflow.docker_ops.client.get_client", return_value=client),
+            patch("oduflow.docker_ops.system_ops._exec_sql", side_effect=fake_sql),
+            patch("oduflow.docker_ops.system_ops._wait_pg_ready"),
+            patch("oduflow.docker_ops.system_ops._ensure_pg_container") as ensure_pg,
+        ):
+            _migrate_team_pg_tablespaces(_settings(tmp_path))
+        return executed, pg, ensure_pg
+
+    def test_moves_only_foreign_tablespace_dbs(self, tmp_path):
+        executed, pg, ensure_pg = self._run(
+            tmp_path,
+            db_rows=[
+                "postgres|",
+                "oduflow_1_main|",  # to move
+                "oduflow_template_1_prod|oduflow_team_1",  # already moved
+                "oduflow_2_other|",  # another team: not configured here
+            ],
+        )
+
+        moves = [sql for sql in executed if "SET TABLESPACE" in sql]
+        assert moves == [
+            'ALTER DATABASE "oduflow_1_main" SET TABLESPACE "oduflow_team_1";'
+        ]
+        # Connections blocked before the move and restored after.
+        assert any("ALLOW_CONNECTIONS false" in sql for sql in executed)
+        assert any("ALLOW_CONNECTIONS true" in sql for sql in executed)
+        assert any("pg_terminate_backend" in sql for sql in executed)
+        # Mount present: the PG container is not recreated.
+        pg.stop.assert_not_called()
+        ensure_pg.assert_not_called()
+
+    def test_recreates_pg_container_when_mount_missing(self, tmp_path):
+        executed, pg, ensure_pg = self._run(
+            tmp_path, db_rows=["postgres|"], has_mount=False
+        )
+
+        pg.stop.assert_called_once()
+        pg.remove.assert_called_once()
+        ensure_pg.assert_called_once()

--- a/tests/test_team_networks.py
+++ b/tests/test_team_networks.py
@@ -1,0 +1,155 @@
+from unittest.mock import MagicMock, patch
+
+import docker
+
+from oduflow.docker_ops.system_ops import ensure_team_network
+from oduflow.migrations import _migrate_per_team_networks
+from oduflow.naming import get_team_network_name
+from oduflow.settings import Settings, TeamSettings
+
+TEAM = TeamSettings(team_id="1")
+SETTINGS = Settings(teams={"1": TEAM})
+
+
+def test_network_name():
+    assert get_team_network_name("1") == "oduflow-1-net"
+
+
+class TestEnsureTeamNetwork:
+    def test_creates_and_attaches_infra(self):
+        client = MagicMock()
+        client.networks.get.side_effect = docker.errors.NotFound("nf")
+        net = MagicMock()
+        client.networks.create.return_value = net
+        pg = MagicMock()
+        client.containers.get.return_value = pg
+
+        with patch("oduflow.docker_ops.system_ops._ensure_iptables_accept"):
+            name = ensure_team_network(client, SETTINGS, TEAM)
+
+        assert name == "oduflow-1-net"
+        labels = client.networks.create.call_args[1]["labels"]
+        assert labels["oduflow.team"] == "1"
+        net.connect.assert_called_once_with(pg)  # port mode: PG only
+
+    def test_traefik_attached_in_traefik_mode(self):
+        settings = Settings(
+            routing_mode="traefik", acme_email="x@y.z", teams={"1": TEAM}
+        )
+        client = MagicMock()
+        net = MagicMock()
+        client.networks.get.return_value = net  # network already exists
+
+        ensure_team_network(client, settings, TEAM)
+
+        # PG and Traefik both attached.
+        assert net.connect.call_count == 2
+
+    def test_already_connected_is_fine(self):
+        client = MagicMock()
+        net = MagicMock()
+        client.networks.get.return_value = net
+        net.connect.side_effect = docker.errors.APIError(
+            "endpoint already exists in network"
+        )
+
+        assert ensure_team_network(client, SETTINGS, TEAM) == "oduflow-1-net"
+
+
+class _FakeNet:
+    def __init__(self):
+        self.connected: list[str] = []
+        self.disconnected: list[str] = []
+
+    def connect(self, container):
+        self.connected.append(container.name)
+
+    def disconnect(self, container):
+        self.disconnected.append(container.name)
+
+
+class TestPerTeamNetworksMigration:
+    def _container(self, name, labels, networks, network_mode="bridge"):
+        c = MagicMock()
+        c.name = name
+        c.labels = labels
+        c.attrs = {
+            "HostConfig": {"NetworkMode": network_mode},
+            "NetworkSettings": {"Networks": {n: {} for n in networks}},
+            "Config": {"Cmd": []},
+        }
+        return c
+
+    def test_moves_containers_and_recreates_traefik(self):
+        env = self._container(
+            "oduflow-1-main-odoo",
+            {"oduflow.managed": "true", "oduflow.team": "1"},
+            ["oduflow-net"],
+        )
+        hostsvc = self._container(
+            "oduflow-1-svc-vpn",
+            {"oduflow.managed": "true", "oduflow.team": "1"},
+            [],
+            network_mode="host",
+        )
+        traefik = MagicMock()
+        traefik.attrs = {"Config": {"Cmd": ["--providers.docker.network=oduflow-net"]}}
+
+        team_net = _FakeNet()
+        shared_net = _FakeNet()
+        client = MagicMock()
+        client.containers.get.return_value = traefik
+        client.containers.list.return_value = [env, hostsvc]
+        client.networks.get.side_effect = lambda name: (
+            shared_net if name == "oduflow-net" else team_net
+        )
+
+        settings = Settings(
+            routing_mode="traefik", acme_email="x@y.z", teams={"1": TEAM}
+        )
+        with (
+            patch("oduflow.docker_ops.client.get_client", return_value=client),
+            patch(
+                "oduflow.docker_ops.system_ops.ensure_team_network",
+                return_value="oduflow-1-net",
+            ),
+        ):
+            _migrate_per_team_networks(settings)
+
+        # Stale traefik removed (system init recreates it after migrations).
+        traefik.stop.assert_called_once()
+        traefik.remove.assert_called_once()
+        # Env container moved; host-mode service untouched.
+        assert team_net.connected == ["oduflow-1-main-odoo"]
+        assert shared_net.disconnected == ["oduflow-1-main-odoo"]
+
+    def test_idempotent(self):
+        env = self._container(
+            "oduflow-1-main-odoo",
+            {"oduflow.managed": "true", "oduflow.team": "1"},
+            ["oduflow-1-net"],  # already moved
+        )
+        traefik = MagicMock()
+        traefik.attrs = {"Config": {"Cmd": ["--entrypoints.web.address=:80"]}}
+
+        team_net = _FakeNet()
+        shared_net = _FakeNet()
+        client = MagicMock()
+        client.containers.get.return_value = traefik
+        client.containers.list.return_value = [env]
+        client.networks.get.side_effect = lambda name: (
+            shared_net if name == "oduflow-net" else team_net
+        )
+
+        with (
+            patch("oduflow.docker_ops.client.get_client", return_value=client),
+            patch(
+                "oduflow.docker_ops.system_ops.ensure_team_network",
+                return_value="oduflow-1-net",
+            ),
+        ):
+            _migrate_per_team_networks(SETTINGS)
+
+        traefik.stop.assert_not_called()
+        assert team_net.connected == []
+        assert shared_net.disconnected == []

--- a/tests/test_template_update.py
+++ b/tests/test_template_update.py
@@ -81,8 +81,8 @@ def _build(tmp_path, envs, mounted_envs, statuses=None):
         env_dicts.append(
             {"env_name": env_name, "template_name": tpl, "odoo_image": "odoo:17.0"}
         )
-        mapping[get_resource_name(env_name, "odoo", settings.prefix)] = FakeContainer(
-            status=statuses.get(env_name, "running")
+        mapping[get_resource_name(env_name, "odoo", settings.prefix, team.team_id)] = (
+            FakeContainer(status=statuses.get(env_name, "running"))
         )
         if env_name in mounted_envs:
             mounted.add(paths["merged"])
@@ -100,8 +100,9 @@ def _patched(team, env_dicts, mounted):
     mount_mock = MagicMock()
     with (
         patch.object(env_ops, "list_environments", return_value=env_dicts),
-        patch.object(env_ops, "_unmount_filestore", side_effect=fake_unmount)
-        as unmount_mock,
+        patch.object(
+            env_ops, "_unmount_filestore", side_effect=fake_unmount
+        ) as unmount_mock,
         patch.object(env_ops, "_mount_filestore", mount_mock),
         patch("os.path.ismount", side_effect=lambda p: p in mounted),
     ):
@@ -150,9 +151,7 @@ class TestRemountTemplateOverlays:
 
         # Delta removed, upper dir recreated empty.
         assert not os.path.exists(_marker(team, "env1"))
-        assert os.path.isdir(
-            get_filestore_paths("env1", team.workspaces_dir)["upper"]
-        )
+        assert os.path.isdir(get_filestore_paths("env1", team.workspaces_dir)["upper"])
         assert mount_mock.call_count == 1
 
     def test_skips_other_template_and_unmounted(self, tmp_path):
@@ -212,7 +211,7 @@ class TestRemountTemplateOverlays:
         # Still unmounted + remounted, but never started back up.
         assert unmount_mock.call_count == 1
         assert mount_mock.call_count == 1
-        container = mapping[get_resource_name("env1", "odoo", settings.prefix)]
+        container = mapping[get_resource_name("env1", "odoo", settings.prefix, "1")]
         assert container.start_calls == 0
 
     def test_partial_unmount_failure_isolated(self, tmp_path):

--- a/tests/test_volume_ops.py
+++ b/tests/test_volume_ops.py
@@ -318,9 +318,7 @@ class TestResolveVolumeBinds:
 
         mock_docker_client.volumes.get.side_effect = _get
 
-        mounts = [
-            {"volume": "my-external-data", "mount_path": "/data", "mode": "ro"}
-        ]
+        mounts = [{"volume": "my-external-data", "mount_path": "/data", "mode": "ro"}]
         result = volume_ops.resolve_volume_binds(TEST_TEAM, mounts)
 
         assert "my-external-data" in result

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -199,9 +199,7 @@ def test_login_rate_limited_after_repeated_failures():
     # Issue #56: the login endpoint must throttle brute-force attempts.
     client = TestClient(_full_app(_settings()))
     for _ in range(10):
-        resp = client.post(
-            "/login", data={"password": "nope"}, follow_redirects=False
-        )
+        resp = client.post("/login", data={"password": "nope"}, follow_redirects=False)
         assert resp.status_code == 401
     # The 11th attempt (and beyond) is locked out, even with the right password.
     resp = client.post("/login", data={"password": _PW}, follow_redirects=False)
@@ -256,9 +254,7 @@ def test_api_license_activate_uses_settings_etc_dir(tmp_path, monkeypatch):
             email="ada@example.com",
         )
 
-    monkeypatch.setattr(
-        web_ui, "install_license_from_text", install_license_from_text
-    )
+    monkeypatch.setattr(web_ui, "install_license_from_text", install_license_from_text)
     settings = _settings(etc_dir=str(tmp_path / "conf"))
     client = TestClient(_full_app(settings))
 


### PR DESCRIPTION
Hardens the team model (ADR 0014) so one machine can host mutually-untrusting clients. Environment containers execute arbitrary client code, so the container, network, database, and filesystem layers now enforce the team boundary — not just application logic.

## Startup migrations subsystem (ADR 0023)

Odoo-style one-shot upgrade steps: an append-only registry in code, applied state in `base_data_dir/migrations.json`, diffed and applied on server start. Fresh installs are stamped without running anything; a failing step aborts startup and resumes at the failed step on the next start. Existing installs are converted automatically by four migrations (see Upgrade notes).

## Isolation

- **Team-scoped container names** (`oduflow-{team}-{env}-{type}`, `oduflow-{team}-svc-{name}`): two teams using the same branch/service name can no longer collide on — or delete — each other's containers. Also fixes `restart_service`/`delete_service`/`get_service_logs` resolving containers globally without a team.
- **Per-team Docker networks** (`oduflow-{team}-net`): env/service containers join only their team's network; shared PostgreSQL and Traefik attach to every team network and are the only cross-team surface. Traefik backend selection moves to the per-container `traefik.docker.network` label.
- **Per-team PostgreSQL tablespaces** (ADR 0024): each team's databases live under `pg_tablespaces/team_{id}/` on the host; only that directory is mounted into the PG container. WAL stays in shared PGDATA, so a team at quota gets aborted transactions, never a server-wide PANIC.
- **Strict HTTP team resolution**: the single-team / team "1" fallback applies to stdio only; in HTTP mode an unresolved request is rejected, and multi-team HTTP requires an auth_token for every team at startup.

## Quotas and noisy-neighbor protection (ADR 0025)

- `db_quota_gb` (default 50, 0=off): caps the team's combined PG database size, checked with one catalog query before operations that create a new database.
- `disk_quota_gb` (default 0): kernel-enforced via XFS project quotas — the team dir and its PG tablespace share one project ID, so a single limit covers the client's files and databases. Unsupported filesystems log one warning and stay monitoring-only.
- Default resource limits on env containers, auto-derived from host size: memory = RAM/4 clamped to 2–8 GB, pids_limit 4096; CPU deliberately uncapped.

## Usage visibility

- Env cards show DB size / disk size after the CPU/RAM stats with a per-card refresh control; values are cached (`storage_stats.json`) and never recomputed in the polling loop.
- `GET /api/usage` + `POST /api/usage/refresh`: cached per-env and team-total usage together with the team's quotas — the surface for external billing/quota tooling.

## Upgrade notes

First start after upgrade runs migrations 0001–0004 automatically: container renames → PG container recreated once with the tablespaces mount + `ALTER DATABASE ... SET TABLESPACE` per database (time proportional to total DB size) → containers moved to team networks live (Traefik recreated; ACME volume persists) → resource limits applied via `docker update`. Covered by unit tests with mocked Docker; a staging pass on a real Linux host before rolling to client machines is recommended.

## Records

ADRs 0023–0025 in `specs/`; hosting docs updated in `docs/multi-instance.md`, REST API docs in `docs/web-api.md`.