### PR TITLE
Widen the Import from Odoo.sh modal to 80vw

### DIFF
--- a/specs/0023-import-from-odoo-sh.md
+++ b/specs/0023-import-from-odoo-sh.md
@@ -45,26 +45,39 @@ single-purpose token** minted by a dashboard button, not the UI password.
   name and returns a ready-to-paste command. The token is one JSON file per
   team carrying only auth + the target template; it is deleted on finalize or
   expiry. A stale token left in terminal scrollback is inert.
-- **Resume is disk-derived, not token-derived.** `status` reports what is
-  actually staged in the template directory (metadata written → manifest done;
-  `dump.sql.gz` present → dump done; each hash-dir present → that chunk done,
-  since a chunk dir only appears after its tar was received in full and
-  extracted). Keeping resume state on disk rather than in the token means a
-  fresh token minted for the same template — e.g. after the first expired
-  mid-upload — still continues from what already landed.
+- **Staging directory + atomic swap.** Uploads land in
+  `<team>/import_staging/<template>/`, never in the live template. Each
+  filestore chunk is extracted into a temp sibling and renamed into staging
+  only once fully unpacked, so a truncated upload can't masquerade as a
+  complete chunk. `finalize` promotes the whole staged set into the template
+  directory inside the overlay remount guard — re-importing over an existing
+  template therefore replaces it with fresh data instead of silently
+  "resuming" from the old files, and live envs never see a half-written lower
+  layer.
+- **Resume is disk-derived, not token-derived.** `status` reports what sits in
+  the staging directory (metadata written → manifest done; `dump.sql.gz`
+  present → dump done; each hash-dir present → that chunk done). Keeping
+  resume state on disk rather than in the token means a fresh token minted for
+  the same template — e.g. after the first expired mid-upload — still
+  continues from what already landed.
 - **Client (`import-odoo.sh`).** Served unauthenticated from `/import-odoo.sh`.
   It reads `$PGDATABASE`, finds `~/backup.daily/<db>_daily.*` (erroring cleanly
-  if absent — daily backups exist only on production builds), asks the server
-  what it already has, and uploads only the missing pieces. Nothing large hits
-  disk: the filestore is `tar`-streamed **per top-level hash directory** (256
-  dirs + `checklist`) straight into the upload. It prints an aggregate
-  percentage computed from per-chunk sizes.
+  if absent — daily backups exist only on production builds), resolves any
+  http→https redirect up front (POST bodies must not rely on
+  redirect-following), asks the server what it already has, and uploads only
+  the missing pieces. Nothing large hits disk **or RAM**: the filestore is
+  `tar`-streamed **per top-level hash directory** (256 dirs + `checklist`)
+  via `curl -T` (chunked transfer), not `--data-binary` (which buffers the
+  whole payload in memory). It prints an aggregate percentage computed from
+  per-chunk sizes.
 - **Ingest endpoints.** `/api/templates/import/{status,manifest,dump,filestore,
   finalize}` authenticate by token (a `Bearer` header), so they bypass Basic
-  auth while the mint endpoint stays behind the UI login. `manifest` writes
-  `metadata.json` (Odoo image from `odoo_branch`, module list); `dump` streams
-  `dump.sql.gz`; `filestore?chunk=<hash>` unpacks one tar chunk into the
-  template filestore with a zip-slip guard; `finalize` runs the restore.
+  auth — as EXACT public paths, never a prefix, so sibling routes like
+  `/api/templates/{name}/delete` (with `name="import"`) stay behind auth. The
+  mint endpoint stays behind the UI login. `manifest` writes `metadata.json`
+  (Odoo image from `odoo_branch`, module list); `dump` streams `dump.sql.gz`;
+  `filestore?chunk=<hash>` unpacks one tar chunk (zip-slip guarded);
+  `finalize` swaps staging into the template and runs the restore.
 - **Reuse, not reinvention.** By the time `finalize` runs, the template
   directory already holds exactly what `import_from_odoo` produces
   (`dump.sql.gz` + `filestore/` + `metadata.json`), so finalize is the shared

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1433,13 +1433,10 @@ def import_from_odoo(
 
 
 def extract_filestore_tar(tar_path: str, dest_dir: str) -> int:
-    """Extract a tar stream (one Odoo filestore hash-dir) into ``dest_dir``.
+    """Extract a tar stream into ``dest_dir``.
 
-    Used by the push-based Odoo.sh import: the client streams ``tar -C
-    <filestore> -cf - <chunk>`` per top-level hash directory, and this unpacks
-    it into the template's ``filestore/``. Members that would escape the
-    destination (zip-slip) or are not regular files/dirs are skipped. Returns
-    the number of files written.
+    Members that would escape the destination (zip-slip) or are not regular
+    files/dirs are skipped. Returns the number of files written.
     """
     os.makedirs(dest_dir, exist_ok=True)
     written = 0
@@ -1466,30 +1463,96 @@ def extract_filestore_tar(tar_path: str, dest_dir: str) -> int:
     return written
 
 
+def extract_filestore_chunk(tar_path: str, filestore_dir: str, chunk: str) -> int:
+    """Atomically extract one filestore hash-dir tar (``<chunk>/...``) into
+    ``filestore_dir``.
+
+    The tar is unpacked into a temporary sibling directory first and the chunk
+    is moved into place with a rename only once extraction completed, so a
+    truncated/corrupt upload never leaves a half-extracted ``<chunk>/`` behind —
+    resume (which treats a present chunk dir as complete) stays truthful.
+    Returns the number of files written.
+    """
+    os.makedirs(filestore_dir, exist_ok=True)
+    tmp_root = os.path.join(filestore_dir, f".incoming_{chunk}")
+    if os.path.exists(tmp_root):
+        shutil.rmtree(tmp_root)
+    try:
+        written = extract_filestore_tar(tar_path, tmp_root)
+        extracted = os.path.join(tmp_root, chunk)
+        if not os.path.isdir(extracted):
+            raise ExternalCommandError(
+                "import filestore",
+                1,
+                f"Archive does not contain the expected '{chunk}/' directory",
+            )
+        final = os.path.join(filestore_dir, chunk)
+        if os.path.exists(final):
+            shutil.rmtree(final)
+        os.rename(extracted, final)
+    finally:
+        if os.path.exists(tmp_root):
+            shutil.rmtree(tmp_root)
+    return written
+
+
 def finalize_imported_template(
     settings: Settings,
     team: TeamSettings,
     template_name: str,
-    *,
-    major_version: str = "",
+    staging_dir: str,
 ) -> dict[str, object]:
-    """Load an already-staged template (dump + filestore + metadata on disk).
+    """Promote a fully-staged push import into the live template and load it.
 
-    The push-based Odoo.sh import uploads the pieces incrementally, so by the
-    time this runs the template directory already contains ``dump.sql.gz``,
-    ``filestore/`` and ``metadata.json``. This mirrors the tail of
-    :func:`import_from_odoo`: chown the filestore for the odoo user, remount
-    live overlay envs against the new lower (non-destructive), refresh sizes,
-    then restore the dump into the template DB.
+    The push-based Odoo.sh import uploads into ``staging_dir`` (metadata.json,
+    dump.sql.gz, filestore/); nothing touches the live template until now.
+    This mirrors the tail of :func:`import_from_odoo`: within the overlay
+    remount guard (live envs keep their upper deltas), swap the staged
+    filestore/dump/metadata into the template directory, chown the filestore
+    for the odoo user, then refresh sizes and restore the dump into the
+    template DB. The staging directory is removed on success.
     """
     from oduflow.docker_ops import env_ops
 
+    staged_meta = os.path.join(staging_dir, "metadata.json")
+    staged_dump = os.path.join(staging_dir, "dump.sql.gz")
+    staged_fs = os.path.join(staging_dir, "filestore")
+    if not os.path.isfile(staged_meta) or not os.path.isfile(staged_dump):
+        raise PrerequisiteNotMetError(
+            "Manifest and SQL dump must be uploaded before finalize."
+        )
+    try:
+        with open(staged_meta) as f:
+            major_version = str(json.load(f).get("odoo_version") or "")
+    except (OSError, ValueError):
+        major_version = ""
+
     client = get_client()
+    tpl_dir = team.get_template_dir(template_name)
     template_filestore_path = team.get_template_filestore_path(template_name)
 
     with env_ops.remount_template_overlays(
         client, settings, team, template_name
     ) as remount:
+        os.makedirs(tpl_dir, exist_ok=True)
+
+        # Swap filestore (the overlay lower layer) while envs are unmounted.
+        if os.path.exists(template_filestore_path):
+            shutil.rmtree(template_filestore_path)
+        if os.path.isdir(staged_fs):
+            os.rename(staged_fs, template_filestore_path)
+        else:
+            os.makedirs(template_filestore_path, exist_ok=True)
+
+        # Swap dump: drop stale dumps under other names so
+        # get_template_sql_path resolves to the new gzip'd SQL dump.
+        for stale in ("dump.pgdump", "dump.sql", "dump.pgdump.gz", "dump.sql.gz"):
+            stale_path = os.path.join(tpl_dir, stale)
+            if os.path.isfile(stale_path):
+                os.remove(stale_path)
+        os.rename(staged_dump, os.path.join(tpl_dir, "dump.sql.gz"))
+        os.replace(staged_meta, team.get_template_metadata_path(template_name))
+
         if major_version:
             try:
                 uid_gid = get_odoo_uid_gid(client, f"odoo:{major_version}")
@@ -1507,6 +1570,8 @@ def finalize_imported_template(
 
     _update_template_sizes(team, settings, template_name)
     result = reload_template(settings, team, template_name=template_name)
+
+    shutil.rmtree(staging_dir, ignore_errors=True)
 
     return {
         "status": "imported",

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -66,6 +66,17 @@ class TeamSettings:
     def get_template_metadata_path(self, template_name: str) -> str:
         return os.path.join(self.get_template_dir(template_name), "metadata.json")
 
+    def get_import_staging_dir(self, template_name: str) -> str:
+        """Where a push-based Odoo.sh import stages its upload before finalize.
+
+        Kept outside ``templates/`` so a partial upload never masquerades as (or
+        clobbers) a live template; finalize swaps it into place atomically.
+        """
+        from oduflow.naming import validate_template_name
+
+        validate_template_name(template_name)
+        return os.path.join(self.data_dir, "import_staging", template_name)
+
     def list_templates(self) -> list[str]:
         templates_dir = os.path.join(self.data_dir, "templates")
         if not os.path.isdir(templates_dir):

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -528,6 +528,8 @@
     color: var(--text-dim); font-family: var(--font-mono);
   }
   #logs-modal .modal { width: 80vw; max-width: 80vw; }
+  #import-odoo-modal .modal { width: 80vw; max-width: 80vw; }
+  #import-odoo-command { font-size: var(--text-sm); color: var(--text); user-select: all; }
   #logs-modal .modal-body { overflow: auto; }
   #logs-modal .modal-body pre { white-space: pre; word-break: normal; }
   #logs-modal .modal-body pre.wrap { white-space: pre-wrap; word-break: break-all; }
@@ -948,7 +950,7 @@
     .env-meta strong, .svc-meta strong, .tpl-meta strong, .preset-meta strong { word-break: break-all; }
     .system-bar { flex-wrap: wrap; gap: 6px 16px; padding: 8px 16px; }
     .modal { width: calc(100vw - 24px); max-height: 88vh; }
-    #logs-modal .modal { width: calc(100vw - 24px); max-width: none; }
+    #logs-modal .modal, #import-odoo-modal .modal { width: calc(100vw - 24px); max-width: none; }
     .logs-toolbar { flex-wrap: wrap; }
     .toast { left: 16px; right: 16px; max-width: none; }
   }
@@ -1322,7 +1324,7 @@
   </div>
 </div>
 <div class="modal-overlay" id="import-odoo-modal" onclick="closeImportOdooModal(event)">
-  <div class="modal modal-sm">
+  <div class="modal">
     <div class="modal-header">
       <h2>Import from Odoo.sh</h2>
       <button class="modal-close" onclick="closeImportOdooModal()">&times;</button>

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -11,7 +11,7 @@
 # and only sends the missing pieces (manifest, dump, or individual filestore
 # hash-directories).
 #
-#   curl -sSf https://YOUR-ODUFLOW/import-odoo.sh | bash -s -- \
+#   curl -sSfL https://YOUR-ODUFLOW/import-odoo.sh | bash -s -- \
 #        --server https://YOUR-ODUFLOW --token <TOKEN>
 #
 # The --token is minted by the "Import from Odoo.sh" button in the Oduflow
@@ -36,6 +36,14 @@ done
 [ -n "$SERVER" ] || { echo "ERROR: --server is required" >&2; exit 2; }
 [ -n "$TOKEN" ]  || { echo "ERROR: --token is required" >&2; exit 2; }
 SERVER="${SERVER%/}"
+
+# Resolve redirects up front (e.g. http -> https) so every upload hits the
+# final URL directly — POSTs must not rely on redirect-following, which would
+# drop the request body.
+EFFECTIVE="$(curl -fsSIL -o /dev/null -w '%{url_effective}' "${SERVER}/import-odoo.sh" 2>/dev/null || true)"
+if [ -n "$EFFECTIVE" ]; then
+    SERVER="${EFFECTIVE%/import-odoo.sh}"
+fi
 
 DB="${PGDATABASE:-}"
 [ -n "$DB" ] || {
@@ -111,8 +119,9 @@ fi
 
 if [ -z "$have_dump" ]; then
     echo ">> uploading SQL dump ($(human "$(wc -c < "$SQL_GZ")"))"
+    # -T streams from disk; --data-binary would buffer the whole file in RAM.
     curl -fsS -H "$AUTH" -H "Content-Type: application/gzip" \
-        --data-binary @"$SQL_GZ" -X POST "${API}/dump" >/dev/null
+        -T "$SQL_GZ" -X POST "${API}/dump" >/dev/null
 else
     echo ">> SQL dump already uploaded, skipping"
 fi
@@ -160,9 +169,11 @@ progress() {  # done total label
 upload_chunk() {  # name
     local c="$1" tries=0
     while :; do
+        # -T - streams the tar as it is produced (chunked transfer encoding);
+        # --data-binary @- would buffer the whole chunk in RAM first.
         if tar -C "$FS" -cf - "$c" \
             | curl -fsS -H "$AUTH" -H "Content-Type: application/x-tar" \
-                   --data-binary @- -X POST "${API}/filestore?chunk=${c}" >/dev/null; then
+                   -T - -X POST "${API}/filestore?chunk=${c}" >/dev/null; then
             return 0
         fi
         tries=$((tries + 1))
@@ -191,9 +202,12 @@ echo >&2
 echo ">> finalizing (restoring database — this can take a few minutes)…"
 RESULT_FILE="$(mktemp)"
 trap 'rm -f "$STATUS_FILE" "$RESULT_FILE"' EXIT
-if ! curl -fsS -H "$AUTH" -X POST "${API}/finalize" -o "$RESULT_FILE"; then
+# --fail-with-body keeps the server's error body on HTTP >= 400 (plain -f
+# would discard it, hiding the reason the riskiest step failed).
+if ! curl -sS --fail-with-body -H "$AUTH" -X POST "${API}/finalize" -o "$RESULT_FILE"; then
     echo "ERROR: finalize request failed:" >&2
     cat "$RESULT_FILE" >&2 || true
+    echo >&2
     exit 6
 fi
 

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -95,9 +95,21 @@ echo ">> Importing '$DB' into Oduflow at $SERVER"
 
 STATUS_FILE="$(mktemp)"
 trap 'rm -f "$STATUS_FILE"' EXIT
-if ! curl -fsS -H "$AUTH" "${API}/status" -o "$STATUS_FILE" 2>/dev/null; then
+if ! curl -sS --fail-with-body -H "$AUTH" "${API}/status" -o "$STATUS_FILE" 2>/dev/null; then
     echo "ERROR: could not reach $SERVER or token is invalid/expired." >&2
+    [ -s "$STATUS_FILE" ] && { echo "       Server said:" >&2; head -c 300 "$STATUS_FILE" >&2; echo >&2; }
     echo "       Generate a fresh token from the dashboard and retry." >&2
+    exit 4
+fi
+
+# Hard gate: the status body must be Oduflow's JSON with ok=true. Anything
+# else (a proxy page, a redirect body, an HTML error) means the uploads
+# would go nowhere — abort NOW instead of "uploading" gigabytes into a 3xx.
+if [ -z "$(json_field "$STATUS_FILE" 'd.get("ok") and 1 or ""')" ]; then
+    echo "ERROR: unexpected response from ${API}/status:" >&2
+    head -c 300 "$STATUS_FILE" >&2; echo >&2
+    echo "       Check that --server points at your Oduflow dashboard URL" >&2
+    echo "       (https, no proxy pages in between), then retry." >&2
     exit 4
 fi
 
@@ -212,7 +224,15 @@ if ! curl -sS --fail-with-body -H "$AUTH" -X POST "${API}/finalize" -o "$RESULT_
 fi
 
 python3 -c 'import sys,json
-d=json.load(open(sys.argv[1]))
+raw = open(sys.argv[1], "rb").read().decode("utf-8", "replace")
+try:
+    d = json.loads(raw)
+except ValueError:
+    print(">> ERROR: unexpected finalize response (not Oduflow JSON):")
+    print("   " + (raw[:300].strip() or "(empty body)"))
+    print("   The import may still be finishing server-side — check the")
+    print("   Templates tab in the dashboard before retrying.")
+    sys.exit(1)
 if not d.get("ok"):
     print(">> ERROR:", d.get("error","unknown error")); sys.exit(1)
 r=d.get("result",{})

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -48,14 +48,28 @@ _AUTH_COOKIE = "oduflow_ui_auth"
 # Reachable without authentication: the login flow and static brand assets
 # (so the login page can render its logo/favicon/fonts). /static/ serves only
 # vetted extensions from the packaged assets dir (fonts, icons, xterm).
-# /import-odoo.sh (the Odoo.sh client script) and the /api/templates/import/*
-# ingest endpoints authenticate with a short-lived import token, not the UI
-# password, so they bypass Basic auth. NOTE: /api/templates/import-token (which
-# mints the token) is deliberately NOT public — it stays behind the UI login.
+# /import-odoo.sh (the Odoo.sh client script) and the five import ingest
+# endpoints authenticate with a short-lived import token, not the UI password,
+# so they bypass Basic auth. They are listed as EXACT paths (never a prefix):
+# a prefix like "/api/templates/import/" would also expose sibling routes such
+# as /api/templates/{name}/delete with name="import" to unauthenticated calls.
+# NOTE: /api/templates/import-token (which mints the token) is deliberately NOT
+# public — it stays behind the UI login.
 _PUBLIC_PATHS = frozenset(
-    {"/login", "/logout", "/favicon.ico", "/logo.png", "/import-odoo.sh"}
+    {
+        "/login",
+        "/logout",
+        "/favicon.ico",
+        "/logo.png",
+        "/import-odoo.sh",
+        "/api/templates/import/status",
+        "/api/templates/import/manifest",
+        "/api/templates/import/dump",
+        "/api/templates/import/filestore",
+        "/api/templates/import/finalize",
+    }
 )
-_PUBLIC_PREFIXES = ("/static/", "/api/templates/import/")
+_PUBLIC_PREFIXES = ("/static/",)
 _SESSION_SALT = "oduflow.ui-auth.v1"
 _SESSION_MAX_AGE = 7 * 24 * 3600  # 7 days
 _SECRET_FILENAME = ".ui_session_secret"
@@ -841,17 +855,21 @@ def _build_routes(
         return import_tokens.load_token(get_settings(), _import_token_value(request))
 
     def _import_progress(team: TeamSettings, template_name: str) -> dict[str, object]:
-        """Derive upload progress from what is staged on disk, not from the
-        token — so a re-run (even with a fresh token after the old one expired)
-        resumes from what already landed instead of restarting."""
-        tpl_dir = team.get_template_dir(template_name)  # validates the name
-        manifest = os.path.isfile(team.get_template_metadata_path(template_name))
-        dump = os.path.isfile(os.path.join(tpl_dir, "dump.sql.gz"))
-        fs_dir = team.get_template_filestore_path(template_name)
+        """Derive upload progress from what sits in the import STAGING dir (not
+        the token, and never the live template). Disk-derived progress makes a
+        re-run resumable even with a fresh token after the old one expired;
+        reading staging (not the template) means importing over an existing
+        template re-uploads everything instead of silently "resuming" from the
+        old template's files."""
+        staging = team.get_import_staging_dir(template_name)  # validates name
+        manifest = os.path.isfile(os.path.join(staging, "metadata.json"))
+        dump = os.path.isfile(os.path.join(staging, "dump.sql.gz"))
+        fs_dir = os.path.join(staging, "filestore")
         chunks: list[str] = []
         if os.path.isdir(fs_dir):
-            # A chunk directory exists only after its tar was received in full
-            # and extracted, so its presence means that chunk is complete.
+            # A chunk directory appears only after its tar was extracted in
+            # full and atomically renamed into place (extract_filestore_chunk),
+            # so its presence means that chunk is complete.
             for entry in os.listdir(fs_dir):
                 if (
                     re.fullmatch(r"[0-9a-f]{2}", entry) or entry == "checklist"
@@ -894,8 +912,13 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
         base = str(request.base_url).rstrip("/")
+        # Behind a TLS-terminating proxy request.base_url is http://; honour
+        # X-Forwarded-Proto so the pasted command never sends the Bearer token
+        # over plaintext (and -L follows any residual http->https redirect).
+        if _is_secure_request(request) and base.startswith("http://"):
+            base = "https://" + base[len("http://") :]
         command = (
-            f"curl -sSf {base}/import-odoo.sh | bash -s -- "
+            f"curl -sSfL {base}/import-odoo.sh | bash -s -- "
             f"--server {base} --token {record['token']}"
         )
         return JSONResponse(
@@ -952,9 +975,9 @@ def _build_routes(
             "backup_datetime_utc": manifest.get("backup_datetime_utc", ""),
         }
         try:
-            tpl_dir = team.get_template_dir(template_name)
-            os.makedirs(tpl_dir, exist_ok=True)
-            with open(team.get_template_metadata_path(template_name), "w") as f:
+            staging = team.get_import_staging_dir(template_name)
+            os.makedirs(staging, exist_ok=True)
+            with open(os.path.join(staging, "metadata.json"), "w") as f:
                 json.dump(metadata, f, indent=2)
         except ValueError as e:  # invalid template name
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
@@ -967,17 +990,11 @@ def _build_routes(
             return _error_response(e)
         template_name = str(record["template_name"])
         try:
-            tpl_dir = team.get_template_dir(template_name)
+            staging = team.get_import_staging_dir(template_name)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
-        os.makedirs(tpl_dir, exist_ok=True)
-        # Drop any stale dump under other names so get_template_sql_path resolves
-        # to the gzip'd SQL dump we are about to write.
-        for stale in ("dump.pgdump", "dump.sql", "dump.pgdump.gz"):
-            stale_path = os.path.join(tpl_dir, stale)
-            if os.path.isfile(stale_path):
-                os.remove(stale_path)
-        dest = os.path.join(tpl_dir, "dump.sql.gz")
+        os.makedirs(staging, exist_ok=True)
+        dest = os.path.join(staging, "dump.sql.gz")
         tmp = f"{dest}.part"
         try:
             with open(tmp, "wb") as f:
@@ -1004,17 +1021,20 @@ def _build_routes(
             )
         template_name = str(record["template_name"])
         try:
-            tpl_dir = team.get_template_dir(template_name)
+            staging = team.get_import_staging_dir(template_name)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
-        fs_dir = team.get_template_filestore_path(template_name)
-        os.makedirs(tpl_dir, exist_ok=True)
-        tmp_tar = os.path.join(tpl_dir, f".chunk_{chunk}.tar")
+        fs_dir = os.path.join(staging, "filestore")
+        os.makedirs(staging, exist_ok=True)
+        tmp_tar = os.path.join(staging, f".chunk_{chunk}.tar")
         try:
             with open(tmp_tar, "wb") as f:
                 async for data in request.stream():
                     f.write(data)
-            system_ops.extract_filestore_tar(tmp_tar, fs_dir)
+            # Atomic: the chunk dir appears in staging only after the whole tar
+            # extracted, so a truncated upload is never mistaken for a complete
+            # chunk on resume.
+            system_ops.extract_filestore_chunk(tmp_tar, fs_dir, chunk)
         except Exception as e:
             logger.exception(
                 "Failed to receive filestore chunk %s for %s", chunk, template_name
@@ -1043,14 +1063,6 @@ def _build_routes(
                 },
                 status_code=400,
             )
-        # The Odoo image major (e.g. "18.0") drives the filestore chown; read it
-        # from the staged metadata so finalize does not depend on token state.
-        major_version = ""
-        try:
-            with open(team.get_template_metadata_path(template_name)) as f:
-                major_version = str(json.load(f).get("odoo_version") or "")
-        except (OSError, ValueError):
-            pass
         try:
             locks.acquire_team(team.team_id)
         except BusyError as e:
@@ -1060,7 +1072,7 @@ def _build_routes(
                 get_settings(),
                 team,
                 template_name,
-                major_version=major_version,
+                staging_dir=team.get_import_staging_dir(template_name),
             )
             import_tokens.invalidate(team, str(record["token"]))
             return JSONResponse({"ok": True, "result": result})

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -91,19 +91,20 @@ def test_full_push_flow(tmp_path):
         content=json.dumps(manifest).encode(),
     )
     assert r.status_code == 200 and r.json()["ok"] is True
-    meta_path = team.get_template_metadata_path("zipfit")
-    meta = json.loads(open(meta_path).read())
+    staging = team.get_import_staging_dir("zipfit")
+    meta = json.loads(open(os.path.join(staging, "metadata.json")).read())
     assert meta["odoo_image"] == "odoo:18.0"
     assert meta["source"] == "odoo.sh"
     assert meta["source_db"] == "zipfit-odoo-main-7950600"
+    # Nothing touches the live template until finalize.
+    assert not os.path.exists(team.get_template_dir("zipfit"))
 
     # dump (gzip bytes, contents irrelevant here)
     r = client.post(
         "/api/templates/import/dump", headers=hdr, content=b"\x1f\x8bFAKEGZIP"
     )
     assert r.status_code == 200 and r.json()["ok"] is True
-    dump_path = os.path.join(team.get_template_dir("zipfit"), "dump.sql.gz")
-    assert os.path.isfile(dump_path)
+    assert os.path.isfile(os.path.join(staging, "dump.sql.gz"))
 
     # filestore chunk "ab"
     tar = _tar_bytes({"ab/abcdef0123": b"BLOBDATA"})
@@ -111,9 +112,7 @@ def test_full_push_flow(tmp_path):
         "/api/templates/import/filestore?chunk=ab", headers=hdr, content=tar
     )
     assert r.status_code == 200 and r.json()["ok"] is True
-    extracted = os.path.join(
-        team.get_template_filestore_path("zipfit"), "ab", "abcdef0123"
-    )
+    extracted = os.path.join(staging, "filestore", "ab", "abcdef0123")
     assert open(extracted, "rb").read() == b"BLOBDATA"
 
     # status reflects progress
@@ -143,6 +142,7 @@ def test_full_push_flow(tmp_path):
         r = client.post("/api/templates/import/finalize", headers=hdr)
     assert r.status_code == 200 and r.json()["ok"] is True
     fin.assert_called_once()
+    assert fin.call_args.kwargs["staging_dir"] == staging
     assert r.json()["result"]["template_db"] == "oduflow_template_1_zipfit"
 
     # token invalidated after finalize
@@ -225,3 +225,165 @@ def test_filestore_tar_zip_slip_is_skipped(tmp_path):
     assert written == 1
     assert (dest / "ab" / "file").read_bytes() == b"ok"
     assert not (tmp_path / "escape").exists()
+
+
+def test_import_paths_do_not_bypass_auth_for_sibling_routes(tmp_path):
+    """Regression: a public PREFIX /api/templates/import/ used to expose
+    /api/templates/{name}/delete with name="import" without credentials. The
+    ingest endpoints must be public as exact paths only."""
+    team = TeamSettings(
+        team_id="1", data_dir=str(tmp_path / "team1"), ui_password="secret"
+    )
+    settings = Settings(
+        routing_mode="port", base_data_dir=str(tmp_path), teams={"1": team}
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    # Sibling route captured by {name}="import" must require auth.
+    r = client.post("/api/templates/import/delete")
+    assert r.status_code == 401
+
+    # The token-authed ingest endpoint stays reachable without Basic auth
+    # (404 = unknown token, i.e. it got past the auth middleware).
+    r = client.get(
+        "/api/templates/import/status",
+        headers={"Authorization": "Bearer " + "a" * 24},
+    )
+    assert r.status_code == 404
+
+    # Minting a token still requires the UI login.
+    r = client.post("/api/templates/import-token", json={"template_name": "x"})
+    assert r.status_code == 401
+
+
+def test_existing_template_does_not_fake_resume(tmp_path):
+    """Regression: progress must come from the staging dir, not the live
+    template — otherwise re-importing into an existing template name skips
+    every upload and finalize silently restores the OLD data."""
+    client, _s, team = _client(tmp_path)
+    tpl_dir = team.get_template_dir("zipfit")
+    os.makedirs(os.path.join(tpl_dir, "filestore", "ab"))
+    with open(team.get_template_metadata_path("zipfit"), "w") as f:
+        f.write("{}")
+    with open(os.path.join(tpl_dir, "dump.sql.gz"), "wb") as f:
+        f.write(b"old")
+
+    token, _ = _mint(client, "zipfit")
+    st = client.get(
+        "/api/templates/import/status",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+    assert st["progress"]["manifest"] is False
+    assert st["progress"]["dump"] is False
+    assert st["progress"]["filestore_chunks"] == []
+
+
+def test_corrupt_chunk_is_not_marked_complete(tmp_path):
+    """Regression: a truncated/corrupt chunk tar must fail the request AND
+    leave no chunk directory behind, so resume re-uploads it."""
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+
+    r = client.post(
+        "/api/templates/import/filestore?chunk=ab",
+        headers=hdr,
+        content=b"this is not a tar archive",
+    )
+    assert r.status_code == 500
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["filestore_chunks"] == []
+    fs_dir = os.path.join(team.get_import_staging_dir("zipfit"), "filestore")
+    assert not os.path.isdir(os.path.join(fs_dir, "ab"))
+
+    # A good re-upload of the same chunk then completes it.
+    r = client.post(
+        "/api/templates/import/filestore?chunk=ab",
+        headers=hdr,
+        content=_tar_bytes({"ab/f": b"data"}),
+    )
+    assert r.status_code == 200
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["filestore_chunks"] == ["ab"]
+
+
+def test_extract_filestore_chunk_missing_dir_fails_cleanly(tmp_path):
+    """A tar that does not contain the expected <chunk>/ dir is rejected and
+    leaves nothing behind."""
+    import pytest
+
+    from oduflow.errors import ExternalCommandError
+
+    tar_path = tmp_path / "wrong.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        info = tarfile.TarInfo(name="cd/file")
+        info.size = 1
+        tf.addfile(info, io.BytesIO(b"x"))
+    fs = tmp_path / "fs"
+    with pytest.raises(ExternalCommandError):
+        system_ops.extract_filestore_chunk(str(tar_path), str(fs), "ab")
+    assert not (fs / "ab").exists()
+    assert not (fs / ".incoming_ab").exists()
+
+
+def test_finalize_swaps_staging_into_template(tmp_path):
+    """finalize_imported_template promotes the staged upload into the live
+    template inside the remount guard and removes the staging dir."""
+    from contextlib import contextmanager
+    from unittest.mock import MagicMock
+
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team1"))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+
+    staging = team.get_import_staging_dir("zipfit")
+    os.makedirs(os.path.join(staging, "filestore", "ab"))
+    with open(os.path.join(staging, "filestore", "ab", "f"), "wb") as f:
+        f.write(b"blob")
+    with open(os.path.join(staging, "metadata.json"), "w") as f:
+        json.dump({"odoo_version": "18.0"}, f)
+    with open(os.path.join(staging, "dump.sql.gz"), "wb") as f:
+        f.write(b"gz")
+
+    # Pre-existing template content that must be replaced, not merged.
+    tpl_dir = team.get_template_dir("zipfit")
+    os.makedirs(os.path.join(tpl_dir, "filestore", "ff"))
+    with open(os.path.join(tpl_dir, "dump.pgdump"), "wb") as f:
+        f.write(b"old")
+
+    remount = MagicMock(affected=[], failures=[])
+
+    @contextmanager
+    def fake_remount(*a, **kw):
+        yield remount
+
+    from oduflow.docker_ops import env_ops
+
+    with (
+        patch.object(system_ops, "get_client"),
+        patch.object(env_ops, "remount_template_overlays", fake_remount),
+        patch.object(system_ops, "get_odoo_uid_gid", return_value="101:101"),
+        patch.object(system_ops, "chown_recursive"),
+        patch.object(system_ops, "_update_template_sizes"),
+        patch.object(
+            system_ops,
+            "reload_template",
+            return_value={"template_db": "tdb", "restore_seconds": 1.0},
+        ),
+    ):
+        result = system_ops.finalize_imported_template(
+            settings, team, "zipfit", staging_dir=staging
+        )
+
+    assert result["template_db"] == "tdb"
+    fs = team.get_template_filestore_path("zipfit")
+    assert open(os.path.join(fs, "ab", "f"), "rb").read() == b"blob"
+    assert not os.path.exists(os.path.join(fs, "ff"))  # old filestore replaced
+    assert not os.path.exists(os.path.join(tpl_dir, "dump.pgdump"))  # stale gone
+    assert os.path.isfile(os.path.join(tpl_dir, "dump.sql.gz"))
+    assert (
+        json.load(open(team.get_template_metadata_path("zipfit")))["odoo_version"]
+        == "18.0"
+    )
+    assert not os.path.exists(staging)  # staging cleaned up


### PR DESCRIPTION
The generated import command (curl | bash with server URL and token) did not fit the small modal and wrapped unreadably. This reuses the existing logs-modal wide pattern (80vw with the full-width mobile fallback), renders the command at body text size in the primary text colour, and makes it select-all on click. Verified with a live dashboard screenshot; pure CSS/markup change, 542 tests passing.