### PR TITLE
Greptile review cleanups for #91

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1489,18 +1489,15 @@ def ensure_running(settings: Settings, env_name: str, team: TeamSettings) -> boo
 
 
 def _assert_team_owns(
-    container: Any, settings: Settings, team: TeamSettings | None, env_name: str
+    container: Any, settings: Settings, team: TeamSettings, env_name: str
 ) -> None:
     """Reject operating on a container that belongs to another team.
 
     Defence in depth on top of team-scoped container names (issue #39): even
     if a name unexpectedly resolves across teams, the team label must match.
     The NotFound message is reused so the existence of another team's env is
-    not disclosed. Skipped when team is None (internal callers that have no
-    team in scope).
+    not disclosed.
     """
-    if team is None:
-        return
     label = container.labels.get(settings.team_label)
     if label is not None and label != team.team_id:
         raise NotFoundError(

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -141,12 +141,11 @@ def get_environment_logs(
         )
     # Defence in depth on top of team-scoped names: never expose another
     # team's logs even if a name resolves unexpectedly (issue #39).
-    if team is not None:
-        label = container.labels.get(settings.team_label)
-        if label is not None and label != team.team_id:
-            raise NotFoundError(
-                f"Environment '{env_name}' does not exist. Use create_environment first."
-            )
+    label = container.labels.get(settings.team_label)
+    if label is not None and label != team.team_id:
+        raise NotFoundError(
+            f"Environment '{env_name}' does not exist. Use create_environment first."
+        )
     logs = container.logs(tail=fetch_lines, stdout=True, stderr=True)
     logs_str = logs.decode("utf-8") if isinstance(logs, bytes) else str(logs)
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -212,6 +212,20 @@ def delete_service(settings: Settings, team: TeamSettings, name: str) -> dict[st
     }
 
 
+def _traefik_label_by_suffix(labels: dict[str, str], suffix: str) -> str:
+    """Value of the traefik label ending in ``suffix``, or "".
+
+    Router/service names embed the container name, which changed with naming
+    v2; containers created before the rename migration still carry labels
+    keyed by the old name — so labels are matched by suffix, never by exact
+    router name.
+    """
+    for key, value in labels.items():
+        if key.startswith("traefik.http.") and key.endswith(suffix):
+            return str(value)
+    return ""
+
+
 def _describe_service_container(
     settings: Settings, team: TeamSettings, container
 ) -> dict:
@@ -238,28 +252,23 @@ def _describe_service_container(
     is_host_mode = container.labels.get("oduflow.host_mode") == "true"
 
     if settings.routing_mode == "traefik":
-        # Router names embed the container name, which changed with naming v2;
-        # containers created before the rename migration still carry labels
-        # with the old name. Match by label suffix instead of exact router name.
-        def _label_by_suffix(suffix: str) -> str:
-            for key, value in container.labels.items():
-                if key.startswith("traefik.http.") and key.endswith(suffix):
-                    return str(value)
-            return ""
-
-        rule_value = _label_by_suffix(".rule")
+        rule_value = _traefik_label_by_suffix(container.labels, ".rule")
         match = re.search(r"Host\(`([^`]+)`\)", rule_value)
         if match:
             hostname = match.group(1)
             url = f"https://{hostname}"
 
         if is_host_mode:
-            url_value = _label_by_suffix(".loadbalancer.server.url")
+            url_value = _traefik_label_by_suffix(
+                container.labels, ".loadbalancer.server.url"
+            )
             port_match = re.search(r":(\d+)$", url_value)
             if port_match:
                 port_num = int(port_match.group(1))
         else:
-            label_port = _label_by_suffix(".loadbalancer.server.port")
+            label_port = _traefik_label_by_suffix(
+                container.labels, ".loadbalancer.server.port"
+            )
             if label_port:
                 port_num = int(label_port)
     else:
@@ -464,26 +473,22 @@ def update_service(
         hostname: str | None = None
 
         if settings.routing_mode == "traefik":
-            # Suffix-matched: pre-migration containers carry labels keyed by
-            # their old (team-less) container name.
-            def _label_by_suffix(suffix: str) -> str:
-                for key, value in container.labels.items():
-                    if key.startswith("traefik.http.") and key.endswith(suffix):
-                        return str(value)
-                return ""
-
-            rule_value = _label_by_suffix(".rule")
+            rule_value = _traefik_label_by_suffix(container.labels, ".rule")
             match = re.search(r"Host\(`([^`]+)`\)", rule_value)
             if match:
                 hostname = match.group(1)
 
             if is_host_mode:
-                url_value = _label_by_suffix(".loadbalancer.server.url")
+                url_value = _traefik_label_by_suffix(
+                    container.labels, ".loadbalancer.server.url"
+                )
                 port_match = re.search(r":(\d+)$", url_value)
                 if port_match:
                     port = int(port_match.group(1))
             else:
-                label_port = _label_by_suffix(".loadbalancer.server.port")
+                label_port = _traefik_label_by_suffix(
+                    container.labels, ".loadbalancer.server.port"
+                )
                 if label_port:
                     port = int(label_port)
         else:

--- a/src/oduflow/docker_ops/stats.py
+++ b/src/oduflow/docker_ops/stats.py
@@ -329,6 +329,8 @@ def _write_storage_cache(team: TeamSettings, cache: dict[str, Any]) -> None:
     with open(tmp, "w") as f:
         json.dump(cache, f, indent=2)
         f.write("\n")
+        f.flush()
+        os.fsync(f.fileno())
     os.replace(tmp, path)
 
 


### PR DESCRIPTION
Follow-up to #91 addressing the three non-blocking notes from the Greptile review, plus one symmetric case it missed:

- **Dead `team is not None` guard** in `get_environment_logs` — `team` is a required keyword argument since naming v2, so the branch was always taken. Removed.
- **Same dead-guard class in `env_ops._assert_team_owns`** (not flagged, found while verifying): all four callers pass a real team; the parameter is now required and the `None` early-return is gone.
- **Duplicated `_label_by_suffix`** inner function in `service_ops.py` — extracted into a module-level `_traefik_label_by_suffix(labels, suffix)` used by both `_describe_service_container` and `update_service`.
- **Missing `fsync` in `_write_storage_cache`** — the storage cache writer now flushes before the atomic rename, matching the migrations state writer; a crash mid-write can no longer leave an empty renamed file.

No behavior changes; 593 unit tests pass, mypy/ruff at baseline.