### PR TITLE
Update Import from Odoo.sh placeholder to oduist-prod

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1346,7 +1346,7 @@
       <div id="import-odoo-form">
         <div class="form-group">
           <label for="import-tpl-name">Template name</label>
-          <input type="text" id="import-tpl-name" placeholder="e.g. zipfit-prod">
+          <input type="text" id="import-tpl-name" placeholder="e.g. oduist-prod">
           <div class="hint">Restores an Odoo.sh daily backup (database + filestore) into a new template of this name.</div>
         </div>
         <div class="form-actions">


### PR DESCRIPTION
Changes the Template name placeholder in the Import from Odoo.sh dialog from `e.g. zipfit-prod` to `e.g. oduist-prod` (`dashboard.html`).