### PR TITLE
Scoped single-environment MCP access (/mcp/<env> + per-env tokens)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -71,6 +71,48 @@ Authorization: Bearer secret-token-team-1
 
 This works whether or not `oauth_base_url` is configured.
 
+## Scoped single-environment access (`/mcp/<env>`)
+
+The team `auth_token` unlocks the **full** tool surface — create, delete, and stop
+environments, manage templates, services, and volumes. To hand an AI agent a
+*confined* handle to one environment only, Oduflow exposes a scoped endpoint:
+
+```
+https://your-server.com/mcp/<env>
+```
+
+On this endpoint only the in-environment tools are available — sync
+(`pull_and_apply`), install/upgrade modules, run tests, open the Odoo shell, run
+SQL, read/write/search files, fetch logs and info, and `restart`. Lifecycle and
+system tools (create/delete/stop/start/recreate, templates, services, volumes,
+listing other environments) are **not exposed and cannot be called**. The
+environment is taken from the URL, so the agent never passes — and cannot
+override — which environment it operates on.
+
+### Per-environment Secret Key
+
+Every environment created after this feature gets its own access token, generated
+at creation time and stored on the container. Use it as a **Bearer token** or as
+an **OAuth** client credential — exactly like a team `auth_token`, but it only
+unlocks its own `/mcp/<env>` endpoint:
+
+```
+Authorization: Bearer <environment-secret-key>
+```
+
+A per-environment token is rejected on the full `/mcp` endpoint and on any other
+environment's URL, so the credential itself is the boundary.
+
+### Getting the URL and Secret Key
+
+In the web dashboard, open an environment's **More → MCP Access**. The dialog
+shows the `/mcp/<env>` URL and the Secret Key (with copy buttons) ready to paste
+into an agent's MCP configuration.
+
+Environments created before this feature carry no Secret Key (Docker labels can't
+be added to a live container); recreate the environment to issue one. Recreating
+an environment also rotates its token.
+
 ## Web Dashboard Auth
 
 The web dashboard and REST API use HTTP Basic authentication with a **separate** password:

--- a/specs/0028-scoped-environment-mcp-access.md
+++ b/specs/0028-scoped-environment-mcp-access.md
@@ -1,0 +1,95 @@
+# 0028 — Scoped single-environment MCP access (`/mcp/<env>` + per-environment tokens)
+
+**Status:** Adopted
+**Type:** Architecture / MCP capability
+**First introduced:** scoped single-environment MCP access (this change)
+**Key code today:** `scoped_access.py` (`ScopedEnvASGI`, `ScopedAccessMiddleware`, `OduflowTokenVerifier`, allowlist), `env_tokens.py` (per-env token generation + resolution), `oauth_provider.py` (env tokens as OAuth clients), `server.py` (`_build_auth`, `_start_http` wiring), `docker_ops/env_ops.py` (`oduflow.mcp_token` label, `get_env_token`), `web_ui.py` + `templates/dashboard.html` (MCP Access modal)
+
+## Context
+
+The MCP HTTP server exposes one endpoint per team (`/mcp`) and, through it, the
+*entire* tool surface: create/delete/stop environments, manage templates,
+services, volumes, repos — plus the per-environment dev-loop tools. Identity is a
+single team `auth_token` ([[0020-authentication-oauth]]) that unlocks everything
+that team owns ([[0014-team-based-multi-tenancy]]).
+
+That is the right granularity for an operator, but the wrong one for handing a
+*coding agent* a single environment to work in. There was no way to give an agent
+a handle that is confined to one environment — able to push code, install/upgrade
+modules, run tests, open a shell, query the DB — yet structurally unable to
+create, delete, or stop environments or touch any other tenant resource. Sharing
+the team token over-grants; the blast radius of a confused or compromised agent is
+the whole team.
+
+## Decision
+
+Add a **scoped single-environment endpoint** addressed by URL, `/mcp/<env>`,
+backed by a **per-environment access token** generated at creation time. On that
+endpoint only an allowlisted, single-environment toolset is visible and callable,
+and the environment is implied by the URL — never passed as a tool argument,
+preserving the "no identity/target in tool signatures" invariant of
+[[0002-remote-multi-user-mcp-access]].
+
+- **Per-environment token.** `create_environment` mints a random token and stores
+  it in the container label `oduflow.mcp_token`. The token doubles as a Bearer
+  token and as an OAuth client credential, so the same Secret Key works for
+  curl/CLI clients and for OAuth clients (claude.ai) alike — mirroring how a team
+  `auth_token` already plays three roles in [[0020-authentication-oauth]].
+- **Default-deny toolset.** The scoped endpoint exposes a curated allowlist (full
+  dev loop + `restart`, plus read-only/diagnostic tools). Everything else —
+  lifecycle, templates, services, volumes, repos, listing other environments — is
+  denied by omission, enforced on *both* `tools/list` and `tools/call`.
+- **One server, two faces.** The same FastMCP instance serves `/mcp` (full, team
+  token) and `/mcp/<env>` (scoped). No second server, no duplicated tools.
+
+The choice of a per-environment credential over "team token + env in URL" was
+deliberate: it makes the credential itself the boundary, so an agent given only
+the scoped URL + Secret Key is *cryptographically* confined to its environment,
+not merely pointed at a narrower endpoint.
+
+## How it works (macro)
+
+- **URL → scope.** An outermost ASGI shim recognises `/mcp/<env>`, stashes the
+  env in the request scope, and rewrites the path to the canonical `/mcp` route so
+  the existing streamable transport, auth, and OAuth resource-metadata serve it
+  unchanged. (The OAuth discovery path `/.well-known/.../mcp/<env>` is rewritten
+  the same way.)
+- **Token → identity.** Token verification resolves a presented token to
+  `(team_id, env_name)`: a team `auth_token` → full access; an `oduflow.mcp_token`
+  label match → scoped, carrying the env in an `oduflow_env:<env>` token scope.
+  Resolution is shared by the Bearer verifier and the OAuth provider, with a small
+  in-memory cache over a Docker label scan.
+- **Policy, default-deny.** A FastMCP middleware combines the two signals — env
+  from the URL and env from the token — into one decision: a team token at `/mcp`
+  is full access (no-op); at `/mcp/<env>` it is scoped to that env; a per-env token
+  is valid *only* at its own `/mcp/<env>` and denied anywhere else. In scoped mode
+  the middleware filters the tool list to the allowlist, strips `env_name` from
+  advertised schemas, and on every call re-checks the allowlist and injects the
+  resolved `env_name` — so a tool can never target another environment, and a
+  leaked listing can never enable a forbidden call.
+- **Operator UX.** Each environment card surfaces an **MCP Access** action showing
+  its `/mcp/<env>` URL and Secret Key (Bearer or OAuth).
+
+## Consequences
+
+- An agent can be given a **confined handle to exactly one environment** — full
+  in-environment dev loop, zero ability to create/delete/stop environments or
+  reach other tenant resources — without ever exposing the team token.
+- The scoped endpoint is **additive and free**: same server, same tools, no new
+  config knobs. Behaviour for the existing `/mcp` endpoint is unchanged.
+- **Defense in depth:** policy is enforced on both list and call, default-deny;
+  the env is injected server-side, so cross-environment access is structurally
+  impossible even if the tool surface were mis-listed.
+- Tokens live in **Docker labels** (the model of [[0021-code-delivery-modes]]'s
+  label-carried env metadata). They survive container recreation but cannot be
+  added to a live container: environments created before this feature carry no
+  token until recreated — acceptable given environments are ephemeral and
+  per-branch. Operators rotate a token by recreating the environment.
+- OAuth on the scoped URL reuses the env token as its client credential; the
+  reliable, always-available path is the Bearer Secret Key.
+
+## History
+
+- (this change) — scoped single-environment MCP access: `/mcp/<env>` endpoint,
+  per-environment `oduflow.mcp_token` (Bearer + OAuth), default-deny allowlist
+  middleware, and the dashboard MCP Access modal.

--- a/specs/README.md
+++ b/specs/README.md
@@ -46,6 +46,7 @@ precursors).
 | [0025](0025-startup-data-migrations.md) | 2026-07-02 | Startup data migrations (Odoo-style upgrade steps) |
 | [0026](0026-per-team-pg-tablespaces.md) | 2026-07-02 | Per-team PostgreSQL tablespaces |
 | [0027](0027-hard-tenant-isolation.md) | 2026-07-02 | Hard tenant isolation: per-team networks, resource limits, disk quotas |
+| [0028](0028-scoped-environment-mcp-access.md) | 2026-07-03 | Scoped single-environment MCP access: `/mcp/<env>` + per-environment tokens |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -29,6 +29,7 @@ from oduflow.docker_ops.system_ops import (
 )
 from oduflow.docker_ops.stats import default_env_limits
 from oduflow.env_credentials import create_credentials, load_credentials
+from oduflow.env_tokens import MCP_TOKEN_LABEL, generate_token, invalidate_cache
 from oduflow.errors import (
     ConflictError,
     ExternalCommandError,
@@ -755,6 +756,8 @@ def create_environment(
         "oduflow.template": template_name if template_name is not None else "none",
         "oduflow.git_branch": branch,
         "oduflow.created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        # Personal token authorizing the scoped MCP endpoint /mcp/<env>.
+        MCP_TOKEN_LABEL: generate_token(),
     }
 
     if extra_addons:
@@ -1184,6 +1187,8 @@ def create_environment(
     result["local_path"] = repo_path if local_mount else ""
     result["elapsed_seconds"] = round(time.time() - start_time, 1)
     activity.touch(team, env_name)
+    # Let the new env's MCP token resolve without waiting for the scan interval.
+    invalidate_cache()
     return result
 
 
@@ -1236,6 +1241,22 @@ def unprotect_environment(
         os.remove(marker)
     logger.info("Environment unprotected", extra={"env_name": env_name})
     return {"env_name": env_name, "protected": False}
+
+
+def get_env_token(settings: Settings, team: TeamSettings, env_name: str) -> str | None:
+    """Return the per-environment MCP access token from the container label.
+
+    Returns ``None`` for environments created before the feature existed (their
+    container carries no ``oduflow.mcp_token`` label and Docker labels cannot be
+    added without recreating the container).
+    """
+    client = get_client()
+    container_name = get_resource_name(env_name, "odoo", settings.prefix, team.team_id)
+    try:
+        container = client.containers.get(container_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(f"Environment '{env_name}' does not exist.")
+    return container.labels.get(MCP_TOKEN_LABEL) or None
 
 
 def get_note(settings: Settings, team: TeamSettings, env_name: str) -> str:
@@ -1342,6 +1363,7 @@ def delete_environment(
         shutil.rmtree(workspace_path)
 
     activity.remove(team, env_name)
+    invalidate_cache()
     logger.info("Environment deleted", extra={"env_name": env_name})
     return warnings
 

--- a/src/oduflow/env_tokens.py
+++ b/src/oduflow/env_tokens.py
@@ -1,0 +1,123 @@
+"""Per-environment MCP access tokens.
+
+Each environment gets a personal token stored in the Docker label
+``oduflow.mcp_token`` at creation time (see ``env_ops.create_environment``).
+The token doubles as a Bearer token and an OAuth client credential, and
+authorizes the scoped MCP endpoint ``/mcp/<env>`` (single-environment access).
+
+``resolve_token`` maps an incoming token to a ``(team_id, env_name)`` pair:
+
+- a team ``auth_token`` from settings -> ``(team_id, None)``  [full access]
+- a container's ``oduflow.mcp_token`` label -> ``(team_id, env_name)``  [scoped]
+
+Resolution must stay cheap on the hot path: token verification runs on *every*
+HTTP request, and an unauthenticated caller can spam invalid Bearer tokens at
+the public endpoint. So env-token lookups are served from an in-memory cache
+that is refreshed by scanning Docker at most once per ``_MIN_SCAN_INTERVAL``;
+within that window unknown tokens are rejected without a rescan (implicit
+negative cache), which bounds a token flood to one scan per interval. The
+blocking Docker scan is offloaded to a thread by ``resolve_token_async`` so it
+never stalls the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import threading
+import time
+
+from oduflow.settings import Settings
+
+logger = logging.getLogger("oduflow")
+
+MCP_TOKEN_LABEL = "oduflow.mcp_token"
+
+# Minimum seconds between full Docker scans. Bounds a flood of invalid tokens to
+# one scan per interval and caps how long a freshly created env token waits to
+# become resolvable (create/delete call invalidate_cache to force an early scan).
+_MIN_SCAN_INTERVAL = 5.0
+
+_lock = threading.Lock()
+# token -> (team_id, env_name) for env-scoped tokens. Team tokens are resolved
+# directly from settings and are never cached here.
+_env_tokens: dict[str, tuple[str, str]] = {}
+_last_scan: float = 0.0
+
+
+def generate_token() -> str:
+    """Generate a fresh per-environment access token."""
+    return secrets.token_urlsafe(32)
+
+
+def _scan_env_tokens(settings: Settings) -> dict[str, tuple[str, str]]:
+    """Scan managed containers and build ``{token: (team_id, env_name)}``."""
+    from oduflow.docker_ops.client import get_client
+
+    result: dict[str, tuple[str, str]] = {}
+    try:
+        client = get_client()
+        containers = client.containers.list(
+            all=True, filters={"label": f"{settings.managed_label}=true"}
+        )
+    except Exception as e:  # pragma: no cover - docker unavailable
+        logger.debug("env-token scan failed: %s", e)
+        return result
+    for container in containers:
+        labels = container.labels or {}
+        token = labels.get(MCP_TOKEN_LABEL)
+        env_name = labels.get(settings.branch_label)
+        team_id = labels.get(settings.team_label)
+        if token and env_name and team_id:
+            result[token] = (team_id, env_name)
+    return result
+
+
+def resolve_token(settings: Settings, token: str) -> tuple[str, str | None] | None:
+    """Resolve a presented token to ``(team_id, env_name)``.
+
+    Returns ``(team_id, None)`` for a team ``auth_token`` (full access),
+    ``(team_id, env_name)`` for a per-environment token (scoped access), or
+    ``None`` if the token is unknown.
+
+    May block on a Docker scan (rate-limited); async callers should prefer
+    :func:`resolve_token_async` to keep the event loop free.
+    """
+    global _last_scan
+    if not token:
+        return None
+    # 1. Team tokens (static, from settings) — never touches Docker.
+    for team_id, team in settings.teams.items():
+        if team.auth_token and secrets.compare_digest(token, team.auth_token):
+            return (team_id, None)
+    # 2. Env tokens: serve from cache; rescan at most once per interval.
+    with _lock:
+        hit = _env_tokens.get(token)
+        if hit is not None:
+            return hit
+        fresh_enough = (time.monotonic() - _last_scan) < _MIN_SCAN_INTERVAL
+    if fresh_enough:
+        return None  # unknown token, rate-limited: don't rescan
+    fresh = _scan_env_tokens(settings)  # outside the lock (blocking Docker call)
+    with _lock:
+        _env_tokens.clear()
+        _env_tokens.update(fresh)
+        _last_scan = time.monotonic()
+    return fresh.get(token)
+
+
+async def resolve_token_async(
+    settings: Settings, token: str
+) -> tuple[str, str | None] | None:
+    """Async wrapper that offloads :func:`resolve_token` to a worker thread."""
+    import anyio
+
+    return await anyio.to_thread.run_sync(resolve_token, settings, token)
+
+
+def invalidate_cache() -> None:
+    """Drop the cached env-token map and force the next lookup to rescan."""
+    global _last_scan
+    with _lock:
+        _env_tokens.clear()
+        _last_scan = 0.0

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -24,6 +24,8 @@ from mcp.shared.auth import (
 )
 from pydantic import AnyUrl
 
+from oduflow import env_tokens
+from oduflow.scoped_access import ENV_SCOPE_PREFIX
 from oduflow.settings import Settings
 
 logger = logging.getLogger("oduflow")
@@ -73,6 +75,7 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
             raise ValueError("oauth_base_url is required for self-hosted OAuth")
         super().__init__(base_url=settings.oauth_base_url)
 
+        self._settings = settings
         self._token_to_team: dict[str, str] = {}
         placeholder_redirect = AnyUrl("https://claude.ai/")
 
@@ -100,6 +103,56 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
                 expires_at=None,
             )
 
+    async def _env_identity(self, token: str | None) -> tuple[str, str] | None:
+        """Return ``(team_id, env_name)`` for a valid per-environment token.
+
+        Team tokens are handled by the preseeded clients/access tokens, so they
+        return ``None`` here.
+        """
+        if not token:
+            return None
+        resolved = await env_tokens.resolve_token_async(self._settings, token)
+        if resolved is None:
+            return None
+        team_id, env_name = resolved
+        if env_name is None:
+            return None
+        return (team_id, env_name)
+
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        client = await super().get_client(client_id)
+        if client is not None:
+            return client
+        # A per-environment token acts as its own OAuth client.
+        if await self._env_identity(client_id) is not None:
+            return _FlexibleClient(
+                client_id=client_id,
+                client_secret=client_id,
+                redirect_uris=[AnyUrl("https://claude.ai/")],
+                grant_types=["authorization_code", "refresh_token"],
+                response_types=["code"],
+                token_endpoint_auth_method="client_secret_post",
+                scope=None,
+            )
+        return None
+
+    async def load_access_token(  # type: ignore[override]
+        self, token: str
+    ) -> AccessToken | None:
+        existing = await super().load_access_token(token)
+        if existing is not None:
+            return existing
+        identity = await self._env_identity(token)
+        if identity is None:
+            return None
+        team_id, env_name = identity
+        return AccessToken(
+            token=token,
+            client_id=team_id,
+            scopes=[f"{ENV_SCOPE_PREFIX}{env_name}"],
+            expires_at=None,
+        )
+
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         raise ValueError(
             "Dynamic client registration is disabled. "
@@ -114,12 +167,15 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         # Single-use code.
         self.auth_codes.pop(authorization_code.code, None)
 
-        if client.client_id is None or client.client_id not in self._token_to_team:
+        cid = client.client_id
+        if cid is None or (
+            cid not in self._token_to_team and await self._env_identity(cid) is None
+        ):
             from mcp.server.auth.provider import TokenError
 
             raise TokenError("invalid_client", "Unknown client.")
 
-        token = client.client_id
+        token = cid
         scope = (
             " ".join(authorization_code.scopes) if authorization_code.scopes else None
         )
@@ -136,14 +192,17 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         client: OAuthClientInformationFull,
         refresh_token: str,
     ) -> RefreshToken | None:
+        cid = client.client_id
         if (
-            client.client_id is not None
-            and refresh_token == client.client_id
-            and refresh_token in self._token_to_team
+            cid is not None
+            and refresh_token == cid
+            and (
+                cid in self._token_to_team or await self._env_identity(cid) is not None
+            )
         ):
             return RefreshToken(
                 token=refresh_token,
-                client_id=client.client_id,
+                client_id=cid,
                 scopes=[],
                 expires_at=None,
             )

--- a/src/oduflow/scoped_access.py
+++ b/src/oduflow/scoped_access.py
@@ -1,0 +1,292 @@
+"""Scoped single-environment MCP access (``/mcp/<env>``).
+
+The same FastMCP server serves both the full ``/mcp`` endpoint and a scoped
+``/mcp/<env>`` endpoint that exposes only the tools needed to work *inside* one
+environment. Three pieces cooperate:
+
+- :class:`ScopedEnvASGI` — an outer ASGI shim that recognises ``/mcp/<env>``,
+  stashes the env in the request scope, and rewrites the path to the canonical
+  ``/mcp`` route so the existing streamable transport + auth handle it.
+- :class:`OduflowTokenVerifier` — a Bearer verifier that accepts both team
+  ``auth_token`` values (full access) and per-environment tokens (scoped), the
+  latter carrying the env in an ``oduflow_env:<env>`` scope.
+- :class:`ScopedAccessMiddleware` — a FastMCP middleware enforcing, default-deny,
+  which tools are visible/callable and injecting the resolved ``env_name``.
+
+Access policy (see :func:`decide`):
+
+============== ================== ============================
+Token          URL ``/mcp``       URL ``/mcp/<env>``
+============== ================== ============================
+team token     full (unchanged)   scoped to ``<env>``
+env-A token    deny               scoped iff ``<env> == A``
+============== ================== ============================
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth.auth import AccessToken, TokenVerifier
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+
+from oduflow import env_tokens
+from oduflow.settings import Settings
+
+logger = logging.getLogger("oduflow")
+
+# ASGI scope key holding the env parsed from a /mcp/<env> URL.
+SCOPE_KEY = "oduflow_scoped_env"
+# Prefix of the access-token scope that binds a per-env token to its env.
+ENV_SCOPE_PREFIX = "oduflow_env:"
+
+# Tools exposed on the scoped endpoint: full dev loop + restart, read-only and
+# diagnostics. Everything else (create/delete/stop/start/update/recreate,
+# list_environments, templates, services, volumes, extra repos, repo auth,
+# save/import template) is denied — default-deny, not enumerated here.
+SCOPED_ALLOWLIST = frozenset(
+    {
+        "get_agent_instructions",
+        "get_odoo_development_guide",
+        "read_output",
+        "get_environment_info",
+        "get_environment_logs",
+        "pull_and_apply",
+        "install_odoo_modules",
+        "upgrade_odoo_modules",
+        "run_odoo_tests",
+        "run_odoo_shell",
+        "run_odoo_command",
+        "run_db_query",
+        "reset_admin_password",
+        "write_file_in_odoo",
+        "read_file_in_odoo",
+        "search_in_odoo",
+        "http_request_to_odoo",
+        "list_installed_modules",
+        "restart_environment",
+    }
+)
+
+
+# -- Pure helpers (unit-tested directly) --
+
+
+def decide(url_env: str | None, token_env: str | None) -> tuple[str, str | None]:
+    """Decide access mode from the URL env and the token-bound env.
+
+    Returns ``(mode, env)`` where ``mode`` is ``"full"``, ``"scoped"`` or
+    ``"deny"``. In ``"scoped"`` mode ``env`` is the environment to operate on.
+    """
+    if url_env is None:
+        # Root /mcp: a per-env token must use its own /mcp/<env> URL.
+        if token_env is not None:
+            return ("deny", None)
+        return ("full", None)
+    # Scoped /mcp/<env>: a per-env token must match the URL's env.
+    if token_env is not None and token_env != url_env:
+        return ("deny", None)
+    return ("scoped", url_env)
+
+
+def strip_env_name(parameters: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of a tool's JSON schema with ``env_name`` removed.
+
+    On the scoped endpoint the env is implied by the URL, so the agent neither
+    sees nor supplies ``env_name``.
+    """
+    params = copy.deepcopy(parameters)
+    props = params.get("properties")
+    if isinstance(props, dict):
+        props.pop("env_name", None)
+    required = params.get("required")
+    if isinstance(required, list):
+        params["required"] = [r for r in required if r != "env_name"]
+    return params
+
+
+def build_env_param_tools(mcp: Any) -> set[str]:
+    """Allowlisted tool names that declare an ``env_name`` parameter.
+
+    Computed once from the registered tools so the env is injected only where
+    the tool actually accepts it (avoids drift in a hand-kept mapping).
+    """
+    tools = getattr(getattr(mcp, "_tool_manager", None), "_tools", {}) or {}
+    result: set[str] = set()
+    for name in SCOPED_ALLOWLIST:
+        tool = tools.get(name)
+        if tool is None:
+            continue
+        props = (getattr(tool, "parameters", None) or {}).get("properties", {})
+        if "env_name" in props:
+            result.add(name)
+    return result
+
+
+# -- Request-context readers (thin; monkeypatched in tests) --
+
+
+def scoped_env_from_request() -> str | None:
+    """The env parsed from a /mcp/<env> URL for the current request, if any."""
+    try:
+        from fastmcp.server.dependencies import get_http_request
+
+        request = get_http_request()
+        return request.scope.get(SCOPE_KEY)
+    except Exception:
+        return None
+
+
+def env_from_access_token() -> str | None:
+    """The env a per-env token is bound to, from its access-token scopes."""
+    try:
+        from fastmcp.server.dependencies import get_access_token
+
+        token = get_access_token()
+    except Exception:
+        return None
+    if not token:
+        return None
+    for scope in token.scopes or []:
+        if scope.startswith(ENV_SCOPE_PREFIX):
+            return scope[len(ENV_SCOPE_PREFIX) :]
+    return None
+
+
+# -- Auth: Bearer verifier accepting team + per-env tokens --
+
+
+class OduflowTokenVerifier(TokenVerifier):
+    """Verify Bearer tokens against team ``auth_token`` and per-env tokens."""
+
+    def __init__(self, settings: Settings) -> None:
+        super().__init__()
+        self._settings = settings
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        resolved = await env_tokens.resolve_token_async(self._settings, token)
+        if resolved is None:
+            return None
+        team_id, env_name = resolved
+        scopes = [f"{ENV_SCOPE_PREFIX}{env_name}"] if env_name else []
+        return AccessToken(
+            token=token, client_id=team_id, scopes=scopes, expires_at=None
+        )
+
+
+# -- Routing: /mcp/<env> -> /mcp + scope tag --
+
+
+class ScopedEnvASGI:
+    """Route ``/mcp/<env>`` to the canonical ``/mcp`` endpoint, tagging the env.
+
+    The env is stashed in the ASGI scope (read back via
+    ``get_http_request().scope``) and the path rewritten so the existing
+    streamable transport + auth + OAuth resource metadata serve it unchanged.
+    Non-HTTP scopes (lifespan, websocket) and other paths pass through untouched.
+    """
+
+    _WELL_KNOWN_PREFIX = "/.well-known/oauth-protected-resource"
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") == "http":
+            path = scope.get("path", "")
+            env = self._scoped_env(path)
+            if env is not None:
+                # ASGI ``path`` is already percent-decoded, so ``env`` is the
+                # plain environment name (slashes in branch names included).
+                scope = dict(scope)
+                scope[SCOPE_KEY] = env
+                scope["path"] = "/mcp"
+                scope["raw_path"] = b"/mcp"
+            else:
+                rewritten = self._well_known(path)
+                if rewritten is not None:
+                    scope = dict(scope)
+                    scope["path"] = rewritten
+                    scope["raw_path"] = rewritten.encode()
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    def _scoped_env(path: str) -> str | None:
+        """Return the env segment of ``/mcp/<env>`` (anything after ``/mcp/``)."""
+        prefix = "/mcp/"
+        if path.startswith(prefix) and len(path) > len(prefix):
+            return path[len(prefix) :]
+        return None
+
+    @classmethod
+    def _well_known(cls, path: str) -> str | None:
+        """Map a scoped OAuth resource-metadata path back to the ``/mcp`` one."""
+        base = cls._WELL_KNOWN_PREFIX
+        prefix = base + "/mcp/"
+        if path.startswith(prefix) and len(path) > len(prefix):
+            return base + "/mcp"
+        return None
+
+
+# -- Enforcement: tool list/call gating --
+
+
+class ScopedAccessMiddleware(Middleware):
+    """Default-deny the tool surface and inject ``env_name`` on scoped requests.
+
+    On the full ``/mcp`` endpoint with a team token this is a no-op. The same
+    policy is enforced on both ``tools/list`` and ``tools/call`` so a leaked
+    listing can never enable a call.
+    """
+
+    def __init__(
+        self,
+        env_param_tools: set[str],
+        allowlist: frozenset[str] = SCOPED_ALLOWLIST,
+    ) -> None:
+        self._allow = frozenset(allowlist)
+        self._env_param = frozenset(env_param_tools)
+
+    def _decide(self) -> tuple[str, str | None]:
+        return decide(scoped_env_from_request(), env_from_access_token())
+
+    async def on_list_tools(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        tools = await call_next(context)
+        mode, _env = self._decide()
+        if mode == "full":
+            return tools
+        if mode == "deny":
+            return []
+        out = []
+        for tool in tools:
+            if tool.name not in self._allow:
+                continue
+            if tool.name in self._env_param:
+                tool = tool.model_copy(
+                    update={"parameters": strip_env_name(tool.parameters)}
+                )
+            out.append(tool)
+        return out
+
+    async def on_call_tool(
+        self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]
+    ) -> Any:
+        mode, env = self._decide()
+        if mode == "full":
+            return await call_next(context)
+        name = context.message.name
+        if mode == "deny" or name not in self._allow:
+            raise ToolError(
+                f"Tool '{name}' is not available on this single-environment "
+                "MCP endpoint."
+            )
+        if name in self._env_param:
+            args = dict(context.message.arguments or {})
+            args["env_name"] = env
+            context.message.arguments = args
+        return await call_next(context)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3544,6 +3544,16 @@ def _start_http() -> None:
 
     app = create_streamable_http_app(mcp, "/mcp", auth=auth, stateless_http=True)
 
+    # Scoped single-environment access: gate the tool surface for /mcp/<env>
+    # requests and inject the resolved env_name. No-op for the full /mcp.
+    from oduflow.scoped_access import (
+        ScopedAccessMiddleware,
+        ScopedEnvASGI,
+        build_env_param_tools,
+    )
+
+    mcp.add_middleware(ScopedAccessMiddleware(build_env_param_tools(mcp)))
+
     reaper.start_reaper(_get_settings, _locks)
 
     from oduflow.web_ui import mount_web_ui
@@ -3566,7 +3576,8 @@ def _start_http() -> None:
 
     import uvicorn
 
-    uvicorn.run(app, host=host, port=port, ws="websockets-sansio")
+    # Outermost shim so /mcp/<env> routes to the canonical /mcp route.
+    uvicorn.run(ScopedEnvASGI(app), host=host, port=port, ws="websockets-sansio")
 
 
 def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
@@ -3582,13 +3593,10 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
       auth_token is consumed directly from the Authorization header.
       Suitable for curl, CLI clients, and IDEs that don't need OAuth.
     """
-    tokens: dict[str, dict[str, object]] = {}
-    for team_id, team in settings.teams.items():
-        if team.auth_token:
-            tokens[team.auth_token] = {"client_id": team_id, "scopes": []}
+    has_team_token = any(t.auth_token for t in settings.teams.values())
 
     if settings.oauth_enabled:
-        if not tokens:
+        if not has_team_token:
             logger.warning(
                 "oauth_base_url is set but no team has auth_token; OAuth disabled"
             )
@@ -3597,10 +3605,12 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
 
         return OduflowOAuthProvider(settings)
 
-    if tokens:
-        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+    if has_team_token:
+        # Verifies team auth_token (full access) and per-environment tokens
+        # (scoped /mcp/<env> access) — see oduflow.scoped_access.
+        from oduflow.scoped_access import OduflowTokenVerifier
 
-        return StaticTokenVerifier(tokens=tokens)
+        return OduflowTokenVerifier(settings)
 
     logger.warning("HTTP auth DISABLED (no auth_token or oauth_base_url set)")
     return None

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -901,6 +901,8 @@
   .modal-note { font-size: var(--text-sm); color: var(--text-dim); margin-bottom: 16px; }
   .modal-note a { color: var(--accent); }
   .mono-input { font-family: var(--font-mono); font-size: var(--text-xs); }
+  .copy-row { display: flex; gap: 8px; align-items: stretch; }
+  .copy-row input { flex: 1 1 auto; min-width: 0; }
   .guide-viewer-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
   .guide-viewer-title { font-size: var(--text-md); font-weight: 600; color: var(--text); }
   .guide-file { font-size: var(--text-xs); color: var(--text-dim); }
@@ -1402,6 +1404,36 @@
         <button class="btn danger" id="note-delete-btn" onclick="deleteNote()">Delete note</button>
         <button class="btn" onclick="closeNoteModal()">Cancel</button>
         <button class="btn-create" onclick="saveNote()">Save note</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal-overlay" id="mcp-access-modal" onclick="closeMcpAccess(event)">
+  <div class="modal modal-sm">
+    <div class="modal-header">
+      <h2 id="mcp-access-title">MCP Access</h2>
+      <button class="modal-close" onclick="closeMcpAccess()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p class="modal-note">Scoped MCP endpoint for this environment only. Use the Secret Key as a Bearer token or as an OAuth client credential. It exposes the in-environment tools (sync, install/upgrade, tests, shell, SQL, logs); it cannot create, delete or stop environments.</p>
+      <div class="form-group">
+        <label for="mcp-access-url">Endpoint URL</label>
+        <div class="copy-row">
+          <input id="mcp-access-url" class="mono-input" type="text" readonly>
+          <button class="btn" type="button" onclick="copyMcpField('mcp-access-url', 'URL copied')">Copy</button>
+        </div>
+      </div>
+      <div class="form-group" id="mcp-access-secret-group">
+        <label for="mcp-access-token">Secret Key</label>
+        <div class="copy-row">
+          <input id="mcp-access-token" class="mono-input" type="password" readonly>
+          <button class="btn" type="button" id="mcp-access-reveal" onclick="toggleMcpSecret()" aria-pressed="false">Show</button>
+          <button class="btn" type="button" onclick="copyMcpField('mcp-access-token', 'Secret Key copied')">Copy</button>
+        </div>
+      </div>
+      <p class="modal-note" id="mcp-access-missing" style="display:none;">This environment was created before per-environment tokens existed. Recreate it to issue a Secret Key.</p>
+      <div class="form-actions">
+        <button class="btn" onclick="closeMcpAccess()">Close</button>
       </div>
     </div>
   </div>
@@ -1918,6 +1950,7 @@ function renderEnvironments(envs, force) {
                 (allStopped ? 'disabled' : '') + '>Open console</button>' +
               '<button role="menuitem" title="psql session on the environment database" onclick="openSqlConsole(\'' + escAttr(env.branch) + '\')" ' +
                 (allStopped ? 'disabled' : '') + '>Open SQL console</button>' +
+              '<button role="menuitem" title="Scoped MCP endpoint and Secret Key for this environment only" onclick="openMcpAccess(\'' + escAttr(env.branch) + '\')">MCP Access</button>' +
               '<button role="menuitem" title="' + (env.note ? 'Edit the note on this environment' : 'Add a note to this environment') + '" onclick="editNote(\'' + escAttr(env.branch) + '\')">' +
                 (env.note ? 'Edit note' : 'Add note') + '</button>' +
               '<button role="menuitem" title="' + (env.protected ? 'Allow Stop, Update, Recreate and Delete again' : 'Disable Stop, Update, Recreate and Delete') + '" onclick="doProtect(\'' + escAttr(env.branch) + '\',' + (env.protected ? 'true' : 'false') + ')" ' + dis + '>' +
@@ -2176,6 +2209,54 @@ async function saveNote() {
 
 async function deleteNote() {
   await _putNote(_noteBranch, '', 'Note deleted');
+}
+
+async function openMcpAccess(branch) {
+  document.getElementById('mcp-access-title').textContent = 'MCP Access — ' + branch;
+  var tokenEl = document.getElementById('mcp-access-token');
+  // Reset the secret to its masked state every time the modal opens.
+  tokenEl.type = 'password';
+  var reveal = document.getElementById('mcp-access-reveal');
+  reveal.textContent = 'Show';
+  reveal.setAttribute('aria-pressed', 'false');
+  document.getElementById('mcp-access-url').value = '';
+  tokenEl.value = '';
+  document.getElementById('mcp-access-secret-group').style.display = '';
+  document.getElementById('mcp-access-missing').style.display = 'none';
+  showModal('mcp-access-modal');
+  try {
+    var r = await fetch(API + '/' + encodeURIComponent(branch) + '/mcp-access');
+    var data = await r.json();
+    if (!data.ok) { showToast(data.error || 'Failed to load MCP access', true); return; }
+    document.getElementById('mcp-access-url').value = data.result.url || '';
+    if (data.result.token) {
+      tokenEl.value = data.result.token;
+    } else {
+      document.getElementById('mcp-access-secret-group').style.display = 'none';
+      document.getElementById('mcp-access-missing').style.display = '';
+    }
+  } catch (e) {
+    showToast('Connection error: ' + e.message, true);
+  }
+}
+
+function closeMcpAccess(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('mcp-access-modal');
+}
+
+function toggleMcpSecret() {
+  var el = document.getElementById('mcp-access-token');
+  var btn = document.getElementById('mcp-access-reveal');
+  var show = el.type === 'password';
+  el.type = show ? 'text' : 'password';
+  btn.textContent = show ? 'Hide' : 'Show';
+  btn.setAttribute('aria-pressed', show ? 'true' : 'false');
+}
+
+function copyMcpField(id, label) {
+  var val = document.getElementById(id).value;
+  if (val) copyToClipboard(val, label);
 }
 
 async function loadEnvironments(force) {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -12,6 +12,7 @@ import re
 import secrets
 import threading
 import time
+from urllib.parse import quote
 
 from itsdangerous import BadData, URLSafeTimedSerializer
 from starlette.requests import HTTPConnection, Request
@@ -1783,6 +1784,21 @@ def _build_routes(
             logger.exception("Unexpected error in api_set_note")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
 
+    def api_mcp_access(request: Request) -> JSONResponse:
+        branch = request.path_params["branch"]
+        try:
+            settings = get_settings()
+            team = _get_ui_team(request)
+            token = env_ops.get_env_token(settings, team, branch)
+            base = (settings.oauth_base_url or str(request.base_url)).rstrip("/")
+            url = f"{base}/mcp/{quote(branch, safe='/')}"
+            return JSONResponse({"ok": True, "result": {"url": url, "token": token}})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_mcp_access")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
     async def ws_terminal(websocket: WebSocket) -> None:
         branch = websocket.path_params["branch"]
         await websocket.accept()
@@ -2038,6 +2054,11 @@ def _build_routes(
             "/api/environments/{branch:path}/unprotect", api_unprotect, methods=["POST"]
         ),
         Route("/api/environments/{branch:path}/note", api_set_note, methods=["POST"]),
+        Route(
+            "/api/environments/{branch:path}/mcp-access",
+            api_mcp_access,
+            methods=["GET"],
+        ),
         Route("/api/environments/{branch:path}/update", api_update, methods=["POST"]),
         Route(
             "/api/environments/{branch:path}/recreate", api_recreate, methods=["POST"]

--- a/tests/test_env_tokens.py
+++ b/tests/test_env_tokens.py
@@ -1,0 +1,93 @@
+"""Unit tests for per-environment access token resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from oduflow import env_tokens
+from oduflow.settings import Settings, TeamSettings
+
+
+def _settings() -> Settings:
+    return Settings(
+        teams={
+            "1": TeamSettings(
+                team_id="1",
+                auth_token="team-tok-1",
+                port_range_start=50000,
+                port_range_end=50100,
+            ),
+            "2": TeamSettings(
+                team_id="2",
+                auth_token="team-tok-2",
+                port_range_start=50100,
+                port_range_end=50200,
+            ),
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    env_tokens.invalidate_cache()
+    yield
+    env_tokens.invalidate_cache()
+
+
+def test_generate_token_unique():
+    a = env_tokens.generate_token()
+    b = env_tokens.generate_token()
+    assert a != b
+    assert len(a) >= 20
+
+
+def test_resolve_team_token():
+    s = _settings()
+    assert env_tokens.resolve_token(s, "team-tok-1") == ("1", None)
+    assert env_tokens.resolve_token(s, "team-tok-2") == ("2", None)
+
+
+def test_resolve_env_token(monkeypatch):
+    s = _settings()
+    monkeypatch.setattr(
+        env_tokens,
+        "_scan_env_tokens",
+        lambda settings: {"env-secret": ("2", "feature/x")},
+    )
+    assert env_tokens.resolve_token(s, "env-secret") == ("2", "feature/x")
+
+
+def test_resolve_unknown(monkeypatch):
+    s = _settings()
+    monkeypatch.setattr(env_tokens, "_scan_env_tokens", lambda settings: {})
+    assert env_tokens.resolve_token(s, "nope") is None
+    assert env_tokens.resolve_token(s, "") is None
+
+
+def test_team_token_wins_over_scan(monkeypatch):
+    s = _settings()
+    # Even if a scan would also report this token, the team match short-circuits
+    # before any Docker scan happens.
+    called = {"n": 0}
+
+    def fake_scan(settings):
+        called["n"] += 1
+        return {}
+
+    monkeypatch.setattr(env_tokens, "_scan_env_tokens", fake_scan)
+    assert env_tokens.resolve_token(s, "team-tok-1") == ("1", None)
+    assert called["n"] == 0
+
+
+def test_env_token_cached(monkeypatch):
+    s = _settings()
+    calls = {"n": 0}
+
+    def fake_scan(settings):
+        calls["n"] += 1
+        return {"env-secret": ("1", "main")}
+
+    monkeypatch.setattr(env_tokens, "_scan_env_tokens", fake_scan)
+    assert env_tokens.resolve_token(s, "env-secret") == ("1", "main")
+    assert env_tokens.resolve_token(s, "env-secret") == ("1", "main")
+    assert calls["n"] == 1  # second lookup served from the cache

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -140,6 +140,35 @@ class TestOduflowOAuthProvider:
         with pytest.raises(InvalidRedirectUriError):
             client.validate_redirect_uri(AnyUrl("http://evil.example/cb"))
 
+    def test_env_token_acts_as_client(self, monkeypatch):
+        from oduflow import oauth_provider as op
+
+        mapping = {"env-secret": ("2", "feature/x"), "tok-a": ("1", None)}
+        monkeypatch.setattr(
+            op.env_tokens,
+            "resolve_token",
+            lambda settings, token: mapping.get(token),
+        )
+        provider = OduflowOAuthProvider(_settings())
+
+        # A per-env token resolves as its own OAuth client.
+        client = _run(provider.get_client("env-secret"))
+        assert client is not None
+        assert client.client_id == "env-secret"
+        assert client.client_secret == "env-secret"
+
+        # Its access token carries the team_id and an env-binding scope.
+        access = _run(provider.verify_token("env-secret"))
+        assert access is not None
+        assert access.client_id == "2"
+        assert access.scopes == ["oduflow_env:feature/x"]
+
+        # Team tokens still resolve via the preseeded path (no env scope).
+        team_access = _run(provider.verify_token("tok-a"))
+        assert team_access is not None
+        assert team_access.client_id == "1"
+        assert team_access.scopes == []
+
     def test_well_known_route_exposed(self):
         provider = OduflowOAuthProvider(_settings())
         routes = provider.get_routes("/mcp")

--- a/tests/test_scoped_access.py
+++ b/tests/test_scoped_access.py
@@ -1,0 +1,380 @@
+"""Unit tests for scoped single-environment MCP access."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+
+import pytest
+from fastmcp.exceptions import ToolError
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow import scoped_access
+from oduflow.docker_ops import env_ops
+from oduflow.errors import NotFoundError
+from oduflow.locking import LockManager
+from oduflow.scoped_access import (
+    OduflowTokenVerifier,
+    ScopedAccessMiddleware,
+    ScopedEnvASGI,
+    build_env_param_tools,
+    decide,
+    strip_env_name,
+)
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# --- decide ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url_env,token_env,expected",
+    [
+        (None, None, ("full", None)),  # root /mcp + team token
+        (None, "a", ("deny", None)),  # env token must use its /mcp/<env> URL
+        ("a", None, ("scoped", "a")),  # team token scoped by URL
+        ("a", "a", ("scoped", "a")),  # env token matching its URL
+        ("a", "b", ("deny", None)),  # env token against another env's URL
+    ],
+)
+def test_decide(url_env, token_env, expected):
+    assert decide(url_env, token_env) == expected
+
+
+# --- strip_env_name --------------------------------------------------------
+
+
+def test_strip_env_name():
+    params = {
+        "type": "object",
+        "properties": {"env_name": {"type": "string"}, "modules": {"type": "string"}},
+        "required": ["env_name", "modules"],
+    }
+    out = strip_env_name(params)
+    assert "env_name" not in out["properties"]
+    assert "modules" in out["properties"]
+    assert out["required"] == ["modules"]
+    # The original schema is left untouched.
+    assert "env_name" in params["properties"]
+
+
+# --- build_env_param_tools -------------------------------------------------
+
+
+class _FakeTool:
+    def __init__(self, name, parameters):
+        self.name = name
+        self.parameters = parameters
+
+    def model_copy(self, update):
+        return _FakeTool(self.name, update.get("parameters", self.parameters))
+
+
+class _FakeMcp:
+    def __init__(self, tools):
+        self._tool_manager = type("Mgr", (), {"_tools": tools})()
+
+
+def test_build_env_param_tools_only_allowlisted_with_env():
+    tools = {
+        "pull_and_apply": _FakeTool(
+            "pull_and_apply", {"properties": {"env_name": {}, "install": {}}}
+        ),
+        "get_agent_instructions": _FakeTool(
+            "get_agent_instructions", {"properties": {}}
+        ),
+        # Has env_name but is NOT allowlisted -> never injected into.
+        "delete_environment": _FakeTool(
+            "delete_environment", {"properties": {"env_name": {}}}
+        ),
+    }
+    result = build_env_param_tools(_FakeMcp(tools))
+    assert "pull_and_apply" in result
+    assert "get_agent_instructions" not in result
+    assert "delete_environment" not in result
+
+
+# --- ScopedEnvASGI ---------------------------------------------------------
+
+
+class _Recorder:
+    def __init__(self):
+        self.scope = None
+
+    async def __call__(self, scope, receive, send):
+        self.scope = scope
+
+
+def test_asgi_rewrites_scoped_path():
+    rec = _Recorder()
+    _run(
+        ScopedEnvASGI(rec)(
+            {"type": "http", "path": "/mcp/feature/x", "raw_path": b"/mcp/feature/x"},
+            None,
+            None,
+        )
+    )
+    assert rec.scope["path"] == "/mcp"
+    assert rec.scope["raw_path"] == b"/mcp"
+    assert rec.scope[scoped_access.SCOPE_KEY] == "feature/x"
+
+
+def test_asgi_passthrough_root_mcp():
+    rec = _Recorder()
+    _run(ScopedEnvASGI(rec)({"type": "http", "path": "/mcp"}, None, None))
+    assert rec.scope["path"] == "/mcp"
+    assert scoped_access.SCOPE_KEY not in rec.scope
+
+
+def test_asgi_passthrough_other_paths():
+    rec = _Recorder()
+    _run(ScopedEnvASGI(rec)({"type": "http", "path": "/api/environments"}, None, None))
+    assert rec.scope["path"] == "/api/environments"
+    assert scoped_access.SCOPE_KEY not in rec.scope
+
+
+def test_asgi_rewrites_scoped_well_known():
+    rec = _Recorder()
+    _run(
+        ScopedEnvASGI(rec)(
+            {
+                "type": "http",
+                "path": "/.well-known/oauth-protected-resource/mcp/env1",
+            },
+            None,
+            None,
+        )
+    )
+    assert rec.scope["path"] == "/.well-known/oauth-protected-resource/mcp"
+
+
+def test_asgi_non_http_untouched():
+    rec = _Recorder()
+    scope = {"type": "lifespan"}
+    _run(ScopedEnvASGI(rec)(scope, None, None))
+    assert rec.scope is scope
+
+
+# --- ScopedAccessMiddleware ------------------------------------------------
+
+
+def _scope(monkeypatch, url_env, token_env):
+    monkeypatch.setattr(scoped_access, "scoped_env_from_request", lambda: url_env)
+    monkeypatch.setattr(scoped_access, "env_from_access_token", lambda: token_env)
+
+
+def _tools():
+    return [
+        _FakeTool(
+            "pull_and_apply",
+            {"properties": {"env_name": {}, "install": {}}, "required": ["env_name"]},
+        ),
+        _FakeTool("get_agent_instructions", {"properties": {}}),
+        _FakeTool("delete_environment", {"properties": {"env_name": {}}}),
+    ]
+
+
+def _middleware():
+    return ScopedAccessMiddleware(env_param_tools={"pull_and_apply"})
+
+
+async def _list_next(_ctx):
+    return _tools()
+
+
+class _Msg:
+    def __init__(self, name, arguments):
+        self.name = name
+        self.arguments = arguments
+
+
+class _Ctx:
+    def __init__(self, name, arguments=None):
+        self.message = _Msg(name, arguments if arguments is not None else {})
+
+
+async def _call_next(ctx):
+    return ("called", ctx.message.name, ctx.message.arguments)
+
+
+def test_list_full_mode_unchanged(monkeypatch):
+    _scope(monkeypatch, None, None)
+    result = _run(_middleware().on_list_tools(object(), _list_next))
+    assert [t.name for t in result] == [
+        "pull_and_apply",
+        "get_agent_instructions",
+        "delete_environment",
+    ]
+
+
+def test_list_scoped_filters_and_strips(monkeypatch):
+    _scope(monkeypatch, "main", None)
+    result = _run(_middleware().on_list_tools(object(), _list_next))
+    assert [t.name for t in result] == ["pull_and_apply", "get_agent_instructions"]
+    pa = next(t for t in result if t.name == "pull_and_apply")
+    assert "env_name" not in pa.parameters["properties"]
+    assert pa.parameters["required"] == []
+
+
+def test_list_deny_returns_empty(monkeypatch):
+    _scope(monkeypatch, None, "main")  # env token at root
+    assert _run(_middleware().on_list_tools(object(), _list_next)) == []
+
+
+def test_call_scoped_injects_env(monkeypatch):
+    _scope(monkeypatch, "main", None)
+    ctx = _Ctx("pull_and_apply", {"install": ["sale"]})
+    res = _run(_middleware().on_call_tool(ctx, _call_next))
+    assert ctx.message.arguments["env_name"] == "main"
+    assert ctx.message.arguments["install"] == ["sale"]
+    assert res[0] == "called"
+
+
+def test_call_scoped_no_env_param_not_injected(monkeypatch):
+    _scope(monkeypatch, "main", None)
+    ctx = _Ctx("get_agent_instructions", {})
+    _run(_middleware().on_call_tool(ctx, _call_next))
+    assert "env_name" not in ctx.message.arguments
+
+
+def test_call_scoped_rejects_non_allowlisted(monkeypatch):
+    _scope(monkeypatch, "main", None)
+    ctx = _Ctx("delete_environment", {})
+    with pytest.raises(ToolError):
+        _run(_middleware().on_call_tool(ctx, _call_next))
+
+
+def test_call_deny_rejects(monkeypatch):
+    _scope(monkeypatch, "a", "b")  # cross-env
+    ctx = _Ctx("pull_and_apply", {})
+    with pytest.raises(ToolError):
+        _run(_middleware().on_call_tool(ctx, _call_next))
+
+
+def test_call_full_mode_passthrough(monkeypatch):
+    _scope(monkeypatch, None, None)
+    ctx = _Ctx("delete_environment", {})
+    res = _run(_middleware().on_call_tool(ctx, _call_next))
+    assert res[0] == "called"
+
+
+# --- OduflowTokenVerifier --------------------------------------------------
+
+
+def _settings() -> Settings:
+    return Settings(
+        teams={
+            "1": TeamSettings(
+                team_id="1",
+                auth_token="team-tok",
+                port_range_start=50000,
+                port_range_end=50100,
+            ),
+        }
+    )
+
+
+def test_token_verifier(monkeypatch):
+    mapping = {"team-tok": ("1", None), "env-tok": ("2", "envx")}
+    monkeypatch.setattr(
+        scoped_access.env_tokens,
+        "resolve_token",
+        lambda settings, token: mapping.get(token),
+    )
+    v = OduflowTokenVerifier(_settings())
+
+    team_at = _run(v.verify_token("team-tok"))
+    assert team_at is not None
+    assert team_at.client_id == "1"
+    assert team_at.scopes == []
+
+    env_at = _run(v.verify_token("env-tok"))
+    assert env_at is not None
+    assert env_at.client_id == "2"
+    assert env_at.scopes == ["oduflow_env:envx"]
+
+    assert _run(v.verify_token("nope")) is None
+
+
+# --- env_ops.get_env_token -------------------------------------------------
+
+
+def test_get_env_token_uses_team_scoped_container_name(monkeypatch):
+    from oduflow.naming import get_resource_name
+
+    captured = {}
+
+    class _Container:
+        labels = {"oduflow.mcp_token": "sekret"}
+
+    class _Containers:
+        def get(self, name):
+            captured["name"] = name
+            return _Container()
+
+    class _Client:
+        containers = _Containers()
+
+    monkeypatch.setattr(env_ops, "get_client", lambda: _Client())
+    settings = Settings(prefix="oduflow-", teams={"7": TeamSettings(team_id="7")})
+    team = settings.teams["7"]
+
+    assert env_ops.get_env_token(settings, team, "feature/x") == "sekret"
+    # The container name must be team-scoped (team_id in the name); a missing
+    # team_id would raise TypeError from get_resource_name.
+    assert captured["name"] == get_resource_name("feature/x", "odoo", "oduflow-", "7")
+
+
+# --- web_ui /mcp-access endpoint -------------------------------------------
+
+
+def _ui_settings() -> Settings:
+    return Settings(
+        base_data_dir=tempfile.mkdtemp(prefix="oduflow-mcpacc-"),
+        teams={"1": TeamSettings(team_id="1")},  # no ui_password -> open
+    )
+
+
+def _ui_client(settings) -> TestClient:
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def test_mcp_access_endpoint_returns_url_and_token(monkeypatch):
+    settings = _ui_settings()
+    monkeypatch.setattr(env_ops, "get_env_token", lambda s, t, e: "the-secret")
+    resp = _ui_client(settings).get("/api/environments/feature%2Fx/mcp-access")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["result"]["token"] == "the-secret"
+    assert data["result"]["url"].endswith("/mcp/feature/x")
+
+
+def test_mcp_access_endpoint_token_missing(monkeypatch):
+    settings = _ui_settings()
+    monkeypatch.setattr(env_ops, "get_env_token", lambda s, t, e: None)
+    resp = _ui_client(settings).get("/api/environments/main/mcp-access")
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["result"]["token"] is None
+    assert data["result"]["url"].endswith("/mcp/main")
+
+
+def test_mcp_access_endpoint_unknown_env(monkeypatch):
+    settings = _ui_settings()
+
+    def _raise(s, t, e):
+        raise NotFoundError("Environment 'ghost' does not exist.")
+
+    monkeypatch.setattr(env_ops, "get_env_token", _raise)
+    resp = _ui_client(settings).get("/api/environments/ghost/mcp-access")
+    data = resp.json()
+    assert data["ok"] is False


### PR DESCRIPTION
Adds a scoped MCP endpoint `/mcp/<env>` that exposes only the in-environment dev-loop tools (sync, install/upgrade modules, tests, Odoo shell, SQL, file read/write/search, HTTP request, logs, info, restart) while denying all lifecycle and system tools by default. Access is isolated by a per-environment token generated at creation time and stored in the `oduflow.mcp_token` container label, usable as a Bearer token or an OAuth client credential — surfaced in the dashboard via **More → MCP Access** (URL + Secret Key). Enforcement is a default-deny FastMCP middleware (allowlist + server-side `env_name` injection, applied to both `tools/list` and `tools/call`) plus an outer ASGI shim that routes `/mcp/<env>` to the canonical `/mcp` route, so no second server or duplicated tools are needed. Env-token resolution is rate-limited and offloaded off the event loop (`anyio.to_thread`) to avoid a DoS from invalid-token floods at the public HTTP endpoint. Includes decision record `specs/0028`, docs in `docs/security.md`, and unit tests.