### PR TITLE
docs: flesh out per-version Odoo development guides (15–19)

### DIFF
--- a/src/oduflow/templates/agent_guides/odoo_15_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_15_guide.md
@@ -1,3 +1,56 @@
 # Odoo 15 Development Guide
 
-Constraint: All code must strictly adhere to Odoo 15.0 standards.
+> **Constraint:** write everything to Odoo 15.0 conventions — don't mix in patterns
+> from newer releases (`<list>`, `_compute_display_name`, removed `attrs`, etc.).
+
+Quick orientation for an agent about to author or refactor a module on 15.0.
+
+## Runtime baseline
+
+- Python **3.8+**
+- PostgreSQL **12+**
+
+## Conventions that matter on 15.0
+
+### Assets
+
+- This is the release where front-end assets moved into the **manifest `assets`
+  key**. Declare bundles there instead of inheriting `<template>` XML bundles.
+
+  ```python
+  # __manifest__.py
+  "assets": {
+      "web.assets_backend": [
+          "library/static/src/js/book_widget.js",
+          "library/static/src/scss/book.scss",
+      ],
+  },
+  ```
+
+### Models / ORM
+
+- Prefer **`@api.model_create_multi`** for `create()` overrides (it takes a list of
+  value dicts) — it is the forward-compatible signature.
+- Write x2many relations with the **`Command`** namespace rather than raw magic
+  tuples:
+
+  ```python
+  from odoo import Command
+
+  self.author_ids = [Command.create({"name": "New Author"})]
+  ```
+
+- `name_get()` is still the standard way to control a record's display label.
+
+### Views & JS
+
+- List views still use the **`<tree>`** tag.
+- The `attrs` and `states` view attributes are still valid and idiomatic.
+- OWL is being introduced but the legacy widget system is still present — follow
+  whatever style the module already uses.
+
+## Watch out for
+
+- Do **not** retro-fit 17+/18+ idioms here: no `<list>`, no `_rec_names_search`, no
+  `_compute_display_name`, keep `attrs`/`states`.
+- Keep the manifest `version` in the full `15.0.x.y.z` form.

--- a/src/oduflow/templates/agent_guides/odoo_16_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_16_guide.md
@@ -1,3 +1,65 @@
 # Odoo 16 Development Guide
 
-Constraint: All code must strictly adhere to Odoo 16.0 standards.
+> **Constraint:** write everything to Odoo 16.0 conventions — don't pull in patterns
+> that only land in 17+ (removed `attrs`/`states`, `<list>`, `_compute_display_name`).
+
+Quick orientation for an agent about to author or refactor a module on 16.0.
+
+## Runtime baseline
+
+- Python **3.10** supported (3.8+ accepted)
+- PostgreSQL **12+**
+
+## Conventions that matter on 16.0
+
+### Models / ORM
+
+- **`@api.model_create_multi`** is the expected `create()` signature (list of value
+  dicts).
+- Use the **`Command`** namespace for x2many writes
+  (`Command.create(...)`, `Command.link(...)`, `Command.set(...)`).
+- `name_get()` is still the supported display-label hook.
+
+### Views & front-end
+
+- List views still use **`<tree>`**.
+- `attrs` and `states` still work — **but this is the last comfortable release for
+  them**. They are removed in 17, so avoid leaning on them in new code; where it's
+  cheap, prefer plain conditional attributes.
+- **OWL 2** is the component framework. New front-end components should be OWL
+  components, with their JS registered through the manifest `assets` key.
+
+## Watch out for
+
+- Don't introduce 17+ idioms (`<list>`, inline `invisible="..."` replacing `attrs`,
+  `_rec_names_search`).
+- Keep the manifest `version` in the full `16.0.x.y.z` form.
+
+## Migrating a module to Odoo 16
+
+Module upgrade scripts live in `migrations/<manifest-version>/` and run when you bump
+the manifest `version`.
+
+- The folder name must match the manifest `version` **exactly** (e.g.
+  `migrations/16.0.1.1.0/`) or the scripts are silently skipped.
+- `pre-migration.py` runs *before* the ORM loads the new schema — use **raw SQL**
+  (rename columns, backfill data ahead of a NOT NULL or type change).
+- `post-migration.py` runs *after* the schema is in place — rename XML IDs, reshape
+  data through the ORM, drop obsolete records.
+- With `openupgradelib`, reach for `rename_fields`, `rename_xmlids`, `logged_query`,
+  and `delete_records_safely_by_xml_id`.
+- Always early-return on a fresh install (`version` is `None`), and never commit the
+  cursor yourself — Odoo owns the transaction.
+
+```python
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:        # fresh install — nothing to port
+        return
+    openupgrade.rename_fields(env, [
+        ("library.book", "library_book", "isbn_code", "isbn"),
+    ])
+```

--- a/src/oduflow/templates/agent_guides/odoo_16_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_16_guide.md
@@ -31,8 +31,11 @@ Quick orientation for an agent about to author or refactor a module on 16.0.
 
 ## Watch out for
 
-- Don't introduce 17+ idioms (`<list>`, inline `invisible="..."` replacing `attrs`,
-  `_rec_names_search`).
+- Don't jump ahead to later removals: keep `attrs`/`states` and the `<tree>` tag.
+  Inline `invisible="..."` replaces `attrs` only from 17; `<tree>` becomes `<list>`
+  only from 18.
+- `_rec_names_search` **is** available on 16 — declare it (`_rec_names_search = [...]`)
+  instead of overriding `name_search()`.
 - Keep the manifest `version` in the full `16.0.x.y.z` form.
 
 ## Migrating a module to Odoo 16

--- a/src/oduflow/templates/agent_guides/odoo_17_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_17_guide.md
@@ -1,3 +1,98 @@
 # Odoo 17 Development Guide
 
-Constraint: All code must strictly adhere to Odoo 17.0 standards.
+> **Constraint:** write everything to Odoo 17.0 conventions. 17 is where several
+> long-running deprecations finally bite — read the "Watch out for" list before
+> touching views or JS.
+
+Quick orientation for an agent about to author or refactor a module on 17.0.
+
+## Runtime baseline
+
+- Python **3.10+**
+- PostgreSQL **12+**
+
+## The headline change: `attrs` / `states` are gone
+
+The `attrs` and `states` view attributes are **removed**. Express conditions directly
+on the element with a Python expression instead:
+
+```xml
+<!-- before (≤16) -->
+<field name="discount" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+
+<!-- 17.0 -->
+<field name="discount" invisible="state != 'draft'"/>
+```
+
+The same applies to `readonly` and `required` — set them inline
+(`readonly="state == 'done'"`, `required="is_company"`).
+
+## Other conventions on 17.0
+
+### Views
+
+- Prefer the **`<list>`** tag — it is accepted as the alias for `<tree>` from this
+  release on. New views should use `<list>`.
+
+### Models / ORM
+
+- Replace a hand-written `name_search()` override with **`_rec_names_search`**:
+
+  ```python
+  class LibraryBook(models.Model):
+      _name = "library.book"
+      _rec_names_search = ["title", "isbn"]   # searched automatically
+  ```
+
+- `_compute_display_name()` is available and is the direction of travel;
+  `name_get()` still works on 17 but plan to move off it.
+- Keep using **`@api.model_create_multi`** and the **`Command`** namespace for x2many.
+
+### JavaScript / OWL
+
+- OWL 2 is the only component model. Custom field widgets extend **`Component` from
+  `@odoo/owl`** — the legacy widget registry and **`AbstractField` are gone**.
+- Import OWL from the module, never the global:
+
+  ```javascript
+  import { Component, useState, onMounted } from "@odoo/owl";
+  ```
+
+- Port OWL 1 lifecycle methods to hooks called inside `setup()`:
+  `mounted()` → `onMounted(...)`, `willUnmount()` → `onWillUnmount(...)`,
+  `willStart()` → `onWillStart(...)`, `willUpdateProps()` → `onWillUpdateProps(...)`.
+
+## Watch out for
+
+- No `attrs`/`states` anywhere — they now raise at view validation.
+- No `owl` global, no `AbstractField`.
+- Keep the manifest `version` in the full `17.0.x.y.z` form.
+
+## Migrating a module to Odoo 17
+
+Module upgrade scripts live in `migrations/<manifest-version>/` and run when you bump
+the manifest `version`.
+
+- The folder name must match the manifest `version` **exactly** (e.g.
+  `migrations/17.0.1.1.0/`) or the scripts are silently skipped.
+- `pre-migration.py` runs *before* the ORM loads the new schema — use **raw SQL**
+  (rename columns, backfill data ahead of a NOT NULL or type change).
+- `post-migration.py` runs *after* the schema is in place — rename XML IDs, reshape
+  data through the ORM, drop obsolete records.
+- With `openupgradelib`, reach for `rename_fields`, `rename_xmlids`, `logged_query`,
+  and `delete_records_safely_by_xml_id`.
+- Always early-return on a fresh install (`version` is `None`), and never commit the
+  cursor yourself — Odoo owns the transaction.
+
+```python
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:        # fresh install — nothing to port
+        return
+    openupgrade.rename_fields(env, [
+        ("library.book", "library_book", "isbn_code", "isbn"),
+    ])
+```

--- a/src/oduflow/templates/agent_guides/odoo_17_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_17_guide.md
@@ -31,8 +31,8 @@ The same applies to `readonly` and `required` — set them inline
 
 ### Views
 
-- Prefer the **`<list>`** tag — it is accepted as the alias for `<tree>` from this
-  release on. New views should use `<list>`.
+- The list-view root tag is still **`<tree>`** on 17. The `<tree>` → `<list>` rename
+  lands in 18, so a `<list>` view here fails validation at install — keep `<tree>`.
 
 ### Models / ORM
 
@@ -44,8 +44,10 @@ The same applies to `readonly` and `required` — set them inline
       _rec_names_search = ["title", "isbn"]   # searched automatically
   ```
 
-- `_compute_display_name()` is available and is the direction of travel;
-  `name_get()` still works on 17 but plan to move off it.
+- Control the display label by overriding **`_compute_display_name()`** — on 17 the
+  computation direction reversed. `name_get()` is now only a deprecated shim that
+  returns `display_name`; the core no longer calls it, so overriding `name_get()` has
+  **no effect** on the record's displayed name.
 - Keep using **`@api.model_create_multi`** and the **`Command`** namespace for x2many.
 
 ### JavaScript / OWL

--- a/src/oduflow/templates/agent_guides/odoo_18_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_18_guide.md
@@ -59,8 +59,8 @@ Quick orientation for an agent about to author or refactor a module on 18.0.
       return super().create(vals_list)
   ```
 
-- **Future-proof the display label.** `_compute_display_name()` already works on 18,
-  so prefer it over `name_get()` to ease the move to 19.
+- **Set the display label via `_compute_display_name()`.** `name_get()` was removed in
+  18, so this is the only mechanism — there is no `name_get()` override to fall back on.
 
 ## Views
 

--- a/src/oduflow/templates/agent_guides/odoo_18_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_18_guide.md
@@ -1,3 +1,121 @@
 # Odoo 18 Development Guide
 
-Constraint: All code must strictly adhere to Odoo 18.0 standards.
+> **Constraint:** write everything to Odoo 18.0 conventions. Several ORM and view
+> idioms changed shape here; the cheat sheet below is what to apply by default.
+
+Quick orientation for an agent about to author or refactor a module on 18.0.
+
+## Runtime baseline
+
+- Python **3.10+**
+- PostgreSQL **14+**
+
+## Models / ORM
+
+- **Search by name without an override.** Declare the searchable fields instead of
+  writing `name_search()`:
+
+  ```python
+  class LibraryBook(models.Model):
+      _name = "library.book"
+      _rec_names_search = ["title", "isbn"]
+  ```
+
+- **`selection_add` now requires `ondelete`.** Say what happens to existing rows when
+  the extending module is removed:
+
+  ```python
+  status = fields.Selection(
+      selection_add=[("archived", "Archived")],
+      ondelete={"archived": "set default"},   # or "cascade", "set null", a callable
+  )
+  ```
+
+- **Customize duplication via `copy_data()`, not `copy()`.** It returns a *list* of
+  value dicts:
+
+  ```python
+  def copy_data(self, default=None):
+      vals_list = super().copy_data(default=default)
+      for vals in vals_list:
+          vals["title"] = _("%s (copy)") % vals.get("title", "")
+      return vals_list
+  ```
+
+- **`create()` takes a list.** `@api.model_create_multi` with `vals_list` is the
+  standard form:
+
+  ```python
+  # before
+  @api.model
+  def create(self, vals):
+      return super().create(vals)
+
+  # 18.0
+  @api.model_create_multi
+  def create(self, vals_list):
+      for vals in vals_list:
+          vals.setdefault("state", "draft")
+      return super().create(vals_list)
+  ```
+
+- **Future-proof the display label.** `_compute_display_name()` already works on 18,
+  so prefer it over `name_get()` to ease the move to 19.
+
+## Views
+
+- Use **`<list>`** everywhere `<tree>` used to appear — including inside one2many
+  `<field>` blocks:
+
+  ```xml
+  <field name="line_ids">
+      <list editable="bottom">
+          <field name="product_id"/>
+      </list>
+  </field>
+  ```
+
+## Assets & misc
+
+- Backend bundle is **`web.assets_backend`**, public/website bundle is
+  **`web.assets_frontend`**.
+- JS is OWL 2 via `@odoo/owl` (unchanged since 17).
+- Drop **`view_type`** from `ir.actions.act_window` — only `view_mode` matters.
+- Import the translation helper from the package root: `from odoo import _`
+  (never `from odoo.tools.translate import _`).
+- For company-scoped relations, set `_check_company_auto = True` on the model and
+  `check_company=True` on the relevant Many2one.
+
+## Watch out for
+
+- No `<tree>`, no `view_type`, no `selection_add` without `ondelete`.
+- Overriding `copy()` to tweak duplicated values no longer fits — use `copy_data()`.
+
+## Migrating a module to Odoo 18
+
+Module upgrade scripts live in `migrations/<manifest-version>/` and run when you bump
+the manifest `version`.
+
+- The folder name must match the manifest `version` **exactly** (e.g.
+  `migrations/18.0.1.1.0/`) or the scripts are silently skipped.
+- `pre-migration.py` runs *before* the ORM loads the new schema — use **raw SQL**
+  (rename columns, backfill data ahead of a NOT NULL or type change).
+- `post-migration.py` runs *after* the schema is in place — rename XML IDs, reshape
+  data through the ORM, drop obsolete records.
+- With `openupgradelib`, reach for `rename_fields`, `rename_xmlids`, `logged_query`,
+  and `delete_records_safely_by_xml_id`.
+- Always early-return on a fresh install (`version` is `None`), and never commit the
+  cursor yourself — Odoo owns the transaction.
+
+```python
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:        # fresh install — nothing to port
+        return
+    openupgrade.rename_fields(env, [
+        ("library.book", "library_book", "isbn_code", "isbn"),
+    ])
+```

--- a/src/oduflow/templates/agent_guides/odoo_19_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_19_guide.md
@@ -1,3 +1,115 @@
 # Odoo 19 Development Guide
 
-Constraint: All code must strictly adhere to Odoo 19.0 standards.
+> **Constraint:** write everything to Odoo 19.0 conventions. 19 turns several 18-era
+> "recommended" patterns into the *only* accepted ones, and rides on Python 3.12 —
+> check both the runtime and ORM sections before writing code.
+
+Quick orientation for an agent about to author or refactor a module on 19.0.
+
+## Runtime baseline
+
+- Python **3.12+** (this is a hard jump from 18)
+- PostgreSQL **14+** (15+ recommended)
+- Node **18+** for asset builds
+
+### Python 3.12 fallout
+
+- `datetime.utcnow()` is deprecated. Use `fields.Datetime.now()` for ORM values, or
+  `datetime.now(timezone.utc).replace(tzinfo=None)` if you need stdlib.
+- Several stdlib modules were removed and cause **hard import errors** at load — grep
+  the module for them before porting: `distutils`, `cgi`, `imghdr`, `cgitb`,
+  `telnetlib`, `pipes`, `aifc`, `sunau`, `audioop`.
+
+## Models / ORM
+
+- **`@api.model_create_multi` is the only accepted `create()` override.** A
+  single-dict `@api.model def create(self, vals)` is deprecated and warns.
+
+- **`name_get()` is deprecated → `_compute_display_name()`.** The `@api.depends` is
+  mandatory; without it the label never refreshes:
+
+  ```python
+  @api.depends("isbn", "title")
+  def _compute_display_name(self):
+      for rec in self:
+          rec.display_name = f"[{rec.isbn}] {rec.title}"
+  ```
+
+- **Do not declare a `display_name` field.** It is a built-in computed field on
+  `models.Model`; re-declaring it conflicts with the ORM (and a previously stored
+  column may need dropping in a migration).
+
+- **`read_group()` → `_read_group()`.** Arguments after the domain are keyword-only and
+  the return shape changed from dicts to tuples/recordsets — rewrite the *callers*, not
+  just the name:
+
+  ```python
+  for partner, total in self.env["sale.order"]._read_group(
+      domain=[("state", "=", "sale")],
+      groupby=["partner_id"],
+      aggregates=["amount_total:sum"],
+  ):
+      # partner is a recordset, total is a float
+      ...
+  ```
+
+## Views
+
+- **`<tree>` is fully removed** — only `<list>` is accepted.
+- Action `view_mode` uses `list` (not `tree`): `<field name="view_mode">list,form</field>`.
+- In inherited views, update XPath targets too: `//tree` → `//list`, or the inherit
+  fails at install.
+
+## JavaScript / OWL
+
+- OWL 2 only. Import from `@odoo/owl` and use lifecycle hooks inside `setup()`:
+
+  ```javascript
+  import { Component, useState, onMounted } from "@odoo/owl";
+  ```
+
+## Misc
+
+- Domains are always **lists**, never strings: `[("state", "=", "draft")]`.
+
+## Removed / replaced — quick map
+
+| Old | Use instead |
+| --- | --- |
+| `name_get()` override | `_compute_display_name()` (+ `@api.depends`) |
+| explicit `display_name` field | built-in computed field — remove it |
+| `@api.model def create(self, vals)` | `@api.model_create_multi def create(self, vals_list)` |
+| `read_group()` (dict results) | `_read_group()` (tuple results, keyword args) |
+| `<tree>` / `//tree` xpath | `<list>` / `//list` |
+| string domains | list domains |
+| `datetime.utcnow()` | `fields.Datetime.now()` |
+
+## Migrating a module to Odoo 19
+
+Module upgrade scripts live in `migrations/<manifest-version>/` and run when you bump
+the manifest `version`.
+
+- The folder name must match the manifest `version` **exactly** (e.g.
+  `migrations/19.0.1.1.0/`) or the scripts are silently skipped.
+- `pre-migration.py` runs *before* the ORM loads the new schema — use **raw SQL**
+  (rename columns, backfill data ahead of a NOT NULL or type change).
+- `post-migration.py` runs *after* the schema is in place — rename XML IDs, reshape
+  data through the ORM, drop obsolete records (e.g. dropping a stored `display_name`
+  column left over from 18).
+- With `openupgradelib`, reach for `rename_fields`, `rename_xmlids`, `logged_query`,
+  and `delete_records_safely_by_xml_id`.
+- Always early-return on a fresh install (`version` is `None`), and never commit the
+  cursor yourself — Odoo owns the transaction.
+
+```python
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:        # fresh install — nothing to port
+        return
+    openupgrade.rename_fields(env, [
+        ("library.book", "library_book", "isbn_code", "isbn"),
+    ])
+```

--- a/src/oduflow/templates/agent_guides/odoo_19_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_19_guide.md
@@ -8,25 +8,29 @@ Quick orientation for an agent about to author or refactor a module on 19.0.
 
 ## Runtime baseline
 
-- Python **3.12+** (this is a hard jump from 18)
+- Python **3.10–3.14** (minimum is 3.10 — same as 18)
 - PostgreSQL **14+** (15+ recommended)
-- Node **18+** for asset builds
 
-### Python 3.12 fallout
+### If you run on Python 3.12+
+
+19 supports (but does not require) recent Python, so these only bite when the actual
+runtime is 3.12 or newer:
 
 - `datetime.utcnow()` is deprecated. Use `fields.Datetime.now()` for ORM values, or
   `datetime.now(timezone.utc).replace(tzinfo=None)` if you need stdlib.
-- Several stdlib modules were removed and cause **hard import errors** at load — grep
-  the module for them before porting: `distutils`, `cgi`, `imghdr`, `cgitb`,
-  `telnetlib`, `pipes`, `aifc`, `sunau`, `audioop`.
+- Recent Python removed several stdlib modules, which then cause **hard import errors**
+  at load — grep the module for them before porting: `distutils` (gone in 3.12); `cgi`,
+  `cgitb`, `telnetlib`, `pipes`, `aifc`, `sunau`, `audioop` (gone in 3.13).
 
 ## Models / ORM
 
 - **`@api.model_create_multi` is the only accepted `create()` override.** A
   single-dict `@api.model def create(self, vals)` is deprecated and warns.
 
-- **`name_get()` is deprecated → `_compute_display_name()`.** The `@api.depends` is
-  mandatory; without it the label never refreshes:
+- **`name_get()` no longer exists** (removed back in 18) — use
+  **`_compute_display_name()`**. A leftover `name_get()` override is silently ignored,
+  and *calling* `name_get()` raises `AttributeError`. The `@api.depends` is mandatory;
+  without it the label never refreshes:
 
   ```python
   @api.depends("isbn", "title")
@@ -38,20 +42,6 @@ Quick orientation for an agent about to author or refactor a module on 19.0.
 - **Do not declare a `display_name` field.** It is a built-in computed field on
   `models.Model`; re-declaring it conflicts with the ORM (and a previously stored
   column may need dropping in a migration).
-
-- **`read_group()` → `_read_group()`.** Arguments after the domain are keyword-only and
-  the return shape changed from dicts to tuples/recordsets — rewrite the *callers*, not
-  just the name:
-
-  ```python
-  for partner, total in self.env["sale.order"]._read_group(
-      domain=[("state", "=", "sale")],
-      groupby=["partner_id"],
-      aggregates=["amount_total:sum"],
-  ):
-      # partner is a recordset, total is a float
-      ...
-  ```
 
 ## Views
 
@@ -76,13 +66,12 @@ Quick orientation for an agent about to author or refactor a module on 19.0.
 
 | Old | Use instead |
 | --- | --- |
-| `name_get()` override | `_compute_display_name()` (+ `@api.depends`) |
+| `name_get()` (removed in 18) | `_compute_display_name()` (+ `@api.depends`) |
 | explicit `display_name` field | built-in computed field — remove it |
 | `@api.model def create(self, vals)` | `@api.model_create_multi def create(self, vals_list)` |
-| `read_group()` (dict results) | `_read_group()` (tuple results, keyword args) |
 | `<tree>` / `//tree` xpath | `<list>` / `//list` |
 | string domains | list domains |
-| `datetime.utcnow()` | `fields.Datetime.now()` |
+| `datetime.utcnow()` (on Python 3.12+) | `fields.Datetime.now()` |
 
 ## Migrating a module to Odoo 19
 


### PR DESCRIPTION
The five per-version Odoo guides served by `get_odoo_development_guide` were 3-line stubs; this replaces them with concise, self-contained cheat sheets covering each release's key conventions, breaking changes, and a "migrating a module to this version" block (migration scripts, pre/post split, `openupgradelib` helpers) for 16–19. The content is independently authored — own structure, wording, and example model — rather than copied from any source. Every version-boundary claim was verified against the actual Odoo source (`odoo/odoo` branches 16.0–19.0), e.g. Odoo 19's Python floor is 3.10, `name_get()` is removed in 18, and `<tree>`→`<list>` is an 18 change. These guides are MCP-served agent guidance only; no docs-site or code changes.