### PR TITLE
fix: write Traefik dynamic config as .yml (file provider rejects .json)

### DIFF
--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -165,6 +165,9 @@ def _write_traefik_dynamic_config(settings: Settings, config_path: str) -> None:
     # Written to a ``.yml`` file: Traefik's file provider only accepts
     # .toml/.yaml/.yml (it rejects .json), and JSON is a valid subset of YAML,
     # so json.dump output parses fine. Do not switch the extension back to .json.
+    parent = os.path.dirname(config_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     with open(config_path, "w") as f:
         json.dump(config, f, indent=2)
     logger.info("Traefik dynamic config written to %s", config_path)
@@ -182,7 +185,11 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
         client.volumes.create(settings.traefik_acme_volume, labels=system_labels)
         logger.info("Created volume %s", settings.traefik_acme_volume)
 
-    traefik_config = "/etc/oduflow/traefik.yml"
+    # Host path for the dynamic config, bind-mounted into the container below.
+    # Use the resolved config dir (``/etc/oduflow`` when writable, else
+    # ``~/.oduflow/conf``) so it works without root on macOS and lands under a
+    # path Docker Desktop shares — same placement as postgresql.conf.
+    traefik_config = os.path.join(settings.etc_dir, "traefik.yml")
     _write_traefik_dynamic_config(settings, traefik_config)
 
     try:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -162,6 +162,9 @@ def _write_traefik_dynamic_config(settings: Settings, config_path: str) -> None:
         }
     }
 
+    # Written to a ``.yml`` file: Traefik's file provider only accepts
+    # .toml/.yaml/.yml (it rejects .json), and JSON is a valid subset of YAML,
+    # so json.dump output parses fine. Do not switch the extension back to .json.
     with open(config_path, "w") as f:
         json.dump(config, f, indent=2)
     logger.info("Traefik dynamic config written to %s", config_path)
@@ -179,7 +182,7 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
         client.volumes.create(settings.traefik_acme_volume, labels=system_labels)
         logger.info("Created volume %s", settings.traefik_acme_volume)
 
-    traefik_config = "/etc/oduflow/traefik.json"
+    traefik_config = "/etc/oduflow/traefik.yml"
     _write_traefik_dynamic_config(settings, traefik_config)
 
     try:
@@ -200,13 +203,13 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
         volumes={
             "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "ro"},
             settings.traefik_acme_volume: {"bind": "/acme", "mode": "rw"},
-            traefik_config: {"bind": "/etc/traefik/dynamic/oduflow.json", "mode": "ro"},
+            traefik_config: {"bind": "/etc/traefik/dynamic/oduflow.yml", "mode": "ro"},
         },
         command=[
             "--log.level=INFO",
             "--providers.docker=true",
             "--providers.docker.exposedbydefault=false",
-            "--providers.file.filename=/etc/traefik/dynamic/oduflow.json",
+            "--providers.file.filename=/etc/traefik/dynamic/oduflow.yml",
             "--providers.file.watch=true",
             "--entrypoints.web.address=:80",
             "--entrypoints.websecure.address=:443",

--- a/src/oduflow/migrations.py
+++ b/src/oduflow/migrations.py
@@ -303,6 +303,41 @@ def _migrate_env_resource_limits(settings: Settings) -> None:
                 )
 
 
+def _migrate_traefik_yml_config(settings: Settings) -> None:
+    """Recreate Traefik if it still mounts the old ``.json`` dynamic config.
+
+    Traefik's file provider only accepts ``.toml``/``.yaml``/``.yml`` and
+    rejects ``.json`` ("unsupported file extension"), so the dynamic config is
+    now written to ``oduflow.yml``. ``_ensure_traefik`` early-returns on an
+    existing container and never rewrites its args, so the stale container is
+    removed here (the ACME volume persists → certificates survive) and system
+    init recreates it right after migrations with the corrected ``.yml`` path.
+    Idempotent: once recreated the arg is ``.yml``, so a rerun finds nothing.
+    """
+    import docker
+
+    from oduflow.docker_ops.client import get_client
+
+    if settings.routing_mode != "traefik":
+        return
+
+    client = get_client()
+    old_arg = "--providers.file.filename=/etc/traefik/dynamic/oduflow.json"
+    try:
+        traefik = client.containers.get(settings.traefik_container)
+        cmd = traefik.attrs.get("Config", {}).get("Cmd") or []
+        if any(str(arg) == old_arg for arg in cmd):
+            logger.info(
+                "Removing %s (stale .json dynamic config); system init "
+                "recreates it with oduflow.yml",
+                settings.traefik_container,
+            )
+            traefik.stop()
+            traefik.remove()
+    except docker.errors.NotFound:
+        pass
+
+
 # Append-only registry, executed in list order. Ids are recorded in
 # migrations.json once applied; reordering or renaming entries would re-run
 # or skip steps on existing installs.
@@ -338,6 +373,14 @@ MIGRATIONS: list[Migration] = [
             "containers via docker update"
         ),
         apply=_migrate_env_resource_limits,
+    ),
+    Migration(
+        id="0005-traefik-yml-dynamic-config",
+        description=(
+            "Recreate Traefik if it still mounts the old .json dynamic config "
+            "(file provider rejects .json); init recreates it with oduflow.yml"
+        ),
+        apply=_migrate_traefik_yml_config,
     ),
 ]
 


### PR DESCRIPTION
Traefik's file provider only accepts `.toml`/`.yaml`/`.yml` and rejects `.json` ("unsupported file extension for file /etc/traefik/dynamic/oduflow.json"), so the dynamic config routing each team's hostname to the Oduflow dashboard was never loaded. This writes it to `oduflow.yml` instead — JSON is a valid subset of YAML, so the existing `json.dump` output parses fine and no new dependency is needed.

It also adds migration `0005` to recreate an already-running Traefik container still mounting the old `.json` path: `_ensure_traefik` early-returns on an existing container and never rewrites its args, so the stale container is removed (the ACME volume persists, so certificates survive) and system init recreates it with the corrected `.yml` path on the next start. Docker-provider environment routing is unaffected; only the dashboard hostname routing via the file provider was broken.

Verified with `ruff check`/`ruff format --check` (clean) and the full unit suite (`pytest -m "not integration and not heavyweight"`, 625 passed).