### PR TITLE
Agent follow-up: address Greptile review on #99

### DIFF
--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -94,6 +94,10 @@ log "base Codex config written (MCP wiring is per session)"
 # present, ANTHROPIC_API_KEY MUST be unset or it wins by precedence. With no
 # credential at all, an interactive `claude` login persists to the home volume.
 if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+    # ANTHROPIC_API_KEY is already excluded from the container env by
+    # _agent_env_vars() in env_ops.py; this unset is belt-and-suspenders for
+    # the entrypoint's own shell only (docker exec sessions inherit the
+    # container-level env, which already lacks the key).
     unset ANTHROPIC_API_KEY || true
     log "Claude auth: subscription (CLAUDE_CODE_OAUTH_TOKEN)"
 elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then

--- a/src/oduflow/agent_sessions.py
+++ b/src/oduflow/agent_sessions.py
@@ -54,13 +54,12 @@ def _save(team: TeamSettings, data: dict[str, dict[str, str]]) -> None:
     os.makedirs(team.data_dir, exist_ok=True)
     path = _path(team)
     tmp = f"{path}.tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
+    # 0o600 from birth: os.replace carries the tmp file's mode over, so the
+    # session ids are never readable beyond the owner, even briefly.
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, sort_keys=True)
     os.replace(tmp, path)
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
 
 
 def get_session(team: TeamSettings, branch: str, agent_type: str) -> str | None:

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1469,6 +1469,12 @@ def _agent_remove_env(
 
     Best-effort; the container itself keeps running (it serves other envs).
     """
+    # A name that slugifies to nothing would make the checkout dir /workspace/
+    # itself — never rm -rf the shared volume holding every env's checkout.
+    # (clone-env.sh has the matching guard on the create side.)
+    if not slugify_branch(env_name):
+        logger.warning("Agent checkout removal skipped: empty slug for '%s'", env_name)
+        return
     try:
         container = client.containers.get(
             get_agent_container_name(team.team_id, settings.prefix)

--- a/src/oduflow/templates/static/acp-client.js
+++ b/src/oduflow/templates/static/acp-client.js
@@ -146,6 +146,10 @@
       this._emit('update', params);
     } else if (method === '_chat/error') {
       this._emit('error', (params && params.message) || 'unknown error');
+    } else if (method === '_chat/notice') {
+      // Non-fatal relay-side note (e.g. degraded MCP wiring); rendered as a
+      // system line, the session keeps going.
+      this._emit('notice', (params && params.message) || '');
     }
     // $/ping and anything else: ignore.
   };

--- a/src/oduflow/templates/static/chat.js
+++ b/src/oduflow/templates/static/chat.js
@@ -432,6 +432,7 @@
       inst.client.on('update', function (p) { handleUpdate(inst, p); });
       inst.client.on('permission', function (p) { renderPermission(inst, p.requestId, p.params); });
       inst.client.on('error', function (msg) { addErrorLine(inst, msg); });
+      inst.client.on('notice', function (msg) { if (msg) addSystemLine(inst, msg); });
       inst.client.on('close', function () { setStatus(inst, 'closed'); setBusy(inst, false); });
       return inst.client.connect().then(function () {
         return inst.client.initialize();

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2333,6 +2333,21 @@ def _build_routes(
             except Exception:
                 pass
 
+        async def _notice(msg: str) -> None:
+            """Non-fatal system line in the chat (unlike _err, keeps going)."""
+            try:
+                await websocket.send_text(
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "_chat/notice",
+                            "params": {"message": msg},
+                        }
+                    )
+                )
+            except Exception:
+                pass
+
         try:
             import docker as _docker
             from docker.utils.socket import (
@@ -2412,6 +2427,19 @@ def _build_routes(
                 )
             except Exception:
                 mcp_token = None
+            if not mcp_token:
+                await _notice(
+                    "This environment has no scoped MCP token (created before "
+                    "MCP Access existed) — the agent cannot drive it over MCP. "
+                    "Update or recreate the environment."
+                )
+            if agent_type == "codex":
+                await _notice(
+                    "Codex chat cannot reach the Oduflow MCP server yet (its "
+                    "ACP adapter has no configuration channel) — the agent can "
+                    "edit and push code, but use Claude chat or the Agent CLI "
+                    "to drive the environment."
+                )
             exec_env = {
                 "ODUFLOW_MCP_URL": env_ops.get_agent_mcp_url(settings, branch),
                 "ODUFLOW_MCP_TOKEN": mcp_token or "",

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1744,3 +1744,16 @@ class TestAgentContainer:
 
         cmd = agent.exec_run.call_args.args[0]
         assert cmd[1] == ""  # no repo URL for live-mount envs
+
+    def test_remove_env_guards_empty_slug(self, mock_docker_client):
+        # "..." slugifies to "" -> checkout dir would be /workspace/ itself;
+        # the removal must refuse rather than rm -rf the whole shared volume.
+        team = self._team()
+        agent = MagicMock()
+        mock_docker_client.containers.get.return_value = agent
+
+        env_ops._agent_remove_env(
+            mock_docker_client, self._settings(team=team), team, "..."
+        )
+
+        agent.exec_run.assert_not_called()


### PR DESCRIPTION
Follow-up to #99 (merged before this landed on the branch) — the four Greptile review findings:

- `_agent_remove_env` now refuses an environment name that slugifies to an empty string: the checkout dir would be `/workspace/` itself and `rm -rf` would wipe every environment's checkout from the shared agent volume (covered by a test).
- `agent_sessions._save` creates the temp file with mode 0600 from birth via `os.open` instead of chmod-after-rename, closing the brief default-permissions window.
- The ACP chat relay sends non-fatal `_chat/notice` frames (rendered as system lines) for two previously silent degraded modes: an environment without a scoped MCP token, and Codex chat lacking Oduflow MCP wiring.
- Clarified in `entrypoint.sh` that the real `ANTHROPIC_API_KEY` guard is `_agent_env_vars()` server-side; the shell `unset` is belt-and-suspenders only.