### PR TITLE
docs: sync docs & llms.txt/llms-full.txt with code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ mkdocs gh-deploy --force
 MCP Clients (Cursor, Claude, etc.)
         │ MCP (Streamable HTTP)
         ▼
-   server.py ── FastMCP + CLI entry point (43 tools)
+   server.py ── FastMCP + CLI entry point (MCP tools + CLI)
         │         ├── @handle_errors decorator → ToolError
         │         └── LockManager (per-branch / per-team / system) → BusyError
         ├── web_ui.py ── Starlette dashboard + REST API + Basic auth

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For full documentation, visit **[oduflow.dev](https://oduflow.dev)** or see the 
 - [Use Cases & Workflows](docs/use-cases.md)
 - [Template Management](docs/templates.md)
 - [Environment Management](docs/environments.md)
+- [Coding Agent](docs/agent.md)
 - [Auxiliary Services](docs/services.md)
 - [Extra Addons Repositories](docs/extra-addons.md)
 - [Web Dashboard & REST API](docs/web-api.md)

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,110 @@
+# Coding Agent
+
+Oduflow can host a **coding agent** for a team: an opt-in feature where the
+client grows their Odoo by chatting with an AI agent directly from the browser
+dashboard. Oduflow runs one agent container per team
+(`oduist/oduflow-coder`, bundling Claude Code + OpenAI Codex) and exposes two
+front-ends for every environment.
+
+!!! note "Hosting feature — off by default"
+    The coding agent is for **hosted** deployments. A local developer already
+    has the code and their own agents, so it is disabled unless you set
+    `agent_enabled` for the team. It is also **hidden for live-mount
+    (`local_path`) environments** — there is nothing for the containerized
+    agent to clone.
+
+## Agent CLI vs Agent Chat
+
+Both drive the same agent container over the dashboard's existing
+WebSocket ↔ `docker exec` bridge:
+
+- **Agent CLI** — the agent's own terminal UI (TUI) rendered in the browser,
+  exec'd with a PTY at the environment's git checkout. Full access to the
+  agent's native command-line experience.
+- **Agent Chat** — a structured, framework-free browser chat that speaks the
+  **Agent Client Protocol (ACP)** to the agent's adapter. Each environment has
+  a **durable session** that resumes across reloads; chats minimize to a dock,
+  so several can run in parallel. Assistant messages render as markdown, with
+  collapsible reasoning, tool-call cards, plans, and inline approve/deny
+  prompts for permission requests.
+
+## How it works
+
+The agent never touches host files. It holds one full git checkout per
+environment (at `/workspace/<slug>` in the container), edits its own clone,
+`git push`es, and then drives the environment **only through the Oduflow MCP
+server** (`pull_and_apply`, `run_odoo_tests`, etc.) — the same closed loop a
+remote MCP client uses.
+
+Lifecycle is automatic: the container is created on startup for each enabled
+team and removed for disabled ones; `create_environment` adds the environment's
+checkout, `delete_environment` removes it. The container carries a hash of its
+injected config as a label and is **recreated automatically** when the config
+changes. The only runtime state is a durable ACP-session file in the team's
+data directory.
+
+## Enabling it
+
+Configuration lives entirely in `oduflow.toml` — there is no runtime editing.
+The global `[agent]` section holds deployment-wide settings; per-team
+enablement and credentials live in the `[team.*]` sections:
+
+```toml
+# Deployment-wide (optional)
+[agent]
+image = "oduist/oduflow-coder:latest"
+# claude_model = ""     # optional Claude model override; empty = CLI default
+# codex_model = ""      # optional Codex model override; empty = CLI default
+
+[team.1]
+hostname = "localhost"
+auth_token = "…"
+agent_enabled = true    # turn the coding agent on for this team
+agent_default = "claude"  # "claude" | "codex" — which agent opens by default
+
+# Provider credentials injected into the team's agent container
+[team.1.agent_env]
+CLAUDE_CODE_OAUTH_TOKEN = ""   # Claude subscription token (`claude setup-token`); outranks the API key
+ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
+OPENAI_API_KEY = ""            # Codex API key
+```
+
+See the [`[agent]`](installation.md#agent-settings) and
+[per-team](installation.md#per-team-settings) settings tables for the full
+reference.
+
+## Security model
+
+!!! warning "A console/chat is arbitrary code execution"
+    Opening an Agent CLI or Agent Chat is arbitrary code execution **inside the
+    team's agent container**. It is confined to that container, its clones, and
+    the session's scoped MCP token.
+
+- **Per-team isolation.** Each team gets its own agent container, volumes, and
+  network. Cross-team reach is blocked; the dashboard auth middleware resolves
+  the team, so a team can only ever reach its own agent.
+- **Scoped MCP access.** The team `auth_token` never enters the agent
+  container. Each session injects that **environment's** scoped per-environment
+  token, which grants only the dev-loop allowlist on the one environment the
+  session already controls. The agent **cannot** create, delete, or stop
+  environments, or touch templates, services, or volumes — those remain
+  operator actions.
+- **Credentials.** Server-level provider keys are inherited by the container
+  only in single-team deployments; with several teams, each team sets its own
+  keys in `[team.X.agent_env]` so an operator credential never leaks to
+  tenants.
+
+## Limitations
+
+- The agent UI is hidden for live-mount (`local_path`) environments.
+- Environments created before per-environment tokens existed have no scoped
+  token; their consoles warn and the agent works without MCP until the
+  environment is updated/recreated.
+- The Codex ACP adapter has no config-override channel yet, so **Codex *chat*
+  runs without Oduflow MCP** for now (the Codex CLI console is fully wired);
+  Claude is the fully supported path.
+
+The published image redistributes only Apache-2.0 software (Codex CLI + its ACP
+adapter). Claude Code and its adapter are installed at first container start
+onto the persistent home volume — downloaded directly from npm by the end
+user's container.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -222,7 +222,7 @@ Configure (or disable with `0`) in `oduflow.toml`:
 ```toml
 [lifecycle]
 auto_stop_hours = 48    # stop after N hours without work; 0 disables
-auto_delete_hours = 72  # delete N hours after the environment stopped; 0 disables
+auto_delete_hours = 0   # delete N hours after stop; 0 disables (opt-in; DESTRUCTIVE)
 ```
 
 ## Viewing Logs

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 
 ### Integration
 - **AI-agent friendly** — the server exposes tools via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), so LLM-based coding agents (Cursor, Cline, Amp, etc.) can provision and manage Odoo environments programmatically
+- **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
 - **Web dashboard** — a built-in HTML dashboard for managing environments from a browser
 - **REST API** — full JSON API for programmatic control from any HTTP client
 - **CLI tools** — every MCP tool can be called directly from the command line via `oduflow call`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -108,12 +108,15 @@ hostname = "localhost"
 [server]
 host = "0.0.0.0"           # HTTP server bind address
 port = 8000                 # HTTP server port
+allow_local_path = true     # allow live-mount (bind local checkout) environments
+# allow_insecure_http = false  # serve /mcp over HTTP with NO auth (only behind your own proxy)
 # trace = false             # verbose tracing for git analysis & env ops
 
 # ── Routing ───────────────────────────────────────────
 [routing]
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik"
+# hostname = "localhost"    # default hostname for teams that don't set their own
 
 # ── OAuth (optional) ──────────────────────────────────
 # Set to the public URL of this instance to turn Oduflow into a self-hosted
@@ -125,7 +128,7 @@ mode = "port"               # "port" (direct host port) | "traefik" (reverse pro
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"               # PostgreSQL user for the shared database container
-password = "odoo"           # PostgreSQL password
+password = "odoo"           # PostgreSQL password (auto-generated on first init; set to override)
 image = "postgres:15"       # PostgreSQL Docker image
 
 # ── Storage ───────────────────────────────────────────
@@ -136,7 +139,15 @@ overlay_threshold_mb = 50            # template filestore size threshold (MB) �
 # ── Lifecycle ─────────────────────────────────────────
 [lifecycle]
 auto_stop_hours = 48        # auto-stop environments idle for N hours (no MCP/dashboard work); 0 disables
-auto_delete_hours = 72      # auto-delete environments stopped for N hours; 0 disables (protected envs are exempt)
+auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 disables (opt-in; DESTRUCTIVE, protected envs exempt)
+
+# ── Coding agent (optional) ───────────────────────────
+# One agent container per team (Claude Code + OpenAI Codex), driven from the
+# dashboard (Agent Chat / Agent CLI). Opt-in per team via agent_enabled below.
+# [agent]
+# image = "oduist/oduflow-coder:latest"
+# claude_model = ""         # optional Claude model override; empty = CLI default
+# codex_model = ""          # optional Codex model override; empty = CLI default
 
 # ── Teams ─────────────────────────────────────────────
 # Each team gets isolated workspaces, templates, credentials, and services.
@@ -147,6 +158,12 @@ hostname = "localhost"               # port mode: http://{hostname}:{port}, trae
 auth_token = ""                      # MCP bearer token (empty = MCP auth disabled)
 ui_password = ""                     # Web UI password (empty = UI auth disabled)
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
+# agent_enabled = false              # enable the per-team coding agent (Agent Chat / Agent CLI)
+# agent_default = "claude"           # "claude" | "codex" — default agent for consoles/chats
+# [team.1.agent_env]                 # provider credentials injected into the agent container
+# CLAUDE_CODE_OAUTH_TOKEN = ""
+# ANTHROPIC_API_KEY = ""
+# OPENAI_API_KEY = ""
 ```
 
 ### Server settings
@@ -155,6 +172,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[server].host` | `0.0.0.0` | HTTP server bind address |
 | `[server].port` | `8000` | HTTP server port |
+| `[server].allow_local_path` | `true` | Allow live-mount (`local_path`) environments that bind-mount a local checkout instead of cloning. Set `false` to force git-clone delivery only |
+| `[server].allow_insecure_http` | `false` | Serve the `/mcp` endpoint over plain HTTP with **no** authentication. Only enable behind your own authenticating proxy |
 | `[server].trace` | `false` | Enable detailed trace logging for git analysis and environment operations |
 | `[server].disable_telemetry` | `false` | Disable anonymous usage telemetry (see [Telemetry](#telemetry)) |
 
@@ -164,6 +183,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
 | `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` |
+| `[routing].hostname` | `localhost` | Default hostname for teams that don't set their own `hostname` |
 
 ### OAuth settings
 
@@ -176,7 +196,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 | Key | Default | Description |
 |---|---|---|
 | `[database].user` | `odoo` | PostgreSQL user for the shared database container |
-| `[database].password` | `odoo` | PostgreSQL password |
+| `[database].password` | `odoo` | PostgreSQL password. The bundled config omits it and one is auto-generated on first init; set explicitly to override |
 | `[database].image` | `postgres:15` | PostgreSQL Docker image |
 
 ### Storage settings
@@ -186,7 +206,17 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 | `[storage].data_dir` | `/srv/oduflow` or `~/.oduflow/data` | Base directory for all data. Team data directories are `team_{ID}` subdirectories inside |
 | `[storage].overlay_threshold_mb` | `50` | Template filestore size threshold (MB). Templates smaller than this use a simple copy per environment; larger templates use fuse-overlayfs. The decision is stored in `metadata.json` at template creation time |
 | `[lifecycle].auto_stop_hours` | `48` | Auto-stop environments after N hours without work (env-scoped MCP calls or dashboard actions). `0` disables. Protected environments are exempt |
-| `[lifecycle].auto_delete_hours` | `72` | Auto-delete environments N hours after they stopped (manual stops count). `0` disables. Protected environments are exempt; `pull_and_apply` wakes a stopped environment automatically |
+| `[lifecycle].auto_delete_hours` | `0` | Auto-delete stopped environments N hours after they stopped (manual stops count). Default `0` = **disabled** — auto-delete is opt-in and destructive; set a positive value to enable. Protected environments are exempt; `pull_and_apply` wakes a stopped environment automatically |
+
+### Agent settings
+
+The global `[agent]` section holds deployment-wide settings for the per-team coding agent (see [Coding Agent](agent.md)). Per-team enablement lives in the `[team.*]` sections below.
+
+| Key | Default | Description |
+|---|---|---|
+| `[agent].image` | `oduist/oduflow-coder:latest` | Image for the per-team coding-agent container (Claude Code + OpenAI Codex) |
+| `[agent].claude_model` | *(empty)* | Optional Claude model override for the agent; empty = CLI default |
+| `[agent].codex_model` | *(empty)* | Optional Codex model override for the agent; empty = CLI default |
 
 ### Per-team settings
 
@@ -198,6 +228,9 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `auth_token` | *(empty)* | Bearer token for MCP HTTP auth. Empty = MCP auth disabled for this team |
 | `ui_password` | *(empty)* | Password for Web UI Basic auth (user: `admin`). Separate from MCP auth token. Empty = UI auth disabled |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
+| `agent_enabled` | `false` | Enable the per-team coding agent (dashboard Agent Chat / Agent CLI). Off by default |
+| `agent_default` | `claude` | Which agent consoles/chats open by default: `claude` or `codex` |
+| `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and any custom vars |
 
 Team data is stored at `{data_dir}/team_{ID}/`:
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -92,7 +92,7 @@ src/oduflow/
     stats.py            # Container and system CPU/RAM stats (parallel collection)
 
   templates/
-    oduflow.toml          # Default TOML configuration (copied on first `oduflow init`)
+    oduflow.toml          # Default TOML configuration (copied on first startup)
     odoo.conf             # Odoo configuration template (addons path, limits, security)
     postgresql.conf       # PostgreSQL tuning (shared_buffers, WAL, autovacuum, etc.)
     dashboard.html        # Web dashboard UI (single-page application)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -49,7 +49,7 @@ mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 
 [database]
 user = "odoo"
-password = "odoo"
+password = "odoo"                     # auto-generated on first init; set to override
 image = "postgres:15"
 
 [storage]
@@ -58,20 +58,27 @@ overlay_threshold_mb = 50             # filestore size threshold for overlay vs 
 
 [lifecycle]
 auto_stop_hours = 48                  # auto-stop after N hours without MCP/dashboard work; 0 disables
-auto_delete_hours = 72                # auto-delete N hours after the environment stopped; 0 disables
+auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disables (opt-in; DESTRUCTIVE)
+
+# Per-team coding agent (dashboard Agent Chat / Agent CLI); opt-in, off by default.
+# [agent]
+# image = "oduist/oduflow-coder:latest"
 
 [team.1]
 hostname = "localhost"
 auth_token = ""                       # MCP bearer token (empty = auth disabled)
 ui_password = ""                      # Web UI password (empty = UI open)
 port_range = [50000, 50100]           # port range for Odoo containers
+# agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
+# agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
+# [team.1.agent_env]                  # provider credentials injected into the agent container
+# ANTHROPIC_API_KEY = ""
+# OPENAI_API_KEY = ""
 ```
 
 ### Initialize
 
-```bash
-oduflow init              # Create shared Docker network, PostgreSQL, team directories
-```
+No separate init step is needed. On first launch Oduflow automatically creates a default `oduflow.toml` (if none exists) and initializes shared infrastructure (Docker network, PostgreSQL, team directories). Just start the server (below).
 
 ### Set up a template
 
@@ -121,7 +128,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `create_environment` — provision a new Odoo environment for a branch (optional `env_vars` injects container environment variables)
 - `delete_environment` — tear down an environment
 - `start_environment` / `stop_environment` / `restart_environment` — lifecycle control
-- Idle environments auto-stop after 48h without work; stopped ones auto-delete after 72h (configurable via `[lifecycle]`; protected environments are exempt). Container-level tools (pull_and_apply, shell/tests/installs/file ops) wake a stopped environment automatically and note it in the response
+- Idle environments auto-stop after 48h without work (`[lifecycle].auto_stop_hours`). Auto-delete of long-stopped environments is opt-in and off by default (`auto_delete_hours = 0`; set a positive value to enable — destructive; protected environments are exempt). Container-level tools (pull_and_apply, shell/tests/installs/file ops) wake a stopped environment automatically and note it in the response
 - `update_environment` — re-create the container preserving DB and filestore (optional `odoo_image` switches image, `env_vars` replaces container environment variables)
 - `install_odoo_modules` — install Odoo modules
 - `upgrade_odoo_modules` — upgrade Odoo modules
@@ -149,6 +156,10 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `get_agent_instructions` — get AI agent instructions for using Oduflow
 - `get_odoo_development_guide` — get Odoo development standards guide for a specific version (15–19)
 
+## Coding Agent (hosting)
+
+An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with durable per-environment sessions). The agent edits its own git checkout, `git push`es, and drives the environment only through the Oduflow MCP server with a scoped per-environment token. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments. See the **Coding Agent** section below for details.
+
 ## Typical Agent Workflow
 
 1. Call `list_environments` to check if an environment for the branch exists
@@ -161,7 +172,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 - Repository: <https://github.com/oduist/oduflow>
 - Documentation: <https://docs.oduflow.dev>
-- License: Polyform Noncommercial 1.0.0
+- License: BUSL-1.1 (Business Source License 1.1) — free for non-commercial use; commercial use requires a paid license; converts to MPL 2.0 four years after publication
 - Website: <https://oduflow.dev>
 
 ---
@@ -261,11 +272,7 @@ hostname = "localhost"
 
 ## 2. Initialize the system
 
-Create the shared Docker network, PostgreSQL container, and all team directories:
-
-```bash
-oduflow init
-```
+No separate step is needed — on first launch Oduflow automatically creates a default `oduflow.toml` (if none exists) and initializes shared infrastructure (Docker network, PostgreSQL container, team directories).
 
 To set up a template database, use `oduflow init-template` (see [Template Management](templates.md)).
 
@@ -354,7 +361,7 @@ All settings are configured via a TOML file. Oduflow searches for `oduflow.toml`
 2. `/etc/oduflow/oduflow.toml`
 3. `~/.oduflow/oduflow.toml`
 
-If no config file exists when running `oduflow init`, the bundled default is automatically copied to the appropriate location.
+If no config file exists, the bundled default is automatically copied to the appropriate location on first startup.
 
 ### Minimal configuration
 
@@ -370,12 +377,15 @@ hostname = "localhost"
 [server]
 host = "0.0.0.0"           # HTTP server bind address
 port = 8000                 # HTTP server port
+allow_local_path = true     # allow live-mount (bind local checkout) environments
+# allow_insecure_http = false  # serve /mcp over HTTP with NO auth (only behind your own proxy)
 # trace = false             # verbose tracing for git analysis & env ops
 
 # ── Routing ───────────────────────────────────────────
 [routing]
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik"
+# hostname = "localhost"    # default hostname for teams that don't set their own
 
 # ── OAuth (optional) ──────────────────────────────────
 # Set to the public URL of this instance to turn Oduflow into a self-hosted
@@ -387,13 +397,26 @@ mode = "port"               # "port" (direct host port) | "traefik" (reverse pro
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"               # PostgreSQL user for the shared database container
-password = "odoo"           # PostgreSQL password
+password = "odoo"           # PostgreSQL password (auto-generated on first init; set to override)
 image = "postgres:15"       # PostgreSQL Docker image
 
 # ── Storage ───────────────────────────────────────────
 [storage]
 # data_dir = "/srv/oduflow"         # base directory for all data (default: /srv/oduflow or ~/.oduflow/data)
 overlay_threshold_mb = 50            # template filestore size threshold (MB) — larger uses fuse-overlayfs, smaller uses copy
+
+# ── Lifecycle ─────────────────────────────────────────
+[lifecycle]
+auto_stop_hours = 48                 # auto-stop idle environments after N hours; 0 disables
+auto_delete_hours = 0                # auto-delete stopped environments after N hours; 0 disables (opt-in; DESTRUCTIVE)
+
+# ── Coding agent (optional) ───────────────────────────
+# One agent container per team (Claude Code + OpenAI Codex), driven from the
+# dashboard (Agent Chat / Agent CLI). Opt-in per team via agent_enabled below.
+# [agent]
+# image = "oduist/oduflow-coder:latest"
+# claude_model = ""         # optional Claude model override; empty = CLI default
+# codex_model = ""          # optional Codex model override; empty = CLI default
 
 # ── Teams ─────────────────────────────────────────────
 # Each team gets isolated workspaces, templates, credentials, and services.
@@ -404,6 +427,12 @@ hostname = "localhost"               # port mode: http://{hostname}:{port}, trae
 auth_token = ""                      # MCP bearer token (empty = MCP auth disabled)
 ui_password = ""                     # Web UI password (empty = UI auth disabled)
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
+# agent_enabled = false              # enable the per-team coding agent (Agent Chat / Agent CLI)
+# agent_default = "claude"           # "claude" | "codex" — default agent for consoles/chats
+# [team.1.agent_env]                 # provider credentials injected into the agent container
+# CLAUDE_CODE_OAUTH_TOKEN = ""
+# ANTHROPIC_API_KEY = ""
+# OPENAI_API_KEY = ""
 ```
 
 ### Server settings
@@ -412,6 +441,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[server].host` | `0.0.0.0` | HTTP server bind address |
 | `[server].port` | `8000` | HTTP server port |
+| `[server].allow_local_path` | `true` | Allow live-mount (`local_path`) environments that bind-mount a local checkout instead of cloning. Set `false` to force git-clone delivery only |
+| `[server].allow_insecure_http` | `false` | Serve the `/mcp` endpoint over plain HTTP with **no** authentication. Only enable behind your own authenticating proxy |
 | `[server].trace` | `false` | Enable detailed trace logging for git analysis and environment operations |
 
 ### Routing settings
@@ -420,6 +451,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
 | `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` |
+| `[routing].hostname` | `localhost` | Default hostname for teams that don't set their own `hostname` |
 
 ### OAuth settings
 
@@ -432,7 +464,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 | Key | Default | Description |
 |---|---|---|
 | `[database].user` | `odoo` | PostgreSQL user for the shared database container |
-| `[database].password` | `odoo` | PostgreSQL password |
+| `[database].password` | `odoo` | PostgreSQL password. The bundled config omits it and one is auto-generated on first init; set explicitly to override |
 | `[database].image` | `postgres:15` | PostgreSQL Docker image |
 
 ### Storage settings
@@ -442,7 +474,17 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 | `[storage].data_dir` | `/srv/oduflow` or `~/.oduflow/data` | Base directory for all data. Team data directories are `team_{ID}` subdirectories inside |
 | `[storage].overlay_threshold_mb` | `50` | Template filestore size threshold (MB). Templates smaller than this use a simple copy per environment; larger templates use fuse-overlayfs. The decision is stored in `metadata.json` at template creation time |
 | `[lifecycle].auto_stop_hours` | `48` | Auto-stop environments after N hours without work (env-scoped MCP calls or dashboard actions). `0` disables. Protected environments are exempt |
-| `[lifecycle].auto_delete_hours` | `72` | Auto-delete environments N hours after they stopped (manual stops count). `0` disables. Protected environments are exempt; container-level tools wake a stopped environment automatically |
+| `[lifecycle].auto_delete_hours` | `0` | Auto-delete stopped environments N hours after they stopped (manual stops count). Default `0` = **disabled** — auto-delete is opt-in and destructive; set a positive value to enable. Protected environments are exempt; container-level tools wake a stopped environment automatically |
+
+### Agent settings
+
+The global `[agent]` section holds deployment-wide settings for the per-team coding agent (see [Coding Agent](#coding-agent)). Per-team enablement lives in the `[team.*]` sections below.
+
+| Key | Default | Description |
+|---|---|---|
+| `[agent].image` | `oduist/oduflow-coder:latest` | Image for the per-team coding-agent container (Claude Code + OpenAI Codex) |
+| `[agent].claude_model` | *(empty)* | Optional Claude model override for the agent; empty = CLI default |
+| `[agent].codex_model` | *(empty)* | Optional Codex model override for the agent; empty = CLI default |
 
 ### Per-team settings
 
@@ -454,6 +496,9 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `auth_token` | *(empty)* | Bearer token for MCP HTTP auth. Empty = MCP auth disabled for this team |
 | `ui_password` | *(empty)* | Password for Web UI Basic auth (user: `admin`). Separate from MCP auth token. Empty = UI auth disabled |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
+| `agent_enabled` | `false` | Enable the per-team coding agent (dashboard Agent Chat / Agent CLI). Off by default |
+| `agent_default` | `claude` | Which agent consoles/chats open by default: `claude` or `codex` |
+| `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and any custom vars |
 
 Team data is stored at `{data_dir}/team_{ID}/`:
 
@@ -469,7 +514,7 @@ team_{ID}/
 
 ### Configuration file overrides
 
-When `oduflow init` runs, it copies the bundled `postgresql.conf` and `odoo.conf` to the config directory. These files take **priority** over the bundled defaults — edit them to customize PostgreSQL tuning or Odoo settings globally:
+On first startup, Oduflow copies the bundled `postgresql.conf` and `odoo.conf` to the config directory. These files take **priority** over the bundled defaults — edit them to customize PostgreSQL tuning or Odoo settings globally:
 
 ```
 /etc/oduflow/             (or ~/.oduflow/conf/)
@@ -495,11 +540,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Install oduflow as a tool (as root)
 uv tool install oduflow
 
-# Create the configuration file
-# (oduflow init will auto-create a default oduflow.toml if none exists)
-
-# Initialize shared infrastructure and all team directories
-oduflow init
+# On first start, Oduflow auto-creates a default oduflow.toml (if none exists)
+# and initializes shared infrastructure — no separate init command is needed.
 ```
 
 ### Install the service
@@ -1022,7 +1064,7 @@ Both folders support `.sql` and `.py` files, executed in alphabetical order (fir
 
 ### Team-level sanitization
 
-During `oduflow init`, the folder `{team_data_dir}/odoo_sanitize/` is created and seeded with a default script:
+On first startup, the folder `{team_data_dir}/odoo_sanitize/` is created and seeded with a default script:
 
 **`01_disable_mail.sql`** — disables incoming and outgoing mail servers:
 
@@ -1285,6 +1327,77 @@ Click the **🔓 Protect** button on any environment card to toggle protection. 
 - The button shows **🔒 Protected** (highlighted)
 - The **Delete** button is disabled
 - Attempting to delete via MCP or API returns a `ProtectedError`
+
+---
+
+# Coding Agent
+
+[TOC]
+
+Oduflow can host a **coding agent** for a team: an opt-in feature where the client grows their Odoo by chatting with an AI agent directly from the browser dashboard. Oduflow runs one agent container per team (`oduist/oduflow-coder`, bundling Claude Code + OpenAI Codex) and exposes two front-ends for every environment.
+
+It is a **hosting feature, off by default.** A local developer already has the code and their own agents, so it is disabled unless you set `agent_enabled` for the team, and it is **hidden for live-mount (`local_path`) environments** — there is nothing for the containerized agent to clone.
+
+## Agent CLI vs Agent Chat
+
+Both drive the same agent container over the dashboard's existing WebSocket ↔ `docker exec` bridge:
+
+- **Agent CLI** — the agent's own terminal UI (TUI) rendered in the browser, exec'd with a PTY at the environment's git checkout.
+- **Agent Chat** — a structured, framework-free browser chat that speaks the **Agent Client Protocol (ACP)** to the agent's adapter. Each environment has a **durable session** that resumes across reloads; chats minimize to a dock, so several can run in parallel. Assistant messages render as markdown, with collapsible reasoning, tool-call cards, plans, and inline approve/deny prompts for permission requests.
+
+## How it works
+
+The agent never touches host files. It holds one full git checkout per environment (at `/workspace/<slug>` in the container), edits its own clone, `git push`es, and then drives the environment **only through the Oduflow MCP server** (`pull_and_apply`, `run_odoo_tests`, etc.) — the same closed loop a remote MCP client uses.
+
+Lifecycle is automatic: the container is created on startup for each enabled team and removed for disabled ones; `create_environment` adds the environment's checkout, `delete_environment` removes it. The container carries a hash of its injected config as a label and is **recreated automatically** when the config changes.
+
+The dashboard exposes one status endpoint and two WebSocket surfaces (available only when `agent_enabled` is set):
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/agent` | Whether the coding agent is enabled for the team and its default type (`claude` / `codex`) |
+| `WebSocket` | `/api/environments/{branch}/agent` | **Agent CLI** — the agent's interactive TUI |
+| `WebSocket` | `/api/environments/{branch}/agent-acp` | **Agent Chat** — line-framed relay to the agent's ACP adapter |
+
+## Enabling it
+
+Configuration lives entirely in `oduflow.toml` — there is no runtime editing. The global `[agent]` section holds deployment-wide settings; per-team enablement and credentials live in the `[team.*]` sections:
+
+```toml
+# Deployment-wide (optional)
+[agent]
+image = "oduist/oduflow-coder:latest"
+# claude_model = ""     # optional Claude model override; empty = CLI default
+# codex_model = ""      # optional Codex model override; empty = CLI default
+
+[team.1]
+hostname = "localhost"
+auth_token = "…"
+agent_enabled = true      # turn the coding agent on for this team
+agent_default = "claude"  # "claude" | "codex" — which agent opens by default
+
+# Provider credentials injected into the team's agent container
+[team.1.agent_env]
+CLAUDE_CODE_OAUTH_TOKEN = ""   # Claude subscription token (`claude setup-token`); outranks the API key
+ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
+OPENAI_API_KEY = ""            # Codex API key
+```
+
+## Security model
+
+Opening an Agent CLI or Agent Chat is arbitrary code execution **inside the team's agent container** — confined to that container, its clones, and the session's scoped MCP token.
+
+- **Per-team isolation.** Each team gets its own agent container, volumes, and network; the dashboard auth middleware resolves the team, so a team can only ever reach its own agent.
+- **Scoped MCP access.** The team `auth_token` never enters the agent container. Each session injects that **environment's** scoped per-environment token, which grants only the dev-loop allowlist on the one environment the session already controls. The agent **cannot** create, delete, or stop environments, or touch templates, services, or volumes — those remain operator actions.
+- **Credentials.** Server-level provider keys are inherited by the container only in single-team deployments; with several teams, each team sets its own keys in `[team.X.agent_env]`.
+
+## Limitations
+
+- Hidden for live-mount (`local_path`) environments.
+- Environments created before per-environment tokens existed have no scoped token; their consoles warn and the agent works without MCP until the environment is updated/recreated.
+- The Codex ACP adapter has no config-override channel yet, so **Codex *chat*** runs without Oduflow MCP for now (the Codex CLI console is fully wired); Claude is the fully supported path.
+
+The published image redistributes only Apache-2.0 software (Codex CLI + its ACP adapter). Claude Code and its adapter are installed at first container start onto the persistent home volume — downloaded directly from npm by the end user's container.
 
 ---
 
@@ -1714,13 +1827,9 @@ By default, the server starts on `http://0.0.0.0:8000`. Configuration is loaded 
 
 ## System Commands
 
+Shared infrastructure (Docker network, PostgreSQL, team directories) is initialized automatically on startup — there is no separate init command.
+
 ```bash
-# Initialize shared infrastructure (network, DB, Traefik) and all team directories
-oduflow init
-
-# Initialize and install a license in one step
-oduflow init --license /path/to/license.key
-
 # Destroy all shared infrastructure (requires no active environments)
 oduflow destroy
 ```
@@ -1855,7 +1964,7 @@ For production-like access with HTTPS, Oduflow can deploy a **Traefik** reverse 
    hostname = "dev.example.com"
    ```
 
-3. **Run `oduflow init`** (or restart the server). Oduflow will create a Traefik v3 container that:
+3. **Restart the server** (initialization runs automatically on startup). Oduflow will create a Traefik v3 container that:
    - Listens on ports 80 and 443
    - Automatically redirects HTTP to HTTPS
    - Obtains a separate TLS certificate from Let's Encrypt for each environment subdomain via HTTP-01 challenge
@@ -2093,7 +2202,7 @@ Validation checks the credential against the provider's API (GitHub, GitLab, Bit
 
 ## iptables rule
 
-During `oduflow init`, an `iptables ACCEPT` rule is automatically added for the `oduflow-net` Docker bridge interface. This ensures that containers on the shared network can communicate with the host (required for Traefik `host.docker.internal` routing and PostgreSQL access). If `iptables` is not available, the rule is skipped with a warning.
+On startup, an `iptables ACCEPT` rule is automatically added for the `oduflow-net` Docker bridge interface. This ensures that containers on the shared network can communicate with the host (required for Traefik `host.docker.internal` routing and PostgreSQL access). If `iptables` is not available, the rule is skipped with a warning.
 
 ## Odoo security defaults
 
@@ -2157,33 +2266,20 @@ docker run -d \
 The Oduflow container must be on the same Docker network as the containers it creates. The simplest approach is to connect it to `oduflow-net` after initialization:
 
 ```bash
-# 1. Start Oduflow
+# 1. Start Oduflow (Docker image defaults to HTTP mode)
 docker run -d --name oduflow -p 8000:8000 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v oduflow_data:/srv/oduflow \
   -v /etc/oduflow:/etc/oduflow \
-  oduflow
+  oduist/oduflow
 
-# 2. Initialize shared infrastructure (creates oduflow-net, PostgreSQL, etc.)
-docker exec oduflow oduflow init
-
-# 3. Connect Oduflow to the shared network
+# 2. Connect Oduflow to the shared network (created automatically on startup)
 docker network connect oduflow-net oduflow
 ```
 
 Alternatively, start with `--network oduflow-net` if the network already exists.
 
-## Initialization
-
-On first run, you need to initialize the shared infrastructure:
-
-```bash
-# Create shared Docker network, PostgreSQL container, and team directories
-docker exec oduflow oduflow init
-
-# Connect to the shared network
-docker network connect oduflow-net oduflow
-```
+Shared infrastructure (Docker network, PostgreSQL, team directories) is initialized automatically on startup — no separate init step needed.
 
 To set up a template database:
 
@@ -2243,11 +2339,7 @@ networks:
     name: oduflow-net
 ```
 
-After `docker compose up -d`, run initialization:
-
-```bash
-docker compose exec oduflow oduflow init
-```
+After `docker compose up -d`, Oduflow initializes shared infrastructure automatically.
 
 ## Security Notes
 
@@ -2379,7 +2471,7 @@ src/oduflow/
     stats.py            # Container and system CPU/RAM stats (parallel collection)
 
   templates/
-    oduflow.toml          # Default TOML configuration (copied on first `oduflow init`)
+    oduflow.toml          # Default TOML configuration (copied on first startup)
     odoo.conf             # Odoo configuration template (addons path, limits, security)
     postgresql.conf       # PostgreSQL tuning (shared_buffers, WAL, autovacuum, etc.)
     dashboard.html        # Web dashboard UI (single-page application)
@@ -2504,28 +2596,26 @@ The bundled `postgresql.conf` is optimized for a 2 vCPU / 4 GB RAM development s
 
 [TOC]
 
-Oduflow is source-available under the [Polyform Noncommercial License 1.0.0](https://github.com/oduist/oduflow/blob/main/LICENSE). Commercial use requires a license.
+Oduflow is source-available under the [Business Source License 1.1](https://github.com/oduist/oduflow/blob/main/LICENSE) (BUSL-1.1).
+
+- **Free forever for non-commercial use**: evaluation, education, academic research, personal and hobby projects, non-profits.
+- **Commercial use requires a paid license** in one of three tiers (below).
+- Standard BUSL mechanics: each release converts to the open-source **MPL 2.0** four years after publication.
 
 ## License Types
 
-| Type | Label | Description |
+| Type | Label | Who needs it |
 |---|---|---|
-| `unlicensed` | UNLICENSED — NON-COMMERCIAL USE ONLY | Default when no license key is installed |
-| `individual` | Licensed to individual | Personal commercial license |
-| `business` | Licensed to company (internal use only) | Company license for internal use |
-| `integrator` | Licensed to Odoo integrator | License for Odoo integrators and consultancies |
+| `unlicensed` | UNLICENSED — NON-COMMERCIAL USE ONLY | Default when no license key is installed; fine for evaluation, education, and other non-commercial use |
+| `individual` | Licensed to individual | One natural person (freelancer, sole developer) using Oduflow commercially on their own account |
+| `business` | Licensed to company (internal use only) | A company using Oduflow internally, for its own Odoo systems |
+| `integrator` | Licensed to Odoo integrator | A person or company using Oduflow to deliver Odoo services (implementation, development, support, hosting) to clients |
 
 ## Installing a License
 
-**Via CLI (during init):**
+**Via CLI:**
 
-```bash
-oduflow init --license /path/to/license.key
-```
-
-**Via CLI (standalone):**
-
-The license file is stored at `/etc/oduflow/license.key`.
+Copy the license file to `<config-dir>/license.key`. The config directory is usually `/etc/oduflow`; when that path is not writable, Oduflow uses `~/.oduflow/conf`. Oduflow reads the license automatically on startup.
 
 **Via Web Dashboard:**
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -52,7 +52,7 @@ mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 
 [database]
 user = "odoo"
-password = "odoo"
+password = "odoo"                     # auto-generated on first init; set to override
 image = "postgres:15"
 
 [storage]
@@ -61,20 +61,27 @@ overlay_threshold_mb = 50             # filestore size threshold for overlay vs 
 
 [lifecycle]
 auto_stop_hours = 48                  # auto-stop after N hours without MCP/dashboard work; 0 disables
-auto_delete_hours = 72                # auto-delete N hours after the environment stopped; 0 disables
+auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disables (opt-in; DESTRUCTIVE)
+
+# Per-team coding agent (dashboard Agent Chat / Agent CLI); opt-in, off by default.
+# [agent]
+# image = "oduist/oduflow-coder:latest"
 
 [team.1]
 hostname = "localhost"
 auth_token = ""                       # MCP bearer token (empty = auth disabled)
 ui_password = ""                      # Web UI password (empty = UI open)
 port_range = [50000, 50100]           # port range for Odoo containers
+# agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
+# agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
+# [team.1.agent_env]                  # provider credentials injected into the agent container
+# ANTHROPIC_API_KEY = ""
+# OPENAI_API_KEY = ""
 ```
 
 ### Initialize
 
-```bash
-oduflow init              # Create shared Docker network, PostgreSQL, team directories
-```
+No separate init step is needed. On first launch Oduflow automatically creates a default `oduflow.toml` (if none exists) and initializes shared infrastructure (Docker network, PostgreSQL, team directories). Just start the server (below).
 
 ### Upgrade
 
@@ -140,7 +147,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, set `[oauth].oauth_base_u
 - `create_environment` — provision a new Odoo environment for a branch (optional `env_vars` injects container environment variables)
 - `delete_environment` — tear down an environment
 - `start_environment` / `stop_environment` / `restart_environment` — lifecycle control
-- Idle environments auto-stop after 48h without work; stopped ones auto-delete after 72h (configurable via `[lifecycle]`; protected environments are exempt). Container-level tools (pull_and_apply, shell/tests/installs/file ops) wake a stopped environment automatically and note it in the response
+- Idle environments auto-stop after 48h without work (`[lifecycle].auto_stop_hours`). Auto-delete of long-stopped environments is opt-in and off by default (`auto_delete_hours = 0`; set a positive value to enable — destructive; protected environments are exempt). Container-level tools (pull_and_apply, shell/tests/installs/file ops) wake a stopped environment automatically and note it in the response
 - `update_environment` — re-create the container preserving DB and filestore (optional `odoo_image` switches image, `env_vars` replaces container environment variables)
 - `install_odoo_modules` — install Odoo modules
 - `upgrade_odoo_modules` — upgrade Odoo modules
@@ -170,6 +177,10 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, set `[oauth].oauth_base_u
 - `get_agent_instructions` — get AI agent instructions for using Oduflow
 - `get_odoo_development_guide` — get Odoo development standards guide for a specific version (15–19)
 
+## Coding Agent (hosting)
+
+An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with durable per-environment sessions). The agent edits its own git checkout, `git push`es, and drives the environment only through the Oduflow MCP server with a scoped per-environment token. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
+
 ## Typical Agent Workflow
 
 1. Call `list_environments` to check if an environment for the branch exists
@@ -182,5 +193,5 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, set `[oauth].oauth_base_u
 
 - Repository: <https://github.com/oduist/oduflow>
 - Documentation: <https://docs.oduflow.dev>
-- License: Polyform Noncommercial 1.0.0
+- License: BUSL-1.1 (Business Source License 1.1) — free for non-commercial use; commercial use requires a paid license; converts to MPL 2.0 four years after publication
 - Website: <https://oduflow.dev>

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -18,6 +18,7 @@ When running in HTTP mode, a web dashboard is available at the server root (`htt
 - **Git credential management** — list, add, delete, and validate stored git credentials
 - **Template listing** — view available template profiles with their status
 - **License management** — view current license and activate license keys
+- **Coding agent** (opt-in, per team) — **Agent CLI** (the agent's terminal in the browser) and **Agent Chat** (a structured ACP chat) for each environment, when `agent_enabled` is set for the team. Hidden for live-mount (`local_path`) environments. See [Coding Agent](agent.md)
 
 ## REST API Endpoints
 
@@ -103,3 +104,13 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 |---|---|---|
 | `GET` | `/api/agent-guides` | List all available agent guides |
 | `GET` | `/api/agent-guides/{filename}` | Get content of a specific agent guide |
+
+### Coding Agent
+
+The per-team coding agent (see [Coding Agent](agent.md)) exposes one status endpoint and two WebSocket surfaces. Available only when `agent_enabled` is set for the team.
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/agent` | Whether the coding agent is enabled for the team and its default type (`claude` / `codex`) |
+| `WebSocket` | `/api/environments/{branch}/agent` | **Agent CLI** — the agent's interactive TUI, bridged from a PTY `docker exec` in the team's agent container (used by the dashboard console) |
+| `WebSocket` | `/api/environments/{branch}/agent-acp` | **Agent Chat** — a line-framed relay to the agent's ACP adapter (`claude-code-acp` / `codex-acp`), rendered by the browser chat client with durable per-environment sessions |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Use Cases & Workflows: use-cases.md
       - Template Management: templates.md
       - Environment Management: environments.md
+      - Coding Agent: agent.md
       - Auxiliary Services: services.md
       - Extra Addons Repositories: extra-addons.md
   - Reference:


### PR DESCRIPTION
Audit of the documentation (`docs/`, `llms.txt`, `llms-full.txt`) against the code (v1.61.0). Fixes drifts and documents the new coding-agent feature. **Docs-only** — the code is the source of truth and is already correct. Verified with `mkdocs build --strict`.

## Factual corrections (docs contradicted code)
- **License** — `llms.txt` / `llms-full.txt` still named the retired *"Polyform Noncommercial 1.0.0"*; the project relicensed to **BUSL-1.1** (#90). Fixed the name and rewrote the llms-full *Licensing* section to match `docs/licensing.md`.
- **`auto_delete_hours` default** — is `0` (opt-in, off; #82), not `72`. Corrected in `installation.md`, `environments.md`, `llms.txt`, `llms-full.txt` (samples, prose, tables).
- **Retired `oduflow init` command / nonexistent `oduflow init --license` flag** — init is automatic on startup (#255); the canonical `.md` pages were already updated, but the llms files were a stale snapshot (~17 mentions). Brought them in line; fixed one straggler in `internals.md`.

## Config completeness
- Documented `[server].allow_local_path`, `[server].allow_insecure_http`, `[routing].hostname`; noted DB password auto-generation.
- Dropped the stale `(43 tools)` count from `AGENTS.md` (actual: 54).

## Coding agent (v1.61.0, spec 0029) — previously only in the changelog
- `installation.md`: `[agent]` section + per-team `agent_enabled` / `agent_default` and `[team.X.agent_env]` tables.
- `web-api.md`: dashboard note + `/api/agent` and the two agent WebSocket endpoints.
- New **`docs/agent.md`** page wired into mkdocs nav; Coding Agent sections in `llms.txt` / `llms-full.txt`; mentions in `index.md` and `README.md`.

## Verified in sync (unchanged)
`docs/mcp-tools.md` — exactly 54 tools, matching `@mcp.tool()`; Odoo guides 15–19; CLI subcommands; OAuth/storage config.