### PR TITLE
docs: address Greptile review on #101

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -3,7 +3,7 @@
 Oduflow can host a **coding agent** for a team: an opt-in feature where the
 client grows their Odoo by chatting with an AI agent directly from the browser
 dashboard. Oduflow runs one agent container per team
-(`oduist/oduflow-coder`, bundling Claude Code + OpenAI Codex) and exposes two
+(`oduist/oduflow-coder`, running Claude Code + OpenAI Codex) and exposes two
 front-ends for every environment.
 
 !!! note "Hosting feature — off by default"

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1334,7 +1334,7 @@ Click the **🔓 Protect** button on any environment card to toggle protection. 
 
 [TOC]
 
-Oduflow can host a **coding agent** for a team: an opt-in feature where the client grows their Odoo by chatting with an AI agent directly from the browser dashboard. Oduflow runs one agent container per team (`oduist/oduflow-coder`, bundling Claude Code + OpenAI Codex) and exposes two front-ends for every environment.
+Oduflow can host a **coding agent** for a team: an opt-in feature where the client grows their Odoo by chatting with an AI agent directly from the browser dashboard. Oduflow runs one agent container per team (`oduist/oduflow-coder`, running Claude Code + OpenAI Codex) and exposes two front-ends for every environment.
 
 It is a **hosting feature, off by default.** A local developer already has the code and their own agents, so it is disabled unless you set `agent_enabled` for the team, and it is **hidden for live-mount (`local_path`) environments** — there is nothing for the containerized agent to clone.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -75,6 +75,7 @@ port_range = [50000, 50100]           # port range for Odoo containers
 # agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
 # agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
 # [team.1.agent_env]                  # provider credentials injected into the agent container
+# CLAUDE_CODE_OAUTH_TOKEN = ""
 # ANTHROPIC_API_KEY = ""
 # OPENAI_API_KEY = ""
 ```


### PR DESCRIPTION
Follow-up to the merged #101 addressing the two Greptile review comments
(https://github.com/oduist/oduflow/pull/101#pullrequestreview-4627094483).

## Fixes

**P1 — inaccurate "bundling" claim.** The Coding Agent intro said the
`oduist/oduflow-coder` image was "bundling Claude Code + OpenAI Codex". That
implies the image redistributes Claude Code, which contradicts `AGENTS.md` and
the page's own **Limitations** section: the published image redistributes only
Apache-2.0 software (Codex CLI + its ACP adapter); Claude Code is npm-installed
at first container start onto the persistent home volume. Reworded to
"running…" in `docs/agent.md` and the mirrored paragraph in
`docs/llms-full.txt` (Greptile flagged only the former; both carried the same
wording).

**P2 — missing credential key.** The abbreviated `[team.1.agent_env]` example
in `docs/llms.txt` omitted `CLAUDE_CODE_OAUTH_TOKEN`. Added it so the block
matches `installation.md` and `llms-full.txt` (plain form, no inline comment,
to keep the abbreviated file abbreviated).

## Verification
`mkdocs build --strict` passes clean.