### PR TITLE
feat(traefik): HTTP-only mode for Cloudflare tunnel / TLS upstream

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,7 +115,8 @@ allow_local_path = true     # allow live-mount (bind local checkout) environment
 # ── Routing ───────────────────────────────────────────
 [routing]
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
-# acme_email = "admin@example.com"  # required when mode = "traefik"
+# acme_email = "admin@example.com"  # required when mode = "traefik" and tls = true
+# tls = true                # traefik only. false = plain HTTP on :80, no ACME (behind a Cloudflare tunnel / TLS proxy)
 # hostname = "localhost"    # default hostname for teams that don't set their own
 
 # ── OAuth (optional) ──────────────────────────────────
@@ -182,7 +183,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 | Key | Default | Description |
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
-| `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` |
+| `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` and `tls = true` |
+| `[routing].tls` | `true` | Traefik only. `true`: Traefik terminates TLS (:443, HTTP→HTTPS redirect, Let's Encrypt). `false`: plain HTTP on :80 only, no redirect/ACME — for a TLS-terminating upstream (e.g. a Cloudflare tunnel). Public URLs stay `https://` either way |
 | `[routing].hostname` | `localhost` | Default hostname for teams that don't set their own `hostname` |
 
 ### OAuth settings

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -41,3 +41,26 @@ Wildcard certificates (`*.dev.example.com`) via DNS-01 validation are also possi
 ## Service routing with Traefik
 
 Auxiliary services also get Traefik routing. A service named `meilisearch` with base domain `dev.example.com` becomes accessible at `https://meilisearch.dev.example.com`. Custom hostnames are also supported.
+
+## Behind a Cloudflare tunnel (or other TLS-terminating upstream)
+
+If HTTPS is terminated upstream — for example by a **Cloudflare tunnel** (`cloudflared`) that already serves a valid certificate — Traefik should not obtain its own certificates or redirect to HTTPS. Set `tls = false`:
+
+```toml
+[routing]
+mode = "traefik"
+tls = false          # Traefik listens on plain HTTP :80 only
+
+[team.1]
+hostname = "dev.example.com"
+```
+
+With `tls = false` Traefik:
+
+- Listens on **port 80 only** (443 is not published), serving plain HTTP.
+- Does **not** redirect HTTP→HTTPS and does **not** request Let's Encrypt certificates (`acme_email` is not required).
+- Routes by the same `Host` rules as before, so each environment keeps its own subdomain.
+
+Point the tunnel at the server's port 80 and route the wildcard hostname to it (e.g. `*.dev.example.com → http://localhost:80`). Cloudflare provides the certificate and forwards requests over HTTP; the tunnel sets `X-Forwarded-Proto: https`. On the `web` entrypoint Oduflow enables `forwardedHeaders.insecure` so Traefik passes those headers through (by default Traefik would overwrite `X-Forwarded-Proto` with the plain-HTTP connection scheme), letting Oduflow see the request as secure — the dashboard's session cookie stays `Secure` and every environment/service URL Oduflow reports is still `https://…`. Because this entrypoint trusts all forwarded headers, expose port 80 **only** to the tunnel, not to the public internet.
+
+> **Changing `tls` on a running deployment recreates Traefik but not your environments.** Each environment and service bakes its Traefik routing labels in at creation time — `entrypoints=websecure` (with Let's Encrypt) when `tls = true`, `entrypoints=web` when `tls = false`. Restarting Oduflow recreates the Traefik container in the new mode, but pre-existing environments and services keep their old labels: after the switch their routers point at an entrypoint that no longer matches, so they become unreachable until **recreated** (or, going `false → true`, get caught by the HTTP→HTTPS redirect). Treat `tls` as a deploy-time choice; if you must flip it on a live server, recreate the existing environments and services afterwards. The default is `tls = true` (Traefik terminates TLS with Let's Encrypt, as described above).

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -783,15 +783,24 @@ def create_environment(
             {
                 "traefik.enable": "true",
                 f"traefik.http.routers.{traefik_router}.rule": f"Host(`{traefik_host}`)",
-                f"traefik.http.routers.{traefik_router}.entrypoints": "websecure",
-                f"traefik.http.routers.{traefik_router}.tls": "true",
-                f"traefik.http.routers.{traefik_router}.tls.certresolver": "letsencrypt",
                 f"traefik.http.services.{traefik_router}.loadbalancer.server.port": "8069",
                 "traefik.docker.network": get_team_network_name(
                     team.team_id, settings.prefix
                 ),
             }
         )
+        if settings.routing_tls:
+            labels.update(
+                {
+                    f"traefik.http.routers.{traefik_router}.entrypoints": "websecure",
+                    f"traefik.http.routers.{traefik_router}.tls": "true",
+                    f"traefik.http.routers.{traefik_router}.tls.certresolver": "letsencrypt",
+                }
+            )
+        else:
+            # Upstream (e.g. Cloudflare tunnel) terminates TLS; Traefik routes
+            # plain HTTP on the web entrypoint. Public URL stays https://.
+            labels[f"traefik.http.routers.{traefik_router}.entrypoints"] = "web"
 
     logger.info(
         "Creating environment",

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -109,10 +109,15 @@ def create_service(
             hostname = f"{hostname}.{team.hostname}"
         labels["traefik.enable"] = "true"
         labels[f"traefik.http.routers.{container_name}.rule"] = f"Host(`{hostname}`)"
-        labels[f"traefik.http.routers.{container_name}.entrypoints"] = "websecure"
-        labels[f"traefik.http.routers.{container_name}.tls.certresolver"] = (
-            "letsencrypt"
-        )
+        if settings.routing_tls:
+            labels[f"traefik.http.routers.{container_name}.entrypoints"] = "websecure"
+            labels[f"traefik.http.routers.{container_name}.tls.certresolver"] = (
+                "letsencrypt"
+            )
+        else:
+            # Upstream terminates TLS (e.g. Cloudflare tunnel): plain HTTP on the
+            # web entrypoint. Public URL stays https:// below.
+            labels[f"traefik.http.routers.{container_name}.entrypoints"] = "web"
         if host_mode:
             labels[
                 f"traefik.http.services.{container_name}.loadbalancer.server.url"

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -137,12 +137,21 @@ def _write_traefik_dynamic_config(settings: Settings, config_path: str) -> None:
         if not team.hostname:
             continue
         router_name = f"oduflow-team-{team_id}"
-        routers[router_name] = {
-            "rule": f"Host(`{team.hostname}`)",
-            "service": "oduflow",
-            "entryPoints": ["websecure"],
-            "tls": {"certResolver": "letsencrypt"},
-        }
+        if settings.routing_tls:
+            routers[router_name] = {
+                "rule": f"Host(`{team.hostname}`)",
+                "service": "oduflow",
+                "entryPoints": ["websecure"],
+                "tls": {"certResolver": "letsencrypt"},
+            }
+        else:
+            # Behind an upstream TLS terminator (e.g. Cloudflare tunnel): plain
+            # HTTP on the web entrypoint, no TLS/ACME.
+            routers[router_name] = {
+                "rule": f"Host(`{team.hostname}`)",
+                "service": "oduflow",
+                "entryPoints": ["web"],
+            }
 
     if not routers:
         return
@@ -179,11 +188,13 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
 
     system_labels = {settings.managed_label: "true", settings.system_label: "true"}
 
-    try:
-        client.volumes.get(settings.traefik_acme_volume)
-    except docker.errors.NotFound:
-        client.volumes.create(settings.traefik_acme_volume, labels=system_labels)
-        logger.info("Created volume %s", settings.traefik_acme_volume)
+    # ACME/Let's Encrypt only when Traefik terminates TLS itself.
+    if settings.routing_tls:
+        try:
+            client.volumes.get(settings.traefik_acme_volume)
+        except docker.errors.NotFound:
+            client.volumes.create(settings.traefik_acme_volume, labels=system_labels)
+            logger.info("Created volume %s", settings.traefik_acme_volume)
 
     # Host path for the dynamic config, bind-mounted into the container below.
     # Use the resolved config dir (``/etc/oduflow`` when writable, else
@@ -194,38 +205,74 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
 
     try:
         t = client.containers.get(settings.traefik_container)
-        if t.status != "running":
-            t.start()
-        return
+        # Self-correcting drift control: _ensure_traefik never rewrites an
+        # existing container's args, so a flipped routing tls setting would
+        # otherwise be ignored until a manual recreate. The HTTP->HTTPS redirect
+        # arg is present only in TLS mode, so its presence must match
+        # routing_tls; recreate on mismatch (in either direction).
+        cmd = t.attrs.get("Config", {}).get("Cmd") or []
+        has_redirect = any("redirections" in str(arg) for arg in cmd)
+        if has_redirect != settings.routing_tls:
+            logger.info(
+                "Recreating %s: routing tls changed (was tls=%s, now tls=%s)",
+                settings.traefik_container,
+                has_redirect,
+                settings.routing_tls,
+            )
+            t.stop()
+            t.remove()
+        else:
+            if t.status != "running":
+                t.start()
+            return
     except docker.errors.NotFound:
         pass
 
-    client.containers.run(
-        "traefik:v3",
-        name=settings.traefik_container,
-        detach=True,
-        network=settings.shared_network,
-        ports={"80/tcp": 80, "443/tcp": 443},
-        extra_hosts={"host.docker.internal": "host-gateway"},
-        volumes={
-            "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "ro"},
-            settings.traefik_acme_volume: {"bind": "/acme", "mode": "rw"},
-            traefik_config: {"bind": "/etc/traefik/dynamic/oduflow.yml", "mode": "ro"},
-        },
-        command=[
-            "--log.level=INFO",
-            "--providers.docker=true",
-            "--providers.docker.exposedbydefault=false",
-            "--providers.file.filename=/etc/traefik/dynamic/oduflow.yml",
-            "--providers.file.watch=true",
-            "--entrypoints.web.address=:80",
+    volumes = {
+        "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "ro"},
+        traefik_config: {"bind": "/etc/traefik/dynamic/oduflow.yml", "mode": "ro"},
+    }
+    command = [
+        "--log.level=INFO",
+        "--providers.docker=true",
+        "--providers.docker.exposedbydefault=false",
+        "--providers.file.filename=/etc/traefik/dynamic/oduflow.yml",
+        "--providers.file.watch=true",
+        "--entrypoints.web.address=:80",
+    ]
+    if settings.routing_tls:
+        ports = {"80/tcp": 80, "443/tcp": 443}
+        volumes[settings.traefik_acme_volume] = {"bind": "/acme", "mode": "rw"}
+        command += [
             "--entrypoints.websecure.address=:443",
             "--entrypoints.web.http.redirections.entryPoint.to=websecure",
             "--entrypoints.web.http.redirections.entryPoint.scheme=https",
             "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web",
             f"--certificatesresolvers.letsencrypt.acme.email={settings.acme_email}",
             "--certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json",
-        ],
+        ]
+    else:
+        # Plain HTTP on :80 only — an upstream (e.g. Cloudflare tunnel)
+        # terminates TLS and forwards here over HTTP.
+        ports = {"80/tcp": 80}
+        # Trust the upstream's X-Forwarded-* headers. Without this Traefik
+        # overwrites X-Forwarded-Proto with the actual connection scheme (http
+        # on this entrypoint), so the tunnel's `X-Forwarded-Proto: https` would
+        # be lost and Oduflow would treat the request as insecure (dropping the
+        # cookie Secure flag and generating http:// links). This entrypoint is
+        # only meant to receive traffic from the trusted TLS terminator, so
+        # trusting all forwarded headers here is intended.
+        command.append("--entrypoints.web.forwardedHeaders.insecure=true")
+
+    client.containers.run(
+        "traefik:v3",
+        name=settings.traefik_container,
+        detach=True,
+        network=settings.shared_network,
+        ports=ports,
+        extra_hosts={"host.docker.internal": "host-gateway"},
+        volumes=volumes,
+        command=command,
         labels=system_labels,
         restart_policy={"Name": "unless-stopped"},
     )

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -127,6 +127,13 @@ class Settings:
     # Routing
     routing_mode: str = "port"
     acme_email: str = ""
+    # Whether Traefik terminates TLS itself. True (default): Traefik listens on
+    # :443, redirects HTTP->HTTPS and obtains Let's Encrypt certificates. False:
+    # Traefik listens on plain HTTP :80 only, no redirect and no ACME — for
+    # running behind a TLS-terminating upstream (e.g. a Cloudflare tunnel) that
+    # already serves HTTPS. Public URLs stay https:// (the upstream provides the
+    # certificate). Ignored in port mode.
+    routing_tls: bool = True
 
     # Database
     db_user: str = "odoo"
@@ -230,9 +237,12 @@ class Settings:
         if self.routing_mode not in ("port", "traefik"):
             raise ValueError("routing_mode must be 'port' or 'traefik'")
 
-        if self.routing_mode == "traefik":
+        if self.routing_mode == "traefik" and self.routing_tls:
             if not self.acme_email:
-                raise ValueError("acme_email must be set when routing_mode=traefik")
+                raise ValueError(
+                    "acme_email must be set when routing_mode=traefik and "
+                    "routing tls is enabled"
+                )
 
         # Validate per-team settings
         for team in self.teams.values():
@@ -381,6 +391,7 @@ class Settings:
             allow_insecure_http=bool(server.get("allow_insecure_http", False)),
             routing_mode=str(routing.get("mode", "port")).strip().lower(),
             acme_email=str(routing.get("acme_email", "")).strip(),
+            routing_tls=bool(routing.get("tls", True)),
             db_user=str(database.get("user", "odoo")),
             db_password=str(database.get("password", "odoo")),
             postgres_image=str(database.get("image", "postgres:15")),

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -9,8 +9,16 @@ allow_local_path = true        # allow live-mount (bind local checkout) workflow
 # ── Routing ───────────────────────────────────────────
 [routing]
 mode = "port"                   # "port" | "traefik"
-# acme_email = "admin@example.com"  # required for traefik
+# acme_email = "admin@example.com"  # required for traefik (when tls = true)
 # hostname = "localhost"           # default hostname for teams that don't set their own
+# tls = true                       # traefik only. true: Traefik terminates TLS
+#                                  # (:443, HTTP->HTTPS redirect, Let's Encrypt).
+#                                  # false: plain HTTP on :80 only, no redirect/ACME —
+#                                  # for a TLS-terminating upstream (e.g. Cloudflare
+#                                  # tunnel). Public URLs stay https:// either way.
+#                                  # Deploy-time choice: flipping it on a live server
+#                                  # requires recreating existing environments/services
+#                                  # (their routing labels are fixed at creation).
 
 # ── Database ──────────────────────────────────────────
 [database]

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -120,6 +120,45 @@ class TestCreateService:
         )
         # No port mapping in traefik mode
         assert "ports" not in run_kwargs[1]
+        # TLS mode: router uses websecure with Let's Encrypt.
+        assert (
+            labels["traefik.http.routers.oduflow-1-svc-meilisearch.entrypoints"]
+            == "websecure"
+        )
+        assert (
+            labels["traefik.http.routers.oduflow-1-svc-meilisearch.tls.certresolver"]
+            == "letsencrypt"
+        )
+
+    def test_create_traefik_no_tls(self, mock_docker_client):
+        # tls=false (e.g. behind a Cloudflare tunnel): router on the plain-HTTP
+        # web entrypoint, no certresolver — but the public URL stays https://.
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        settings = Settings(
+            routing_mode="traefik",
+            routing_tls=False,
+            base_data_dir="/tmp/flow-test",
+            db_user="odoo",
+            db_password="odoo",
+            teams={"1": TRAEFIK_TEAM},
+        )
+        result = service_ops.create_service(
+            settings, TRAEFIK_TEAM, "meilisearch", "getmeili/meilisearch:v1.6", 7700
+        )
+
+        assert result["url"] == "https://meilisearch.example.com"
+        labels = mock_docker_client.containers.run.call_args[1]["labels"]
+        assert (
+            labels["traefik.http.routers.oduflow-1-svc-meilisearch.entrypoints"]
+            == "web"
+        )
+        assert (
+            "traefik.http.routers.oduflow-1-svc-meilisearch.tls.certresolver"
+            not in labels
+        )
 
     def test_create_traefik_custom_hostname(self, mock_docker_client):
         mock_docker_client.networks.get.return_value = MagicMock()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -94,6 +94,35 @@ class TestSettings:
         with pytest.raises(ValueError, match="Duplicate auth_token"):
             s.validate()
 
+    def test_routing_tls_default(self):
+        # Traefik terminates TLS by default.
+        assert Settings().routing_tls is True
+
+    def test_routing_tls_from_toml(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[routing]\nmode = "traefik"\ntls = false\n'
+            '[team.1]\nhostname = "dev.example.com"\n'
+        )
+        s = Settings.from_toml(str(toml))
+        assert s.routing_tls is False
+
+    def test_validate_traefik_tls_requires_acme_email(self):
+        # tls = true (default) still requires an ACME e-mail.
+        team = TeamSettings(team_id="1", hostname="dev.example.com")
+        s = Settings(routing_mode="traefik", acme_email="", teams={"1": team})
+        with pytest.raises(ValueError, match="acme_email"):
+            s.validate()
+
+    def test_validate_traefik_no_tls_acme_email_optional(self):
+        # Behind a TLS-terminating upstream (tls = false) ACME is unused, so
+        # acme_email is not required.
+        team = TeamSettings(team_id="1", hostname="dev.example.com")
+        s = Settings(
+            routing_mode="traefik", routing_tls=False, acme_email="", teams={"1": team}
+        )
+        s.validate()
+
 
 class TestOAuthSettings:
     def _team(self, **kw):

--- a/tests/test_traefik_tls.py
+++ b/tests/test_traefik_tls.py
@@ -1,0 +1,104 @@
+import json
+from unittest.mock import MagicMock
+
+import docker
+
+from oduflow.docker_ops import system_ops
+from oduflow.settings import Settings, TeamSettings
+
+
+def _traefik_settings(tmp_path, tls):
+    team = TeamSettings(team_id="1", hostname="dev.example.com")
+    return Settings(
+        routing_mode="traefik",
+        routing_tls=tls,
+        acme_email="admin@example.com",
+        etc_dir=str(tmp_path),
+        teams={"1": team},
+    )
+
+
+class TestWriteDynamicConfig:
+    def test_tls_router_uses_websecure(self, tmp_path):
+        cfg = tmp_path / "traefik.yml"
+        system_ops._write_traefik_dynamic_config(
+            _traefik_settings(tmp_path, True), str(cfg)
+        )
+        router = json.loads(cfg.read_text())["http"]["routers"]["oduflow-team-1"]
+        assert router["entryPoints"] == ["websecure"]
+        assert router["tls"] == {"certResolver": "letsencrypt"}
+
+    def test_no_tls_router_uses_web(self, tmp_path):
+        cfg = tmp_path / "traefik.yml"
+        system_ops._write_traefik_dynamic_config(
+            _traefik_settings(tmp_path, False), str(cfg)
+        )
+        router = json.loads(cfg.read_text())["http"]["routers"]["oduflow-team-1"]
+        assert router["entryPoints"] == ["web"]
+        assert "tls" not in router
+
+
+class TestEnsureTraefik:
+    def _client_no_container(self):
+        client = MagicMock()
+        client.containers.get.side_effect = docker.errors.NotFound("nf")
+        client.volumes.get.side_effect = docker.errors.NotFound("nf")
+        return client
+
+    def test_tls_mode_publishes_443_and_acme(self, tmp_path):
+        client = self._client_no_container()
+        system_ops._ensure_traefik(client, _traefik_settings(tmp_path, True))
+        kwargs = client.containers.run.call_args[1]
+        assert kwargs["ports"] == {"80/tcp": 80, "443/tcp": 443}
+        cmd = kwargs["command"]
+        assert "--entrypoints.websecure.address=:443" in cmd
+        assert any("redirections" in a for a in cmd)
+        assert any("certificatesresolvers" in a for a in cmd)
+        assert "oduflow-traefik-acme" in kwargs["volumes"]
+        # Traefik terminates TLS itself, so no upstream forwarded-header trust.
+        assert not any("forwardedHeaders" in a for a in cmd)
+
+    def test_no_tls_mode_port_80_only(self, tmp_path):
+        client = self._client_no_container()
+        system_ops._ensure_traefik(client, _traefik_settings(tmp_path, False))
+        kwargs = client.containers.run.call_args[1]
+        assert kwargs["ports"] == {"80/tcp": 80}
+        cmd = kwargs["command"]
+        assert "--entrypoints.web.address=:80" in cmd
+        assert "--entrypoints.websecure.address=:443" not in cmd
+        assert not any("redirections" in a for a in cmd)
+        assert not any("certificatesresolvers" in a for a in cmd)
+        assert "oduflow-traefik-acme" not in kwargs["volumes"]
+        # Trust the upstream tunnel's X-Forwarded-* headers so X-Forwarded-Proto:
+        # https survives to Oduflow (cookie Secure flag, https:// links).
+        assert "--entrypoints.web.forwardedHeaders.insecure=true" in cmd
+        # ACME volume is not created when TLS is off.
+        client.volumes.create.assert_not_called()
+
+    def test_drift_recreates_on_tls_change(self, tmp_path):
+        # Existing container was built in TLS mode, but config now wants
+        # tls=false: the stale container is removed and a new one created.
+        existing = MagicMock()
+        existing.attrs = {
+            "Config": {
+                "Cmd": ["--entrypoints.web.http.redirections.entryPoint.to=websecure"]
+            }
+        }
+        client = MagicMock()
+        client.containers.get.return_value = existing
+        system_ops._ensure_traefik(client, _traefik_settings(tmp_path, False))
+        existing.stop.assert_called_once()
+        existing.remove.assert_called_once()
+        client.containers.run.assert_called_once()
+        assert client.containers.run.call_args[1]["ports"] == {"80/tcp": 80}
+
+    def test_no_drift_when_mode_matches(self, tmp_path):
+        # Existing container already in the desired (no-TLS) mode: reuse it.
+        existing = MagicMock()
+        existing.attrs = {"Config": {"Cmd": ["--entrypoints.web.address=:80"]}}
+        existing.status = "running"
+        client = MagicMock()
+        client.containers.get.return_value = existing
+        system_ops._ensure_traefik(client, _traefik_settings(tmp_path, False))
+        existing.remove.assert_not_called()
+        client.containers.run.assert_not_called()


### PR DESCRIPTION
Adds a `[routing].tls` setting (bool, default `true`) so that with `mode = "traefik", tls = false` Traefik listens on plain HTTP :80 only — no HTTP→HTTPS redirect and no Let's Encrypt/ACME — for running behind a TLS-terminating upstream such as a Cloudflare tunnel, while public URLs stay `https://` (the upstream serves the certificate). Environment and service routers bind to the `web` entrypoint without TLS, the `acme_email` requirement is lifted in this mode, and the web entrypoint enables `forwardedHeaders.insecure` so the tunnel's `X-Forwarded-Proto: https` reaches Oduflow (preserving the cookie `Secure` flag and `https://` links). `_ensure_traefik` self-corrects on a flipped `tls` value by recreating the container, and the docs note that flipping it on a live server requires recreating existing environments/services since their routing labels are fixed at creation. Covered by new unit tests in `tests/test_traefik_tls.py` plus additions to `test_settings.py` and `test_service_ops.py`; docs updated in `docs/traefik.md`, `docs/installation.md`, and the `oduflow.toml` template.