### PR TITLE
feat(dashboard): red "boom-boom" flash on the unlicensed license badge

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -991,6 +991,39 @@
     32% { opacity: 1; transform: scale(1); }
     100% { opacity: 0; transform: scale(1.16); }
   }
+  .license-alert {
+    animation:
+      license-alert-flash 1.1s cubic-bezier(0.22, 1, 0.36, 1) both,
+      license-alert-jolt 1.1s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @keyframes license-alert-flash {
+    /* bum — first ring + edge flare */
+    0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--red) 55%, transparent);
+           background: color-mix(in oklab, var(--red) 12%, transparent);
+           border-color: color-mix(in oklab, var(--red) 30%, transparent); }
+    9%   { background: color-mix(in oklab, var(--red) 40%, transparent);
+           border-color: color-mix(in oklab, var(--red) 85%, transparent); }
+    22%  { box-shadow: 0 0 0 7px color-mix(in oklab, var(--red) 0%, transparent);
+           background: color-mix(in oklab, var(--red) 12%, transparent);
+           border-color: color-mix(in oklab, var(--red) 30%, transparent); }
+    40%  { box-shadow: 0 0 0 0 color-mix(in oklab, var(--red) 0%, transparent); }
+    /* bum — second ring + edge flare */
+    50%  { box-shadow: 0 0 0 0 color-mix(in oklab, var(--red) 55%, transparent); }
+    59%  { background: color-mix(in oklab, var(--red) 40%, transparent);
+           border-color: color-mix(in oklab, var(--red) 85%, transparent); }
+    72%  { box-shadow: 0 0 0 7px color-mix(in oklab, var(--red) 0%, transparent);
+           background: color-mix(in oklab, var(--red) 12%, transparent);
+           border-color: color-mix(in oklab, var(--red) 30%, transparent); }
+    100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--red) 0%, transparent);
+           background: color-mix(in oklab, var(--red) 12%, transparent);
+           border-color: color-mix(in oklab, var(--red) 30%, transparent); }
+  }
+  @keyframes license-alert-jolt {
+    0%, 40%, 50%, 100% { transform: translateX(0); }
+    6%, 56%  { transform: translateX(-2px); }
+    14%, 64% { transform: translateX(2px); }
+    22%, 72% { transform: translateX(0); }
+  }
   .tab-toolbar { display: flex; justify-content: flex-end; gap: 8px; margin-bottom: 12px; }
   .hint { font-size: var(--text-xs); color: var(--text-dim); margin-top: 4px; }
   .label-hint { color: var(--text-dim); font-weight: 400; }
@@ -1077,6 +1110,7 @@
     .spinner { animation: none; opacity: 0.7; }
     .badge-pulse { animation: none; }
     .license-reveal { animation: none; }
+    .license-alert { animation: none; }
     .license-active.license-reveal::after { animation: none; }
     .license-owner-reveal, .license-owner-reveal::before { animation: none; }
     .toast { transition: opacity 0.1s; transform: none; }
@@ -3830,6 +3864,16 @@ async function loadLicense() {
       badge.style.cursor = 'pointer';
       badge.onclick = openLicenseModal;
       badge.title = 'Click to activate a license';
+      if (badge.dataset.alertPlayed !== 'true') {
+        badge.dataset.alertPlayed = 'true';
+        void badge.offsetWidth;                 // reflow — guarantee the animation starts
+        badge.classList.add('license-alert');
+        badge.addEventListener('animationend', function onEnd(e) {
+          if (e.animationName !== 'license-alert-flash') return;  // the longer of the two
+          badge.classList.remove('license-alert');
+          badge.removeEventListener('animationend', onEnd);
+        }, false);
+      }
     } else {
       badge.style.cursor = 'default';
       badge.onclick = null;


### PR DESCRIPTION
## What

Adds a special effect for the **unlicensed** state of the header license badge, mirroring the celebratory reveal the badge already plays when a license is **activated**.

On dashboard load, the `UNLICENSED — NON-COMMERCIAL USE ONLY` badge now **pulses red at its edges twice and gives a small jolt** ("bum-bum") — a gentle "register" nudge.

## How

`src/oduflow/templates/dashboard.html` only (no backend changes):

- **CSS** — new `.license-alert` class + `@keyframes license-alert-flash` (double red ring/edge flare via `box-shadow` + border/background) and `license-alert-jolt` (subtle `translateX ±2px`). Uses only the existing `--red` token and the same `cubic-bezier(0.22, 1, 0.36, 1)` easing as the license reveal — no new `var(--*)`.
- **JS** — `loadLicense()` adds the class once per page load (guarded by `dataset.alertPlayed`, cleared on `animationend`). `loadLicense()` only runs at startup and after activation, so auto-refresh never replays it.
- **Accessibility** — disabled under `prefers-reduced-motion`; the banner text still carries the meaning (status never by color/motion alone).

This follows DESIGN.md §5 Badges — *"the badge pulses twice in its own signal color"* — applied to the license badge in red.

## Verify

1. Open the dashboard on an instance **without** a license → badge flashes red twice + jolts on load.
2. Activate a license → normal celebratory reveal plays; red flash no longer appears.
3. Enable "reduce motion" → no flash, static red badge.
4. Narrow viewport (≤880px, badge full-width) → ring/jolt don't break the header layout.