### PR TITLE
fix(dashboard): tighten unlicensed flash lifecycle (Greptile review on #104)

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3866,13 +3866,18 @@ async function loadLicense() {
       badge.title = 'Click to activate a license';
       if (badge.dataset.alertPlayed !== 'true') {
         badge.dataset.alertPlayed = 'true';
-        void badge.offsetWidth;                 // reflow — guarantee the animation starts
-        badge.classList.add('license-alert');
-        badge.addEventListener('animationend', function onEnd(e) {
-          if (e.animationName !== 'license-alert-flash') return;  // the longer of the two
-          badge.classList.remove('license-alert');
-          badge.removeEventListener('animationend', onEnd);
-        }, false);
+        // Under reduced motion the CSS sets animation:none, so animationend would
+        // never fire — skip the class/listener entirely to keep the lifecycle tight.
+        var reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (!reduceMotion) {
+          void badge.offsetWidth;                 // reflow — guarantee the animation starts
+          badge.classList.add('license-alert');
+          badge.addEventListener('animationend', function onEnd(e) {
+            if (e.animationName !== 'license-alert-flash') return;  // canonical: both are 1.1s; pick one to trigger cleanup
+            badge.classList.remove('license-alert');
+            badge.removeEventListener('animationend', onEnd);
+          }, false);
+        }
       }
     } else {
       badge.style.cursor = 'default';


### PR DESCRIPTION
Addresses the two P2 comments from Greptile's review on #104.

## Changes

`src/oduflow/templates/dashboard.html` — `loadLicense()` unlicensed branch:

1. **Reduced-motion listener leak** — under `prefers-reduced-motion` the CSS sets `.license-alert { animation: none; }`, so `animationend` never fires and the class + `onEnd` listener would stay stranded for the page session. Now we read `matchMedia('(prefers-reduced-motion: reduce)').matches` and skip adding the class/listener entirely when motion is reduced (CSS already suppresses the animation). Lifecycle is airtight.
2. **Misleading comment** — both `license-alert-flash` and `license-alert-jolt` share the same 1.1s duration, so "the longer of the two" was inaccurate. Reworded to "canonical: both are 1.1s; pick one to trigger cleanup".

No visual/behavioral change for normal (motion-enabled) users.