### PR TITLE
Import Odoo.sh addons and chunk large uploads

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -35,6 +35,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `save_as_template` | ✓ | ⚠️ Save a branch DB + filestore as a new template |
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
+| `rename_template` | ✓ | Rename a template (directory + PostgreSQL template DB); refused if any environment uses it |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |

--- a/specs/0030-odoo-sh-addons-import.md
+++ b/specs/0030-odoo-sh-addons-import.md
@@ -1,0 +1,138 @@
+# 0030 — Odoo.sh import brings the addons-path, not just the database
+
+**Status:** Adopted (still in force)
+**Type:** Architecture / Capability
+**First introduced:** `litnimax/madrid-v1` branch (2026-07-04)
+**Key code today:** `templates/import-odoo.sh` (addons-path detection + `--with-*` flags + tar/remote upload), `web_ui.py` (`/api/templates/import/addon` + `/addon-remote` ingest, addon progress in `import/status`, `--with-*` composition in `import-token`), `docker_ops/system_ops.py` (`extract_addon_dir`, `_wire_imported_addons`, `rename_template`), `extra_addons.py` (`create_local_repo`, `.local` fetch short-circuit), dashboard import modal checkboxes + template Rename
+
+## Context
+
+The push-based Odoo.sh import ([[0023-import-from-odoo-sh]]) restores a template
+from the platform's daily backup — but that backup contains only the **database
+and filestore**. Odoo.sh actually runs with a much wider `--addons-path`, and a
+restored database will not boot without the modules it references. A real build
+line looks like:
+
+```
+--addons-path=/home/odoo/src/odoo/addons,/home/odoo/src/odoo/odoo/addons,
+  /home/odoo/src/enterprise,/home/odoo/src/themes,/home/odoo/src/user,
+  /home/odoo/src/user/OCA/account-reconcile,/home/odoo/src/user/OCA/bank-statement-import
+```
+
+Those paths fall into distinct classes with different reachability:
+
+- **Standard Odoo addons** (`.../src/odoo/addons`, `.../src/odoo/odoo/addons`) —
+  already ship inside the `odoo:<ver>` Docker image; nothing to fetch.
+- **Enterprise** (`odoo/enterprise`) and **Themes** (`odoo/design-themes`) —
+  proprietary Odoo repos over SSH with **no public access**; Oduflow cannot
+  clone them. The only copy a shell can reach is the checked-out files on the
+  build filesystem.
+- **The customer's own repo** (`.../src/user`) — they already have it (their
+  `repo_url`); not ours to fetch.
+- **Extra repos** (OCA and similar, added in Odoo.sh settings) — git worktrees
+  whose `origin` is usually a **reachable public** `https://` URL.
+
+The addons live on the build filesystem, not in the backup, so they must be
+inspected and transferred separately from the DB/filestore stream. Reuse of
+[[0010-extra-addons-repositories]] was the obvious target — but that subsystem
+assumed **every** extra repo has a remote to clone and fetch from, which is
+false for Enterprise/Themes.
+
+A separate, long-standing gap: templates could be created and deleted but never
+**renamed**.
+
+## Decision
+
+Extend the Odoo.sh client so that, when asked, it also carries over the
+addons-path as Oduflow **extra-addons** wired into the new template — reusing
+[[0010-extra-addons-repositories]] end to end. Reachability decides the
+mechanism, not the user: reachable repos are **cloned from their origin** (and
+stay updatable); unreachable ones (Enterprise, Themes, private extras) are
+**downloaded as files** into a new kind of **local, remote-less** extra-addons
+repo. Selection is three checkboxes in the import dialog, gated behind a
+licensing acknowledgment. Separately, add **template rename**.
+
+The design deliberately does **not** offer to push imported addons into a
+user-supplied empty repo, and does not try to preserve both the exact Odoo.sh
+commit *and* updatability: a branch-based extra-addons model can give one or the
+other, and updatability (a reachable remote) is the more useful of the two.
+
+## How it works (macro)
+
+- **Checkboxes → flags, classification at runtime.** The modal has static
+  *Enterprise / Themes / Extra Addons* checkboxes plus an acknowledgment tied to
+  a licensing-notes link (`oduflow.dev/odoo-sh-import-notes`). Checked boxes make
+  the mint endpoint append `--with-enterprise` / `--with-themes` /
+  `--with-extra-addons` to the one-line command. There is no second "analysis"
+  script and no report round-trip: the client itself reads the live
+  `--addons-path` (from the running `odoo-bin`, falling back to `odoo.conf`) and
+  classifies each entry at run time. If it cannot find the addons-path it warns
+  and still imports the DB/filestore.
+- **Two ingest shapes, mirroring the filestore stream.** For a repo that will
+  become local (Enterprise, Themes, a private extra), the client tars the
+  directory (`--exclude=.git`) and streams it to
+  `/api/templates/import/addon?name=…&branch=…`; the server extracts it
+  atomically (temp dir → rename, zip-slip guarded) into
+  `staging/<tpl>/addons/<name>/`, exactly like a filestore chunk. For a reachable
+  extra it uploads **nothing** — it announces `{name, origin_url, branch}` to
+  `/api/templates/import/addon-remote`. Both record the addon in a staged
+  `addons.json`. Progress for both is disk/manifest-derived and surfaced in
+  `import/status`, so a resumed run skips what already landed.
+- **Finalize wires addons into the template.** After the DB restore,
+  `_wire_imported_addons` turns each staged addon into an extra-addons repo:
+  `kind == "remote"` is `clone_extra_repo`'d from its origin (updatable via the
+  normal `update_extra_repo`), everything else is seeded by the new
+  `create_local_repo`. Their `{name: branch}` is merged into the template's
+  `extra_addons` metadata, so environments created from the template mount the
+  same addons-path Odoo.sh ran with. One bad addon is logged, never fatal — the
+  database/filestore is the critical artifact.
+- **Local (remote-less) extra-addons.** `create_local_repo` builds a real bare
+  git repo with a single branch seeded from the uploaded files and drops a
+  `.local` marker. The whole worktree / mount / `pull_and_apply` machinery is
+  unchanged because the repo has a genuine branch. The one behavioural change is
+  a short-circuit at the top of `fetch_extra_repo`: a `.local` repo reports
+  "up to date" instead of running `git fetch` (there is no origin). That single
+  guard covers worktree creation, pulls, and the REST/MCP update path; the UI
+  tags such repos "local (no remote)".
+- **Template rename.** `rename_template` renames the template directory and,
+  when loaded, `ALTER DATABASE … RENAME`s the PostgreSQL template DB
+  (`datistemplate` toggled off/on, sessions terminated first). DB rename runs
+  first (reversible) then the directory; a directory failure rolls the DB name
+  back so the two never diverge. It is **refused** when any environment
+  references the template — the `oduflow.template` container label is immutable
+  on a running container and the overlay-remount path matches on it, so renaming
+  out from under an environment would orphan it (same stance as
+  `delete_extra_repo` on in-use repos). Exposed as an MCP tool, a
+  `/api/templates/{name}/rename` endpoint, and a dashboard Rename button.
+
+## Consequences
+
+- **Imported templates boot.** A template restored from Odoo.sh can carry the
+  Enterprise/Themes/extra modules its database needs, so environments spun from
+  it come up with the same addons-path — no manual repo wiring afterward.
+- **Reachability, not a wizard, picks the mechanism.** Public repos stay
+  updatable (cloned, fetchable); proprietary/private code is vendored as a local
+  copy. Bandwidth is spent only where a clone is impossible.
+- **A new repo class.** Extra-addons are no longer always remote-backed. The
+  `.local` marker and the fetch short-circuit are the whole cost; a local repo
+  is simply never updatable from an origin, which is correct for
+  Enterprise/Themes.
+- **Licensing is surfaced, not enforced.** Downloading Enterprise/Themes copies
+  proprietary Odoo code; the dialog links the rights/obligations notes and gates
+  the download options behind an acknowledgment, but the responsibility remains
+  the operator's.
+- **Rename is intentionally conservative.** Blocking rename of an in-use
+  template avoids container relabeling/recreation; the operator deletes the
+  environments first or leaves the name. New public surface is unchanged — the
+  two new ingest endpoints join the existing token-authed
+  `/api/templates/import/*` family; rename stays behind the UI login.
+
+## History
+
+- `litnimax/madrid-v1` (2026-07-04) — addons-path import: `--with-*` flags and
+  runtime classification in `import-odoo.sh`; `/api/templates/import/addon` +
+  `/addon-remote` ingest and addon progress in `import/status`;
+  `extract_addon_dir` + `_wire_imported_addons` in `system_ops`; local
+  remote-less repos (`create_local_repo` + `.local` fetch short-circuit) in
+  `extra_addons`; dashboard import checkboxes + licensing acknowledgment; and
+  `rename_template` (MCP tool + REST + dashboard Rename).

--- a/specs/0030-odoo-sh-addons-import.md
+++ b/specs/0030-odoo-sh-addons-import.md
@@ -127,6 +127,23 @@ other, and updatability (a reachable remote) is the more useful of the two.
   two new ingest endpoints join the existing token-authed
   `/api/templates/import/*` family; rename stays behind the UI login.
 
+## Evolution
+
+- **Chunked large-payload upload (2026-07-04).** Deploying behind a Cloudflare
+  Tunnel surfaced Cloudflare's 100 MB request-body cap: the ~114 MB SQL dump (and
+  Enterprise/Themes tars, also >100 MB) were rejected at the edge with `413`
+  before reaching Oduflow. The dump and addon uploads were therefore made
+  **chunked**: the client splits the file into ≤90 MiB byte-range parts
+  (`offset`/`total` query params) and the server appends them in order,
+  assembling the file when the last part lands — mirroring how the filestore is
+  already split by hash-directory. It is resumable (the dump resumes from the
+  server's reported `dump_bytes`) and idempotent (a re-sent final part after
+  completion just reports done; an out-of-order part gets a `409` with the
+  expected offset). The legacy single-shot upload path is retained for callers
+  that don't pass `offset`. This keeps the import working under any body-size
+  cap, not just Cloudflare's. (Note: filestore hash-dir chunks are assumed
+  <100 MB; a single oversized bucket would need the same treatment.)
+
 ## History
 
 - `litnimax/madrid-v1` (2026-07-04) — addons-path import: `--with-*` flags and

--- a/specs/README.md
+++ b/specs/README.md
@@ -48,6 +48,7 @@ precursors).
 | [0027](0027-hard-tenant-isolation.md) | 2026-07-02 | Hard tenant isolation: per-team networks, resource limits, disk quotas |
 | [0028](0028-scoped-environment-mcp-access.md) | 2026-07-03 | Scoped single-environment MCP access: `/mcp/<env>` + per-environment tokens |
 | [0029](0029-agent-console-and-chat.md) | 2026-07-03 | Per-team coding agent: browser console and ACP chat |
+| [0030](0030-odoo-sh-addons-import.md) | 2026-07-04 | Odoo.sh import brings the addons-path (Enterprise/Themes/extra) + local extra-addons + template rename |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -17,6 +17,7 @@ from docker import DockerClient
 from oduflow.docker_ops.client import chown_recursive, get_client, get_odoo_uid_gid
 from oduflow.docker_ops.stats import default_env_limits
 from oduflow.errors import (
+    ConflictError,
     ExternalCommandError,
     NotFoundError,
     PrerequisiteNotMetError,
@@ -26,6 +27,7 @@ from oduflow.naming import (
     get_tablespace_name,
     get_team_network_name,
     get_template_db_name,
+    validate_template_name,
 )
 from oduflow.settings import Settings, TeamSettings
 
@@ -1760,6 +1762,120 @@ def extract_filestore_chunk(tar_path: str, filestore_dir: str, chunk: str) -> in
     return written
 
 
+def extract_addon_dir(tar_path: str, addons_dir: str, name: str) -> int:
+    """Atomically extract one addon-repo tar (``<name>/...``) into ``addons_dir``.
+
+    Mirrors :func:`extract_filestore_chunk`: unpack into a temporary sibling,
+    verify the expected top-level ``<name>/`` directory is present, then rename
+    into place, so a truncated upload never leaves a half-extracted addon behind
+    (resume treats a present addon dir as complete). Returns files written.
+    """
+    os.makedirs(addons_dir, exist_ok=True)
+    tmp_root = os.path.join(addons_dir, f".incoming_{name}")
+    if os.path.exists(tmp_root):
+        shutil.rmtree(tmp_root)
+    cleanup = tmp_root
+    try:
+        written = extract_filestore_tar(tar_path, tmp_root)
+        entries = [e for e in os.listdir(tmp_root) if not e.startswith(".")]
+        dirs = [e for e in entries if os.path.isdir(os.path.join(tmp_root, e))]
+        # The client tars the repo directory (top-level "<repodir>/..."), so a
+        # single top-level dir is the addon root; otherwise (a tar of the repo's
+        # bare contents) tmp_root itself is the root. Either way it lands as
+        # addons/<name>.
+        if len(entries) == 1 and len(dirs) == 1:
+            src = os.path.join(tmp_root, dirs[0])
+        else:
+            src = tmp_root
+        final = os.path.join(addons_dir, name)
+        if os.path.exists(final):
+            shutil.rmtree(final)
+        os.rename(src, final)
+        if src == tmp_root:
+            cleanup = None  # renamed away, nothing to clean
+    finally:
+        if cleanup and os.path.exists(cleanup):
+            shutil.rmtree(cleanup)
+    return written
+
+
+def _wire_imported_addons(
+    team: TeamSettings, staging_dir: str, major_version: str
+) -> dict[str, str]:
+    """Turn staged Odoo.sh addons into Oduflow extra-addons repos.
+
+    Reads ``addons.json`` (a list of ``{name, kind, branch, origin_url}``) from
+    the staging dir. For each entry: ``kind == "remote"`` is cloned from its
+    origin (updatable via update_extra_repo); everything else is seeded as a
+    local (remote-less) repo from ``addons/<name>/``. A repo that already exists
+    is left as-is. Returns ``{name: branch}`` for every addon that is available
+    for the template to reference (existing or freshly created).
+    """
+    from oduflow import extra_addons
+
+    manifest = os.path.join(staging_dir, "addons.json")
+    if not os.path.isfile(manifest):
+        return {}
+    try:
+        with open(manifest) as f:
+            entries = json.load(f)
+        if not isinstance(entries, list):
+            return {}
+    except (OSError, ValueError):
+        logger.warning("Could not read staged addons manifest %s", manifest)
+        return {}
+
+    addons_src = os.path.join(staging_dir, "addons")
+    wired: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        if not name:
+            continue
+        kind = str(entry.get("kind") or "local").strip()
+        branch = str(entry.get("branch") or "").strip()
+        if branch in ("", "HEAD"):
+            branch = major_version or "import"
+        origin_url = str(entry.get("origin_url") or "").strip()
+        repo_path = os.path.join(team.shared_repos_dir, name)
+
+        # Already registered (e.g. a re-run, or the user added it manually):
+        # reference it, don't recreate.
+        if os.path.isdir(repo_path):
+            wired[name] = branch
+            logger.info("Extra repo '%s' already exists; referencing it", name)
+            continue
+
+        src_dir = os.path.join(addons_src, name)
+        try:
+            if kind == "remote" and origin_url:
+                try:
+                    extra_addons.clone_extra_repo(team, name, origin_url)
+                    wired[name] = branch
+                    continue
+                except Exception as exc:  # noqa: BLE001 - fall back to local files
+                    logger.warning(
+                        "Clone of extra repo '%s' from %s failed (%s); "
+                        "falling back to local copy if available",
+                        name,
+                        origin_url,
+                        exc,
+                    )
+            if os.path.isdir(src_dir):
+                extra_addons.create_local_repo(team, name, src_dir, branch)
+                wired[name] = branch
+            else:
+                logger.warning(
+                    "Addon '%s' has no uploaded files and no usable origin; skipped",
+                    name,
+                )
+        except Exception as exc:  # noqa: BLE001 - one bad addon must not abort import
+            logger.warning("Could not wire imported addon '%s': %s", name, exc)
+
+    return wired
+
+
 def finalize_imported_template(
     settings: Settings,
     team: TeamSettings,
@@ -1835,6 +1951,24 @@ def finalize_imported_template(
     _update_template_sizes(team, settings, template_name)
     result = reload_template(settings, team, template_name=template_name)
 
+    # Turn any uploaded/announced addons (Enterprise, Themes, extra repos) into
+    # Oduflow extra-addons repos and record them on the template so environments
+    # created from it mount the same addons-path Odoo.sh ran with. Done after the
+    # DB restore and before staging cleanup; a single bad addon is logged, not
+    # fatal — the database/filestore import is the critical part.
+    wired = _wire_imported_addons(team, staging_dir, major_version)
+    if wired:
+        meta_path = team.get_template_metadata_path(template_name)
+        try:
+            with open(meta_path) as f:
+                md = json.load(f)
+            existing = _normalize_extra_addons(md.get("extra_addons", {}))
+            md["extra_addons"] = {**existing, **wired}
+            with open(meta_path, "w") as f:
+                json.dump(md, f, indent=2)
+        except (OSError, ValueError) as exc:
+            logger.warning("Could not record imported addons on template: %s", exc)
+
     shutil.rmtree(staging_dir, ignore_errors=True)
 
     return {
@@ -1844,6 +1978,7 @@ def finalize_imported_template(
         "restore_seconds": result.get("restore_seconds", 0),
         "affected_envs": remount.affected,
         "remount_failures": remount.failures,
+        "extra_addons": wired,
     }
 
 
@@ -2025,6 +2160,125 @@ def delete_template(
         logger.info("Removed template directory %s", template_dir_path)
 
     return {"status": "dropped", "template_name": template_name, "template_db": tpl_db}
+
+
+def rename_template(
+    settings: Settings, team: TeamSettings, template_name: str, new_name: str
+) -> dict[str, str]:
+    """Rename a template's directory and (if loaded) its PostgreSQL template DB.
+
+    Blocked when any environment was created from the template: the
+    ``oduflow.template`` label is immutable on a running container and
+    :func:`env_ops.remount_template_overlays` matches environments by it, so
+    renaming out from under them would orphan them (mirrors how
+    ``delete_extra_repo`` refuses in-use repos).
+
+    The DB is renamed first (reversible with a second ``ALTER``), then the
+    directory; if the directory rename fails, the DB name is rolled back so the
+    two never diverge.
+    """
+    validate_template_name(template_name)
+    validate_template_name(new_name)
+    if new_name == template_name:
+        raise ConflictError("New template name is the same as the current one.")
+
+    old_dir = team.get_template_dir(template_name)
+    new_dir = team.get_template_dir(new_name)
+    if not os.path.isdir(old_dir):
+        raise NotFoundError(f"Template '{template_name}' not found.")
+    if os.path.isdir(new_dir):
+        raise ConflictError(f"Template '{new_name}' already exists.")
+
+    client = get_client()
+    old_db = get_template_db_name(template_name, team.team_id)
+    new_db = get_template_db_name(new_name, team.team_id)
+
+    # Refuse if any environment references this template (immutable label).
+    filters = {
+        "label": [
+            f"{settings.managed_label}=true",
+            f"{settings.team_label}={team.team_id}",
+        ]
+    }
+    dependent: list[str] = []
+    for c in client.containers.list(all=True, filters=filters):
+        if c.labels.get("oduflow.template", "none") == template_name:
+            dependent.append(c.labels.get(settings.branch_label, c.name))
+    if dependent:
+        raise ConflictError(
+            f"Cannot rename template '{template_name}': used by environments: "
+            f"{', '.join(dependent)}. Delete those environments first."
+        )
+
+    db_renamed = False
+    if _db_exists(client, settings, old_db):
+        if _db_exists(client, settings, new_db):
+            raise ConflictError(f"A template database named '{new_db}' already exists.")
+        _wait_pg_ready(client, settings)
+        _exec_sql(
+            client,
+            settings,
+            f"UPDATE pg_database SET datistemplate=false WHERE datname='{old_db}';",
+        )
+        # ALTER DATABASE ... RENAME fails if the database has open sessions.
+        _exec_sql(
+            client,
+            settings,
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            f"WHERE datname='{old_db}' AND pid<>pg_backend_pid();",
+        )
+        try:
+            _exec_sql(
+                client, settings, f'ALTER DATABASE "{old_db}" RENAME TO "{new_db}";'
+            )
+            db_renamed = True
+        finally:
+            # Re-mark whichever name is live as a template.
+            live_db = new_db if db_renamed else old_db
+            _exec_sql(
+                client,
+                settings,
+                f"UPDATE pg_database SET datistemplate=true WHERE datname='{live_db}';",
+            )
+        logger.info("Renamed template DB %s -> %s", old_db, new_db)
+
+    try:
+        os.makedirs(os.path.dirname(new_dir), exist_ok=True)
+        os.rename(old_dir, new_dir)
+    except OSError as exc:
+        if db_renamed:
+            try:
+                _exec_sql(
+                    client,
+                    settings,
+                    f"UPDATE pg_database SET datistemplate=false "
+                    f"WHERE datname='{new_db}';",
+                )
+                _exec_sql(
+                    client, settings, f'ALTER DATABASE "{new_db}" RENAME TO "{old_db}";'
+                )
+                _exec_sql(
+                    client,
+                    settings,
+                    f"UPDATE pg_database SET datistemplate=true "
+                    f"WHERE datname='{old_db}';",
+                )
+                logger.warning("Rolled back template DB rename after directory failure")
+            except Exception:  # noqa: BLE001 - rollback is best-effort
+                logger.error(
+                    "Template DB renamed to %s but directory rename failed and the "
+                    "DB rollback also failed; manual reconciliation needed.",
+                    new_db,
+                )
+        raise ExternalCommandError("rename template directory", 1, str(exc))
+
+    logger.info("Renamed template '%s' -> '%s'", template_name, new_name)
+    return {
+        "status": "renamed",
+        "template_name": new_name,
+        "old_name": template_name,
+        "template_db": new_db,
+    }
 
 
 def list_templates(settings: Settings, team: TeamSettings) -> list[dict]:

--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 
 from oduflow.docker_ops.client import get_client
 from oduflow.errors import (
@@ -96,6 +97,112 @@ def clone_extra_repo(
     return {"name": name, "repo_url": repo_url, "path": target}
 
 
+def create_local_repo(
+    team: TeamSettings, name: str, source_dir: str, branch: str
+) -> dict:
+    """Create an extra-addons repo from local files, with no remote origin.
+
+    Used by the Odoo.sh import for addons that cannot be cloned (Enterprise,
+    Themes, private extra repos): the uploaded directory is seeded into a real
+    bare git repo with a single *branch*, so the normal worktree / mount /
+    pull_and_apply machinery works unchanged. A ``.local`` marker file records
+    that the repo has no origin; :func:`fetch_extra_repo` short-circuits on it,
+    so worktree creation and pulls never attempt a (non-existent) fetch.
+    """
+    if not _NAME_RE.match(name):
+        raise ValueError(
+            f"Invalid repo name '{name}': only [a-zA-Z0-9_-] allowed, "
+            "no dots or slashes, max 63 chars."
+        )
+    if not branch:
+        raise ValueError("A branch name is required for a local extra repo.")
+
+    target = os.path.join(team.shared_repos_dir, name)
+    if os.path.exists(target):
+        raise ConflictError(f"Extra repo '{name}' already exists at {target}")
+
+    os.makedirs(team.shared_repos_dir, exist_ok=True)
+
+    # A clean environment has no git identity configured, so the seed commit
+    # would fail — supply one explicitly for this operation only.
+    seed_env = {
+        **GIT_ENV,
+        "GIT_AUTHOR_NAME": "Oduflow",
+        "GIT_AUTHOR_EMAIL": "import@oduflow.local",
+        "GIT_COMMITTER_NAME": "Oduflow",
+        "GIT_COMMITTER_EMAIL": "import@oduflow.local",
+    }
+
+    def _git(args: list[str], timeout: int = 300) -> None:
+        subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=seed_env,
+        )
+
+    tmp = tempfile.mkdtemp(prefix="oduflow-localrepo-")
+    try:
+        _git(["git", "init", "--bare", target], timeout=30)
+        _git(["git", "-C", tmp, "init"], timeout=30)
+        # Copy the source tree in, skipping any stray VCS metadata (Odoo.sh
+        # worktrees leave a .git gitdir pointer; the tar upload excludes it, but
+        # be defensive here too).
+        for entry in os.listdir(source_dir):
+            if entry == ".git":
+                continue
+            src = os.path.join(source_dir, entry)
+            dst = os.path.join(tmp, entry)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst, symlinks=True)
+            else:
+                shutil.copy2(src, dst)
+        _git(["git", "-C", tmp, "add", "-A"], timeout=120)
+        _git(
+            [
+                "git",
+                "-C",
+                tmp,
+                "commit",
+                "--allow-empty",
+                "-m",
+                "Imported from Odoo.sh",
+            ],
+            timeout=120,
+        )
+        _git(["git", "-C", tmp, "branch", "-M", branch], timeout=30)
+        _git(["git", "-C", tmp, "push", target, f"{branch}:{branch}"], timeout=300)
+    except subprocess.CalledProcessError as e:
+        shutil.rmtree(target, ignore_errors=True)
+        raise ExternalCommandError(
+            "git (create local repo)", e.returncode, e.stderr or ""
+        )
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(target, ignore_errors=True)
+        raise ExternalCommandError("git (create local repo)", -1, "Seed timed out.")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    # Mark as local (no origin) — the marker is what fetch_extra_repo keys on.
+    open(os.path.join(target, ".local"), "w").close()
+
+    logger.info("Created local extra repo '%s' (branch '%s')", name, branch)
+    return {
+        "name": name,
+        "repo_url": "",
+        "path": target,
+        "local": True,
+        "branch": branch,
+    }
+
+
+def is_local_repo(team: TeamSettings, name: str) -> bool:
+    """True if the extra repo is a remote-less local repo (Odoo.sh import)."""
+    return os.path.exists(os.path.join(team.shared_repos_dir, name, ".local"))
+
+
 def list_extra_repos(team: TeamSettings) -> list[dict]:
     repos_dir = team.shared_repos_dir
     if not os.path.isdir(repos_dir):
@@ -131,12 +238,14 @@ def list_extra_repos(team: TeamSettings) -> list[dict]:
             branches = []
 
         protected = os.path.exists(os.path.join(path, ".protected"))
+        local = os.path.exists(os.path.join(path, ".local"))
         result.append(
             {
                 "name": entry,
                 "repo_url": sanitize_repo_url(url),
                 "branches": branches,
                 "protected": protected,
+                "local": local,
             }
         )
 
@@ -247,6 +356,19 @@ def fetch_extra_repo(team: TeamSettings, name: str) -> dict:
     path = os.path.join(team.shared_repos_dir, name)
     if not os.path.isdir(path):
         raise NotFoundError(f"Extra repo '{name}' not found.")
+
+    # Local (remote-less) repos have no origin to fetch from. Short-circuit so
+    # every caller — create_worktree, pull_extra_worktree, the pull REST/MCP
+    # path — treats them as always up to date instead of failing on git fetch.
+    if os.path.exists(os.path.join(path, ".local")):
+        return {
+            "name": name,
+            "local": True,
+            "up_to_date": True,
+            "new_branches": [],
+            "deleted_branches": [],
+            "updated_branches": [],
+        }
 
     # Ensure fetch refspec is configured (bare repos created before the fix lack it)
     try:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -369,6 +369,8 @@ def update_extra_repo(name: str, ctx: Context = None) -> str:
 
 def _format_fetch_summary(summary: dict) -> str:
     name = summary["name"]
+    if summary.get("local"):
+        return f"Extra repo '{name}' is local (no remote) — nothing to pull."
     if summary["up_to_date"]:
         return f"Extra repo '{name}': already up to date."
     parts = [f"Extra repo '{name}' updated:"]
@@ -923,6 +925,30 @@ def delete_template(template_name: str, ctx: Context = None) -> str:
     team = _resolve_team(ctx)
     result = system_ops.delete_template(settings, team, template_name)
     return f"Template '{result['template_name']}' deleted. Template DB '{result['template_db']}' removed."
+
+
+@mcp.tool()
+@handle_errors
+@with_team_lock
+def rename_template(template_name: str, new_name: str, ctx: Context = None) -> str:
+    """
+    Rename a template profile — renames its directory and PostgreSQL template DB.
+
+    Refused if any environment was created from this template (its template
+    reference is fixed at creation time and cannot be updated on a running
+    environment): delete those environments first, or leave the template as is.
+
+    Args:
+        template_name: Current name of the template.
+        new_name: New name for the template.
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = system_ops.rename_template(settings, team, template_name, new_name)
+    return (
+        f"Template '{result['old_name']}' renamed to '{result['template_name']}' "
+        f"(DB '{result['template_db']}')."
+    )
 
 
 # =============================================================================

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1528,6 +1528,13 @@
           <div class="hint">Restores an Odoo.sh daily backup (database + filestore) into a new template of this name.</div>
         </div>
         <div class="form-group">
+          <div class="hint" style="margin-top:0;">Enterprise and Themes are proprietary Odoo code. Before downloading them, review your rights and obligations: <a href="https://oduflow.dev/odoo-sh-import-notes" target="_blank" rel="noopener">oduflow.dev/odoo-sh-import-notes</a> (opens in a new tab).</div>
+          <div class="check-row" style="margin-top:8px;">
+            <input type="checkbox" id="import-ack" onchange="onImportAckChange()" aria-controls="import-addons-options">
+            <label for="import-ack">I have read the import notes and accept responsibility for the addons I download.</label>
+          </div>
+        </div>
+        <div class="form-group" id="import-addons-options" hidden>
           <label>Also bring over addons</label>
           <div class="hint" style="margin-top:0;">The standard Odoo modules ship with the image. These options download the rest of the Odoo.sh addons-path into extra-addons for this template.</div>
           <div class="check-row" style="margin-top:8px;">
@@ -1541,13 +1548,6 @@
           <div class="check-row" style="margin-top:6px;">
             <input type="checkbox" id="import-with-extra" disabled>
             <label for="import-with-extra">Extra addons <span class="label-hint">— OCA and other repos; reachable ones stay updatable</span></label>
-          </div>
-        </div>
-        <div class="form-group">
-          <div class="hint" style="margin-top:0;">Enterprise and Themes are proprietary Odoo code. Before downloading them, review your rights and obligations: <a href="https://oduflow.dev/odoo-sh-import-notes" target="_blank" rel="noopener">oduflow.dev/odoo-sh-import-notes</a> (opens in a new tab).</div>
-          <div class="check-row" style="margin-top:8px;">
-            <input type="checkbox" id="import-ack" onchange="onImportAckChange()">
-            <label for="import-ack">I have read the import notes and accept responsibility for the addons I download.</label>
           </div>
         </div>
         <div class="form-actions">
@@ -2910,12 +2910,14 @@ function openImportOdooModal() {
     cb.disabled = true;
   });
   document.getElementById('import-ack').checked = false;
+  document.getElementById('import-addons-options').hidden = true;
   showModal('import-odoo-modal');
   document.getElementById('import-tpl-name').focus();
 }
 
 function onImportAckChange() {
   var ack = document.getElementById('import-ack').checked;
+  document.getElementById('import-addons-options').hidden = !ack;
   ['import-with-enterprise', 'import-with-themes', 'import-with-extra'].forEach(function(id) {
     var cb = document.getElementById(id);
     cb.disabled = !ack;

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1527,6 +1527,29 @@
           <input type="text" id="import-tpl-name" placeholder="e.g. oduist-prod">
           <div class="hint">Restores an Odoo.sh daily backup (database + filestore) into a new template of this name.</div>
         </div>
+        <div class="form-group">
+          <label>Also bring over addons</label>
+          <div class="hint" style="margin-top:0;">The standard Odoo modules ship with the image. These options download the rest of the Odoo.sh addons-path into extra-addons for this template.</div>
+          <div class="check-row" style="margin-top:8px;">
+            <input type="checkbox" id="import-with-enterprise" disabled>
+            <label for="import-with-enterprise">Enterprise addons <span class="label-hint">— downloaded as a local repo (no remote)</span></label>
+          </div>
+          <div class="check-row" style="margin-top:6px;">
+            <input type="checkbox" id="import-with-themes" disabled>
+            <label for="import-with-themes">Themes <span class="label-hint">— downloaded as a local repo (no remote)</span></label>
+          </div>
+          <div class="check-row" style="margin-top:6px;">
+            <input type="checkbox" id="import-with-extra" disabled>
+            <label for="import-with-extra">Extra addons <span class="label-hint">— OCA and other repos; reachable ones stay updatable</span></label>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="hint" style="margin-top:0;">Enterprise and Themes are proprietary Odoo code. Before downloading them, review your rights and obligations: <a href="https://oduflow.dev/odoo-sh-import-notes" target="_blank" rel="noopener">oduflow.dev/odoo-sh-import-notes</a> (opens in a new tab).</div>
+          <div class="check-row" style="margin-top:8px;">
+            <input type="checkbox" id="import-ack" onchange="onImportAckChange()">
+            <label for="import-ack">I have read the import notes and accept responsibility for the addons I download.</label>
+          </div>
+        </div>
         <div class="form-actions">
           <button class="btn" onclick="closeImportOdooModal()">Cancel</button>
           <button class="btn-create" id="import-odoo-submit" onclick="submitImportOdoo()">Generate command</button>
@@ -1539,6 +1562,27 @@
           <button class="btn" onclick="closeImportOdooModal()">Close</button>
           <button class="btn-create" onclick="copyImportOdooCommand()">Copy command</button>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-overlay" id="rename-tpl-modal" onclick="closeRenameTemplateModal(event)">
+  <div class="modal">
+    <div class="modal-header">
+      <h2>Rename template</h2>
+      <button class="modal-close" onclick="closeRenameTemplateModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-error" id="rename-tpl-error"></div>
+      <div class="form-group">
+        <label for="rename-tpl-name">New name</label>
+        <input type="text" id="rename-tpl-name" placeholder="new template name">
+        <div class="hint">Renames the template's directory and its PostgreSQL template database. Refused if any environment was created from this template.</div>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeRenameTemplateModal()">Cancel</button>
+        <button class="btn-create" id="rename-tpl-submit" onclick="submitRenameTemplate()">Rename</button>
       </div>
     </div>
   </div>
@@ -2860,8 +2904,23 @@ function openImportOdooModal() {
   document.getElementById('import-odoo-command').textContent = '';
   document.getElementById('import-odoo-submit').disabled = false;
   document.getElementById('import-odoo-submit').textContent = 'Generate command';
+  ['import-with-enterprise', 'import-with-themes', 'import-with-extra'].forEach(function(id) {
+    var cb = document.getElementById(id);
+    cb.checked = false;
+    cb.disabled = true;
+  });
+  document.getElementById('import-ack').checked = false;
   showModal('import-odoo-modal');
   document.getElementById('import-tpl-name').focus();
+}
+
+function onImportAckChange() {
+  var ack = document.getElementById('import-ack').checked;
+  ['import-with-enterprise', 'import-with-themes', 'import-with-extra'].forEach(function(id) {
+    var cb = document.getElementById(id);
+    cb.disabled = !ack;
+    if (!ack) cb.checked = false;
+  });
 }
 
 function closeImportOdooModal(event) {
@@ -2889,7 +2948,12 @@ async function submitImportOdoo() {
     var r = await fetch(API_TEMPLATES + '/import-token', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ template_name: name })
+      body: JSON.stringify({
+        template_name: name,
+        with_enterprise: document.getElementById('import-with-enterprise').checked,
+        with_themes: document.getElementById('import-with-themes').checked,
+        with_extra_addons: document.getElementById('import-with-extra').checked
+      })
     });
     var data = await r.json();
     if (data.ok) {
@@ -2906,6 +2970,67 @@ async function submitImportOdoo() {
   } finally {
     btn.disabled = false;
     btn.textContent = 'Generate command';
+  }
+}
+
+var _renameTplName = '';
+
+function openRenameTemplateModal(name) {
+  _renameTplName = name;
+  var errEl = document.getElementById('rename-tpl-error');
+  errEl.style.display = 'none';
+  errEl.textContent = '';
+  var input = document.getElementById('rename-tpl-name');
+  input.value = name;
+  document.getElementById('rename-tpl-submit').disabled = false;
+  document.getElementById('rename-tpl-submit').textContent = 'Rename';
+  showModal('rename-tpl-modal');
+  input.focus();
+  input.select();
+}
+
+function closeRenameTemplateModal(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('rename-tpl-modal');
+}
+
+async function submitRenameTemplate() {
+  var newName = document.getElementById('rename-tpl-name').value.trim();
+  var errEl = document.getElementById('rename-tpl-error');
+  if (!newName) {
+    errEl.textContent = 'New name is required.';
+    errEl.style.display = 'block';
+    return;
+  }
+  if (newName === _renameTplName) {
+    closeRenameTemplateModal();
+    return;
+  }
+  errEl.style.display = 'none';
+  var btn = document.getElementById('rename-tpl-submit');
+  btn.disabled = true;
+  btn.textContent = 'Renaming...';
+  try {
+    var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(_renameTplName) + '/rename', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ new_name: newName })
+    });
+    var data = await r.json();
+    if (data.ok) {
+      showToast('Template renamed to "' + newName + '"');
+      hideModal('rename-tpl-modal');
+      await loadTemplates();
+    } else {
+      errEl.textContent = data.error || 'Rename failed';
+      errEl.style.display = 'block';
+    }
+  } catch (e) {
+    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Rename';
   }
 }
 
@@ -2952,6 +3077,7 @@ function renderTemplates(templates) {
         '<div class="tpl-head-right">' +
           '<div class="tpl-meta">' + dbTag + sqlTag + fsTag + modeTag + sizeHtml + '</div>' +
           '<button class="btn-create btn-sm" onclick="openCreateFromTemplate(\'' + escAttr(t.template_name) + '\')">+ New Env</button>' +
+          '<button class="btn btn-sm" onclick="openRenameTemplateModal(\'' + escAttr(t.template_name) + '\')">Rename</button>' +
           '<button class="btn btn-delete btn-sm" onclick="doDeleteTemplate(\'' + escAttr(t.template_name) + '\')">Remove</button>' +
         '</div>' +
       '</div>' +
@@ -3966,6 +4092,7 @@ function renderExtraRepos(repos) {
       '<div class="svc-header">' +
         '<div class="left">' +
           '<span class="svc-name">' + esc(r.name) + '</span>' +
+          (r.local ? '<span class="badge badge-neutral" title="Imported from Odoo.sh; no remote, cannot be updated from origin">local</span>' : '') +
           (r.protected ? '<span class="badge badge-protected" title="Deletion is disabled">protected</span>' : '') +
         '</div>' +
         '<div class="svc-actions">' +
@@ -3978,7 +4105,7 @@ function renderExtraRepos(repos) {
         '</div>' +
       '</div>' +
       '<div class="svc-meta">' +
-        '<span>URL: <strong>' + esc(r.repo_url) + '</strong></span>' +
+        '<span>URL: <strong>' + (r.local ? 'local (no remote)' : esc(r.repo_url)) + '</strong></span>' +
       '</div>' +
       (branches ? '<div class="svc-meta"><span>Branches: <strong>' + branches + '</strong></span></div>' : '') +
     '</div>';

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -8,11 +8,19 @@
 # the filestore is tarred on the fly and streamed straight to the upload.
 #
 # The upload is resumable: on a re-run it asks the server what it already has
-# and only sends the missing pieces (manifest, dump, or individual filestore
-# hash-directories).
+# and only sends the missing pieces (manifest, dump, individual filestore
+# hash-directories, or addon repositories).
 #
 #   curl -sSfL https://YOUR-ODUFLOW/import-odoo.sh | bash -s -- \
 #        --server https://YOUR-ODUFLOW --token <TOKEN>
+#
+# Optional flags (usually set for you by the dashboard checkboxes) also bring
+# over the addons Odoo.sh ran with, beyond the standard modules in the image:
+#   --with-enterprise    download Odoo Enterprise into a local extra-addons repo
+#   --with-themes        download Odoo Themes into a local extra-addons repo
+#   --with-extra-addons  add the extra repos (OCA etc.): reachable ones are
+#                        cloned from their origin (stay updatable), private ones
+#                        are downloaded as local extra-addons repos
 #
 # The --token is minted by the "Import from Odoo.sh" button in the Oduflow
 # dashboard and is valid for 15 minutes.
@@ -20,14 +28,20 @@ set -euo pipefail
 
 SERVER=""
 TOKEN=""
+WITH_ENTERPRISE=0
+WITH_THEMES=0
+WITH_EXTRA=0
 while [ $# -gt 0 ]; do
     case "$1" in
         --server) SERVER="${2:-}"; shift 2 ;;
         --server=*) SERVER="${1#*=}"; shift ;;
         --token) TOKEN="${2:-}"; shift 2 ;;
         --token=*) TOKEN="${1#*=}"; shift ;;
+        --with-enterprise) WITH_ENTERPRISE=1; shift ;;
+        --with-themes) WITH_THEMES=1; shift ;;
+        --with-extra-addons) WITH_EXTRA=1; shift ;;
         -h|--help)
-            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -n 20
+            grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -n 28
             exit 0 ;;
         *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
     esac
@@ -116,6 +130,8 @@ fi
 have_manifest="$(json_field "$STATUS_FILE" 'd.get("progress",{}).get("manifest") and 1 or ""')"
 have_dump="$(json_field "$STATUS_FILE" 'd.get("progress",{}).get("dump") and 1 or ""')"
 done_chunks=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("filestore_chunks",[]))') "
+done_addons=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("addons",[]))') "
+done_remote=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("remote_addons",[]))') "
 
 # ---- manifest --------------------------------------------------------------
 
@@ -208,6 +224,143 @@ for c in "${remaining[@]}"; do
 done
 progress "$total_bytes" "$total_bytes" "complete"
 echo >&2
+
+# ---- addons (optional: enterprise / themes / extra repos) ------------------
+#
+# The daily backup holds only the database and filestore; the addons Odoo.sh
+# runs with live on the build filesystem. When asked (--with-*), inspect the
+# running server's --addons-path, classify each entry, and bring over what the
+# image doesn't already ship. Reachable extra repos are announced by their
+# origin (Oduflow clones them, keeping them updatable); everything else is
+# tarred and streamed as a local (remote-less) extra-addons repo.
+
+detect_addons_path() {
+    # Prefer the live odoo-bin command line (source of truth), fall back to the
+    # generated odoo.conf. Only the "--addons-path=..." (=-joined) form is used
+    # by Odoo.sh.
+    local ap
+    # -e is essential: without it ps only lists processes sharing the caller's
+    # controlling terminal, and the odoo-bin daemon (started outside the SSH
+    # tty) would never be seen — detection would always fall through to
+    # odoo.conf. Verified empirically on an Odoo.sh shell.
+    ap="$(ps -eww -o args= 2>/dev/null | tr ' ' '\n' \
+          | grep -m1 -E '^--addons-path=' | sed 's/^--addons-path=//')" || true
+    if [ -n "$ap" ]; then printf '%s' "$ap"; return 0; fi
+    local conf="$HOME/.config/odoo/odoo.conf"
+    if [ -f "$conf" ]; then
+        ap="$(grep -E '^[[:space:]]*addons_path[[:space:]]*=' "$conf" \
+              | head -n1 | sed -E 's/^[^=]*=[[:space:]]*//')" || true
+        if [ -n "$ap" ]; then printf '%s' "$ap"; return 0; fi
+    fi
+    return 1
+}
+
+addon_branch() {  # path -> current branch name (may be empty / "HEAD")
+    git -C "$1" rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+sanitize_addon_name() {  # path -> [a-z0-9_-] name (<=63)
+    local raw="$1" rel
+    case "$raw" in
+        */src/user/*) rel="${raw##*/src/user/}" ;;
+        *) rel="$(basename "$raw")" ;;
+    esac
+    rel="$(printf '%s' "$rel" | tr '[:upper:]/' '[:lower:]-' | tr -cd 'a-z0-9_-')"
+    printf '%s' "${rel:0:63}"
+}
+
+upload_addon_files() {  # path name branch category
+    local path="$1" name="$2" branch="$3" cat="$4" tries=0
+    local base parent
+    base="$(basename "$path")"; parent="$(dirname "$path")"
+    while :; do
+        if tar --exclude='.git' -C "$parent" -cf - "$base" \
+            | curl -fsS -H "$AUTH" -H "Content-Type: application/x-tar" \
+                   -T - -X POST "${API}/addon?name=${name}&branch=${branch}&category=${cat}" >/dev/null; then
+            return 0
+        fi
+        tries=$((tries + 1))
+        [ "$tries" -ge 3 ] && return 1
+        sleep 2
+    done
+}
+
+announce_addon_remote() {  # name origin branch
+    curl -fsS -H "$AUTH" -H "Content-Type: application/json" \
+        --data-binary "$(printf '{"name":"%s","origin_url":"%s","branch":"%s"}' "$1" "$2" "$3")" \
+        -X POST "${API}/addon-remote" >/dev/null
+}
+
+process_addons() {
+    local addons_path="$1"
+    local p base name origin branch
+    local IFS=','
+    local -a paths
+    read -ra paths <<< "$addons_path"
+    for p in "${paths[@]}"; do
+        p="${p%/}"
+        [ -n "$p" ] && [ -d "$p" ] || continue
+        case "$p" in
+            */src/odoo/addons|*/src/odoo/odoo/addons) continue ;;  # in the image
+            */src/user) continue ;;                                # customer's own repo
+            */src/enterprise)
+                [ "$WITH_ENTERPRISE" = 1 ] || continue
+                name="enterprise"; branch="$(addon_branch "$p")"
+                if [[ "$done_addons" == *" $name "* ]]; then
+                    echo ">> enterprise: already uploaded, skipping"; continue
+                fi
+                echo ">> enterprise: uploading ($(du -sh "$p" 2>/dev/null | cut -f1))"
+                upload_addon_files "$p" "$name" "$branch" "enterprise" \
+                    || { echo "ERROR: failed to upload enterprise addons." >&2; exit 5; }
+                ;;
+            */src/themes)
+                [ "$WITH_THEMES" = 1 ] || continue
+                name="themes"; branch="$(addon_branch "$p")"
+                if [[ "$done_addons" == *" $name "* ]]; then
+                    echo ">> themes: already uploaded, skipping"; continue
+                fi
+                echo ">> themes: uploading ($(du -sh "$p" 2>/dev/null | cut -f1))"
+                upload_addon_files "$p" "$name" "$branch" "themes" \
+                    || { echo "ERROR: failed to upload themes." >&2; exit 5; }
+                ;;
+            *)
+                [ "$WITH_EXTRA" = 1 ] || continue
+                name="$(sanitize_addon_name "$p")"
+                [ -n "$name" ] || continue
+                origin="$(git -C "$p" remote get-url origin 2>/dev/null || true)"
+                branch="$(addon_branch "$p")"
+                case "$origin" in
+                    https://*)
+                        if [[ "$done_remote" == *" $name "* ]]; then
+                            echo ">> extra '$name': already announced, skipping"; continue
+                        fi
+                        echo ">> extra '$name': from remote $origin @ ${branch:-?}"
+                        announce_addon_remote "$name" "$origin" "$branch" \
+                            || { echo "ERROR: failed to announce extra repo '$name'." >&2; exit 5; }
+                        ;;
+                    *)
+                        if [[ "$done_addons" == *" $name "* ]]; then
+                            echo ">> extra '$name': already uploaded, skipping"; continue
+                        fi
+                        echo ">> extra '$name': uploading files (origin: ${origin:-none})"
+                        upload_addon_files "$p" "$name" "$branch" "extra" \
+                            || { echo "ERROR: failed to upload extra repo '$name'." >&2; exit 5; }
+                        ;;
+                esac
+                ;;
+        esac
+    done
+}
+
+if [ "$WITH_ENTERPRISE" = 1 ] || [ "$WITH_THEMES" = 1 ] || [ "$WITH_EXTRA" = 1 ]; then
+    ADDONS_PATH="$(detect_addons_path || true)"
+    if [ -z "$ADDONS_PATH" ]; then
+        echo ">> WARNING: could not determine the Odoo addons-path; skipping addon download." >&2
+        echo "   (the database and filestore import continues normally)" >&2
+    else
+        process_addons "$ADDONS_PATH"
+    fi
+fi
 
 # ---- finalize --------------------------------------------------------------
 

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -87,6 +87,11 @@ fi
 AUTH="Authorization: Bearer ${TOKEN}"
 API="${SERVER}/api/templates/import"
 
+# Large single payloads (SQL dump, addon tarballs) are uploaded in parts so
+# they survive proxies that cap request body size — Cloudflare, for one, rejects
+# bodies over 100 MB with a 413. 90 MiB per part stays safely under that.
+PART_BYTES=$((90 * 1024 * 1024))
+
 # ---- helpers ---------------------------------------------------------------
 
 human() {  # bytes -> human readable
@@ -101,6 +106,44 @@ json_field() {  # file expr  (expr is python on obj `d`)
     python3 -c 'import sys,json
 d=json.load(open(sys.argv[1]))
 print('"$2"')' "$1" 2>/dev/null || true
+}
+
+upload_ranges() {  # file url extra_query start_offset [label]
+    # POST a local file to `url` in <=PART_BYTES parts, one request each, so no
+    # single request exceeds a proxy's body limit. Each part carries
+    # offset=<byte>&total=<size>; the server appends in order and assembles the
+    # file once the last part lands. Resumable: pass the server's current byte
+    # count as start_offset. dd reads byte ranges directly (no temp splits).
+    local file="$1" url="$2" extra="$3" off="${4:-0}" label="${5:-upload}"
+    local total len q
+    total="$(wc -c < "$file")"
+    [ "$off" -lt 0 ] && off=0
+    [ "$off" -gt "$total" ] && off=0   # stale/invalid resume point -> restart
+    while [ "$off" -lt "$total" ]; do
+        len=$PART_BYTES
+        [ $((off + len)) -gt "$total" ] && len=$((total - off))
+        q="offset=${off}&total=${total}"
+        [ -n "$extra" ] && q="${extra}&${q}"
+        local tries=0
+        while :; do
+            if dd if="$file" bs=1048576 iflag=skip_bytes,count_bytes \
+                   skip="$off" count="$len" 2>/dev/null \
+               | curl -fsS -H "$AUTH" -H "Content-Type: application/octet-stream" \
+                      -T - -X POST "${url}?${q}" >/dev/null; then
+                break
+            fi
+            tries=$((tries + 1))
+            [ "$tries" -ge 3 ] && return 1
+            sleep 2
+        done
+        off=$((off + len))
+        local pct=0
+        [ "$total" -gt 0 ] && pct=$(( off * 100 / total ))
+        printf '\r>> %s [%3d%%] %s / %s\033[K' \
+            "$label" "$pct" "$(human "$off")" "$(human "$total")" >&2
+    done
+    echo >&2
+    return 0
 }
 
 # ---- status (drives resume) ------------------------------------------------
@@ -129,6 +172,8 @@ fi
 
 have_manifest="$(json_field "$STATUS_FILE" 'd.get("progress",{}).get("manifest") and 1 or ""')"
 have_dump="$(json_field "$STATUS_FILE" 'd.get("progress",{}).get("dump") and 1 or ""')"
+have_dump_bytes="$(json_field "$STATUS_FILE" 'str(d.get("progress",{}).get("dump_bytes",0))')"
+[ -n "$have_dump_bytes" ] || have_dump_bytes=0
 done_chunks=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("filestore_chunks",[]))') "
 done_addons=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("addons",[]))') "
 done_remote=" $(json_field "$STATUS_FILE" '" ".join(d.get("progress",{}).get("remote_addons",[]))') "
@@ -146,10 +191,15 @@ fi
 # ---- dump ------------------------------------------------------------------
 
 if [ -z "$have_dump" ]; then
-    echo ">> uploading SQL dump ($(human "$(wc -c < "$SQL_GZ")"))"
-    # -T streams from disk; --data-binary would buffer the whole file in RAM.
-    curl -fsS -H "$AUTH" -H "Content-Type: application/gzip" \
-        -T "$SQL_GZ" -X POST "${API}/dump" >/dev/null
+    dump_total="$(wc -c < "$SQL_GZ")"
+    echo ">> uploading SQL dump ($(human "$dump_total"), resuming from $(human "$have_dump_bytes"))"
+    # Chunked so no single request exceeds a proxy body limit (e.g. Cloudflare's
+    # 100 MB); resumes from what the server already has.
+    if ! upload_ranges "$SQL_GZ" "${API}/dump" "" "$have_dump_bytes" "dump"; then
+        echo "ERROR: failed to upload SQL dump after retries." >&2
+        echo "       Re-run the same command to resume." >&2
+        exit 5
+    fi
 else
     echo ">> SQL dump already uploaded, skipping"
 fi
@@ -270,19 +320,21 @@ sanitize_addon_name() {  # path -> [a-z0-9_-] name (<=63)
 }
 
 upload_addon_files() {  # path name branch category
-    local path="$1" name="$2" branch="$3" cat="$4" tries=0
-    local base parent
+    # Addon tars can exceed a proxy body limit (Enterprise is hundreds of MB),
+    # so buffer the tar to a file and upload it in parts. The temp lives next to
+    # the backups ($HOME), which has room; the filestore is streamed elsewhere.
+    local path="$1" name="$2" branch="$3" cat="$4"
+    local base parent tmptar rc
     base="$(basename "$path")"; parent="$(dirname "$path")"
-    while :; do
-        if tar --exclude='.git' -C "$parent" -cf - "$base" \
-            | curl -fsS -H "$AUTH" -H "Content-Type: application/x-tar" \
-                   -T - -X POST "${API}/addon?name=${name}&branch=${branch}&category=${cat}" >/dev/null; then
-            return 0
-        fi
-        tries=$((tries + 1))
-        [ "$tries" -ge 3 ] && return 1
-        sleep 2
-    done
+    tmptar="$(mktemp "$HOME/.oduflow-addon-XXXXXX.tar")"
+    if ! tar --exclude='.git' -C "$parent" -cf "$tmptar" "$base"; then
+        rm -f "$tmptar"; return 1
+    fi
+    upload_ranges "$tmptar" "${API}/addon" \
+        "name=${name}&branch=${branch}&category=${cat}" 0 "addon ${name}"
+    rc=$?
+    rm -f "$tmptar"
+    return "$rc"
 }
 
 announce_addon_remote() {  # name origin branch

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -77,6 +77,8 @@ _PUBLIC_PATHS = frozenset(
         "/api/templates/import/manifest",
         "/api/templates/import/dump",
         "/api/templates/import/filestore",
+        "/api/templates/import/addon",
+        "/api/templates/import/addon-remote",
         "/api/templates/import/finalize",
     }
 )
@@ -924,6 +926,37 @@ def _build_routes(
         finally:
             locks.release_team(team.team_id)
 
+    async def api_template_rename(request: Request) -> JSONResponse:
+        name = request.path_params["name"]
+        team = _get_ui_team(request)
+        try:
+            body = await request.json()
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body"}, status_code=400
+            )
+        new_name = str((body or {}).get("new_name") or "").strip()
+        if not new_name:
+            return JSONResponse(
+                {"ok": False, "error": "new_name is required"}, status_code=400
+            )
+        try:
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            result = system_ops.rename_template(get_settings(), team, name, new_name)
+            return JSONResponse({"ok": True, "result": result})
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_template_rename")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_team(team.team_id)
+
     # --- Import from Odoo.sh (push-based template ingest) ------------------
 
     def _import_token_value(request: Request) -> str:
@@ -960,10 +993,37 @@ def _build_routes(
                     re.fullmatch(r"[0-9a-f]{2}", entry) or entry == "checklist"
                 ) and os.path.isdir(os.path.join(fs_dir, entry)):
                     chunks.append(entry)
+        # File-backed addons (Enterprise/Themes/private extras): a dir under
+        # addons/ appears only after its tar fully extracted (extract_addon_dir).
+        addons_dir = os.path.join(staging, "addons")
+        addons: list[str] = []
+        if os.path.isdir(addons_dir):
+            for entry in os.listdir(addons_dir):
+                if not entry.startswith(".") and os.path.isdir(
+                    os.path.join(addons_dir, entry)
+                ):
+                    addons.append(entry)
+        # Remote addons (cloned server-side) are announced in addons.json only.
+        remote_addons: list[str] = []
+        addons_manifest = os.path.join(staging, "addons.json")
+        if os.path.isfile(addons_manifest):
+            try:
+                with open(addons_manifest) as f:
+                    for e in json.load(f):
+                        if (
+                            isinstance(e, dict)
+                            and e.get("kind") == "remote"
+                            and e.get("name")
+                        ):
+                            remote_addons.append(str(e["name"]))
+            except (OSError, ValueError):
+                pass
         return {
             "manifest": manifest,
             "dump": dump,
             "filestore_chunks": sorted(chunks),
+            "addons": sorted(addons),
+            "remote_addons": sorted(set(remote_addons)),
         }
 
     def import_odoo_script(request: Request) -> Response:
@@ -975,12 +1035,19 @@ def _build_routes(
         )
 
     async def api_import_token(request: Request) -> JSONResponse:
-        """Mint a short-lived import token for a target template (UI-authed)."""
+        """Mint a short-lived import token for a target template (UI-authed).
+
+        Optional booleans ``with_enterprise`` / ``with_themes`` /
+        ``with_extra_addons`` append the matching ``--with-*`` flags to the
+        returned command so the checkboxes in the import dialog drive what the
+        Odoo.sh client downloads.
+        """
         team = _get_ui_team(request)
+        with_flags: list[str] = []
         try:
             body = await request.body()
-            data = json.loads(body or b"{}")
-            template_name = str((data or {}).get("template_name") or "").strip()
+            data = json.loads(body or b"{}") or {}
+            template_name = str(data.get("template_name") or "").strip()
             if not template_name:
                 return JSONResponse(
                     {"ok": False, "error": "template_name is required"},
@@ -989,6 +1056,12 @@ def _build_routes(
             from oduflow.naming import validate_template_name
 
             validate_template_name(template_name)
+            if data.get("with_enterprise"):
+                with_flags.append("--with-enterprise")
+            if data.get("with_themes"):
+                with_flags.append("--with-themes")
+            if data.get("with_extra_addons"):
+                with_flags.append("--with-extra-addons")
             record = import_tokens.create_token(team, template_name)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
@@ -1006,6 +1079,8 @@ def _build_routes(
             f"curl -sSfL {base}/import-odoo.sh | bash -s -- "
             f"--server {base} --token {record['token']}"
         )
+        if with_flags:
+            command += " " + " ".join(with_flags)
         return JSONResponse(
             {
                 "ok": True,
@@ -1128,6 +1203,125 @@ def _build_routes(
         finally:
             if os.path.exists(tmp_tar):
                 os.remove(tmp_tar)
+        return JSONResponse({"ok": True})
+
+    _ADDON_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,63}$")
+
+    def _record_import_addon(
+        team: TeamSettings, template_name: str, entry: dict[str, object]
+    ) -> None:
+        """Append/replace an addon descriptor in the staging addons.json.
+
+        Keyed by name so a resumed upload updates rather than duplicates.
+        """
+        staging = team.get_import_staging_dir(template_name)  # validates name
+        os.makedirs(staging, exist_ok=True)
+        path = os.path.join(staging, "addons.json")
+        entries: list = []
+        if os.path.isfile(path):
+            try:
+                with open(path) as f:
+                    loaded = json.load(f)
+                if isinstance(loaded, list):
+                    entries = [
+                        e
+                        for e in loaded
+                        if isinstance(e, dict) and e.get("name") != entry["name"]
+                    ]
+            except (OSError, ValueError):
+                entries = []
+        entries.append(entry)
+        with open(path, "w") as f:
+            json.dump(entries, f, indent=2)
+
+    async def api_import_addon(request: Request) -> JSONResponse:
+        """Receive one addon directory (tar stream) that becomes a local
+        (remote-less) extra-addons repo — Enterprise, Themes or a private extra
+        repo that cannot be cloned."""
+        try:
+            team, record = _resolve_import_token(request)
+        except FlowError as e:
+            return _error_response(e)
+        name = request.query_params.get("name", "").strip()
+        if not _ADDON_NAME_RE.match(name):
+            return JSONResponse(
+                {"ok": False, "error": f"Invalid addon name '{name}'"},
+                status_code=400,
+            )
+        branch = request.query_params.get("branch", "").strip()
+        category = request.query_params.get("category", "").strip()
+        template_name = str(record["template_name"])
+        try:
+            staging = team.get_import_staging_dir(template_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        addons_dir = os.path.join(staging, "addons")
+        os.makedirs(staging, exist_ok=True)
+        tmp_tar = os.path.join(staging, f".addon_{name}.tar")
+        try:
+            with open(tmp_tar, "wb") as f:
+                async for data in request.stream():
+                    f.write(data)
+            system_ops.extract_addon_dir(tmp_tar, addons_dir, name)
+            _record_import_addon(
+                team,
+                template_name,
+                {
+                    "name": name,
+                    "kind": "local",
+                    "branch": branch,
+                    "origin_url": "",
+                    "category": category,
+                },
+            )
+        except Exception as e:
+            logger.exception("Failed to receive addon %s for %s", name, template_name)
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            if os.path.exists(tmp_tar):
+                os.remove(tmp_tar)
+        return JSONResponse({"ok": True})
+
+    async def api_import_addon_remote(request: Request) -> JSONResponse:
+        """Announce a reachable extra repo (no files uploaded) — it is cloned
+        from its origin at finalize so it stays updatable via Oduflow."""
+        try:
+            team, record = _resolve_import_token(request)
+        except FlowError as e:
+            return _error_response(e)
+        try:
+            body = await request.json()
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body"}, status_code=400
+            )
+        name = str((body or {}).get("name") or "").strip()
+        if not _ADDON_NAME_RE.match(name):
+            return JSONResponse(
+                {"ok": False, "error": f"Invalid addon name '{name}'"},
+                status_code=400,
+            )
+        origin_url = str((body or {}).get("origin_url") or "").strip()
+        if not origin_url:
+            return JSONResponse(
+                {"ok": False, "error": "origin_url is required"}, status_code=400
+            )
+        branch = str((body or {}).get("branch") or "").strip()
+        template_name = str(record["template_name"])
+        try:
+            _record_import_addon(
+                team,
+                template_name,
+                {
+                    "name": name,
+                    "kind": "remote",
+                    "branch": branch,
+                    "origin_url": origin_url,
+                    "category": "extra",
+                },
+            )
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         return JSONResponse({"ok": True})
 
     def api_import_finalize(request: Request) -> JSONResponse:
@@ -2575,8 +2769,15 @@ def _build_routes(
         Route(
             "/api/templates/import/filestore", api_import_filestore, methods=["POST"]
         ),
+        Route("/api/templates/import/addon", api_import_addon, methods=["POST"]),
+        Route(
+            "/api/templates/import/addon-remote",
+            api_import_addon_remote,
+            methods=["POST"],
+        ),
         Route("/api/templates/import/finalize", api_import_finalize, methods=["POST"]),
         Route("/api/templates/{name}/delete", api_template_delete, methods=["POST"]),
+        Route("/api/templates/{name}/rename", api_template_rename, methods=["POST"]),
         Route("/api/environments", api_list, methods=["GET"]),
         Route("/api/environments/create", api_create, methods=["POST"]),
         Route("/api/stats", api_stats, methods=["GET"]),

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -982,6 +982,13 @@ def _build_routes(
         staging = team.get_import_staging_dir(template_name)  # validates name
         manifest = os.path.isfile(os.path.join(staging, "metadata.json"))
         dump = os.path.isfile(os.path.join(staging, "dump.sql.gz"))
+        # dump_bytes lets a chunked upload resume mid-file: bytes already on the
+        # server, whether the dump is complete (final file) or partial (.part).
+        if dump:
+            dump_bytes = os.path.getsize(os.path.join(staging, "dump.sql.gz"))
+        else:
+            dpart = os.path.join(staging, "dump.sql.gz.part")
+            dump_bytes = os.path.getsize(dpart) if os.path.isfile(dpart) else 0
         fs_dir = os.path.join(staging, "filestore")
         chunks: list[str] = []
         if os.path.isdir(fs_dir):
@@ -1018,11 +1025,21 @@ def _build_routes(
                             remote_addons.append(str(e["name"]))
             except (OSError, ValueError):
                 pass
+        # Partial addon tars (chunked upload in progress): received bytes per
+        # addon, so a resumed run can restart an incomplete one.
+        addon_bytes: dict[str, int] = {}
+        if os.path.isdir(staging):
+            for entry in os.listdir(staging):
+                if entry.startswith(".addon_") and entry.endswith(".tar.part"):
+                    nm = entry[len(".addon_") : -len(".tar.part")]
+                    addon_bytes[nm] = os.path.getsize(os.path.join(staging, entry))
         return {
             "manifest": manifest,
             "dump": dump,
+            "dump_bytes": dump_bytes,
             "filestore_chunks": sorted(chunks),
             "addons": sorted(addons),
+            "addon_bytes": addon_bytes,
             "remote_addons": sorted(set(remote_addons)),
         }
 
@@ -1143,6 +1160,34 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         return JSONResponse({"ok": True})
 
+    async def _receive_offset_chunk(
+        request: Request, part_path: str, offset: int
+    ) -> tuple[str, int]:
+        """Append a byte-range chunk to ``part_path`` at ``offset`` (in order).
+
+        Chunked uploads work around proxies that cap request body size (e.g.
+        Cloudflare's 100 MB limit) by splitting a large payload into parts the
+        server concatenates. Returns ``(state, size)`` where state is
+        ``"written"`` (appended), ``"duplicate"`` (offset already covered — a
+        resent part, discarded) or ``"gap"`` (offset beyond current size —
+        caller should 409). ``offset == 0`` truncates/starts fresh. The request
+        body is always drained so the connection closes cleanly.
+        """
+        cur = os.path.getsize(part_path) if os.path.exists(part_path) else 0
+        if offset > cur:
+            async for _ in request.stream():
+                pass
+            return "gap", cur
+        if 0 < offset < cur:
+            async for _ in request.stream():
+                pass
+            return "duplicate", cur
+        mode = "wb" if offset == 0 else "ab"
+        with open(part_path, mode) as f:
+            async for data in request.stream():
+                f.write(data)
+        return "written", os.path.getsize(part_path)
+
     async def api_import_dump(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1155,18 +1200,54 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         os.makedirs(staging, exist_ok=True)
         dest = os.path.join(staging, "dump.sql.gz")
-        tmp = f"{dest}.part"
+        part = f"{dest}.part"
+
+        offset_raw = request.query_params.get("offset")
+        if offset_raw is None:
+            # Legacy single-shot upload (no chunking): stream straight through.
+            try:
+                with open(part, "wb") as f:
+                    async for chunk in request.stream():
+                        f.write(chunk)
+                os.replace(part, dest)
+            except Exception as e:
+                if os.path.exists(part):
+                    os.remove(part)
+                logger.exception("Failed to receive dump for %s", template_name)
+                return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse({"ok": True})
+
+        # Chunked upload: append at `offset`, complete when the part hits `total`.
+        if os.path.isfile(dest):  # already assembled — retry after completion
+            return JSONResponse(
+                {"ok": True, "received": os.path.getsize(dest), "complete": True}
+            )
         try:
-            with open(tmp, "wb") as f:
-                async for chunk in request.stream():
-                    f.write(chunk)
-            os.replace(tmp, dest)
+            offset = int(offset_raw)
+            total = int(request.query_params.get("total", "0"))
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "offset and total must be integers"},
+                status_code=400,
+            )
+        try:
+            state, size = await _receive_offset_chunk(request, part, offset)
         except Exception as e:
-            if os.path.exists(tmp):
-                os.remove(tmp)
-            logger.exception("Failed to receive dump for template %s", template_name)
+            logger.exception("Failed to receive dump chunk for %s", template_name)
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
-        return JSONResponse({"ok": True})
+        if state == "gap":
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": f"unexpected offset {offset}, expected {size}",
+                    "expected": size,
+                },
+                status_code=409,
+            )
+        complete = total > 0 and size >= total
+        if complete:
+            os.replace(part, dest)
+        return JSONResponse({"ok": True, "received": size, "complete": complete})
 
     async def api_import_filestore(request: Request) -> JSONResponse:
         try:
@@ -1257,30 +1338,85 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         addons_dir = os.path.join(staging, "addons")
         os.makedirs(staging, exist_ok=True)
-        tmp_tar = os.path.join(staging, f".addon_{name}.tar")
+        final_tar = os.path.join(staging, f".addon_{name}.tar")
+        part = f"{final_tar}.part"
+
+        def _finish() -> None:
+            """Extract the assembled tar and record the addon; clean up."""
+            try:
+                system_ops.extract_addon_dir(final_tar, addons_dir, name)
+                _record_import_addon(
+                    team,
+                    template_name,
+                    {
+                        "name": name,
+                        "kind": "local",
+                        "branch": branch,
+                        "origin_url": "",
+                        "category": category,
+                    },
+                )
+            finally:
+                if os.path.exists(final_tar):
+                    os.remove(final_tar)
+
+        offset_raw = request.query_params.get("offset")
+        if offset_raw is None:
+            # Legacy single-shot upload (no chunking).
+            try:
+                with open(part, "wb") as f:
+                    async for data in request.stream():
+                        f.write(data)
+                os.replace(part, final_tar)
+                _finish()
+            except Exception as e:
+                logger.exception(
+                    "Failed to receive addon %s for %s", name, template_name
+                )
+                return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            finally:
+                if os.path.exists(part):
+                    os.remove(part)
+            return JSONResponse({"ok": True})
+
+        # Chunked upload: append at `offset`, extract when the part hits `total`.
+        if os.path.isdir(os.path.join(addons_dir, name)):  # already extracted
+            return JSONResponse({"ok": True, "complete": True})
         try:
-            with open(tmp_tar, "wb") as f:
-                async for data in request.stream():
-                    f.write(data)
-            system_ops.extract_addon_dir(tmp_tar, addons_dir, name)
-            _record_import_addon(
-                team,
-                template_name,
-                {
-                    "name": name,
-                    "kind": "local",
-                    "branch": branch,
-                    "origin_url": "",
-                    "category": category,
-                },
+            offset = int(offset_raw)
+            total = int(request.query_params.get("total", "0"))
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "offset and total must be integers"},
+                status_code=400,
             )
+        try:
+            state, size = await _receive_offset_chunk(request, part, offset)
         except Exception as e:
-            logger.exception("Failed to receive addon %s for %s", name, template_name)
+            logger.exception(
+                "Failed to receive addon chunk %s for %s", name, template_name
+            )
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
-        finally:
-            if os.path.exists(tmp_tar):
-                os.remove(tmp_tar)
-        return JSONResponse({"ok": True})
+        if state == "gap":
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": f"unexpected offset {offset}, expected {size}",
+                    "expected": size,
+                },
+                status_code=409,
+            )
+        complete = total > 0 and size >= total
+        if complete:
+            try:
+                os.replace(part, final_tar)
+                _finish()
+            except Exception as e:
+                logger.exception(
+                    "Failed to finalize addon %s for %s", name, template_name
+                )
+                return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        return JSONResponse({"ok": True, "received": size, "complete": complete})
 
     async def api_import_addon_remote(request: Request) -> JSONResponse:
         """Announce a reachable extra repo (no files uploaded) — it is cloned

--- a/tests/test_extra_addons_local.py
+++ b/tests/test_extra_addons_local.py
@@ -1,0 +1,102 @@
+"""Unit tests for remote-less (local) extra-addons repos used by Odoo.sh import.
+
+These exercise real git (no network, no Docker): create_local_repo seeds a bare
+repo from files, fetch short-circuits on the .local marker, and a worktree can
+be checked out from it.
+"""
+
+import os
+
+import pytest
+
+from oduflow.extra_addons import (
+    create_local_repo,
+    create_worktree,
+    fetch_extra_repo,
+    is_local_repo,
+    list_extra_repos,
+    pull_extra_worktree,
+)
+from oduflow.settings import TeamSettings
+
+
+@pytest.fixture
+def team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _make_source(tmp_path):
+    src = tmp_path / "src_enterprise"
+    mod = src / "sale_enterprise"
+    mod.mkdir(parents=True)
+    (mod / "__manifest__.py").write_text("{'name': 'Sale Enterprise'}")
+    # A stray .git pointer (as left by Odoo.sh worktrees) must be ignored.
+    (src / ".git").write_text("gitdir: /somewhere/else")
+    return str(src)
+
+
+class TestCreateLocalRepo:
+    def test_creates_bare_repo_with_branch_and_marker(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        result = create_local_repo(team, "enterprise", src, "18.0")
+
+        assert result["local"] is True
+        assert result["branch"] == "18.0"
+        assert result["repo_url"] == ""
+        assert is_local_repo(team, "enterprise")
+        assert os.path.exists(
+            os.path.join(team.shared_repos_dir, "enterprise", ".local")
+        )
+
+    def test_requires_branch(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        with pytest.raises(ValueError):
+            create_local_repo(team, "enterprise", src, "")
+
+    def test_rejects_bad_name(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        with pytest.raises(ValueError):
+            create_local_repo(team, "bad/name", src, "18.0")
+
+    def test_listed_as_local(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        create_local_repo(team, "enterprise", src, "18.0")
+        repos = list_extra_repos(team)
+        assert len(repos) == 1
+        assert repos[0]["name"] == "enterprise"
+        assert repos[0]["local"] is True
+        assert repos[0]["repo_url"] == ""
+
+
+class TestFetchShortCircuit:
+    def test_fetch_is_noop_for_local(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        create_local_repo(team, "enterprise", src, "18.0")
+        summary = fetch_extra_repo(team, "enterprise")
+        assert summary["local"] is True
+        assert summary["up_to_date"] is True
+
+
+class TestWorktreeFromLocal:
+    def test_worktree_checks_out_files(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        create_local_repo(team, "enterprise", src, "18.0")
+
+        wt = tmp_path / "wt"
+        create_worktree(team, "enterprise", "18.0", str(wt))
+
+        assert (wt / "sale_enterprise" / "__manifest__.py").is_file()
+        # The stray .git pointer from the source must not have been committed.
+        assert (
+            not (wt / ".git").is_file()
+            or (wt / ".git").read_text() != "gitdir: /somewhere/else"
+        )
+
+    def test_pull_reports_no_changes(self, team, tmp_path):
+        src = _make_source(tmp_path)
+        create_local_repo(team, "enterprise", src, "18.0")
+        wt = tmp_path / "wt"
+        create_worktree(team, "enterprise", "18.0", str(wt))
+
+        old_head, changed = pull_extra_worktree(team, "enterprise", "18.0", str(wt))
+        assert changed == []

--- a/tests/test_import_addons.py
+++ b/tests/test_import_addons.py
@@ -1,0 +1,105 @@
+"""Unit tests for the Odoo.sh addon ingest server-side contract (no Docker).
+
+Covers extract_addon_dir (tar → staged addon dir) and _wire_imported_addons
+(staged addon → local extra-addons repo + template mapping). The remote (clone)
+branch needs network and is not exercised here.
+"""
+
+import json
+import os
+import tarfile
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.extra_addons import is_local_repo
+from oduflow.settings import TeamSettings
+
+
+@pytest.fixture
+def team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _make_repo_dir(tmp_path, top="enterprise_src"):
+    src = tmp_path / top
+    mod = src / "sale_enterprise"
+    mod.mkdir(parents=True)
+    (mod / "__manifest__.py").write_text("{'name': 'Sale Enterprise'}")
+    return src
+
+
+def _tar_dir(src_dir, tar_path, arcname):
+    """Mirror the script's `tar -C parent -cf - base` (top-level dir = base)."""
+    with tarfile.open(tar_path, "w") as tf:
+        tf.add(str(src_dir), arcname=arcname)
+
+
+class TestExtractAddonDir:
+    def test_single_top_dir_renamed_to_name(self, tmp_path):
+        src = _make_repo_dir(tmp_path)
+        tar_path = tmp_path / "a.tar"
+        _tar_dir(src, tar_path, "enterprise_src")
+        addons_dir = tmp_path / "staging" / "addons"
+        system_ops.extract_addon_dir(str(tar_path), str(addons_dir), "enterprise")
+        assert (
+            addons_dir / "enterprise" / "sale_enterprise" / "__manifest__.py"
+        ).is_file()
+        assert not (addons_dir / "enterprise_src").exists()
+        assert not (addons_dir / ".incoming_enterprise").exists()
+
+    def test_bare_contents_multiple_top_dirs(self, tmp_path):
+        # A tar whose top level is several module dirs (no single wrapper).
+        base = tmp_path / "content"
+        (base / "mod_a").mkdir(parents=True)
+        (base / "mod_a" / "__manifest__.py").write_text("{}")
+        (base / "mod_b").mkdir(parents=True)
+        (base / "mod_b" / "__manifest__.py").write_text("{}")
+        tar_path = tmp_path / "c.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            tf.add(str(base / "mod_a"), arcname="mod_a")
+            tf.add(str(base / "mod_b"), arcname="mod_b")
+        addons_dir = tmp_path / "staging" / "addons"
+        system_ops.extract_addon_dir(str(tar_path), str(addons_dir), "themes")
+        assert (addons_dir / "themes" / "mod_a" / "__manifest__.py").is_file()
+        assert (addons_dir / "themes" / "mod_b" / "__manifest__.py").is_file()
+
+
+class TestWireImportedAddons:
+    def test_no_manifest_returns_empty(self, team, tmp_path):
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        assert system_ops._wire_imported_addons(team, str(staging), "18.0") == {}
+
+    def test_local_addon_becomes_local_repo(self, team, tmp_path):
+        staging = tmp_path / "staging"
+        addons = staging / "addons" / "enterprise"
+        (addons / "sale_enterprise").mkdir(parents=True)
+        (addons / "sale_enterprise" / "__manifest__.py").write_text("{}")
+        (staging / "addons.json").write_text(
+            json.dumps([{"name": "enterprise", "kind": "local", "branch": "18.0"}])
+        )
+        wired = system_ops._wire_imported_addons(team, str(staging), "18.0")
+        assert wired == {"enterprise": "18.0"}
+        assert is_local_repo(team, "enterprise")
+
+    def test_branch_falls_back_to_major_version(self, team, tmp_path):
+        staging = tmp_path / "staging"
+        addons = staging / "addons" / "themes"
+        addons.mkdir(parents=True)
+        (addons / "readme.txt").write_text("x")
+        (staging / "addons.json").write_text(
+            json.dumps([{"name": "themes", "kind": "local", "branch": "HEAD"}])
+        )
+        wired = system_ops._wire_imported_addons(team, str(staging), "17.0")
+        assert wired == {"themes": "17.0"}
+
+    def test_existing_repo_is_referenced_not_recreated(self, team, tmp_path):
+        os.makedirs(os.path.join(team.shared_repos_dir, "enterprise"))
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        (staging / "addons.json").write_text(
+            json.dumps([{"name": "enterprise", "kind": "local", "branch": "18.0"}])
+        )
+        wired = system_ops._wire_imported_addons(team, str(staging), "18.0")
+        assert wired == {"enterprise": "18.0"}

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -208,6 +208,125 @@ def test_bad_token_rejected(tmp_path):
     assert r.json()["ok"] is False
 
 
+def test_dump_chunked_upload(tmp_path):
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    payload = b"0123456789ABCDEFGHIJ"  # 20 bytes
+    total = len(payload)
+
+    r = client.post(
+        f"/api/templates/import/dump?offset=0&total={total}",
+        headers=hdr,
+        content=payload[:12],
+    )
+    assert r.status_code == 200
+    j = r.json()
+    assert j["ok"] is True and j["complete"] is False and j["received"] == 12
+
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["dump"] is False
+    assert st["progress"]["dump_bytes"] == 12
+
+    r = client.post(
+        f"/api/templates/import/dump?offset=12&total={total}",
+        headers=hdr,
+        content=payload[12:],
+    )
+    assert r.json()["complete"] is True
+    staging = team.get_import_staging_dir("zipfit")
+    assert open(os.path.join(staging, "dump.sql.gz"), "rb").read() == payload
+
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["dump"] is True
+    assert st["progress"]["dump_bytes"] == total
+
+    # Idempotent: a re-sent final chunk after completion just reports complete.
+    r = client.post(
+        f"/api/templates/import/dump?offset=12&total={total}",
+        headers=hdr,
+        content=payload[12:],
+    )
+    assert r.json()["complete"] is True
+
+
+def test_dump_chunk_gap_returns_409(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/api/templates/import/dump?offset=5&total=20", headers=hdr, content=b"xxxxx"
+    )
+    assert r.status_code == 409
+    assert r.json()["expected"] == 0
+
+
+def test_dump_chunk_resume_from_reported_bytes(tmp_path):
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    payload = b"abcdefghijklmnop"  # 16 bytes
+    total = len(payload)
+    client.post(
+        f"/api/templates/import/dump?offset=0&total={total}",
+        headers=hdr,
+        content=payload[:6],
+    )
+    # A fresh token (previous expired mid-upload) still sees progress on disk.
+    token2, _ = _mint(client, "zipfit")
+    hdr2 = {"Authorization": f"Bearer {token2}"}
+    st = client.get("/api/templates/import/status", headers=hdr2).json()
+    off = st["progress"]["dump_bytes"]
+    assert off == 6
+    r = client.post(
+        f"/api/templates/import/dump?offset={off}&total={total}",
+        headers=hdr2,
+        content=payload[off:],
+    )
+    assert r.json()["complete"] is True
+    staging = team.get_import_staging_dir("zipfit")
+    assert open(os.path.join(staging, "dump.sql.gz"), "rb").read() == payload
+
+
+def test_addon_chunked_upload(tmp_path):
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    tar = _tar_bytes({"enterprise_src/mod/__manifest__.py": b"{}"})
+    total = len(tar)
+    half = total // 2
+
+    r = client.post(
+        f"/api/templates/import/addon?name=enterprise&branch=18.0&offset=0&total={total}",
+        headers=hdr,
+        content=tar[:half],
+    )
+    assert r.json()["complete"] is False
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["addon_bytes"]["enterprise"] == half
+
+    r = client.post(
+        f"/api/templates/import/addon?name=enterprise&branch=18.0&offset={half}&total={total}",
+        headers=hdr,
+        content=tar[half:],
+    )
+    assert r.json()["complete"] is True
+    staging = team.get_import_staging_dir("zipfit")
+    assert os.path.isfile(
+        os.path.join(staging, "addons", "enterprise", "mod", "__manifest__.py")
+    )
+    entries = json.loads(open(os.path.join(staging, "addons.json")).read())
+    assert entries[0] == {
+        "name": "enterprise",
+        "kind": "local",
+        "branch": "18.0",
+        "origin_url": "",
+        "category": "",
+    }
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["addons"] == ["enterprise"]
+
+
 def test_addon_upload_and_status(tmp_path):
     client, _s, team = _client(tmp_path)
     token, _ = _mint(client, "zipfit")

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -208,6 +208,87 @@ def test_bad_token_rejected(tmp_path):
     assert r.json()["ok"] is False
 
 
+def test_addon_upload_and_status(tmp_path):
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    tar = _tar_bytes({"enterprise_src/sale_ent/__manifest__.py": b"{}"})
+    r = client.post(
+        "/api/templates/import/addon?name=enterprise&branch=18.0&category=enterprise",
+        headers=hdr,
+        content=tar,
+    )
+    assert r.status_code == 200 and r.json()["ok"] is True
+    staging = team.get_import_staging_dir("zipfit")
+    assert os.path.isfile(
+        os.path.join(staging, "addons", "enterprise", "sale_ent", "__manifest__.py")
+    )
+    entries = json.loads(open(os.path.join(staging, "addons.json")).read())
+    assert entries[0]["name"] == "enterprise"
+    assert entries[0]["kind"] == "local"
+    assert entries[0]["branch"] == "18.0"
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["addons"] == ["enterprise"]
+
+
+def test_addon_remote_announce(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/api/templates/import/addon-remote",
+        headers=hdr,
+        json={
+            "name": "oca-account-reconcile",
+            "origin_url": "https://github.com/OCA/account-reconcile.git",
+            "branch": "18.0",
+        },
+    )
+    assert r.status_code == 200 and r.json()["ok"] is True
+    st = client.get("/api/templates/import/status", headers=hdr).json()
+    assert st["progress"]["remote_addons"] == ["oca-account-reconcile"]
+
+
+def test_addon_invalid_name_rejected(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/api/templates/import/addon?name=bad/name",
+        headers=hdr,
+        content=_tar_bytes({"x/y": b"z"}),
+    )
+    assert r.status_code == 400
+
+
+def test_addon_remote_requires_origin(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    r = client.post(
+        "/api/templates/import/addon-remote",
+        headers=hdr,
+        json={"name": "foo", "branch": "18.0"},
+    )
+    assert r.status_code == 400
+
+
+def test_import_token_flags_in_command(tmp_path):
+    client, _s, _t = _client(tmp_path)
+    r = client.post(
+        "/api/templates/import-token",
+        json={
+            "template_name": "zipfit",
+            "with_enterprise": True,
+            "with_extra_addons": True,
+        },
+    )
+    data = r.json()
+    assert "--with-enterprise" in data["command"]
+    assert "--with-extra-addons" in data["command"]
+    assert "--with-themes" not in data["command"]
+
+
 def test_filestore_tar_zip_slip_is_skipped(tmp_path):
     dest = tmp_path / "fs"
     dest.mkdir()

--- a/tests/test_template_rename.py
+++ b/tests/test_template_rename.py
@@ -1,0 +1,54 @@
+"""Guard-path tests for system_ops.rename_template.
+
+These cover the validation/collision/not-found branches that run BEFORE any
+Docker call, so no Docker is needed. The DB-rename and dependent-env branches
+require Docker and live under the integration marker elsewhere.
+"""
+
+import os
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ConflictError, NotFoundError
+from oduflow.settings import Settings, TeamSettings
+
+
+@pytest.fixture
+def settings():
+    return Settings()
+
+
+@pytest.fixture
+def team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _make_template(team, name):
+    d = team.get_template_dir(name)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def test_invalid_new_name_raises_value_error(settings, team):
+    _make_template(team, "prod")
+    with pytest.raises(ValueError):
+        system_ops.rename_template(settings, team, "prod", "bad name")
+
+
+def test_same_name_raises_conflict(settings, team):
+    _make_template(team, "prod")
+    with pytest.raises(ConflictError):
+        system_ops.rename_template(settings, team, "prod", "prod")
+
+
+def test_missing_source_raises_not_found(settings, team):
+    with pytest.raises(NotFoundError):
+        system_ops.rename_template(settings, team, "ghost", "prod")
+
+
+def test_target_collision_raises_conflict(settings, team):
+    _make_template(team, "prod")
+    _make_template(team, "staging")
+    with pytest.raises(ConflictError):
+        system_ops.rename_template(settings, team, "prod", "staging")


### PR DESCRIPTION
Adds Odoo.sh addons-path import support for Enterprise, Themes, and extra repos, including local remote-less extra-addons repos, docs, tests, and template rename coverage.
The import client and server now support resumable chunked SQL dump and addon tar uploads so large payloads can pass proxy body-size caps such as Cloudflare's 100 MB limit.
The dashboard import modal now hides addon options until the operator accepts the import notes/responsibility acknowledgement.
Validated with `.venv/bin/python -m pytest tests/test_import_odoo_web.py -q`, `.venv/bin/ruff check src/oduflow/web_ui.py tests/test_import_odoo_web.py`, and `git diff --check`.