### PR TITLE
Skip native neutralize on Odoo 15

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -69,7 +69,9 @@ xfonts-75dpi
 
 When an environment is created from a template, Oduflow **automatically sanitizes** the database to prevent the test instance from sending real emails or polling mailboxes. This is enabled by default (`sanitize=True`).
 
-Sanitization uses a **two-tier** approach:
+For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutralize` command inside the serving container, after any auto-installed modules are present. Odoo 15.0 does not include this command, so Oduflow skips the native neutralization step for Odoo 15 and continues with the custom scripts below.
+
+Custom sanitization then uses a **two-tier** approach:
 
 1. **Team-level scripts** from `{team_data_dir}/odoo_sanitize/` — managed by the administrator, shared across all environments in the team
 2. **Per-project scripts** from `.odoo_sanitize/` in the repository root — managed by the developer, specific to the project

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1055,7 +1055,9 @@ xfonts-75dpi
 
 When an environment is created from a template, Oduflow **automatically sanitizes** the database to prevent the test instance from sending real emails or polling mailboxes. This is enabled by default (`sanitize=True`).
 
-Sanitization uses a **two-tier** approach:
+For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutralize` command inside the serving container, after any auto-installed modules are present. Odoo 15.0 does not include this command, so Oduflow skips the native neutralization step for Odoo 15 and continues with the custom scripts below.
+
+Custom sanitization then uses a **two-tier** approach:
 
 1. **Team-level scripts** from `{team_data_dir}/odoo_sanitize/` — managed by the administrator, shared across all environments in the team
 2. **Per-project scripts** from `.odoo_sanitize/` in the repository root — managed by the developer, specific to the project
@@ -2645,4 +2647,3 @@ License keys are RSA-signed and verified against a built-in public key. Invalid 
 For business use or integrator licenses, visit [oduflow.dev](https://oduflow.dev).
 
 ---
-

--- a/src/oduflow/sanitizer.py
+++ b/src/oduflow/sanitizer.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import glob as glob_mod
+import re
 
 from docker import DockerClient
 
@@ -10,6 +11,22 @@ from oduflow.naming import get_db_name, get_repo_path, get_resource_name
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
+
+
+def _detect_odoo_major_from_container(container: object, image_label: str) -> int | None:
+    """Best-effort major version from the Odoo image label."""
+    labels = getattr(container, "labels", {}) or {}
+    if not isinstance(labels, dict):
+        return None
+
+    image = labels.get(image_label, "")
+    if not isinstance(image, str):
+        return None
+
+    match = re.search(r"odoo[:/](\d+)", image)
+    if match:
+        return int(match.group(1))
+    return None
 
 
 def _run_scripts_from_dir(
@@ -130,6 +147,9 @@ def neutralize_environment(
     untouched — it only stops transmission by disabling crons; it does not
     change the database's identity.
 
+    Odoo 15.0 does not provide the native ``neutralize`` CLI command, so it is
+    skipped for that version. Custom sanitization scripts still run afterwards.
+
     Returns a list of human-readable log lines.
     """
     import docker as _docker
@@ -145,6 +165,19 @@ def neutralize_environment(
     except _docker.errors.NotFound:
         logger.warning("[NEUTRALIZE] container not found, skipping")
         logs.append("[NEUTRALIZE] WARNING: container not found, skipping")
+        return logs
+
+    image_label = getattr(settings, "image_label", "")
+    major = (
+        _detect_odoo_major_from_container(container, image_label)
+        if isinstance(image_label, str)
+        else None
+    )
+    if major is not None and major <= 15:
+        logger.info("[NEUTRALIZE] skipped for Odoo %s", major)
+        logs.append(
+            f"[NEUTRALIZE] Skipped: Odoo {major} does not provide native neutralize"
+        )
         return logs
 
     try:

--- a/tests/test_neutralize.py
+++ b/tests/test_neutralize.py
@@ -18,6 +18,7 @@ from oduflow.naming import get_db_name, get_resource_name
 def _settings():
     s = MagicMock()
     s.prefix = "oduflow"
+    s.image_label = "oduflow.image"
     return s
 
 
@@ -37,6 +38,20 @@ def _neutralize_cmd(container) -> str | None:
 
 
 class TestNeutralizeEnvironment:
+    def test_odoo_15_skips_native_neutralize(self):
+        container = MagicMock()
+        container.labels = {"oduflow.image": "odoo:15.0"}
+        client = MagicMock()
+        client.containers.get.return_value = container
+
+        logs = sanitizer.neutralize_environment(
+            client, _settings(), _team(), "feature/foo"
+        )
+
+        container.exec_run.assert_not_called()
+        assert any("Skipped" in line and "Odoo 15" in line for line in logs)
+        assert not any("WARNING" in line for line in logs)
+
     def test_runs_neutralize_command_in_container(self):
         container = MagicMock()
         container.exec_run.return_value = (0, b"Neutralization finished")


### PR DESCRIPTION
Skips Odoo's native `odoo neutralize` command for Odoo 15 images because the official `odoo:15.0` image does not include that CLI subcommand.

For newer or unknown images, Oduflow keeps the existing behavior: try native neutralization, warn only on failure, then continue custom `.odoo_sanitize` scripts. This also adds a unit test for the Odoo 15 skip path and updates the sanitization docs plus LLM context. Validated with `pytest tests/test_neutralize.py -q` and `ruff check src/oduflow/sanitizer.py tests/test_neutralize.py`.