### PR TITLE
security: close web-UI, SSRF, injection and credential-scoping gaps

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1623,6 +1623,14 @@ def delete_environment(
     env_db = get_db_name(env_name, team.team_id)
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
 
+    # Defence in depth before the rmtree below: env_name is validated at creation,
+    # but reject any name whose derived path escapes (or equals) the workspaces
+    # dir — a "." / ".." env_name must never let a delete reach outside it.
+    _ws_root = os.path.realpath(team.workspaces_dir)
+    _target = os.path.realpath(workspace_path)
+    if _target == _ws_root or os.path.commonpath([_ws_root, _target]) != _ws_root:
+        raise NotFoundError(f"Environment '{env_name}' does not exist.")
+
     container_exists = True
     try:
         existing = client.containers.get(odoo_container_name)

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -14,6 +14,22 @@ from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
 
+# Odoo module technical names are Python identifiers ([a-z0-9_]). Validate before
+# they enter an `odoo -i/-u/-u <modules>` command string: even though exec_run
+# tokenizes via shlex.split (no shell), an unvalidated token like
+# "base --load=..." would be split into a *separate* argv flag and smuggle
+# arbitrary Odoo CLI options into the invocation (argument injection).
+_MODULE_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def _validate_module_names(modules: "list[str] | tuple[str, ...]") -> None:
+    for m in modules:
+        if not _MODULE_NAME_RE.match(m or ""):
+            raise ValueError(
+                f"Invalid module name '{m}': only letters, digits and "
+                "underscores are allowed."
+            )
+
 
 def _detect_odoo_major(container: Any, image_label: str) -> int | None:
     """Best-effort major version of the Odoo running in *container*.
@@ -72,8 +88,18 @@ def run_environment_tests(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
 
+    _validate_module_names([m.strip() for m in modules.split(",") if m.strip()])
+    # allow_fallback=False: the creds are interpolated into the odoo CLI as
+    # `-r ... -w ...`, visible in the container's process argv, and tests run
+    # tenant-controlled code inside that container — the shared superuser
+    # password must never be exposed there (cross-tenant DB access on legacy
+    # environments predating per-env credentials).
     creds = load_credentials(
-        env_name, team.workspaces_dir, settings.db_user, settings.db_password
+        env_name,
+        team.workspaces_dir,
+        settings.db_user,
+        settings.db_password,
+        allow_fallback=False,
     )
     # Use -u (upgrade), not -i (install): the module is already installed in the
     # template, and -i on an installed module is a no-op that never enters the test
@@ -168,6 +194,7 @@ def _run_odoo_module_command(
 ) -> dict[str, Any]:
     if not modules:
         raise ValueError("At least one module name is required.")
+    _validate_module_names(modules)
 
     client = get_client()
     odoo_container_name = get_resource_name(
@@ -240,17 +267,14 @@ def read_file_in_environment(
         extra={"env_name": env_name, "path": path},
     )
 
-    # Check if path exists and determine its type
-    exit_code, output = container.exec_run(
-        [
-            "sh",
-            "-c",
-            f'if [ -d "{path}" ]; then echo DIR; elif [ -f "{path}" ]; then echo FILE; else echo NOTFOUND; fi',
-        ]
-    )
-    path_type = (
-        output.decode("utf-8") if isinstance(output, bytes) else str(output)
-    ).strip()
+    # Check if path exists and determine its type. Use argv-form `test` calls so
+    # `path` is never concatenated into a shell string (no `sh -c` injection).
+    if container.exec_run(["test", "-d", path])[0] == 0:
+        path_type = "DIR"
+    elif container.exec_run(["test", "-f", path])[0] == 0:
+        path_type = "FILE"
+    else:
+        path_type = "NOTFOUND"
 
     if path_type == "NOTFOUND":
         return {"error": f"Path not found: {path}"}
@@ -428,7 +452,11 @@ def run_db_query(
         )
 
     creds = load_credentials(
-        env_name, team.workspaces_dir, settings.db_user, settings.db_password
+        env_name,
+        team.workspaces_dir,
+        settings.db_user,
+        settings.db_password,
+        allow_fallback=False,
     )
     if output_format == "human":
         cmd = ["psql", "-U", creds["pg_user"], "-d", env_db, "-c", query]
@@ -527,7 +555,11 @@ def run_odoo_shell(
         )
 
     creds = load_credentials(
-        env_name, team.workspaces_dir, settings.db_user, settings.db_password
+        env_name,
+        team.workspaces_dir,
+        settings.db_user,
+        settings.db_password,
+        allow_fallback=False,
     )
 
     # Write Python code to temp file via tar stream (avoids shell escaping)
@@ -629,6 +661,17 @@ def http_request_to_odoo(
     import urllib.error
 
     from oduflow.docker_ops.env_ops import get_environment_info
+
+    # SSRF guard: `path` is appended to the environment's own base URL. Require a
+    # single leading slash so it cannot rewrite the host — e.g. "@evil/..." would
+    # turn base_url into userinfo (http://host:port@evil/...) and "//evil/" is a
+    # protocol-relative host swap. Both would let a scoped token pivot the host
+    # process to internal services / the cloud-metadata endpoint.
+    if not path.startswith("/") or path.startswith("//"):
+        raise ValueError(
+            "path must be an absolute request path beginning with a single '/' "
+            f"(got {path!r})."
+        )
 
     info = get_environment_info(settings, team, env_name)
     base_url = info["url"]

--- a/src/oduflow/env_credentials.py
+++ b/src/oduflow/env_credentials.py
@@ -3,6 +3,7 @@ import logging
 import os
 import secrets
 
+from oduflow.errors import PrerequisiteNotMetError
 from oduflow.naming import get_workspace_path, slugify_branch
 
 logger = logging.getLogger("oduflow")
@@ -49,17 +50,40 @@ def create_credentials(
     return creds
 
 
+class MissingCredentialsError(PrerequisiteNotMetError):
+    """No per-environment PostgreSQL credentials exist and fallback is disallowed."""
+
+
 def load_credentials(
     env_name: str,
     workspaces_dir: str,
     fallback_user: str,
     fallback_password: str,
+    *,
+    allow_fallback: bool = True,
 ) -> dict[str, str]:
+    """Load an environment's scoped PostgreSQL credentials.
+
+    When the per-environment credentials file is missing, callers that perform
+    *arbitrary* SQL/shell against the environment (interactive psql, run_db_query,
+    run_odoo_shell) must pass ``allow_fallback=False``: the fallback is the
+    cluster **superuser**, and handing it to those surfaces would let a tenant
+    ``\\c`` into another team's database or ``COPY ... FROM PROGRAM`` for RCE.
+    Fixed, admin-time operations keep the fallback so legacy environments still
+    work.
+    """
     workspace_path = get_workspace_path(env_name, workspaces_dir)
     creds_path = os.path.join(workspace_path, _CREDENTIALS_FILE)
     if os.path.isfile(creds_path):
         with open(creds_path) as f:
             return json.load(f)
+    if not allow_fallback:
+        raise MissingCredentialsError(
+            f"Environment '{env_name}' has no scoped database credentials. "
+            "Recreate or update the environment to provision a per-environment "
+            "PostgreSQL role (the shared superuser is never used for interactive "
+            "or arbitrary queries)."
+        )
     return {"pg_user": fallback_user, "pg_password": fallback_password}
 
 

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -95,6 +95,15 @@ def _store_git_credentials(
 def setup_repo_auth(repo_url: str, cred_file: str) -> dict[str, str]:
     clean_url, host, username, password = _parse_authenticated_url(repo_url)
 
+    # SSRF guard (parity with validate_repo_url): refuse to store credentials for
+    # — or run `git ls-remote` against — loopback / link-local (cloud metadata) /
+    # unspecified hosts. Otherwise a caller could point this at an internal host
+    # and exfiltrate the presented PAT (git sends the stored credential to that
+    # host). Internal RFC1918 git servers stay allowed (allow_private=True).
+    from oduflow.url_safety import assert_allowed_host
+
+    assert_allowed_host(host, allow_private=True)
+
     _store_git_credentials(host, username, password, cred_file)
 
     env = git_env_for_team(cred_file)

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -34,6 +34,44 @@ def validate_template_name(template_name: str) -> str:
     return name
 
 
+def validate_env_name(env_name: str) -> str:
+    """Validate an environment/branch name and return it unchanged.
+
+    ``env_name`` becomes a filesystem path segment via
+    ``get_workspace_path`` (``os.path.join(dir, env_name.replace('/', '-'))``).
+    Slashes are folded to ``-`` there, so the only way the result can escape the
+    workspaces dir is a name that IS a traversal component (``.``/``..``) or that
+    smuggles a native path separator/NUL. Reject those (and empty/oversized
+    names) at the creation chokepoint so every derived path stays contained.
+    Legitimate git branch names (``19.0``, ``feature/x``, ``release/v1.2``) pass.
+    Returns the name **unchanged** (it is not canonicalized): a padded name like
+    ``"foo "`` is rejected rather than silently trimmed, because slugified
+    container/DB names strip the space while the workspace path keeps it — so the
+    trimmed and raw forms would collide on containers yet diverge on disk.
+    """
+    name = env_name or ""
+    if name != name.strip():
+        raise ValueError(
+            f"Invalid environment name '{env_name}': leading or trailing "
+            "whitespace is not allowed."
+        )
+    if not name or len(name) > 100:
+        raise ValueError(
+            f"Invalid environment name '{env_name}': must be 1-100 characters."
+        )
+    if "\\" in name or "\x00" in name:
+        raise ValueError(
+            f"Invalid environment name '{env_name}': backslashes and NUL bytes "
+            "are not allowed."
+        )
+    if any(seg in ("", ".", "..") for seg in name.split("/")):
+        raise ValueError(
+            f"Invalid environment name '{env_name}': '/'-separated segments must "
+            "be non-empty and not '.' or '..'."
+        )
+    return name
+
+
 def slugify_branch(env_name: str) -> str:
     slug = env_name.replace("/", "-")
     slug = re.sub(r"[^a-zA-Z0-9_-]", "", slug)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -64,7 +64,13 @@ get_odoo_development_guide(version="..."), follow it immediately before
 editing code.
 """.strip()
 
-mcp = FastMCP("Oduflow", instructions=_MCP_INSTRUCTIONS)
+# mask_error_details=True: only messages from explicitly-raised ToolError (our
+# handle_errors wraps FlowError into one) reach the client. Any other exception
+# is returned as a generic "Error calling tool" without its text, so internal
+# paths, container/DB names and stack detail are not disclosed to MCP callers.
+mcp = FastMCP(
+    "Oduflow", instructions=_MCP_INSTRUCTIONS, mask_error_details=True
+)
 _locks = LockManager()
 _settings: Settings | None = None
 _instance_id: str = ""
@@ -196,6 +202,13 @@ def handle_errors(fn):
                 return result
             except FlowError as e:
                 logger.error("[%s] Error: %s", fn.__name__, e)
+                raise ToolError(str(e))
+            except ValueError as e:
+                # Intentional, developer-authored input validation (invalid
+                # env/module/template names, bad request path, …). These messages
+                # are safe to surface and helpful; every OTHER exception stays
+                # masked by mask_error_details=True so internal detail never leaks.
+                logger.error("[%s] Invalid input: %s", fn.__name__, e)
                 raise ToolError(str(e))
 
         return await anyio.to_thread.run_sync(_run)
@@ -434,7 +447,9 @@ def create_environment(
     """
     import json
 
-    resolved_env_name = env_name or branch
+    from oduflow.naming import validate_env_name
+
+    resolved_env_name = validate_env_name(env_name or branch)
     _locks.acquire_env(resolved_env_name)
     try:
         settings = _get_settings()
@@ -2784,6 +2799,90 @@ def _inject_auth_token(toml_text: str, token: str) -> str:
     return "\n".join(out) + "\n"
 
 
+def _inject_ui_password(toml_text: str, password: str) -> str:
+    """Replace the empty ``ui_password = ""`` in a freshly bootstrapped
+    oduflow.toml with a generated web-UI password, so a fresh HTTP install does
+    NOT serve the dashboard (interactive shells, SQL, agent, service creation)
+    unauthenticated. Only the first empty ui_password (team 1) is set; existing
+    user configs are never rewritten.
+    """
+    replacement = f'ui_password = "{password}"'
+    out: list[str] = []
+    injected = False
+    for raw in toml_text.splitlines():
+        if not injected and raw.split("#", 1)[0].strip() == 'ui_password = ""':
+            indent = raw[: len(raw) - len(raw.lstrip())]
+            comment = raw.split("#", 1)[1].strip() if "#" in raw else ""
+            out.append(f"{indent}{replacement}" + (f"  # {comment}" if comment else ""))
+            injected = True
+        else:
+            out.append(raw)
+    return "\n".join(out) + "\n"
+
+
+def _autofill_ui_passwords(toml_text: str) -> tuple[str, list[str]]:
+    """Fill EVERY empty ``ui_password = ""`` in an existing oduflow.toml with a
+    freshly generated password (one distinct password per team). Used to upgrade
+    older configs that predate the secure-by-default bootstrap without leaving
+    the dashboard open. Returns the rewritten text and the list of generated
+    passwords (empty if there was nothing to fill)."""
+    import secrets
+
+    out: list[str] = []
+    generated: list[str] = []
+    for raw in toml_text.splitlines():
+        if raw.split("#", 1)[0].strip() == 'ui_password = ""':
+            password = secrets.token_urlsafe(18)
+            generated.append(password)
+            indent = raw[: len(raw) - len(raw.lstrip())]
+            comment = raw.split("#", 1)[1].strip() if "#" in raw else ""
+            out.append(
+                f'{indent}ui_password = "{password}"'
+                + (f"  # {comment}" if comment else "")
+            )
+        else:
+            out.append(raw)
+    return "\n".join(out) + "\n", generated
+
+
+def _ensure_web_ui_password(settings: Settings) -> Settings:
+    """Auto-provision a web-UI password for existing configs (HTTP mode only).
+
+    Older installs shipped ``ui_password = ""`` (open dashboard). Rather than
+    hard-fail the whole HTTP transport on upgrade — which would also take down
+    token-protected MCP for headless users — generate a password, persist it to
+    oduflow.toml (symmetric with the fresh-install bootstrap) and reload. Skipped
+    when the operator opted into an open server (``allow_insecure_http``) or a
+    password is already set. On any write failure the caller's fail-closed check
+    still refuses to serve an open dashboard."""
+    global _settings
+    if settings.allow_insecure_http or any(
+        t.ui_password for t in settings.teams.values()
+    ):
+        return settings
+    import pathlib
+
+    try:
+        cfg_path = find_toml()
+        updated, generated = _autofill_ui_passwords(
+            pathlib.Path(cfg_path).read_text(encoding="utf-8")
+        )
+        if not generated:
+            return settings
+        pathlib.Path(cfg_path).write_text(updated, encoding="utf-8")
+    except Exception:
+        logger.exception("Could not auto-provision a web-UI password")
+        return settings
+    for password in generated:
+        logger.warning(
+            "Auto-generated a web-UI password (user 'admin') for a team that had "
+            "none, so upgrading does not serve the dashboard unauthenticated: %s",
+            password,
+        )
+    _settings = None
+    return _get_settings()
+
+
 def _run_reload_template(
     settings: Settings, team: TeamSettings, template_name: str, dump_path: str = ""
 ) -> None:
@@ -3346,20 +3445,27 @@ def _run_cli() -> None:
         bundled = pathlib.Path(__file__).resolve().parent / "templates" / "oduflow.toml"
         dest = os.path.join(dest_dir, "oduflow.toml")
         generated_token = secrets.token_urlsafe(24)
+        generated_ui_password = secrets.token_urlsafe(18)
         rendered = _inject_db_password(
             bundled.read_text(encoding="utf-8"), secrets.token_urlsafe(24)
         )
         rendered = _inject_auth_token(rendered, generated_token)
+        rendered = _inject_ui_password(rendered, generated_ui_password)
         with open(dest, "w", encoding="utf-8") as f:
             f.write(rendered)
         logger.info(
-            "Config created: %s (auto-generated DB password and MCP auth_token)",
+            "Config created: %s (auto-generated DB password, MCP auth_token and "
+            "web-UI password)",
             dest,
         )
         logger.info(
             "Generated MCP auth_token for team 1: %s "
             "(use as Bearer token / OAuth client_id+secret)",
             generated_token,
+        )
+        logger.info(
+            "Generated web-UI password for team 1 (user 'admin'): %s",
+            generated_ui_password,
         )
 
     global _settings
@@ -3500,6 +3606,10 @@ def _start_http() -> None:
     from fastmcp.server.http import create_streamable_http_app
 
     settings = _get_settings()
+    # Secure the dashboard on upgrades without bricking MCP: auto-provision a
+    # ui_password for existing configs that still have none. The fail-closed
+    # check below only trips if this could not write the config.
+    settings = _ensure_web_ui_password(settings)
     host = "0.0.0.0" if settings.routing_mode == "traefik" else settings.host
     port = settings.port
 
@@ -3520,6 +3630,25 @@ def _start_http() -> None:
         logger.warning(
             "HTTP transport starting WITHOUT authentication "
             "(allow_insecure_http=true) — the full MCP tool surface is open."
+        )
+
+    # Fail closed for the WEB DASHBOARD too, symmetric to the MCP check above.
+    # The dashboard exposes MORE than MCP (interactive shells/SQL/agent to every
+    # environment, privileged service creation, credential management) and is
+    # only authenticated when a team sets ui_password. Fresh installs bootstrap
+    # one and _ensure_web_ui_password just auto-provisioned one for existing
+    # configs — so reaching here with none set means both the config write failed
+    # and the operator has not opted into an open server; refuse rather than serve
+    # the dashboard unauthenticated.
+    if not settings.allow_insecure_http and not any(
+        t.ui_password for t in settings.teams.values()
+    ):
+        raise PrerequisiteNotMetError(
+            "Refusing to start the HTTP transport with an unauthenticated web "
+            "dashboard: set a [team.*] ui_password in oduflow.toml (the dashboard "
+            "exposes interactive shells, SQL and privileged service creation for "
+            "every environment). To run it open on purpose (e.g. behind your own "
+            "auth proxy), set [server] allow_insecure_http = true."
         )
 
     # With several teams, every team needs its own token: auth rejects a

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2388,8 +2388,19 @@ function esc(s) {
   return d.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
+// Safe for a value placed inside a double-quoted HTML attribute, including the
+// JS-string form onclick="fn('<value>')": escapes \ and ' for the JS-string
+// context AND entity-encodes " < > & so a value can never break out of the
+// attribute (the browser HTML-decodes the entities before the JS parser sees
+// them). Order matters: encode & first, then backslash before the quote.
 function escAttr(s) {
-  return (s || '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return (s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 // Plain-text relative time ("just now", "5m ago"). Safe for attribute

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -74,7 +74,7 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 [team.1]
 hostname = "localhost"            # port: http://{hostname}:{port}, traefik: https://{slug}.{hostname}
 auth_token = ""                   # MCP bearer token / OAuth client_id+secret (auto-generated on first run; HTTP refuses to start if empty)
-ui_password = ""                  # Web UI password (empty = UI open)
+ui_password = ""                  # Web UI password (auto-generated on first run; HTTP refuses to start if empty unless allow_insecure_http)
 port_range = [50000, 50100]       # port range for Odoo containers
 # db_quota_gb = 50                # combined size cap for the team's PostgreSQL DBs (environments + templates); 0 = off
 # disk_quota_gb = 0               # cap on team files + databases via XFS project quotas (needs data dir on XFS with prjquota)

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import hashlib
 import hmac
+import html
 import json
 import logging
 import os
@@ -251,9 +252,11 @@ _TEMPLATE_DIR = pathlib.Path(__file__).resolve().parent / "templates"
 
 def _render_login(error: str = "") -> str:
     """Render the login page, optionally with a server-controlled error banner."""
-    html = (_TEMPLATE_DIR / "login.html").read_text(encoding="utf-8")
-    banner = f'<div class="error">{error}</div>' if error else ""
-    return html.replace("<!--ERROR-->", banner)
+    page = (_TEMPLATE_DIR / "login.html").read_text(encoding="utf-8")
+    # Escape the message so the banner stays safe even if a future caller passes
+    # user-influenced text (today's callers pass static literals).
+    banner = f'<div class="error">{html.escape(error)}</div>' if error else ""
+    return page.replace("<!--ERROR-->", banner)
 
 
 async def _read_login_password(request: Request) -> str:
@@ -697,6 +700,12 @@ def _build_routes(
                 {"ok": False, "error": "env_name is required."},
                 status_code=400,
             )
+        from oduflow.naming import validate_env_name
+
+        try:
+            env_name = validate_env_name(env_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
 
         # Acquire the env lock in its own try so a BusyError returns WITHOUT
         # entering the try/finally below — otherwise the finally would release a
@@ -2015,11 +2024,26 @@ def _build_routes(
                 await websocket.close(code=1011)
                 return
 
-            from oduflow.env_credentials import load_credentials
-
-            creds = load_credentials(
-                branch, team.workspaces_dir, settings.db_user, settings.db_password
+            from oduflow.env_credentials import (
+                MissingCredentialsError,
+                load_credentials,
             )
+
+            # Never open an interactive psql as the cluster superuser: that would
+            # allow \c into another team's database and COPY ... FROM PROGRAM
+            # (RCE). Require the environment's scoped role.
+            try:
+                creds = load_credentials(
+                    branch,
+                    team.workspaces_dir,
+                    settings.db_user,
+                    settings.db_password,
+                    allow_fallback=False,
+                )
+            except MissingCredentialsError as e:
+                await websocket.send_text(f"\x1b[31mError: {e}\x1b[0m\r\n")
+                await websocket.close(code=1011)
+                return
 
             exec_id = client.api.exec_create(
                 db_container.id,

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -1,0 +1,162 @@
+"""Regression tests for the security-audit fixes.
+
+Each test pins a specific vulnerability that was closed so a future refactor
+cannot silently reopen it. All are pure/unit — no Docker required.
+"""
+
+import pytest
+
+from oduflow.env_credentials import (
+    MissingCredentialsError,
+    create_credentials,
+    load_credentials,
+)
+from oduflow.naming import validate_env_name
+
+
+class TestValidateEnvName:
+    @pytest.mark.parametrize(
+        "name",
+        ["19.0", "feature/my-feature", "release/v1.2.3", "client-a", "a.b_c-1"],
+    )
+    def test_accepts_real_branch_names(self, name):
+        assert validate_env_name(name) == name
+
+    @pytest.mark.parametrize("name", ["", "   ", ".", "..", "a/..", "../b", "a/./b"])
+    def test_rejects_traversal_and_empty(self, name):
+        with pytest.raises(ValueError):
+            validate_env_name(name)
+
+    @pytest.mark.parametrize("name", ["a\\b", "a\x00b", "x" * 101])
+    def test_rejects_separators_nul_and_oversize(self, name):
+        with pytest.raises(ValueError):
+            validate_env_name(name)
+
+    @pytest.mark.parametrize("name", ["foo ", " foo", "\tfoo", "foo\n", " 19.0 "])
+    def test_rejects_whitespace_padding(self, name):
+        # A padded name must not pass: slug strips the space (container/DB) while
+        # the workspace path keeps it, so "foo" and "foo " would collide.
+        with pytest.raises(ValueError):
+            validate_env_name(name)
+
+    def test_returns_name_unchanged(self):
+        # No silent canonicalization — the returned value is byte-for-byte input.
+        assert validate_env_name("feature/My-Env.1") == "feature/My-Env.1"
+
+
+class TestAutofillUiPasswords:
+    def test_fills_every_empty_password_distinctly(self):
+        from oduflow.server import _autofill_ui_passwords
+
+        src = (
+            "[team.1]\n"
+            'ui_password = ""                  # Web UI password\n'
+            "[team.2]\n"
+            'ui_password = ""\n'
+        )
+        out, generated = _autofill_ui_passwords(src)
+        assert len(generated) == 2
+        assert generated[0] != generated[1]
+        assert 'ui_password = ""' not in out
+        for pw in generated:
+            assert f'ui_password = "{pw}"' in out
+        # Untouched lines survive verbatim, including the preserved comment.
+        assert "[team.1]" in out and "[team.2]" in out
+        assert "# Web UI password" in out
+
+    def test_noop_when_already_set(self):
+        from oduflow.server import _autofill_ui_passwords
+
+        src = 'ui_password = "already-set"\n'
+        out, generated = _autofill_ui_passwords(src)
+        assert generated == []
+        assert out.strip() == src.strip()
+
+
+class TestHttpRequestPathGuard:
+    """`http_request_to_odoo` must reject paths that could rewrite the host
+    (SSRF) before it ever builds a request."""
+
+    def _call(self, path):
+        from oduflow.docker_ops.odoo_ops import http_request_to_odoo
+
+        # The guard raises before touching settings/team/Docker, so None is fine.
+        return http_request_to_odoo(None, None, "env", path)
+
+    @pytest.mark.parametrize(
+        "path", ["@evil.com/x", "//evil.com/", "http://evil.com", "evil", ""]
+    )
+    def test_rejects_host_rewriting_paths(self, path):
+        with pytest.raises(ValueError):
+            self._call(path)
+
+
+class TestModuleNameValidation:
+    def test_accepts_plain_modules(self):
+        from oduflow.docker_ops.odoo_ops import _validate_module_names
+
+        _validate_module_names(["sale", "purchase", "stock_account"])
+
+    @pytest.mark.parametrize(
+        "mod",
+        ["base --load=evil", "a;b", "mod space", "--logfile=/x", "a,b", ""],
+    )
+    def test_rejects_argument_injection(self, mod):
+        from oduflow.docker_ops.odoo_ops import _validate_module_names
+
+        with pytest.raises(ValueError):
+            _validate_module_names([mod])
+
+
+class TestCredentialFallback:
+    def test_fallback_returns_shared_when_allowed(self, tmp_path):
+        creds = load_credentials(
+            "env", str(tmp_path), "odoo", "secret", allow_fallback=True
+        )
+        assert creds == {"pg_user": "odoo", "pg_password": "secret"}
+
+    def test_no_fallback_raises_when_missing(self, tmp_path):
+        with pytest.raises(MissingCredentialsError):
+            load_credentials(
+                "env", str(tmp_path), "odoo", "secret", allow_fallback=False
+            )
+
+    def test_no_fallback_uses_scoped_creds_when_present(self, tmp_path):
+        create_credentials("env", "1", str(tmp_path))
+        creds = load_credentials(
+            "env", str(tmp_path), "odoo", "secret", allow_fallback=False
+        )
+        assert creds["pg_user"] != "odoo"
+        assert creds["pg_password"] != "secret"
+
+
+class TestSetupRepoAuthSSRF:
+    def test_blocks_loopback_before_storing_credentials(self, tmp_path):
+        from oduflow.git_ops import setup_repo_auth
+        from oduflow.url_safety import BlockedURLError
+
+        cred_file = str(tmp_path / "creds")
+        with pytest.raises(BlockedURLError):
+            setup_repo_auth("https://user:pat@127.0.0.1/owner/repo.git", cred_file)
+        # The PAT must never have been written to disk.
+        import os
+
+        assert not os.path.exists(cred_file)
+
+
+class TestUiPasswordInjection:
+    def test_injects_into_bootstrap_config(self):
+        from oduflow.server import _inject_ui_password
+
+        src = 'ui_password = ""                  # Web UI password\n'
+        out = _inject_ui_password(src, "s3cret")
+        assert 'ui_password = "s3cret"' in out
+        assert 'ui_password = ""' not in out
+
+    def test_only_first_empty_is_set(self):
+        from oduflow.server import _inject_ui_password
+
+        src = 'ui_password = ""\nui_password = ""\n'
+        out = _inject_ui_password(src, "s3cret")
+        assert out.count('ui_password = "s3cret"') == 1
+        assert out.count('ui_password = ""') == 1

--- a/tests/test_template_local_path.py
+++ b/tests/test_template_local_path.py
@@ -14,6 +14,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastmcp.exceptions import ToolError
 
 from oduflow.docker_ops.system_ops import _source_env_metadata
 from oduflow.settings import Settings, TeamSettings
@@ -127,7 +128,7 @@ class TestCreateFromLiveMountTemplate:
         )
         try:
             with patch("oduflow.server._resolve_team", return_value=team):
-                with pytest.raises(ValueError, match="live-mounted environment"):
+                with pytest.raises(ToolError, match="live-mounted environment"):
                     _call_tool("create_environment", branch="t", template_name="tpl")
             mock_create.assert_not_called()
         finally:
@@ -162,7 +163,7 @@ class TestCreateFromLiveMountTemplate:
             "tpl",
             {"odoo_image": "odoo:19.0", "repo_url": "", "local_path": "/gone/addons"},
         )
-        with pytest.raises(ValueError, match="does not exist"):
+        with pytest.raises(ToolError, match="does not exist"):
             _call_tool("create_environment", branch="t", template_name="tpl")
         mock_create.assert_not_called()
 


### PR DESCRIPTION
Fixes from a security audit of the HTTP/MCP surface. The web dashboard now fails closed — fresh installs bootstrap a `ui_password` and existing configs are auto-provisioned one on HTTP start, so the interactive shell/SQL/agent/service-creation surface is never served unauthenticated and the MCP transport is no longer bricked on upgrade. Closed two SSRF vectors (`http_request_to_odoo` path host-rewrite and `setup_repo_auth` loopback/link-local before storing credentials), and removed the shared-PostgreSQL-superuser fallback from `run_db_query`, `run_odoo_shell`, `run_odoo_tests` and the psql websocket so a tenant can no longer cross into other databases on legacy environments. Hardening: argv-form path probe in `read_file_in_environment` (no `sh -c`), module-name validation, `validate_env_name` with an rmtree containment guard, `mask_error_details=True` (validation messages still surface), escaped login banner, and hardened `escAttr`. Adds `tests/test_security_fixes.py` and updates one error-type assertion; full suite is green (716 tests).