### PR TITLE
OAuth: per-team host-relative issuer in traefik; routing.hostname port-only

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -117,12 +117,15 @@ allow_local_path = true     # allow live-mount (bind local checkout) environment
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik" and tls = true
 # tls = true                # traefik only. false = plain HTTP on :80, no ACME (behind a Cloudflare tunnel / TLS proxy)
-# hostname = "localhost"    # default hostname for teams that don't set their own
+# hostname = "localhost"    # port mode only: default host for teams without their own
+                            # (traefik requires each team to set its own hostname)
 
 # ── OAuth (optional) ──────────────────────────────────
-# Set to the public URL of this instance to turn Oduflow into a self-hosted
-# OAuth 2.1 Authorization Server (for Claude.ai and other OAuth MCP clients).
-# Each team's auth_token doubles as client_id, client_secret, and access token.
+# In traefik mode the self-hosted OAuth 2.1 Authorization Server is enabled
+# automatically and runs on each team's own hostname (issuer derived per-request),
+# so oauth_base_url is NOT needed. Set it only to pin a fixed issuer, or in port
+# mode: the public URL of this instance (for Claude.ai and other OAuth MCP
+# clients). Each team's auth_token doubles as client_id, client_secret, and token.
 [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 
@@ -191,7 +194,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 
 | Key | Default | Description |
 |---|---|---|
-| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance. When set, Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect. Each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. Empty = plain Bearer-token auth only. See [Authentication & Security](security.md) |
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only. See [Authentication & Security](security.md) |
 
 ### Database settings
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -385,12 +385,15 @@ allow_local_path = true     # allow live-mount (bind local checkout) environment
 [routing]
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik"
-# hostname = "localhost"    # default hostname for teams that don't set their own
+# hostname = "localhost"    # port mode only: default host for teams without their own
+                            # (traefik requires each team to set its own hostname)
 
 # ── OAuth (optional) ──────────────────────────────────
-# Set to the public URL of this instance to turn Oduflow into a self-hosted
-# OAuth 2.1 Authorization Server (for Claude.ai and other OAuth MCP clients).
-# Each team's auth_token doubles as client_id, client_secret, and access token.
+# In traefik mode the self-hosted OAuth 2.1 Authorization Server is enabled
+# automatically and runs on each team's own hostname (issuer derived per-request),
+# so oauth_base_url is NOT needed. Set it only to pin a fixed issuer, or in port
+# mode: the public URL of this instance (for Claude.ai and other OAuth MCP
+# clients). Each team's auth_token doubles as client_id, client_secret, and token.
 [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 
@@ -457,7 +460,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 
 | Key | Default | Description |
 |---|---|---|
-| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance. When set, Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect. Each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. Empty = plain Bearer-token auth only |
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only |
 
 ### Database settings
 
@@ -2107,7 +2110,19 @@ When the OAuth flow completes, the issued `access_token` is exactly the team's `
 
 ### Setup
 
-In `oduflow.toml`, set the public URL of this instance and an `auth_token` per team:
+**In traefik mode it's automatic.** The Authorization Server is enabled out of the box and runs on **each team's own hostname** — the OAuth issuer is derived per request from the incoming host (which already has a Let's Encrypt certificate). Just give each team an `auth_token`; no `oauth_base_url` is needed:
+
+```toml
+[routing]
+mode = "traefik"
+acme_email = "admin@example.com"
+
+[team.1]
+hostname = "team-a.example.com"
+auth_token = "secret-token-team-1"
+```
+
+**In port mode** (no per-team TLS host), set `oauth_base_url` to the public https URL where this instance is reachable, so the issuer is a fixed, reachable endpoint:
 
 ```toml
 [oauth]
@@ -2117,7 +2132,7 @@ oauth_base_url = "https://your-server.com"
 auth_token = "secret-token-team-1"
 ```
 
-That's it. Oduflow now exposes:
+Either way, Oduflow exposes:
 
 - `GET /.well-known/oauth-authorization-server` — discovery metadata
 - `GET /authorize` — authorization endpoint (Authorization Code + PKCE)
@@ -2128,7 +2143,7 @@ Dynamic Client Registration (`/register`) is **disabled** — clients must use t
 ### Connecting from Claude.ai
 
 1. Go to Claude.ai Settings → Connectors → Add custom MCP
-2. Enter your Oduflow URL: `https://your-server.com/mcp`
+2. Enter your Oduflow URL: `https://your-server.com/mcp` (in traefik mode, the team's own hostname, e.g. `https://team-a.example.com/mcp`)
 3. In the OAuth fields enter the team's `auth_token` as **both** `Client ID` **and** `Client Secret`:
 
    ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -48,7 +48,7 @@ mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 # acme_email = "admin@example.com"    # required for traefik mode
 
 [oauth]
-# oauth_base_url = "https://oduflow.example.com"  # enable self-hosted OAuth (for Claude.ai); auth_token = client_id = client_secret = access token
+# oauth_base_url = "https://oduflow.example.com"  # OAuth issuer; NOT needed in traefik (auto, per-team host). Set to pin an issuer or in port mode. auth_token = client_id = client_secret = access token
 
 [database]
 user = "odoo"
@@ -141,7 +141,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 ### Claude.ai (self-hosted OAuth)
 
-For OAuth-based MCP clients like Claude.ai Remote MCP, set `[oauth].oauth_base_url` to this instance's public URL. Oduflow then runs its own OAuth 2.1 Authorization Server (no external IdP). In Claude.ai add a custom MCP at `https://<your-oduflow-host>/mcp` and enter the team's `auth_token` as **both** Client ID and Client Secret. The issued access token equals the `auth_token`, so the same value also works as a plain Bearer token.
+For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAuth 2.1 Authorization Server (no external IdP). In **traefik mode** it is enabled automatically and runs on each team's own hostname (issuer derived per-request) — no `oauth_base_url` needed. In **port mode**, set `[oauth].oauth_base_url` to this instance's public URL. In Claude.ai add a custom MCP at `https://<team-hostname>/mcp` and enter the team's `auth_token` as **both** Client ID and Client Secret. The issued access token equals the `auth_token`, so the same value also works as a plain Bearer token.
 
 ## Core MCP Tools
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -83,7 +83,7 @@ MCP auth and Web Dashboard auth are independent — they use different tokens an
 
 ### Self-hosted OAuth (Claude.ai)
 
-Some MCP clients (e.g. Claude.ai Remote MCP) require an OAuth flow instead of a static Bearer token. Oduflow can act as its own OAuth 2.1 Authorization Server — no external identity provider needed. Set the public URL of this instance in `oduflow.toml`:
+Some MCP clients (e.g. Claude.ai Remote MCP) require an OAuth flow instead of a static Bearer token. Oduflow can act as its own OAuth 2.1 Authorization Server — no external identity provider needed. In [traefik mode](traefik.md) it's enabled automatically and runs on each team's own hostname, so no extra config is required. In port mode, set the public URL of this instance in `oduflow.toml`:
 
 ```toml
 [oauth]

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,7 +28,19 @@ When the OAuth flow completes, the issued `access_token` is exactly the team's `
 
 ### Setup
 
-In `oduflow.toml`, set the public URL of this instance and an `auth_token` per team:
+**In [traefik mode](traefik.md) it's automatic.** The Authorization Server is enabled out of the box and runs on **each team's own hostname** — the OAuth issuer is derived per request from the incoming host (which already has a Let's Encrypt certificate). Just give each team an `auth_token`; no `oauth_base_url` is needed:
+
+```toml
+[routing]
+mode = "traefik"
+acme_email = "admin@example.com"
+
+[team.1]
+hostname = "team-a.example.com"
+auth_token = "secret-token-team-1"
+```
+
+**In port mode** (no per-team TLS host), set `oauth_base_url` to the public https URL where this instance is reachable, so the issuer is a fixed, reachable endpoint:
 
 ```toml
 [oauth]
@@ -38,7 +50,7 @@ oauth_base_url = "https://your-server.com"
 auth_token = "secret-token-team-1"
 ```
 
-That's it. Oduflow now exposes:
+Either way, Oduflow exposes:
 
 - `GET /.well-known/oauth-authorization-server` — discovery metadata
 - `GET /authorize` — authorization endpoint (Authorization Code + PKCE)
@@ -49,7 +61,7 @@ Dynamic Client Registration (`/register`) is **disabled** — clients must use t
 ### Connecting from Claude.ai
 
 1. Go to Claude.ai Settings → Connectors → Add custom MCP
-2. Enter your Oduflow URL: `https://your-server.com/mcp`
+2. Enter your Oduflow URL: `https://your-server.com/mcp` (in traefik mode, the team's own hostname, e.g. `https://team-a.example.com/mcp`)
 3. In the OAuth fields enter the team's `auth_token` as **both** `Client ID` **and** `Client Secret`:
 
    ```

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -38,6 +38,10 @@ Traefik requests a **per-subdomain certificate** from Let's Encrypt each time a 
 
 Wildcard certificates (`*.dev.example.com`) via DNS-01 validation are also possible but require additional Traefik configuration with a provider-specific plugin.
 
+## OAuth on each team's hostname
+
+In traefik mode the self-hosted [OAuth Authorization Server](security.md#self-hosted-oauth-for-claudeai-and-other-mcp-clients) is enabled **automatically** and runs on **each team's own hostname** — the OAuth issuer is derived per request from the incoming host, which already has a Let's Encrypt certificate. You do **not** need to set `oauth_base_url`: point Claude.ai at `https://<team-hostname>/mcp` and complete the OAuth flow there.
+
 ## Service routing with Traefik
 
 Auxiliary services also get Traefik routing. A service named `meilisearch` with base domain `dev.example.com` becomes accessible at `https://meilisearch.dev.example.com`. Custom hostnames are also supported.

--- a/specs/0020-authentication-oauth.md
+++ b/specs/0020-authentication-oauth.md
@@ -1,9 +1,9 @@
 # 0020 — Authentication for MCP HTTP transport: GitHub OAuth → self-hosted OAuth Authorization Server
 
-**Status:** Adopted (self-hosted AS is current; static Bearer tokens retained)
+**Status:** Adopted (self-hosted AS is current; traefik uses a per-team, host-relative issuer; static Bearer tokens retained)
 **Type:** Architecture
 **First introduced:** `97c3fc8` "add GitHub OAuth support for MCP HTTP transport" (2026-03-13)
-**Key code today:** `server.py` (`_build_auth`, transport/auth wiring), `oauth_provider.py` (`OduflowOAuthProvider`), `settings.py` (`oauth_base_url`, per-team `auth_token`)
+**Key code today:** `server.py` (`_build_auth`, transport/auth wiring), `oauth_provider.py` (`OduflowOAuthProvider`, host-relative `get_routes`), `settings.py` (`oauth_base_url`, `oauth_enabled`, per-team `auth_token`/`hostname`)
 
 ## Context
 
@@ -84,6 +84,31 @@ request context and threaded into per-team scoping.
   MCP auth and are covered in [[0011-per-user-git-credentials]]; this record is
   only about authenticating the MCP transport.
 
+## Evolution
+
+- **Per-team, host-relative issuer (traefik).** The first self-hosted design used
+  a single global issuer (`oauth_base_url`) for every team. Behind Traefik that
+  forced a separate central hostname whose only job was to be the issuer — but
+  Traefik requests a certificate only for hostnames it actually routes (each
+  **team's** hostname, see [[0027-hard-tenant-isolation]]), so the central issuer
+  host had no cert and the OAuth discovery it advertised was unreachable. Since a
+  team is identified in the flow by its `auth_token`, not by the host, the issuer
+  never needed to be global. Oduflow now **derives the issuer per request from the
+  incoming host** in traefik mode: `OduflowOAuthProvider.get_routes` swaps the
+  SDK's static discovery-metadata endpoints
+  (`/.well-known/oauth-authorization-server`,
+  `/.well-known/oauth-protected-resource`) for handlers that build `issuer`,
+  `authorization_endpoint`, `token_endpoint`, and `resource` from the request's
+  forwarded proto/host. Each team's OAuth flow therefore runs entirely on its own
+  already-certificated hostname ([[0014-team-based-multi-tenancy]]), and
+  `_build_auth` enables the Authorization Server automatically whenever routing is
+  traefik. `oauth_base_url` becomes **optional** — needed only to pin a fixed
+  issuer or in **port** mode (which has no per-team TLS host). The `/authorize`
+  and `/token` operational routes are path-only and unchanged, and static Bearer
+  tokens still work. In the same change, `[routing].hostname` is restricted to
+  port mode (in traefik every team must set its own hostname, so a shared default
+  is dead and would collide two teams on one host).
+
 ## History
 
 - `97c3fc8` (2026-03-13) — GitHub OAuth 2.1 for MCP HTTP transport alongside
@@ -95,3 +120,7 @@ request context and threaded into per-team scoping.
   OAuth vs static tokens (breaking) (#19).
 - `73aa9b9` (2026-06-10) — document self-hosted OAuth in the config reference,
   quick start, and llms docs (#33).
+- `2026-07-04` — derive the OAuth issuer per-request from the team's own hostname
+  in traefik mode (host-relative discovery metadata); enable the Authorization
+  Server automatically in traefik and make `oauth_base_url` optional there;
+  restrict `[routing].hostname` to port mode.

--- a/specs/0020-authentication-oauth.md
+++ b/specs/0020-authentication-oauth.md
@@ -99,7 +99,10 @@ request context and threaded into per-team scoping.
   (`/.well-known/oauth-authorization-server`,
   `/.well-known/oauth-protected-resource`) for handlers that build `issuer`,
   `authorization_endpoint`, `token_endpoint`, and `resource` from the request's
-  forwarded proto/host. Each team's OAuth flow therefore runs entirely on its own
+  forwarded proto/host — validated against the registered team hostnames, so a
+  forged `X-Forwarded-Host` cannot advertise a foreign issuer (and the 401
+  `WWW-Authenticate` challenge is rewritten under the same check). Each team's
+  OAuth flow therefore runs entirely on its own
   already-certificated hostname ([[0014-team-based-multi-tenancy]]), and
   `_build_auth` enables the Authorization Server automatically whenever routing is
   traefik. `oauth_base_url` becomes **optional** — needed only to pin a fixed

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -10,19 +10,29 @@ keeps working unchanged.
 from __future__ import annotations
 
 import logging
+import re
+from typing import Any
+from urllib.parse import urlparse
 
 from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
+from mcp.server.auth.json_response import PydanticJSONResponse
 from mcp.server.auth.provider import (
     AccessToken,
     AuthorizationCode,
     RefreshToken,
 )
+from mcp.server.auth.routes import build_metadata, cors_middleware
+from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
 from mcp.shared.auth import (
     InvalidRedirectUriError,
     OAuthClientInformationFull,
     OAuthToken,
+    ProtectedResourceMetadata,
 )
-from pydantic import AnyUrl
+from pydantic import AnyHttpUrl, AnyUrl
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
 
 from oduflow import env_tokens
 from oduflow.scoped_access import ENV_SCOPE_PREFIX
@@ -35,6 +45,77 @@ logger = logging.getLogger("oduflow")
 # authorization redirect into an XSS / data-exfil primitive.
 _DANGEROUS_REDIRECT_SCHEMES = {"javascript", "data", "vbscript", "file"}
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
+
+_RESOURCE_METADATA_RE = re.compile(r'resource_metadata="([^"]+)"')
+
+
+def _origin_from_forwarded(
+    raw_headers: list[tuple[bytes, bytes]], fallback_scheme: str | None = None
+) -> str:
+    """External origin (``scheme://host``) from ASGI headers.
+
+    Behind Traefik the app is reached over http with the team's public host in
+    the Host header and ``X-Forwarded-Proto: https``; reflect the forwarded
+    proto/host (first hop) so advertised OAuth URLs are reachable.
+    """
+    headers = {k.decode("latin-1").lower(): v.decode("latin-1") for k, v in raw_headers}
+    fwd_host = headers.get("x-forwarded-host", "").split(",")[0].strip()
+    host = fwd_host or headers.get("host", "")
+    fwd_proto = headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    scheme = fwd_proto or fallback_scheme or "https"
+    return f"{scheme}://{host}"
+
+
+def _rewrite_resource_metadata_origin(header_value: bytes, origin: str) -> bytes:
+    """Rewrite the scheme+host of a ``WWW-Authenticate`` ``resource_metadata``
+    URL to ``origin``, preserving its path."""
+    text = header_value.decode("latin-1")
+    m = _RESOURCE_METADATA_RE.search(text)
+    if not m:
+        return header_value
+    old = m.group(1)
+    new = f"{origin}{urlparse(old).path}"
+    return text.replace(
+        f'resource_metadata="{old}"', f'resource_metadata="{new}"'
+    ).encode("latin-1")
+
+
+class HostRelativeAuthChallenge:
+    """ASGI wrapper that makes the 401 auth challenge host-relative.
+
+    In host-relative OAuth mode the issuer is per-team-host, but fastmcp bakes a
+    single static ``resource_metadata`` URL — built from the placeholder
+    base_url — into RequireAuthMiddleware's ``WWW-Authenticate`` challenge. An
+    unauthenticated MCP client (e.g. Claude.ai) begins OAuth discovery from that
+    header, so without this rewrite team B's client would start OAuth on team A's
+    hostname. We rewrite the URL's scheme+host to the host the request actually
+    arrived on, keeping the path; the discovery it points to is already
+    host-relative (see OduflowOAuthProvider.get_routes).
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        origin = _origin_from_forwarded(scope.get("headers", []), scope.get("scheme"))
+
+        async def send_wrapper(message: Any) -> None:
+            if message.get("type") == "http.response.start" and message.get("headers"):
+                message = {
+                    **message,
+                    "headers": [
+                        (k, _rewrite_resource_metadata_origin(v, origin))
+                        if k.lower() == b"www-authenticate"
+                        else (k, v)
+                        for k, v in message["headers"]
+                    ],
+                }
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
 
 
 class _FlexibleClient(OAuthClientInformationFull):
@@ -71,9 +152,25 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
     """OAuth Authorization Server backed by ``team.auth_token`` values."""
 
     def __init__(self, settings: Settings) -> None:
-        if not settings.oauth_base_url:
-            raise ValueError("oauth_base_url is required for self-hosted OAuth")
-        super().__init__(base_url=settings.oauth_base_url)
+        # Host-relative issuer: with no explicit oauth_base_url (the norm in
+        # traefik mode) the issuer is derived per-request from the incoming Host,
+        # so OAuth runs on each team's own TLS-terminated hostname. The
+        # placeholder base_url below is a real team hostname that satisfies the
+        # SDK's issuer validation for the path-only /authorize + /token routes;
+        # it is kept out of every client-facing output by two overrides —
+        # get_routes() rebuilds the discovery metadata per-request, and
+        # HostRelativeAuthChallenge rewrites the 401 WWW-Authenticate
+        # resource_metadata origin to the request host.
+        self._host_relative = not settings.oauth_base_url
+        if settings.oauth_base_url:
+            base_url = settings.oauth_base_url
+        else:
+            placeholder_host = next(
+                (t.hostname for t in settings.teams.values() if t.hostname),
+                "localhost",
+            )
+            base_url = f"https://{placeholder_host}"
+        super().__init__(base_url=base_url)
 
         self._settings = settings
         self._token_to_team: dict[str, str] = {}
@@ -102,6 +199,94 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
                 scopes=[],
                 expires_at=None,
             )
+
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        """OAuth routes, with discovery metadata made per-request when there is
+        no fixed issuer.
+
+        With no explicit ``oauth_base_url`` the SDK would bake the placeholder
+        issuer into static ``/.well-known/...`` documents. We instead swap those
+        two discovery endpoints for handlers that advertise the issuer at the
+        host the client actually reached us on, so each team's OAuth flow runs on
+        its own hostname. ``/authorize`` and ``/token`` are path-only and need no
+        change.
+        """
+        routes = super().get_routes(mcp_path)
+        if not self._host_relative:
+            return routes
+
+        patched: list[Route] = []
+        for route in routes:
+            if not isinstance(route, Route):
+                patched.append(route)
+            elif route.path.startswith("/.well-known/oauth-authorization-server"):
+                patched.append(
+                    Route(
+                        route.path,
+                        endpoint=cors_middleware(
+                            self._authorization_server_metadata, ["GET", "OPTIONS"]
+                        ),
+                        methods=["GET", "OPTIONS"],
+                    )
+                )
+            elif route.path.startswith("/.well-known/oauth-protected-resource"):
+                patched.append(
+                    Route(
+                        route.path,
+                        endpoint=cors_middleware(
+                            self._protected_resource_metadata, ["GET", "OPTIONS"]
+                        ),
+                        methods=["GET", "OPTIONS"],
+                    )
+                )
+            else:
+                patched.append(route)
+        return patched
+
+    @staticmethod
+    def _request_origin(request: Request) -> str:
+        """External origin (scheme://host) the client reached us on."""
+        return _origin_from_forwarded(
+            request.scope["headers"], request.scope.get("scheme")
+        )
+
+    async def _authorization_server_metadata(self, request: Request) -> Response:
+        issuer = AnyHttpUrl(self._request_origin(request))
+        # Default the options exactly as the SDK's create_auth_routes does —
+        # build_metadata dereferences them, and both are None on this provider.
+        metadata = build_metadata(
+            issuer,
+            self.service_documentation_url,
+            self.client_registration_options or ClientRegistrationOptions(),
+            self.revocation_options or RevocationOptions(),
+        )
+        # No-store: the document is host-specific, so a shared cache must not
+        # replay one team's issuer for another host.
+        return PydanticJSONResponse(
+            content=metadata, headers={"Cache-Control": "no-store"}
+        )
+
+    async def _protected_resource_metadata(self, request: Request) -> Response:
+        origin = self._request_origin(request)
+        resource_path = (
+            urlparse(str(self._resource_url)).path if self._resource_url else "/mcp"
+        )
+        supported_scopes = (
+            self.client_registration_options.valid_scopes
+            if (
+                self.client_registration_options
+                and self.client_registration_options.valid_scopes
+            )
+            else self.required_scopes
+        )
+        metadata = ProtectedResourceMetadata(
+            resource=AnyHttpUrl(f"{origin}{resource_path}"),
+            authorization_servers=[AnyHttpUrl(origin)],
+            scopes_supported=supported_scopes,
+        )
+        return PydanticJSONResponse(
+            content=metadata, headers={"Cache-Control": "no-store"}
+        )
 
     async def _env_identity(self, token: str | None) -> tuple[str, str] | None:
         """Return ``(team_id, env_name)`` for a valid per-environment token.

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -31,7 +31,7 @@ from mcp.shared.auth import (
 )
 from pydantic import AnyHttpUrl, AnyUrl
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from oduflow import env_tokens
@@ -49,10 +49,10 @@ _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
 _RESOURCE_METADATA_RE = re.compile(r'resource_metadata="([^"]+)"')
 
 
-def _origin_from_forwarded(
+def _forwarded_scheme_host(
     raw_headers: list[tuple[bytes, bytes]], fallback_scheme: str | None = None
-) -> str:
-    """External origin (``scheme://host``) from ASGI headers.
+) -> tuple[str, str]:
+    """The ``(scheme, host)`` the client reached us on, from ASGI headers.
 
     Behind Traefik the app is reached over http with the team's public host in
     the Host header and ``X-Forwarded-Proto: https``; reflect the forwarded
@@ -63,7 +63,16 @@ def _origin_from_forwarded(
     host = fwd_host or headers.get("host", "")
     fwd_proto = headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
     scheme = fwd_proto or fallback_scheme or "https"
-    return f"{scheme}://{host}"
+    return scheme, host
+
+
+def _unknown_host_response() -> JSONResponse:
+    """400 for a discovery request whose host is not a registered team — never
+    advertise an issuer derived from a forged or absent Host header."""
+    return JSONResponse(
+        {"error": "invalid_request", "error_description": "Unrecognized host."},
+        status_code=400,
+    )
 
 
 def _rewrite_resource_metadata_origin(header_value: bytes, origin: str) -> bytes:
@@ -90,17 +99,28 @@ class HostRelativeAuthChallenge:
     header, so without this rewrite team B's client would start OAuth on team A's
     hostname. We rewrite the URL's scheme+host to the host the request actually
     arrived on, keeping the path; the discovery it points to is already
-    host-relative (see OduflowOAuthProvider.get_routes).
+    host-relative (see OduflowOAuthProvider.get_routes). The rewrite only fires
+    for a host that maps to a registered team, so a forged X-Forwarded-Host can't
+    inject an attacker origin into the challenge.
     """
 
-    def __init__(self, app: Any) -> None:
+    def __init__(self, app: Any, settings: Settings) -> None:
         self.app = app
+        self._settings = settings
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope.get("type") != "http":
             await self.app(scope, receive, send)
             return
-        origin = _origin_from_forwarded(scope.get("headers", []), scope.get("scheme"))
+        scheme, host = _forwarded_scheme_host(
+            scope.get("headers", []), scope.get("scheme")
+        )
+        # Only rewrite for a host that belongs to a registered team; a forged or
+        # unexpected host is left with fastmcp's own (placeholder team) URL.
+        if self._settings.get_team_by_hostname(host) is None:
+            await self.app(scope, receive, send)
+            return
+        origin = f"{scheme}://{host}"
 
         async def send_wrapper(message: Any) -> None:
             if message.get("type") == "http.response.start" and message.get("headers"):
@@ -243,15 +263,24 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
                 patched.append(route)
         return patched
 
-    @staticmethod
-    def _request_origin(request: Request) -> str:
-        """External origin (scheme://host) the client reached us on."""
-        return _origin_from_forwarded(
+    def _validated_origin(self, request: Request) -> str | None:
+        """External origin (scheme://host) the client reached us on, but only for
+        a host that belongs to a registered team; otherwise ``None`` so the caller
+        rejects the request. This keeps a forged ``X-Forwarded-Host`` from
+        advertising an attacker-controlled issuer, and turns a missing Host into a
+        clean 400 rather than an invalid ``https://`` URL."""
+        scheme, host = _forwarded_scheme_host(
             request.scope["headers"], request.scope.get("scheme")
         )
+        if self._settings.get_team_by_hostname(host) is None:
+            return None
+        return f"{scheme}://{host}"
 
     async def _authorization_server_metadata(self, request: Request) -> Response:
-        issuer = AnyHttpUrl(self._request_origin(request))
+        origin = self._validated_origin(request)
+        if origin is None:
+            return _unknown_host_response()
+        issuer = AnyHttpUrl(origin)
         # Default the options exactly as the SDK's create_auth_routes does —
         # build_metadata dereferences them, and both are None on this provider.
         metadata = build_metadata(
@@ -267,7 +296,9 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         )
 
     async def _protected_resource_metadata(self, request: Request) -> Response:
-        origin = self._request_origin(request)
+        origin = self._validated_origin(request)
+        if origin is None:
+            return _unknown_host_response()
         resource_path = (
             urlparse(str(self._resource_url)).path if self._resource_url else "/mcp"
         )

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3611,7 +3611,7 @@ def _start_http() -> None:
     if getattr(auth, "_host_relative", False):
         from oduflow.oauth_provider import HostRelativeAuthChallenge
 
-        served = HostRelativeAuthChallenge(served)
+        served = HostRelativeAuthChallenge(served, settings)
 
     uvicorn.run(served, host=host, port=port, ws="websockets-sansio")
 
@@ -3635,12 +3635,8 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
     has_team_token = any(t.auth_token for t in settings.teams.values())
 
     if settings.oauth_enabled:
-        if not has_team_token:
-            logger.warning(
-                "OAuth is enabled (oauth_base_url or traefik routing) but no "
-                "team has auth_token; OAuth disabled"
-            )
-            return None
+        # oauth_enabled already implies a team auth_token (see Settings), which
+        # doubles as the OAuth client credential.
         from oduflow.oauth_provider import OduflowOAuthProvider
 
         return OduflowOAuthProvider(settings)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 import warnings
-from typing import cast
+from typing import Any, cast
 
 # Suppress a third-party deprecation warning emitted at import time by fastmcp's
 # JWT auth provider (it imports the deprecated authlib.jose module). This keeps
@@ -3603,28 +3603,42 @@ def _start_http() -> None:
     import uvicorn
 
     # Outermost shim so /mcp/<env> routes to the canonical /mcp route.
-    uvicorn.run(ScopedEnvASGI(app), host=host, port=port, ws="websockets-sansio")
+    served: Any = ScopedEnvASGI(app)
+    # When the OAuth issuer is derived per-request (traefik, no fixed
+    # oauth_base_url), also rewrite the 401 challenge's resource_metadata origin
+    # to the request host — otherwise fastmcp's static URL would send every
+    # team's client to discover OAuth on one team's hostname.
+    if getattr(auth, "_host_relative", False):
+        from oduflow.oauth_provider import HostRelativeAuthChallenge
+
+        served = HostRelativeAuthChallenge(served)
+
+    uvicorn.run(served, host=host, port=port, ws="websockets-sansio")
 
 
 def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
     """Build the auth provider from settings.
 
-    Two modes (auto-detected by ``oauth_base_url``):
-    - Self-hosted OAuth Authorization Server (when oauth_base_url is set):
-      Oduflow exposes /authorize, /token, /.well-known/oauth-authorization-server.
-      Each team's auth_token doubles as client_id, client_secret, and the
-      issued access token. Suitable for claude.ai and other MCP clients that
-      require an OAuth flow.
-    - Static Bearer tokens (default when oauth_base_url is empty):
-      auth_token is consumed directly from the Authorization header.
-      Suitable for curl, CLI clients, and IDEs that don't need OAuth.
+    Two modes (auto-detected via ``settings.oauth_enabled``):
+    - Self-hosted OAuth Authorization Server — when ``oauth_base_url`` is set OR
+      routing is traefik. Oduflow exposes /authorize, /token, and
+      /.well-known/oauth-authorization-server. In traefik mode the issuer is
+      derived per-request from the team's own (TLS-terminated) hostname, so no
+      central oauth_base_url is needed; each team's OAuth flow runs on its own
+      host. Each team's auth_token doubles as client_id, client_secret, and the
+      issued access token, so Bearer-token callers keep working unchanged.
+      Suitable for claude.ai and other MCP clients that require an OAuth flow.
+    - Static Bearer tokens — port mode with no oauth_base_url: auth_token is
+      consumed directly from the Authorization header. Suitable for curl, CLI
+      clients, and IDEs that don't need OAuth.
     """
     has_team_token = any(t.auth_token for t in settings.teams.values())
 
     if settings.oauth_enabled:
         if not has_team_token:
             logger.warning(
-                "oauth_base_url is set but no team has auth_token; OAuth disabled"
+                "OAuth is enabled (oauth_base_url or traefik routing) but no "
+                "team has auth_token; OAuth disabled"
             )
             return None
         from oduflow.oauth_provider import OduflowOAuthProvider

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -184,6 +184,9 @@ class Settings:
     # When set, Oduflow exposes /.well-known/oauth-authorization-server,
     # /authorize, and /token, and each team's auth_token doubles as
     # client_id, client_secret, and the issued access token.
+    # In traefik mode this is optional: the issuer is derived per-request from
+    # the team's own hostname (already TLS-terminated), so OAuth works without a
+    # central host. Set it only to pin a fixed issuer or in port mode.
     oauth_base_url: str = ""
 
     # Config location
@@ -217,7 +220,11 @@ class Settings:
 
     @property
     def oauth_enabled(self) -> bool:
-        return bool(self.oauth_base_url)
+        # Self-hosted OAuth is served whenever an explicit issuer is configured
+        # (oauth_base_url) or we run behind Traefik, where each team's own
+        # TLS-terminated hostname is used as a per-request issuer — no central
+        # oauth_base_url needed. Port mode still requires an explicit issuer.
+        return bool(self.oauth_base_url) or self.routing_mode == "traefik"
 
     def get_team_by_ui_password(self, password: str) -> TeamSettings | None:
         if not password:
@@ -312,6 +319,7 @@ class Settings:
         lifecycle = raw.get("lifecycle", {})
         agent = raw.get("agent", {})
         oauth = raw.get("oauth", server)  # [oauth] section or fall back to [server]
+        routing_mode = str(routing.get("mode", "port")).strip().lower()
 
         etc_dir = _resolve_etc_dir()
         base_data_dir = _resolve_data_dir(storage.get("data_dir", ""))
@@ -346,9 +354,15 @@ class Settings:
                     f"got {port_range!r}"
                 )
 
-            raw_hostname = str(
-                team_cfg.get("hostname", routing.get("hostname", "localhost"))
+            # [routing].hostname is a fallback only in port mode. In traefik
+            # mode the validator requires every team to set its own hostname;
+            # silently inheriting one shared default would make two such teams
+            # collide in get_team_by_hostname, so leave it empty and let
+            # validate() report the misconfiguration.
+            default_hostname = (
+                routing.get("hostname", "localhost") if routing_mode == "port" else ""
             )
+            raw_hostname = str(team_cfg.get("hostname", default_hostname))
             hostname = re.sub(r"^https?://", "", raw_hostname).strip()
 
             agent_env_raw = team_cfg.get("agent_env", {})
@@ -389,7 +403,7 @@ class Settings:
             disable_telemetry=bool(server.get("disable_telemetry", False)),
             allow_local_path=bool(server.get("allow_local_path", True)),
             allow_insecure_http=bool(server.get("allow_insecure_http", False)),
-            routing_mode=str(routing.get("mode", "port")).strip().lower(),
+            routing_mode=routing_mode,
             acme_email=str(routing.get("acme_email", "")).strip(),
             routing_tls=bool(routing.get("tls", True)),
             db_user=str(database.get("user", "odoo")),

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -224,7 +224,13 @@ class Settings:
         # (oauth_base_url) or we run behind Traefik, where each team's own
         # TLS-terminated hostname is used as a per-request issuer — no central
         # oauth_base_url needed. Port mode still requires an explicit issuer.
-        return bool(self.oauth_base_url) or self.routing_mode == "traefik"
+        # It also requires a team auth_token (which doubles as the OAuth client
+        # credential): without one nothing is actually served, so the flag stays
+        # False rather than reporting "OAuth ON" for a tokenless deployment.
+        has_token = any(t.auth_token for t in self.teams.values())
+        return has_token and (
+            bool(self.oauth_base_url) or self.routing_mode == "traefik"
+        )
 
     def get_team_by_ui_password(self, password: str) -> TeamSettings | None:
         if not password:

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -10,7 +10,8 @@ allow_local_path = true        # allow live-mount (bind local checkout) workflow
 [routing]
 mode = "port"                   # "port" | "traefik"
 # acme_email = "admin@example.com"  # required for traefik (when tls = true)
-# hostname = "localhost"           # default hostname for teams that don't set their own
+# hostname = "localhost"           # port mode only: default host for teams without their own
+                                   # (traefik requires each team to set its own hostname)
 # tls = true                       # traefik only. true: Traefik terminates TLS
 #                                  # (:443, HTTP->HTTPS redirect, Let's Encrypt).
 #                                  # false: plain HTTP on :80 only, no redirect/ACME —
@@ -53,17 +54,17 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 # codex_model = ""                 # optional model override; empty = CLI default
 
 # ── OAuth (optional) ──────────────────────────────────
-# Set oauth_base_url to the public URL of this Oduflow instance to enable
-# the self-hosted OAuth Authorization Server. Endpoints exposed:
-#   /.well-known/oauth-authorization-server
-#   /authorize
-#   /token
-# For each team, claude.ai (and any OAuth-based MCP client) should be
-# configured with:
-#   client_id     = team.<id>.auth_token
-#   client_secret = team.<id>.auth_token   (same value)
+# In traefik mode the self-hosted OAuth Authorization Server is enabled
+# automatically and each team's OAuth flow runs on its OWN hostname (the issuer
+# is derived per-request), so you do NOT need oauth_base_url. Endpoints:
+#   /.well-known/oauth-authorization-server   /authorize   /token
+# For each team, claude.ai (and any OAuth-based MCP client) is configured with:
+#   client_id = client_secret = team.<id>.auth_token
 # After the OAuth flow the issued access_token is also auth_token, so plain
-# Bearer-token clients keep working. Leave empty to use Bearer-only auth.
+# Bearer-token clients keep working.
+#
+# oauth_base_url is only needed to pin a fixed central issuer, or in PORT mode
+# (no per-team TLS host): set it to this instance's public https URL.
 # [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2197,7 +2197,14 @@ def _build_routes(
             settings = get_settings()
             team = _get_ui_team(request)
             token = env_ops.get_env_token(settings, team, branch)
-            base = (settings.oauth_base_url or str(request.base_url)).rstrip("/")
+            # In traefik mode the MCP endpoint is served on the team's own
+            # (TLS-terminated) hostname, which is also the per-request OAuth
+            # issuer — so advertise that, not a central oauth_base_url or the
+            # internal request host. Port mode keeps the explicit issuer/base.
+            if settings.routing_mode == "traefik":
+                base = f"https://{team.hostname}"
+            else:
+                base = (settings.oauth_base_url or str(request.base_url)).rstrip("/")
             url = f"{base}/mcp/{quote(branch, safe='/')}"
             return JSONResponse({"ok": True, "result": {"url": url, "token": token}})
         except FlowError as e:

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -40,6 +40,23 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
+def _host_settings(*hostnames):
+    """Host-relative Settings (no oauth_base_url) with a team per hostname."""
+    return Settings(
+        oauth_base_url="",
+        teams={
+            str(i): TeamSettings(
+                team_id=str(i),
+                auth_token=f"tok-{i}",
+                hostname=h,
+                port_range_start=50000 + i * 100,
+                port_range_end=50100 + i * 100,
+            )
+            for i, h in enumerate(hostnames, start=1)
+        },
+    )
+
+
 class TestOduflowOAuthProvider:
     def test_host_relative_without_oauth_base_url(self):
         # No oauth_base_url (the traefik norm): the issuer is derived per-request
@@ -205,7 +222,9 @@ class TestOduflowOAuthProvider:
         from starlette.testclient import TestClient
 
         # No fixed issuer → issuer/endpoints derived per-request from the Host.
-        provider = OduflowOAuthProvider(_settings(oauth_base_url=""))
+        provider = OduflowOAuthProvider(
+            _host_settings("zipfit.oduflow.dev", "other.example.com")
+        )
         assert provider._host_relative is True
         app = Starlette(routes=provider.get_routes("/mcp"))
         client = TestClient(app)
@@ -275,7 +294,7 @@ class TestOduflowOAuthProvider:
                 (b"x-forwarded-proto", b"https"),
             ],
         }
-        app = HostRelativeAuthChallenge(inner)
+        app = HostRelativeAuthChallenge(inner, _host_settings("team-b.example.com"))
         _run(app(scope, receive, send))
 
         start = next(m for m in sent if m["type"] == "http.response.start")
@@ -286,3 +305,63 @@ class TestOduflowOAuthProvider:
         )
         # The error parts are preserved untouched.
         assert 'error="invalid_token"' in hdr
+
+    def test_metadata_rejects_unknown_host(self):
+        # A forged/absent host must not be reflected as the issuer: the discovery
+        # endpoints reject it with 400 rather than advertise an attacker origin
+        # or blow up on an invalid https:// URL.
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        provider = OduflowOAuthProvider(_host_settings("zipfit.oduflow.dev"))
+        client = TestClient(Starlette(routes=provider.get_routes("/mcp")))
+
+        for path in (
+            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource/mcp",
+        ):
+            r = client.get(
+                path, headers={"host": "evil.com", "x-forwarded-proto": "https"}
+            )
+            assert r.status_code == 400, path
+
+    def test_auth_challenge_skips_unknown_host(self):
+        # A forged host must not be injected into the 401 challenge; the static
+        # (placeholder team) resource_metadata is left untouched.
+        from oduflow.oauth_provider import HostRelativeAuthChallenge
+
+        static = (
+            'Bearer error="invalid_token", resource_metadata='
+            '"https://team-a.example.com/.well-known/oauth-protected-resource/mcp"'
+        )
+
+        async def inner(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [(b"www-authenticate", static.encode())],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+
+        sent: list = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        async def receive():
+            return {"type": "http.request"}
+
+        scope = {
+            "type": "http",
+            "scheme": "http",
+            "headers": [(b"host", b"evil.com"), (b"x-forwarded-proto", b"https")],
+        }
+        app = HostRelativeAuthChallenge(inner, _host_settings("team-b.example.com"))
+        _run(app(scope, receive, send))
+
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        hdr = dict(start["headers"])[b"www-authenticate"].decode()
+        assert "team-a.example.com" in hdr  # unchanged
+        assert "evil.com" not in hdr

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -41,19 +41,26 @@ def _run(coro):
 
 
 class TestOduflowOAuthProvider:
-    def test_requires_oauth_base_url(self):
+    def test_host_relative_without_oauth_base_url(self):
+        # No oauth_base_url (the traefik norm): the issuer is derived per-request
+        # from the incoming Host, so construction is allowed (host-relative mode)
+        # and uses a team hostname as the placeholder base_url.
         s = Settings(
+            routing_mode="traefik",
+            acme_email="admin@example.com",
+            oauth_base_url="",
             teams={
                 "1": TeamSettings(
                     team_id="1",
                     auth_token="tok",
+                    hostname="team1.example.com",
                     port_range_start=50000,
                     port_range_end=50100,
                 )
-            }
+            },
         )
-        with pytest.raises(ValueError, match="oauth_base_url"):
-            OduflowOAuthProvider(s)
+        provider = OduflowOAuthProvider(s)
+        assert provider._host_relative is True
 
     def test_preregistered_clients(self):
         provider = OduflowOAuthProvider(_settings())
@@ -192,3 +199,90 @@ class TestOduflowOAuthProvider:
         assert "token_endpoint" in meta
         # DCR is disabled — endpoint must not be advertised.
         assert "registration_endpoint" not in meta
+
+    def test_metadata_host_relative(self):
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        # No fixed issuer → issuer/endpoints derived per-request from the Host.
+        provider = OduflowOAuthProvider(_settings(oauth_base_url=""))
+        assert provider._host_relative is True
+        app = Starlette(routes=provider.get_routes("/mcp"))
+        client = TestClient(app)
+
+        headers = {"host": "zipfit.oduflow.dev", "x-forwarded-proto": "https"}
+        meta = json.loads(
+            client.get("/.well-known/oauth-authorization-server", headers=headers).text
+        )
+        assert meta["issuer"].rstrip("/") == "https://zipfit.oduflow.dev"
+        assert meta["authorization_endpoint"] == "https://zipfit.oduflow.dev/authorize"
+        assert meta["token_endpoint"] == "https://zipfit.oduflow.dev/token"
+
+        prm = json.loads(
+            client.get(
+                "/.well-known/oauth-protected-resource/mcp", headers=headers
+            ).text
+        )
+        assert prm["resource"].rstrip("/") == "https://zipfit.oduflow.dev/mcp"
+        assert (
+            prm["authorization_servers"][0].rstrip("/") == "https://zipfit.oduflow.dev"
+        )
+
+        # A different Host yields a different issuer — OAuth is per-team-host.
+        other = json.loads(
+            client.get(
+                "/.well-known/oauth-authorization-server",
+                headers={"host": "other.example.com", "x-forwarded-proto": "https"},
+            ).text
+        )
+        assert other["issuer"].rstrip("/") == "https://other.example.com"
+
+    def test_auth_challenge_rewrites_resource_metadata_host(self):
+        # The 401 WWW-Authenticate resource_metadata origin must follow the
+        # request host, or fastmcp's static URL would point team B's client at
+        # team A's hostname to discover OAuth.
+        from oduflow.oauth_provider import HostRelativeAuthChallenge
+
+        static = (
+            'Bearer error="invalid_token", error_description="Authentication '
+            'required", resource_metadata="https://team-a.example.com/'
+            '.well-known/oauth-protected-resource/mcp"'
+        )
+
+        async def inner(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [(b"www-authenticate", static.encode())],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+
+        sent: list = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        async def receive():
+            return {"type": "http.request"}
+
+        scope = {
+            "type": "http",
+            "scheme": "http",  # Traefik terminates TLS; app sees http
+            "headers": [
+                (b"host", b"team-b.example.com"),
+                (b"x-forwarded-proto", b"https"),
+            ],
+        }
+        app = HostRelativeAuthChallenge(inner)
+        _run(app(scope, receive, send))
+
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        hdr = dict(start["headers"])[b"www-authenticate"].decode()
+        assert (
+            'resource_metadata="https://team-b.example.com/.well-known/'
+            'oauth-protected-resource/mcp"' in hdr
+        )
+        # The error parts are preserved untouched.
+        assert 'error="invalid_token"' in hdr

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,29 @@ class TestSettings:
         assert s.db_user == "odoo"
         assert s.routing_mode == "port"
 
+    def test_routing_hostname_fallback_port_mode(self, tmp_path):
+        # In port mode a team with no hostname inherits [routing].hostname.
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[routing]\nmode = "port"\nhostname = "shared.example.com"\n[team.1]\n'
+        )
+        s = Settings.from_toml(str(toml))
+        assert s.get_team("1").hostname == "shared.example.com"
+
+    def test_routing_hostname_ignored_in_traefik_mode(self, tmp_path):
+        # In traefik mode the shared default is NOT inherited; a team without
+        # its own hostname is left empty so validate() flags the misconfig
+        # instead of silently colliding two teams on one host.
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[routing]\nmode = "traefik"\nacme_email = "a@b.co"\n'
+            'hostname = "shared.example.com"\n[team.1]\n'
+        )
+        s = Settings.from_toml(str(toml))
+        assert s.get_team("1").hostname == ""
+        with pytest.raises(ValueError, match="hostname must be set"):
+            s.validate()
+
     def test_validate_no_teams(self):
         s = Settings()
         with pytest.raises(ValueError, match="No \\[team\\.\\*\\] sections"):


### PR DESCRIPTION
In traefik mode the self-hosted OAuth Authorization Server now derives its issuer per-request from the incoming Host, so each team's OAuth flow runs on its own already-certificated hostname and no central `oauth_base_url` is needed. `OduflowOAuthProvider` replaces the SDK's static discovery-metadata endpoints with host-relative handlers, and a `HostRelativeAuthChallenge` ASGI wrapper rewrites the 401 `WWW-Authenticate` `resource_metadata` origin to the request host so a client never begins OAuth discovery on another team's hostname. `_build_auth` enables OAuth automatically whenever routing is traefik (Bearer tokens keep working), and the dashboard advertises the team's own hostname for the MCP URL. `[routing].hostname` is now applied only in port mode — in traefik every team must set its own hostname, so the shared default was dead and could silently collide two teams on one host. Records the evolution in `specs/0020` and syncs docs, the sample TOML, and llms.txt; adds unit tests for host-relative metadata, the 401 rewrite, and the routing.hostname mode split.