### PR TITLE
fix(overlay): stop duplicating template filestore into each env; unmount without fusermount

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,9 +23,10 @@ sudo apt install fuse-overlayfs
 
 The `/dev/fuse` device must be available (present by default on Ubuntu).
 
-In `/etc/fuse.conf`, uncomment `user_allow_other` so the Docker daemon (root) can access FUSE mountpoints created by the user:
+Oduflow mounts each environment's filestore with `fuse-overlayfs`'s `allow_other` option so the Odoo container's (non-root) user can read it. When Oduflow runs as **root** — the default and recommended setup — no further configuration is needed. Only if you run Oduflow as a **non-root user** must you uncomment `user_allow_other` in `/etc/fuse.conf`:
 
 ```bash
+# Only needed when running Oduflow as a non-root user:
 sudo sed -i 's/^#user_allow_other/user_allow_other/' /etc/fuse.conf
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -172,6 +172,7 @@ An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per
 
 - Repository: <https://github.com/oduist/oduflow>
 - Documentation: <https://docs.oduflow.dev>
+- Troubleshooting: <https://docs.oduflow.dev/troubleshooting/>
 - License: BUSL-1.1 (Business Source License 1.1) — free for non-commercial use; commercial use requires a paid license; converts to MPL 2.0 four years after publication
 - Website: <https://oduflow.dev>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -317,9 +317,10 @@ sudo apt install fuse-overlayfs
 
 The `/dev/fuse` device must be available (present by default on Ubuntu).
 
-In `/etc/fuse.conf`, uncomment `user_allow_other` so the Docker daemon (root) can access FUSE mountpoints created by the user:
+Oduflow mounts each environment's filestore with `fuse-overlayfs`'s `allow_other` option so the Odoo container's (non-root) user can read it. When Oduflow runs as **root** — the default and recommended setup — no further configuration is needed. Only if you run Oduflow as a **non-root user** must you uncomment `user_allow_other` in `/etc/fuse.conf`:
 
 ```bash
+# Only needed when running Oduflow as a non-root user:
 sudo sed -i 's/^#user_allow_other/user_allow_other/' /etc/fuse.conf
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,174 @@
+# Troubleshooting
+
+Recovery playbooks for the operational issues most likely to hit a self-hosted
+Oduflow deployment, organized by symptom. Commands assume the default data
+directory `/srv/oduflow` and team `1`; adjust the paths for your setup.
+
+Oduflow runs as **root** (it needs the Docker socket, `iptables`, host-side
+`chown` and XFS project quotas). All commands below are run on the host.
+
+---
+
+## The server won't start / keeps restarting
+
+`systemctl status oduflow` shows the service failing and restarting in a loop,
+and `journalctl -u oduflow` ends in a traceback.
+
+The most common cause is the **shared PostgreSQL container not being ready** when
+Oduflow initializes. On startup Oduflow waits for `oduflow-db` with `pg_isready`;
+if that container is not running — still starting, or crash-looping — the wait
+now retries and, on timeout, fails with a clear message pointing at its logs
+(older versions crashed with a raw `docker.errors.APIError: 409`).
+
+```bash
+# Is the DB container actually up?
+docker inspect oduflow-db --format '{{.State.Status}} restarting={{.State.Restarting}} restarts={{.RestartCount}} exit={{.State.ExitCode}}'
+
+# Why is PostgreSQL dying? (the decisive check)
+docker logs --tail 200 oduflow-db
+
+# Very common underlying cause — the disk is full:
+df -h /srv/oduflow
+```
+
+The Oduflow version is irrelevant here — the blocker is Docker/container state,
+so upgrading or downgrading Oduflow will not help until `oduflow-db` stays `Up`.
+See [Disk full](#disk-full) below. Once the DB container is healthy:
+
+```bash
+systemctl restart oduflow
+journalctl -u oduflow -f
+```
+
+---
+
+## Disk full
+
+A full disk cascades: PostgreSQL cannot write and crash-loops, new
+environments fail to provision, and Odoo reports "did not become ready".
+
+```bash
+df -h /srv/oduflow          # bytes
+df -i /srv/oduflow          # inodes — can be exhausted even when bytes are free
+```
+
+Find what is using space. Note that **each environment always copies its
+database** (a PostgreSQL `CREATE DATABASE ... TEMPLATE` is a full copy — a few GB
+per env is normal and unavoidable), while the much larger **filestore is shared
+via an overlay** and should cost only a small delta per env (see
+[Overlay filestore](#overlay-filestore)):
+
+```bash
+# Per-environment on-disk cost (upper layer + repo + sessions; the shared
+# template filestore is NOT counted here):
+du -sh /srv/oduflow/team_1/workspaces/*/filestore_upper
+du -sh /srv/oduflow/team_1/workspaces/*/repo
+
+# Templates (the shared lower layers + dumps):
+du -sh /srv/oduflow/team_1/templates/*
+```
+
+To reclaim space, delete unused environments or templates through Oduflow
+(`delete_environment` / `delete_template`, the dashboard, or `oduflow call`) so
+databases, overlays and workspaces are torn down cleanly. **Do not** `rm -rf` a
+template directory by hand while environments still use it — see
+[Deleting a template fails](#deleting-a-template-fails).
+
+---
+
+## An environment won't start / Odoo "did not become ready"
+
+Work down this checklist:
+
+```bash
+# 1. Is the shared DB up and accepting connections?
+docker exec oduflow-db pg_isready -U odoo
+
+# 2. Is the Odoo container running, and what does it say?
+docker ps -a --filter name=<env-slug>
+docker logs --tail 200 oduflow-1-<env-slug>-odoo
+
+# 3. Is the filestore mounted and readable inside the container?
+docker exec oduflow-1-<env-slug>-odoo \
+  sh -c 'ls /var/lib/odoo/.local/share/Odoo/filestore/*/ 2>&1 | head'
+```
+
+If step 3 reports `Transport endpoint is not connected` or an empty filestore,
+the overlay mount is broken — see [Overlay filestore](#overlay-filestore).
+Otherwise the failure is usually inside Odoo (a module install/upgrade error);
+read the container logs.
+
+---
+
+## Overlay filestore
+
+Large template filestores are shared with `fuse-overlayfs` instead of copied.
+Per environment, under `/srv/oduflow/team_1/workspaces/<env-slug>/`:
+
+| Path | Role |
+|------|------|
+| `filestore` | the **merged** mountpoint (bind-mounted into the container) |
+| `filestore_upper` | this env's **own** writes (the only real disk it adds) |
+| `filestore_work` | fuse-overlayfs work dir (kept tiny) |
+
+The **lower** (read-only base) layer is the template's filestore at
+`/srv/oduflow/team_1/templates/<template>/filestore`, shared by every
+environment created from that template.
+
+Inspect the mounts and sizes:
+
+```bash
+# Active overlay mounts and their lower layers:
+grep fuse-overlayfs /proc/mounts
+
+# The upper layer should be small; the merged view shows the full tree
+# (lower + upper) and will look ~template-sized — that is expected:
+du -sh /srv/oduflow/team_1/workspaces/<env-slug>/filestore_upper   # small = healthy
+du -sh /srv/oduflow/team_1/workspaces/<env-slug>/filestore         # ~= template size
+```
+
+### A broken mount (`Transport endpoint is not connected`)
+
+The `fuse-overlayfs` process for a mount died (e.g. it was killed when the disk
+filled). Detach the stale mount, then bring the environment back up through
+Oduflow (which remounts it):
+
+```bash
+umount /srv/oduflow/team_1/workspaces/<env-slug>/filestore \
+  || umount -l /srv/oduflow/team_1/workspaces/<env-slug>/filestore
+```
+
+### fuse-overlayfs prerequisites
+
+```bash
+which fuse-overlayfs          # install: sudo apt install fuse-overlayfs
+ls -l /dev/fuse               # must exist (present by default on Ubuntu)
+```
+
+`fuse-overlayfs` is mounted with `allow_other` so the Odoo container's (non-root)
+user can read it. Running Oduflow **as root** (the supported setup) needs no
+further configuration. Only when running Oduflow as a **non-root user** must you
+uncomment `user_allow_other` in `/etc/fuse.conf`.
+
+!!! note "AppArmor `fusermount3` on Ubuntu 24.04+ (historical)"
+    Older Oduflow unmounted overlays via the setuid `fusermount` helper, which
+    the `fusermount3` AppArmor profile on Ubuntu 24.04+ **denies**, forcing a
+    lazy fallback. Oduflow now unmounts with a direct root `umount` (not mediated
+    by that profile), so this no longer affects root deployments. If you run a
+    non-root/rootless setup and hit `apparmor="DENIED" ... fusermount3`, allow it
+    with a local override — add `umount /srv/oduflow/**,` to
+    `/etc/apparmor.d/local/fusermount3` and run `apparmor_parser -r
+    /etc/apparmor.d/fusermount3`.
+
+---
+
+## Deleting a template fails
+
+```
+Cannot delete template 'X': used by environments: a, b. Delete those environments first.
+```
+
+This is intentional. A template's filestore is the overlay **lower layer** for
+every environment built from it; deleting the template would pull the base out
+from under those live overlays and break them. Delete the listed environments
+first (or keep the template). The same guard applies to renaming a template.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Authentication & Security: security.md
       - Running in Docker: docker.md
       - Internals: internals.md
+      - Troubleshooting: troubleshooting.md
   - About:
       - Licensing: licensing.md
       - Changelog: changelog.md

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -247,7 +247,11 @@ def _mount_filestore(
         )
         hint = ""
         if "allow_other" in error_msg or "permission" in error_msg.lower():
-            hint = " Hint: uncomment 'user_allow_other' in /etc/fuse.conf"
+            hint = (
+                " Hint: Oduflow normally runs as root, where 'allow_other' needs "
+                "no extra config. If you run it as a non-root user, uncomment "
+                "'user_allow_other' in /etc/fuse.conf."
+            )
         raise PrerequisiteNotMetError(
             f"Failed to mount filestore overlay: {error_msg}.{hint}"
         )

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -280,15 +280,24 @@ def _unmount_filestore(env_name: str, team: TeamSettings) -> None:
     if not os.path.isdir(merged) or not os.path.ismount(merged):
         return
 
+    # Prefer a direct, clean ``umount``: Oduflow runs as root, and umount(2) is
+    # not mediated by the AppArmor ``fusermount3`` profile shipped on Ubuntu
+    # 24.04+ (which otherwise DENIES the setuid ``fusermount`` helper, forcing
+    # the lazy fallback). ``fusermount3``/``fusermount`` stay in the chain for
+    # unprivileged/rootless deployments where umount(2) needs the helper. Lazy
+    # ``umount -l`` is the last resort only — it detaches even a busy mount,
+    # which can leave a still-bound container with a broken filestore.
     for cmd in (
+        ["umount", merged],
+        ["fusermount3", "-u", merged],
         ["fusermount", "-u", merged],
         ["umount", "-l", merged],
     ):
         try:
             subprocess.run(cmd, check=True, capture_output=True)
             logger.info(
-                "Filestore overlay unmounted (%s)",
-                cmd[-2],
+                "Filestore overlay unmounted via '%s'",
+                " ".join(cmd[:-1]),
                 extra={"env_name": env_name},
             )
             return
@@ -479,16 +488,31 @@ def _ensure_user_site_packages(container) -> None:
 
     This allows ``pip install --user`` to work inside containers where
     ``/var/lib/odoo/.local`` may not exist or may be owned by root.
+
+    Only the pip target dirs are chowned, never recursively into
+    ``.local/share``: the Odoo filestore is bind-mounted at
+    ``.local/share/Odoo/filestore/<db>`` from an overlay's read-only lower
+    layer, so ``chown -R /var/lib/odoo/.local`` would change ownership on every
+    filestore file and force fuse-overlayfs to copy the entire template
+    filestore up into this environment's upper layer — defeating the overlay
+    (each env would duplicate the full filestore instead of sharing the
+    template's lower layer).
     """
     container.exec_run(
-        "mkdir -p /var/lib/odoo/.local/lib",
+        "mkdir -p /var/lib/odoo/.local/lib /var/lib/odoo/.local/bin",
+        user="root",
+    )
+    # Non-recursive on .local so .local/share (the bind-mounted filestore) is
+    # never touched; recursive only on the pip dirs, which never hold it.
+    container.exec_run(
+        "chown odoo:odoo /var/lib/odoo/.local",
         user="root",
     )
     container.exec_run(
-        "chown -R odoo:odoo /var/lib/odoo/.local",
+        "chown -R odoo:odoo /var/lib/odoo/.local/lib /var/lib/odoo/.local/bin",
         user="root",
     )
-    logger.debug("Ensured /var/lib/odoo/.local is owned by odoo")
+    logger.debug("Ensured pip user dirs under /var/lib/odoo/.local are owned by odoo")
 
 
 def _install_pip_requirements(

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -302,16 +302,35 @@ def _destroy_traefik(
 
 def _wait_pg_ready(client: DockerClient, settings: Settings, timeout: int = 30) -> None:
     container = client.containers.get(settings.shared_db_container)
-    for i in range(timeout):
-        exit_code, _ = container.exec_run(["pg_isready", "-U", settings.db_user])
-        if exit_code == 0:
-            exit_code2, _ = container.exec_run(
-                ["psql", "-U", settings.db_user, "-d", "postgres", "-tAc", "SELECT 1;"]
-            )
-            if exit_code2 == 0:
-                return
+    for _ in range(timeout):
+        try:
+            exit_code, _ = container.exec_run(["pg_isready", "-U", settings.db_user])
+            if exit_code == 0:
+                exit_code2, _ = container.exec_run(
+                    [
+                        "psql",
+                        "-U",
+                        settings.db_user,
+                        "-d",
+                        "postgres",
+                        "-tAc",
+                        "SELECT 1;",
+                    ]
+                )
+                if exit_code2 == 0:
+                    return
+        except docker.errors.APIError:
+            # The DB container isn't running yet — still starting, or restarting
+            # after a crash (e.g. the disk filled up). Docker's exec_create then
+            # returns 409. Treat it as "not ready" and retry instead of letting a
+            # transient state crash the whole server startup (which systemd would
+            # turn into a restart loop).
+            pass
         time.sleep(1)
-    raise PrerequisiteNotMetError(f"PostgreSQL did not become ready within {timeout}s")
+    raise PrerequisiteNotMetError(
+        f"PostgreSQL ({settings.shared_db_container}) did not become ready within "
+        f"{timeout}s. Check its logs: docker logs {settings.shared_db_container}"
+    )
 
 
 def _exec_sql(
@@ -2142,6 +2161,27 @@ def delete_template(
     settings: Settings, team: TeamSettings, template_name: str
 ) -> dict[str, str]:
     client = get_client()
+
+    # Refuse if any environment was created from this template: its filestore is
+    # the overlay lower layer for those envs (see env_ops._mount_filestore), so
+    # deleting it would yank the base out from under a live overlay and break it.
+    # Mirrors the same guard in rename_template.
+    filters = {
+        "label": [
+            f"{settings.managed_label}=true",
+            f"{settings.team_label}={team.team_id}",
+        ]
+    }
+    dependent: list[str] = []
+    for c in client.containers.list(all=True, filters=filters):
+        if c.labels.get("oduflow.template", "none") == template_name:
+            dependent.append(c.labels.get(settings.branch_label, c.name))
+    if dependent:
+        raise ConflictError(
+            f"Cannot delete template '{template_name}': used by environments: "
+            f"{', '.join(dependent)}. Delete those environments first."
+        )
+
     tpl_db = get_template_db_name(template_name, team.team_id)
 
     if _db_exists(client, settings, tpl_db):

--- a/tests/test_dependency_install.py
+++ b/tests/test_dependency_install.py
@@ -105,3 +105,49 @@ class TestInstallPipRequirements:
         assert installed is False
         assert log == ""
         assert _pip_cmd(container) is None
+
+
+def _chown_cmds(container) -> list[str]:
+    """All ``chown`` commands passed to exec_run."""
+    out = []
+    for call in container.exec_run.call_args_list:
+        cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+        if isinstance(cmd, str) and cmd.strip().startswith("chown"):
+            out.append(cmd)
+    return out
+
+
+class TestEnsureUserSitePackages:
+    """Regression guard for the overlay copy-up bug.
+
+    ``_ensure_user_site_packages`` makes pip's ``--user`` target odoo-owned, but
+    the Odoo filestore is bind-mounted at ``.local/share/Odoo/filestore/<db>``
+    from an overlay's read-only lower layer. A recursive ``chown -R`` over the
+    whole ``/var/lib/odoo/.local`` descends into the filestore and rewrites every
+    file's owner, which forces fuse-overlayfs to copy the entire template
+    filestore up into the environment's upper layer — defeating the overlay
+    (each env duplicated the ~10 GB filestore). The chown must therefore never
+    recurse into ``.local`` / ``.local/share``.
+    """
+
+    def test_never_recursively_chowns_all_of_local(self):
+        container = _mock_container()
+        env_ops._ensure_user_site_packages(container)
+        for cmd in _chown_cmds(container):
+            assert not (
+                "-R" in cmd and cmd.rstrip().endswith("/var/lib/odoo/.local")
+            ), f"recursive chown of the whole .local copies the filestore up: {cmd!r}"
+            assert not ("-R" in cmd and "/.local/share" in cmd), (
+                f"recursive chown into .local/share hits the filestore: {cmd!r}"
+            )
+
+    def test_chowns_pip_dirs(self):
+        container = _mock_container()
+        env_ops._ensure_user_site_packages(container)
+        chowns = _chown_cmds(container)
+        # .local itself is made odoo-owned, but only non-recursively.
+        assert any(
+            c.strip() == "chown odoo:odoo /var/lib/odoo/.local" for c in chowns
+        ), chowns
+        # The pip --user lib dir is chowned (recursively is fine — no filestore).
+        assert any("/var/lib/odoo/.local/lib" in c for c in chowns), chowns

--- a/tests/test_dependency_install.py
+++ b/tests/test_dependency_install.py
@@ -149,5 +149,6 @@ class TestEnsureUserSitePackages:
         assert any(
             c.strip() == "chown odoo:odoo /var/lib/odoo/.local" for c in chowns
         ), chowns
-        # The pip --user lib dir is chowned (recursively is fine — no filestore).
+        # Both pip --user dirs are chowned (recursively is fine — no filestore).
         assert any("/var/lib/odoo/.local/lib" in c for c in chowns), chowns
+        assert any("/var/lib/odoo/.local/bin" in c for c in chowns), chowns

--- a/tests/test_filestore_unmount.py
+++ b/tests/test_filestore_unmount.py
@@ -1,0 +1,81 @@
+"""Unit tests for overlay filestore unmount order in env_ops.
+
+The overlay unmount must not depend on the setuid ``fusermount`` helper: the
+AppArmor ``fusermount3`` profile shipped on Ubuntu 24.04+ DENIES its ``umount``
+operation, which previously forced Oduflow onto the lazy ``umount -l`` fallback
+(it detaches even a busy mount, leaving a still-bound container with a broken
+filestore). Oduflow runs as root, so a direct ``umount`` — not mediated by that
+profile — must be tried first.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+from oduflow.docker_ops import env_ops
+from oduflow.naming import get_filestore_paths
+
+
+def _team(workspaces_dir: str):
+    team = MagicMock()
+    team.workspaces_dir = workspaces_dir
+    return team
+
+
+def _mount_present(monkeypatch) -> None:
+    """Make the merged dir look like a live mountpoint."""
+    monkeypatch.setattr(env_ops.os.path, "isdir", lambda p: True)
+    monkeypatch.setattr(env_ops.os.path, "ismount", lambda p: True)
+
+
+class TestUnmountFilestore:
+    def test_tries_clean_umount_first(self, tmp_path, monkeypatch):
+        merged = get_filestore_paths("env1", str(tmp_path))["merged"]
+        _mount_present(monkeypatch)
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return MagicMock(returncode=0)  # first attempt succeeds
+
+        monkeypatch.setattr(env_ops.subprocess, "run", fake_run)
+
+        env_ops._unmount_filestore("env1", _team(str(tmp_path)))
+
+        # Clean `umount` is first — and since it succeeds, nothing else runs
+        # (in particular, the AppArmor-blocked fusermount helper is never used).
+        assert calls == [["umount", merged]]
+
+    def test_falls_back_through_helpers_to_lazy(self, tmp_path, monkeypatch):
+        merged = get_filestore_paths("env1", str(tmp_path))["merged"]
+        _mount_present(monkeypatch)
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            # Clean umount and both fusermount helpers fail; only lazy succeeds.
+            if cmd == ["umount", "-l", merged]:
+                return MagicMock(returncode=0)
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(env_ops.subprocess, "run", fake_run)
+
+        env_ops._unmount_filestore("env1", _team(str(tmp_path)))
+
+        assert calls == [
+            ["umount", merged],
+            ["fusermount3", "-u", merged],
+            ["fusermount", "-u", merged],
+            ["umount", "-l", merged],
+        ]
+
+    def test_noop_when_not_mounted(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(env_ops.os.path, "isdir", lambda p: True)
+        monkeypatch.setattr(env_ops.os.path, "ismount", lambda p: False)
+        called = []
+        monkeypatch.setattr(env_ops.subprocess, "run", lambda *a, **k: called.append(a))
+
+        env_ops._unmount_filestore("env1", _team(str(tmp_path)))
+
+        assert called == []

--- a/tests/test_pg_ready.py
+++ b/tests/test_pg_ready.py
@@ -1,0 +1,59 @@
+"""Tests for system_ops._wait_pg_ready resilience.
+
+When the shared PostgreSQL container is momentarily not running (still starting,
+or restarting after a crash — e.g. the disk filled up), Docker's exec_create
+returns 409. _wait_pg_ready must treat that as "not ready yet" and retry, rather
+than letting the raw APIError crash the whole server startup (which systemd then
+turns into a restart loop).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import docker
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings
+
+
+def _client(exec_side_effect):
+    client = MagicMock()
+    container = MagicMock()
+    container.exec_run.side_effect = exec_side_effect
+    client.containers.get.return_value = container
+    return client
+
+
+def test_tolerates_transient_409_then_ready():
+    # First pg_isready hits a restarting container (409); next round it's up.
+    client = _client(
+        [
+            docker.errors.APIError("409 Client Error: Conflict"),  # pg_isready
+            (0, b""),  # pg_isready OK
+            (0, b"1"),  # psql SELECT 1 OK
+        ]
+    )
+    with patch("oduflow.docker_ops.system_ops.time.sleep"):
+        system_ops._wait_pg_ready(client, Settings(), timeout=5)  # returns, no raise
+
+
+def test_raises_clean_error_when_never_ready():
+    client = _client(docker.errors.APIError("409 Client Error: Conflict"))  # always
+    with patch("oduflow.docker_ops.system_ops.time.sleep"):
+        with pytest.raises(PrerequisiteNotMetError, match="did not become ready"):
+            system_ops._wait_pg_ready(client, Settings(), timeout=3)
+
+
+def test_retries_until_pg_accepts_connections():
+    # pg_isready returns non-zero (starting) a couple of times, then ready.
+    client = _client(
+        [
+            (1, b""),  # pg_isready: not ready
+            (1, b""),  # pg_isready: not ready
+            (0, b""),  # pg_isready: ready
+            (0, b"1"),  # psql: ready
+        ]
+    )
+    with patch("oduflow.docker_ops.system_ops.time.sleep"):
+        system_ops._wait_pg_ready(client, Settings(), timeout=5)

--- a/tests/test_template_delete.py
+++ b/tests/test_template_delete.py
@@ -1,0 +1,83 @@
+"""Guard-path tests for system_ops.delete_template.
+
+Deleting a template `rmtree`s its filestore, which is the overlay lower layer
+for every environment created from it (see env_ops._mount_filestore). So
+delete_template must refuse while any such environment exists — mirroring the
+guard in rename_template — or it would break those envs' overlays.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ConflictError
+from oduflow.settings import Settings, TeamSettings
+
+
+@pytest.fixture
+def settings():
+    return Settings()
+
+
+@pytest.fixture
+def team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _env_container(settings, template, branch="main"):
+    c = MagicMock()
+    c.labels = {"oduflow.template": template, settings.branch_label: branch}
+    c.name = f"oduflow-1-{branch}-odoo"
+    return c
+
+
+def _client(container_list):
+    client = MagicMock()
+    client.containers.list.return_value = container_list
+    return client
+
+
+def test_blocks_when_env_uses_template(settings, team):
+    tpl_dir = team.get_template_dir("prod")
+    os.makedirs(tpl_dir, exist_ok=True)
+    client = _client([_env_container(settings, "prod", branch="feature-x")])
+
+    with patch("oduflow.docker_ops.system_ops.get_client", return_value=client):
+        with pytest.raises(ConflictError, match="used by environments: feature-x"):
+            system_ops.delete_template(settings, team, "prod")
+
+    # Nothing was deleted — the template dir (overlay lower layer) survives.
+    assert os.path.isdir(tpl_dir)
+
+
+def test_allows_when_no_dependents(settings, team):
+    tpl_dir = team.get_template_dir("prod")
+    os.makedirs(tpl_dir, exist_ok=True)
+    client = _client([])
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client", return_value=client),
+        patch("oduflow.docker_ops.system_ops._db_exists", return_value=False),
+    ):
+        result = system_ops.delete_template(settings, team, "prod")
+
+    assert result["status"] == "dropped"
+    assert not os.path.isdir(tpl_dir)
+
+
+def test_ignores_envs_of_other_templates(settings, team):
+    tpl_dir = team.get_template_dir("prod")
+    os.makedirs(tpl_dir, exist_ok=True)
+    # A live env exists, but it was built from a *different* template.
+    client = _client([_env_container(settings, "staging")])
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client", return_value=client),
+        patch("oduflow.docker_ops.system_ops._db_exists", return_value=False),
+    ):
+        result = system_ops.delete_template(settings, team, "prod")
+
+    assert result["status"] == "dropped"
+    assert not os.path.isdir(tpl_dir)


### PR DESCRIPTION
## Context

Triaged from a live disk-full incident: a host ran out of space, PostgreSQL crash-looped, and after recovery a newly created overlay environment consumed ~10 GB even though it was mounted as `fuse-overlayfs`. Root-caused to two defects in overlay filestore handling.

## 1. Copy-up regression (the space bug)

`_ensure_user_site_packages` ran `chown -R odoo:odoo /var/lib/odoo/.local` so pip `--user` installs (run as the `odoo` user) can write to `~/.local/lib`. But the Odoo filestore is bind-mounted at `.local/share/Odoo/filestore/<db>` from the **overlay's read-only lower layer**. The recursive chown descended into it and rewrote every file's owner → `fuse-overlayfs` copied the **entire template filestore up into the env's upper layer**. The overlay stayed mounted but saved **zero** space; each env duplicated the ~10 GB filestore.

**Fix:** chown only the pip dirs — `.local` non-recursively, `.local/lib` and `.local/bin` recursively — never recursing into `.local/share`.

Introduced in `b0551da` ("local changes"); slipped past tests because `_ensure_user_site_packages` was untested and `_install_pip_requirements` tests use a mock container (no real chown over a real overlay).

## 2. fusermount dependency (the unmount bug)

`_unmount_filestore` tried `fusermount -u` first, which the AppArmor `fusermount3` profile shipped on **Ubuntu 24.04+** DENIES — forcing the lazy `umount -l` fallback that detaches even a busy mount (leaving a still-bound container with a broken filestore).

**Fix:** Oduflow runs as root and `umount(2)` is not mediated by that profile, so try a clean `umount` first; keep the `fusermount3`/`fusermount` helpers for unprivileged/rootless deployments; lazy `umount -l` is the last resort only.

## Verification (live host, enforced `fusermount3` profile, no AppArmor override)

| | before | after |
|---|---|---|
| `filestore_upper` after create | 9.8 GB | **4.0K** (0 files) |
| disk delta per env | ~13 GB | ~3.2 GB (DB + repo clone) |
| unmount path | lazy `umount -l` (fusermount DENIED) | clean `umount`, **no new AppArmor denials** |

Recreated the same env (`odoo:18.0`, template `zipfit-dev`) end-to-end: overlay mounted, upper stayed empty, `/web/login` → HTTP 200; delete/create unmounted cleanly with the AppArmor rule removed.

## Tests

- `tests/test_dependency_install.py::TestEnsureUserSitePackages` — guards that the chown never recurses into `.local` / `.local/share`.
- `tests/test_filestore_unmount.py` — guards that clean `umount` is attempted first and the fallback order is correct.

710 unit tests pass; `ruff check`/`ruff format` clean.