### PR TITLE
security: psql WS branch validation + multi-team UI password provisioning

### DIFF
--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2878,11 +2878,14 @@ def _ensure_web_ui_password(settings: Settings) -> Settings:
     hard-fail the whole HTTP transport on upgrade — which would also take down
     token-protected MCP for headless users — generate a password, persist it to
     oduflow.toml (symmetric with the fresh-install bootstrap) and reload. Skipped
-    when the operator opted into an open server (``allow_insecure_http``) or a
-    password is already set. On any write failure the caller's fail-closed check
-    still refuses to serve an open dashboard."""
+    when the operator opted into an open server (``allow_insecure_http``) or
+    every team already has a password. Uses ``all`` (not ``any``) so a team added
+    later with ``ui_password = ""`` still gets provisioned rather than being
+    silently locked out of the web UI while other teams have passwords. On any
+    write failure the caller's fail-closed check still refuses to serve an open
+    dashboard."""
     global _settings
-    if settings.allow_insecure_http or any(
+    if settings.allow_insecure_http or all(
         t.ui_password for t in settings.teams.values()
     ):
         return settings
@@ -3662,11 +3665,13 @@ def _start_http() -> None:
     # The dashboard exposes MORE than MCP (interactive shells/SQL/agent to every
     # environment, privileged service creation, credential management) and is
     # only authenticated when a team sets ui_password. Fresh installs bootstrap
-    # one and _ensure_web_ui_password just auto-provisioned one for existing
-    # configs — so reaching here with none set means both the config write failed
-    # and the operator has not opted into an open server; refuse rather than serve
-    # the dashboard unauthenticated.
-    if not settings.allow_insecure_http and not any(
+    # one and _ensure_web_ui_password just auto-provisioned one for every existing
+    # team — so reaching here with ANY team still passwordless means the config
+    # write failed and the operator has not opted into an open server. Check
+    # ``all`` (not ``any``): a single passwordless team can never log in (auth is
+    # global; empty passwords are skipped), so refuse rather than silently lock it
+    # out.
+    if not settings.allow_insecure_http and not all(
         t.ui_password for t in settings.teams.values()
     ):
         raise PrerequisiteNotMetError(

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2338,7 +2338,18 @@ def _build_routes(
         try:
             import docker as _docker
             from oduflow.docker_ops.client import get_client as _get_client
-            from oduflow.naming import get_db_name
+            from oduflow.naming import get_db_name, validate_env_name
+
+            # Validate before deriving DB/credential paths, matching the REST
+            # create handler: a name like ".." would otherwise resolve
+            # get_workspace_path one level above the workspaces dir when loading
+            # scoped credentials. Reject it explicitly instead of failing opaquely.
+            try:
+                validate_env_name(branch)
+            except ValueError as e:
+                await websocket.send_text(f"\x1b[31mError: {e}\x1b[0m\r\n")
+                await websocket.close(code=1008)
+                return
 
             settings = get_settings()
             team = _get_ui_team(websocket)

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -73,6 +73,66 @@ class TestAutofillUiPasswords:
         assert out.strip() == src.strip()
 
 
+class TestEnsureWebUiPassword:
+    """`_ensure_web_ui_password` must provision EVERY passwordless team, not
+    skip the whole config as soon as one team already has a password."""
+
+    def _settings(self, *ui_passwords, allow_insecure_http=False):
+        from oduflow.settings import Settings, TeamSettings
+
+        return Settings(
+            allow_insecure_http=allow_insecure_http,
+            teams={
+                str(i + 1): TeamSettings(team_id=str(i + 1), ui_password=pw)
+                for i, pw in enumerate(ui_passwords)
+            },
+        )
+
+    def test_provisions_partially_configured_multiteam(self, tmp_path, monkeypatch):
+        import oduflow.server as server
+
+        cfg = tmp_path / "oduflow.toml"
+        cfg.write_text(
+            "[team.1]\n"
+            'ui_password = "already-set"\n'
+            "[team.2]\n"
+            'ui_password = ""\n',
+            encoding="utf-8",
+        )
+        # team 1 has a password, team 2 does not: the old any() guard returned
+        # early here and left team 2 locked out.
+        settings = self._settings("already-set", "")
+        monkeypatch.setattr(server, "find_toml", lambda: str(cfg))
+        sentinel = object()
+        monkeypatch.setattr(server, "_get_settings", lambda: sentinel)
+
+        result = server._ensure_web_ui_password(settings)
+
+        written = cfg.read_text(encoding="utf-8")
+        assert 'ui_password = ""' not in written
+        assert 'ui_password = "already-set"' in written
+        assert result is sentinel  # reloaded after the write
+
+    def test_skips_when_every_team_has_password(self, monkeypatch):
+        import oduflow.server as server
+
+        settings = self._settings("pw-a", "pw-b")
+        # find_toml/_get_settings must never be reached.
+        monkeypatch.setattr(
+            server, "find_toml", lambda: (_ for _ in ()).throw(AssertionError())
+        )
+        assert server._ensure_web_ui_password(settings) is settings
+
+    def test_skips_when_allow_insecure_http(self, monkeypatch):
+        import oduflow.server as server
+
+        settings = self._settings("", "", allow_insecure_http=True)
+        monkeypatch.setattr(
+            server, "find_toml", lambda: (_ for _ in ()).throw(AssertionError())
+        )
+        assert server._ensure_web_ui_password(settings) is settings
+
+
 class TestHttpRequestPathGuard:
     """`http_request_to_odoo` must reject paths that could rewrite the host
     (SSRF) before it ever builds a request."""


### PR DESCRIPTION
Follow-ups to the security audit (#110, already merged), addressing the two open Greptile review comments on that PR.

## Changes

**1. `ws_sql_terminal` validates the branch (`src/oduflow/web_ui.py`)**
The psql WebSocket handler passed the `branch` path param straight to `get_db_name`/`load_credentials` without `validate_env_name`, unlike the REST create handler hardened in #110. There's no direct traversal (slugging strips unsafe chars for the DB name), but for a name like `..` the scoped-credentials lookup resolves `get_workspace_path` one directory *above* the workspaces dir before failing opaquely. It now validates up front and closes the socket (code 1008) with a clear message.

**2. Multi-team UI password provisioning uses `all()` not `any()` (`src/oduflow/server.py`)**
`_ensure_web_ui_password` short-circuited on `any(t.ui_password ...)`, so a multi-team config where team 1 had a password but team 2 was added later with `ui_password = ""` returned early and never provisioned team 2 — silently locking it out of the web UI (auth is global and empty passwords are skipped, so the dashboard is not left open, just inaccessible). Switched the early-return to `all()` so every passwordless team gets provisioned. The fail-closed startup check is switched to `not all()` for symmetry: a single passwordless team can never log in, so refuse to start rather than lock it out silently.

## Tests
Adds `TestEnsureWebUiPassword` covering the partial-multi-team provisioning path and both skip conditions (every team already set; `allow_insecure_http`). Full unit suite (756 passed) and ruff clean.