### PR TITLE
Add database-only Odoo template import

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - **Per-team OAuth issuer with host-relative discovery** — in traefik mode, each team's OAuth Authorization Server derives its issuer from the incoming Host, so each team runs OAuth on its own already-certificated hostname with no need for a central `oauth_base_url`. `OduflowOAuthProvider` makes discovery metadata host-relative, `HostRelativeAuthChallenge` rewrites 401 challenge origins, and `[routing].hostname` is now validated per-mode (shared default deleted in traefik). (#112)
 - **Database-only Odoo template import** — `oduflow import-template` and `import_template_from_odoo` now accept `--without-filestore` / `without_filestore=True`, requesting a PostgreSQL custom-format dump without filestore files and deriving template metadata after restore.
+- **Attach separate template filestores** — new `oduflow attach-filestore` CLI and `attach_filestore` MCP tool attach or replace a template filestore after a database-only import. Sources can be local directories, zip/tar archives, `rsync://` URLs, or SSH rsync paths; wrapper directories such as the database name are auto-detected and live overlay env changes are preserved by default.
 
 ### Security
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,7 @@
 - **Multi-team UI password provisioning for newly-added passwordless teams** — `_ensure_web_ui_password` was using `any()` so a multi-team config with one team already set would skip provisioning for others, locking them out. Now uses `all()` to provision every team and enforce that all are set at startup. (#114)
 - **Template clone now reassigns objects owned by any non-env role** — when creating an environment from a template imported via `import_template_from_odoo`, objects owned by roles other than the template env's own role were not reassigned, leaving the new env unable to touch them. Now reassigns all non-env-role-owned objects unconditionally. (#111)
 - **Odoo template import now refuses existing template names** — `import-template` fails before DB listing or backup download if the target template directory or template database already exists, avoiding accidental overwrites.
-- **Database-only template import can restore newer custom dumps** — when the shared PostgreSQL container's `pg_restore` cannot read a custom dump archive version, Oduflow retries through a temporary `postgres:17` helper container before surfacing the restore failure.
+- **Database-only template import can restore newer custom dumps** — when the shared PostgreSQL container's `pg_restore` cannot read a custom dump archive version, Oduflow converts it to plain SQL with a temporary `postgres:17` helper container and restores that SQL through the shared database container.
 - **Native Odoo neutralize skipped for Odoo 15** — the official `odoo:15.0` image does not include the `odoo neutralize` CLI, so Oduflow now skips it for Odoo 15 and tries only for Odoo 16+, keeping custom `.odoo_sanitize` scripts as the baseline. (#109)
 
 ### Documentation & Testing

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 ### Features
 
 - **Per-team OAuth issuer with host-relative discovery** — in traefik mode, each team's OAuth Authorization Server derives its issuer from the incoming Host, so each team runs OAuth on its own already-certificated hostname with no need for a central `oauth_base_url`. `OduflowOAuthProvider` makes discovery metadata host-relative, `HostRelativeAuthChallenge` rewrites 401 challenge origins, and `[routing].hostname` is now validated per-mode (shared default deleted in traefik). (#112)
-- **Database-only Odoo template import** — `oduflow import-template` and `import_template_from_odoo` now accept `--without-filestore` / `without_filestore=True`, requesting a ZIP backup without filestore files while preserving manifest-based version detection.
+- **Database-only Odoo template import** — `oduflow import-template` and `import_template_from_odoo` now accept `--without-filestore` / `without_filestore=True`, requesting a PostgreSQL custom-format dump without filestore files and deriving template metadata after restore.
 
 ### Security
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@
 - **Multi-team UI password provisioning for newly-added passwordless teams** — `_ensure_web_ui_password` was using `any()` so a multi-team config with one team already set would skip provisioning for others, locking them out. Now uses `all()` to provision every team and enforce that all are set at startup. (#114)
 - **Template clone now reassigns objects owned by any non-env role** — when creating an environment from a template imported via `import_template_from_odoo`, objects owned by roles other than the template env's own role were not reassigned, leaving the new env unable to touch them. Now reassigns all non-env-role-owned objects unconditionally. (#111)
 - **Odoo template import now refuses existing template names** — `import-template` fails before DB listing or backup download if the target template directory or template database already exists, avoiding accidental overwrites.
+- **Database-only template import can restore newer custom dumps** — when the shared PostgreSQL container's `pg_restore` cannot read a custom dump archive version, Oduflow retries through a temporary `postgres:17` helper container before surfacing the restore failure.
 - **Native Odoo neutralize skipped for Odoo 15** — the official `odoo:15.0` image does not include the `odoo neutralize` CLI, so Oduflow now skips it for Odoo 15 and tries only for Odoo 16+, keeping custom `.odoo_sanitize` scripts as the baseline. (#109)
 
 ### Documentation & Testing

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Features
 
 - **Per-team OAuth issuer with host-relative discovery** — in traefik mode, each team's OAuth Authorization Server derives its issuer from the incoming Host, so each team runs OAuth on its own already-certificated hostname with no need for a central `oauth_base_url`. `OduflowOAuthProvider` makes discovery metadata host-relative, `HostRelativeAuthChallenge` rewrites 401 challenge origins, and `[routing].hostname` is now validated per-mode (shared default deleted in traefik). (#112)
+- **Database-only Odoo template import** — `oduflow import-template` and `import_template_from_odoo` now accept `--without-filestore` / `without_filestore=True`, requesting a ZIP backup without filestore files while preserving manifest-based version detection.
 
 ### Security
 
@@ -17,6 +18,7 @@
 - **Overlay unmount now works on Ubuntu 24.04 with enforced fusermount AppArmor profile** — switched mount cleanup to try clean `umount` first (not mediated by the fusermount3 profile on Ubuntu 24.04+), falling back to `fusermount`/`fusermount3` helpers and lazy `umount -l` only as a last resort. (#113)
 - **Multi-team UI password provisioning for newly-added passwordless teams** — `_ensure_web_ui_password` was using `any()` so a multi-team config with one team already set would skip provisioning for others, locking them out. Now uses `all()` to provision every team and enforce that all are set at startup. (#114)
 - **Template clone now reassigns objects owned by any non-env role** — when creating an environment from a template imported via `import_template_from_odoo`, objects owned by roles other than the template env's own role were not reassigned, leaving the new env unable to touch them. Now reassigns all non-env-role-owned objects unconditionally. (#111)
+- **Odoo template import now refuses existing template names** — `import-template` fails before DB listing or backup download if the target template directory or template database already exists, avoiding accidental overwrites.
 - **Native Odoo neutralize skipped for Odoo 15** — the official `odoo:15.0` image does not include the `odoo neutralize` CLI, so Oduflow now skips it for Odoo 15 and tries only for Odoo 16+, keeping custom `.odoo_sanitize` scripts as the baseline. (#109)
 
 ### Documentation & Testing

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,10 +66,10 @@ oduflow list-templates [--team 1]
 oduflow delete-template <template_name> [--team 1]
 
 # Import a template from a running Odoo instance
-oduflow import-template <odoo_url> <master_pwd> --template-name myproject [--db-name <db>] [--team 1]
+oduflow import-template <odoo_url> <master_pwd> --template-name myproject [--db-name <db>] [--without-filestore] [--team 1]
 ```
 
-`template-from-env`, `refresh-template`, `import-template`, and `reload-template --source` are **non-destructive** for live overlay environments: each is unmounted and remounted against the new template filestore while keeping its `upper` changes. Use `--reset-env-changes` (on `template-from-env`/`refresh-template`) to reset environments to the clean baseline instead.
+`template-from-env`, `refresh-template`, and `reload-template --source` are **non-destructive** for live overlay environments: each is unmounted and remounted against the new template filestore while keeping its `upper` changes. Use `--reset-env-changes` (on `template-from-env`/`refresh-template`) to reset environments to the clean baseline instead. `import-template` creates a new template and refuses an existing template name.
 
 ## Service Commands
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,6 +52,9 @@ oduflow template-from-env <branch> --template-name myproject [--reset-env-change
 # (non-destructive by default; --reset-env-changes discards env deltas)
 oduflow refresh-template <template_name> [--reset-env-changes] [--team 1]
 
+# Attach or replace a template filestore from a local dir, archive, rsync://, or SSH rsync source
+oduflow attach-filestore <template_name> <source> [--strip-prefix auto|none|PREFIX] [--reset-env-changes] [--team 1]
+
 # Reload template DB from a dump file
 oduflow reload-template <template_name> [--dump-path /path/to/new.dump] [--team 1]
 
@@ -69,7 +72,7 @@ oduflow delete-template <template_name> [--team 1]
 oduflow import-template <odoo_url> <master_pwd> --template-name myproject [--db-name <db>] [--without-filestore] [--team 1]
 ```
 
-`template-from-env`, `refresh-template`, and `reload-template --source` are **non-destructive** for live overlay environments: each is unmounted and remounted against the new template filestore while keeping its `upper` changes. Use `--reset-env-changes` (on `template-from-env`/`refresh-template`) to reset environments to the clean baseline instead. `import-template` creates a new template and refuses an existing template name.
+`template-from-env`, `refresh-template`, `attach-filestore`, and `reload-template --source` are **non-destructive** for live overlay environments: each is unmounted and remounted against the new template filestore while keeping its `upper` changes. Use `--reset-env-changes` (on `template-from-env`/`refresh-template`/`attach-filestore`) to reset environments to the clean baseline instead. `import-template` creates a new template and refuses an existing template name.
 
 ## Service Commands
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -786,6 +786,8 @@ Options:
 
 This is also available as an MCP tool (`import_template_from_odoo`) for AI agents; pass `without_filestore=true` for a database-only import.
 
+If the database dump and filestore are delivered separately, import with `--without-filestore` first, then run `oduflow attach-filestore <template> <source>` when the filestore archive, local directory, or rsync/SSH source is ready. See [Database Dump and Separate Filestore](templates.md#database-dump-and-separate-filestore) for the full sequence.
+
 **From Odoo Database Manager (manual):**
 
 1. Go to `/web/database/manager` in your Odoo instance
@@ -920,6 +922,53 @@ This operation:
 !!! warning
     **Destructive operation**: All other environments lose their filestore deltas and are reset to the new baseline.
 
+## Database Dump and Separate Filestore
+
+Production backups are often delivered as two artifacts: a database dump first and a filestore archive or directory later. Use this flow when you imported a template with `--without-filestore`, or when a manual backup gives you the database and filestore separately.
+
+```bash
+# 1. Import the database only from a running Odoo instance
+oduflow import-template https://my-odoo.example.com master_password \
+  --db-name odoo19-mirage \
+  --template-name prod \
+  --without-filestore
+
+# 2. Attach the filestore when it is available
+oduflow attach-filestore prod /backups/odoo19-mirage-filestore.zip
+
+# 3. Create environments from the complete template
+oduflow call create_environment '{"branch":"dev","template_name":"prod"}'
+```
+
+`attach-filestore` replaces the template's filestore and updates `metadata.json` (`includes_filestore`, `filestore_size_mb`, and `use_overlay`). It does not reload the database.
+
+Supported sources:
+
+```bash
+# Local archive; entries like odoo19-mirage/60/<sha1> are normalized to 60/<sha1>
+oduflow attach-filestore prod /backups/odoo19-mirage-filestore.zip
+
+# Local directory
+oduflow attach-filestore prod /backups/odoo19-mirage/filestore
+
+# Remote rsync over SSH
+oduflow attach-filestore prod odoo@example.com:/srv/odoo/.local/share/Odoo/filestore/odoo19-mirage
+
+# rsync daemon URL
+oduflow attach-filestore prod rsync://backup.example.com/odoo/filestore/odoo19-mirage
+```
+
+Archives may be `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, `.tar.xz`, or `.txz`. Local directories and remote sources are copied with `rsync -a --delete`, so `rsync` must be installed on the Oduflow host and reachable over SSH for `user@host:/path` sources.
+
+Oduflow detects the wrapper prefix automatically by looking for Odoo filestore paths shaped like `XX/<40-character sha1>`. For example, an archive containing `odoo19-mirage/60/609e7ca59cc05bf0de7233c6781a381b742a2931` is installed as `filestore/60/609e7ca59cc05bf0de7233c6781a381b742a2931`. If a source has multiple possible wrappers, pass the prefix explicitly:
+
+```bash
+oduflow attach-filestore prod /backups/filestore.zip --strip-prefix odoo19-mirage
+oduflow attach-filestore prod /backups/filestore.zip --strip-prefix none
+```
+
+Like `template-from-env`, this is non-destructive for live overlay environments by default: Oduflow remounts them against the new template filestore while preserving their `upper` changes. Pass `--reset-env-changes` only when you intentionally want those environments reset to the new baseline. Copy-mode environments are independent copies and are not changed by attaching a new template filestore.
+
 ## Reloading a Template
 
 Update the template from a newer production dump without touching the filestore:
@@ -989,6 +1038,7 @@ The `use_overlay` flag determines whether new environments use fuse-overlayfs (f
 | Update the template from a newer production dump | `oduflow reload-template default --dump-path /path/to/new.dump` |
 | Sync template from S3 and reload | `oduflow reload-template default --source s3://bucket/prod/` |
 | Save a branch environment as template | `oduflow template-from-env my-branch --template-name default` |
+| Attach a separately delivered filestore | `oduflow attach-filestore default /backups/filestore.zip` |
 | List all templates | `oduflow list-templates` |
 | Delete a template | `oduflow delete-template myproject` |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -149,7 +149,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_info` / `get_service_logs` / `run_service_command` — manage auxiliary services
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets
 - `save_as_template` / `delete_template` / `list_templates` — template management
-- `import_template_from_odoo` — import a template from a running Odoo instance
+- `import_template_from_odoo` — import a template from a running Odoo instance; optional `without_filestore` imports database-only
 - `refresh_template` — re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` is destructive)
 - `setup_repo_auth` — cache git credentials for private repositories
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
@@ -781,8 +781,9 @@ Options:
 
 - `--db-name <db>` — specify the database name (auto-detected if only one DB exists)
 - `--template-name <name>` — template profile name (default: `default`)
+- `--without-filestore` — request a database-only ZIP backup without filestore files
 
-This is also available as an MCP tool (`import_template_from_odoo`) for AI agents.
+This is also available as an MCP tool (`import_template_from_odoo`) for AI agents; pass `without_filestore=true` for a database-only import.
 
 **From Odoo Database Manager (manual):**
 
@@ -1772,7 +1773,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `save_as_template` | ✓ | ⚠️ Save a branch DB + filestore as a new template |
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
-| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
+| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only ZIP backup |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
@@ -1865,7 +1866,7 @@ oduflow list-templates [--team 1]
 oduflow delete-template <template_name> [--team 1]
 
 # Import a template from a running Odoo instance
-oduflow import-template <odoo_url> <master_pwd> --template-name myproject [--db-name <db>] [--team 1]
+oduflow import-template <odoo_url> <master_pwd> --template-name myproject [--db-name <db>] [--without-filestore] [--team 1]
 ```
 
 ## Service Commands

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -151,6 +151,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 - `save_as_template` / `delete_template` / `list_templates` — template management
 - `import_template_from_odoo` — import a template from a running Odoo instance; optional `without_filestore` imports database-only
 - `refresh_template` — re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` is destructive)
+- `attach_filestore` — attach/replace a template filestore from a local dir, archive, `rsync://`, or SSH rsync source; preserves env changes by default
 - `setup_repo_auth` — cache git credentials for private repositories
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
 - `get_agent_instructions` — get AI agent instructions for using Oduflow
@@ -1775,6 +1776,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only PostgreSQL custom dump |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
+| `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -781,7 +781,7 @@ Options:
 
 - `--db-name <db>` — specify the database name (auto-detected if only one DB exists)
 - `--template-name <name>` — template profile name (default: `default`)
-- `--without-filestore` — request a database-only ZIP backup without filestore files
+- `--without-filestore` — request a database-only PostgreSQL custom dump without filestore files
 
 This is also available as an MCP tool (`import_template_from_odoo`) for AI agents; pass `without_filestore=true` for a database-only import.
 
@@ -1773,7 +1773,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `save_as_template` | ✓ | ⚠️ Save a branch DB + filestore as a new template |
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
-| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only ZIP backup |
+| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only PostgreSQL custom dump |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -173,6 +173,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `save_as_template` / `delete_template` / `list_templates` — template management
 - `import_template_from_odoo` — import a template from a running Odoo instance; optional `without_filestore` imports database-only
 - `refresh_template` — re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` is destructive)
+- `attach_filestore` — attach/replace a template filestore from a local dir, archive, `rsync://`, or SSH rsync source; preserves env changes by default
 - `setup_repo_auth` — cache git credentials for private repositories
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
 - `get_agent_instructions` — get AI agent instructions for using Oduflow

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -171,7 +171,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `read_file_in_volume` / `write_file_in_volume` / `search_in_volume` / `delete_file_in_volume` — manage files inside Docker volumes
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets
 - `save_as_template` / `delete_template` / `list_templates` — template management
-- `import_template_from_odoo` — import a template from a running Odoo instance
+- `import_template_from_odoo` — import a template from a running Odoo instance; optional `without_filestore` imports database-only
 - `refresh_template` — re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` is destructive)
 - `setup_repo_auth` — cache git credentials for private repositories
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -36,7 +36,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `rename_template` | ✓ | Rename a template (directory + PostgreSQL template DB); refused if any environment uses it |
-| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API |
+| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only ZIP backup |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -38,6 +38,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `rename_template` | ✓ | Rename a template (directory + PostgreSQL template DB); refused if any environment uses it |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only PostgreSQL custom dump |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
+| `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
 | `delete_service` | ✓ | Stop and remove a service container |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -36,7 +36,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_templates` | | List available template profiles |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `rename_template` | ✓ | Rename a template (directory + PostgreSQL template DB); refused if any environment uses it |
-| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only ZIP backup |
+| `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only PostgreSQL custom dump |
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -98,22 +98,43 @@ oduflow refresh-template default --reset-env-changes   # discard env deltas (des
 
 Use this after changing the template filestore on disk, or to re-sync an environment that was busy/skipped during an import or save.
 
-## Attaching a Separate Filestore
+## Database Dump and Separate Filestore
 
-When the database dump and filestore are delivered separately, import or reload the database first, then attach the filestore:
+Production backups are often delivered as two artifacts: a database dump first and a filestore archive or directory later. Use this flow when you imported a template with `--without-filestore`, or when a manual backup gives you the database and filestore separately.
+
+```bash
+# 1. Import the database only from a running Odoo instance
+oduflow import-template https://my-odoo.example.com master_password \
+  --db-name odoo19-mirage \
+  --template-name prod \
+  --without-filestore
+
+# 2. Attach the filestore when it is available
+oduflow attach-filestore prod /backups/odoo19-mirage-filestore.zip
+
+# 3. Create environments from the complete template
+oduflow call create_environment '{"branch":"dev","template_name":"prod"}'
+```
+
+`attach-filestore` replaces the template's filestore and updates `metadata.json` (`includes_filestore`, `filestore_size_mb`, and `use_overlay`). It does not reload the database.
+
+Supported sources:
 
 ```bash
 # Local archive; entries like odoo19-mirage/60/<sha1> are normalized to 60/<sha1>
-oduflow attach-filestore default /backups/odoo19-mirage-filestore.zip
+oduflow attach-filestore prod /backups/odoo19-mirage-filestore.zip
 
 # Local directory
-oduflow attach-filestore default /backups/odoo19-mirage/filestore
+oduflow attach-filestore prod /backups/odoo19-mirage/filestore
 
 # Remote rsync over SSH
-oduflow attach-filestore default odoo@example.com:/srv/odoo/.local/share/Odoo/filestore/odoo19-mirage
+oduflow attach-filestore prod odoo@example.com:/srv/odoo/.local/share/Odoo/filestore/odoo19-mirage
+
+# rsync daemon URL
+oduflow attach-filestore prod rsync://backup.example.com/odoo/filestore/odoo19-mirage
 ```
 
-Archives may be `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, `.tar.xz`, or `.txz`. Local directories and remote sources are copied with `rsync -a --delete`.
+Archives may be `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, `.tar.xz`, or `.txz`. Local directories and remote sources are copied with `rsync -a --delete`, so `rsync` must be installed on the Oduflow host and reachable over SSH for `user@host:/path` sources.
 
 Oduflow detects the wrapper prefix automatically by looking for Odoo filestore paths shaped like `XX/<40-character sha1>`. For example, an archive containing `odoo19-mirage/60/609e7ca59cc05bf0de7233c6781a381b742a2931` is installed as `filestore/60/609e7ca59cc05bf0de7233c6781a381b742a2931`. If a source has multiple possible wrappers, pass the prefix explicitly:
 
@@ -122,7 +143,7 @@ oduflow attach-filestore default /backups/filestore.zip --strip-prefix odoo19-mi
 oduflow attach-filestore default /backups/filestore.zip --strip-prefix none
 ```
 
-Like `template-from-env`, this is non-destructive for live overlay environments by default: Oduflow remounts them against the new template filestore while preserving their `upper` changes. Pass `--reset-env-changes` only when you intentionally want those environments reset to the new baseline.
+Like `template-from-env`, this is non-destructive for live overlay environments by default: Oduflow remounts them against the new template filestore while preserving their `upper` changes. Pass `--reset-env-changes` only when you intentionally want those environments reset to the new baseline. Copy-mode environments are independent copies and are not changed by attaching a new template filestore.
 
 ## Reloading a Template
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -125,7 +125,7 @@ oduflow reload-template default --source s3://mybucket/prod/ --quiet
 The source directory should contain `dump.pgdump` (or `dump.sql`) and optionally `filestore/`. Files are synced using `aws s3 sync` (S3) or `rsync` (local), then the template DB is reloaded.
 
 !!! info "Non-destructive for live environments"
-    When `--source` replaces the template filestore, live overlay environments on that template are automatically unmounted and remounted against the new lower layer, **keeping their filestore changes**. The same applies to `import-template` re-imports.
+    When `--source` replaces the template filestore, live overlay environments on that template are automatically unmounted and remounted against the new lower layer, **keeping their filestore changes**. `import-template` creates a new template and refuses an existing template name.
 
 ## Listing and Dropping Templates
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -98,6 +98,32 @@ oduflow refresh-template default --reset-env-changes   # discard env deltas (des
 
 Use this after changing the template filestore on disk, or to re-sync an environment that was busy/skipped during an import or save.
 
+## Attaching a Separate Filestore
+
+When the database dump and filestore are delivered separately, import or reload the database first, then attach the filestore:
+
+```bash
+# Local archive; entries like odoo19-mirage/60/<sha1> are normalized to 60/<sha1>
+oduflow attach-filestore default /backups/odoo19-mirage-filestore.zip
+
+# Local directory
+oduflow attach-filestore default /backups/odoo19-mirage/filestore
+
+# Remote rsync over SSH
+oduflow attach-filestore default odoo@example.com:/srv/odoo/.local/share/Odoo/filestore/odoo19-mirage
+```
+
+Archives may be `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, `.tar.xz`, or `.txz`. Local directories and remote sources are copied with `rsync -a --delete`.
+
+Oduflow detects the wrapper prefix automatically by looking for Odoo filestore paths shaped like `XX/<40-character sha1>`. For example, an archive containing `odoo19-mirage/60/609e7ca59cc05bf0de7233c6781a381b742a2931` is installed as `filestore/60/609e7ca59cc05bf0de7233c6781a381b742a2931`. If a source has multiple possible wrappers, pass the prefix explicitly:
+
+```bash
+oduflow attach-filestore default /backups/filestore.zip --strip-prefix odoo19-mirage
+oduflow attach-filestore default /backups/filestore.zip --strip-prefix none
+```
+
+Like `template-from-env`, this is non-destructive for live overlay environments by default: Oduflow remounts them against the new template filestore while preserving their `upper` changes. Pass `--reset-env-changes` only when you intentionally want those environments reset to the new baseline.
+
 ## Reloading a Template
 
 Update the template from a newer production dump without touching the filestore:
@@ -172,5 +198,6 @@ The `use_overlay` flag determines whether new environments use fuse-overlayfs (f
 | Save a branch environment as template (keep other envs' changes) | `oduflow template-from-env my-branch --template-name default` |
 | Save a branch as template and reset all other envs | `oduflow template-from-env my-branch --template-name default --reset-env-changes` |
 | Re-apply a template's filestore to live envs | `oduflow refresh-template default` |
+| Attach a separately delivered filestore | `oduflow attach-filestore default /backups/filestore.zip` |
 | List all templates | `oduflow list-templates` |
 | Delete a template | `oduflow delete-template myproject` |

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -190,8 +190,9 @@ Options:
 
 - `--db-name <db>` — specify the database name (auto-detected if only one DB exists)
 - `--template-name <name>` — template profile name (default: `default`)
+- `--without-filestore` — request a database-only ZIP backup without filestore files
 
-This is also available as an MCP tool (`import_template_from_odoo`) for AI agents.
+This is also available as an MCP tool (`import_template_from_odoo`) for AI agents; pass `without_filestore=true` for a database-only import.
 
 **From Odoo Database Manager (manual):**
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -190,7 +190,7 @@ Options:
 
 - `--db-name <db>` — specify the database name (auto-detected if only one DB exists)
 - `--template-name <name>` — template profile name (default: `default`)
-- `--without-filestore` — request a database-only ZIP backup without filestore files
+- `--without-filestore` — request a database-only PostgreSQL custom dump without filestore files
 
 This is also available as an MCP tool (`import_template_from_odoo`) for AI agents; pass `without_filestore=true` for a database-only import.
 

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -194,6 +194,8 @@ Options:
 
 This is also available as an MCP tool (`import_template_from_odoo`) for AI agents; pass `without_filestore=true` for a database-only import.
 
+If the database dump and filestore are delivered separately, import with `--without-filestore` first, then run `oduflow attach-filestore <template> <source>` when the filestore archive, local directory, or rsync/SSH source is ready. See [Database Dump and Separate Filestore](templates.md#database-dump-and-separate-filestore) for the full sequence.
+
 **From Odoo Database Manager (manual):**
 
 1. Go to `/web/database/manager` in your Odoo instance

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1492,27 +1492,37 @@ def import_from_odoo(
     master_pwd: str,
     db_name: str = "",
     template_name: str = "",
+    without_filestore: bool = False,
 ) -> dict[str, object]:
     """Import a template from a running Odoo instance via its database manager API.
 
-    Downloads a full backup (SQL + filestore), extracts it into the template
+    Downloads a ZIP backup, extracts it into the template
     directory, reads manifest.json to determine the Odoo version, saves
     metadata.json, and loads the dump into PostgreSQL as a template DB.
     """
     import urllib.request
-    import urllib.parse
     import zipfile
 
     from oduflow.url_safety import assert_allowed_url
 
     base = odoo_url.rstrip("/")
+    validate_template_name(template_name)
+    template_dir = team.get_template_dir(template_name)
+    tpl_db = get_template_db_name(template_name, team.team_id)
 
     # SSRF guard: importing a DB from a URL is a clearly-external operation, so
     # block loopback, the cloud metadata endpoint, and internal RFC1918 hosts.
     assert_allowed_url(base, allow_private=False)
 
+    if os.path.exists(template_dir):
+        raise ConflictError(f"Template '{template_name}' already exists.")
+
+    client = get_client()
+    if _db_exists(client, settings, tpl_db):
+        raise ConflictError(f"Template '{template_name}' already exists.")
+
     # Gate on the DB quota before downloading a potentially huge backup.
-    check_db_quota(get_client(), settings, team)
+    check_db_quota(client, settings, team)
 
     # 1. Resolve database name
     if not db_name:
@@ -1549,6 +1559,12 @@ def import_from_odoo(
             f"--{boundary}\r\n"
             f'Content-Disposition: form-data; name="{field_name}"\r\n\r\n'
             f"{field_value}\r\n"
+        )
+    if without_filestore:
+        parts.append(
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="filestore"\r\n\r\n'
+            "false\r\n"
         )
     parts.append(f"--{boundary}--\r\n")
     multipart_body = "".join(parts).encode("utf-8")
@@ -1590,8 +1606,6 @@ def import_from_odoo(
     # 3. Extract ZIP
     from oduflow.docker_ops import env_ops
 
-    client = get_client()
-    template_dir = team.get_template_dir(template_name)
     template_sql_path = os.path.join(template_dir, "dump.sql")
     template_filestore_path = team.get_template_filestore_path(template_name)
 
@@ -1618,51 +1632,54 @@ def import_from_odoo(
                     shutil.copyfileobj(src, dst)
                 logger.info("Extracted dump.sql to %s", template_sql_path)
 
-                # Extract filestore
-                if os.path.exists(template_filestore_path):
-                    shutil.rmtree(template_filestore_path)
-                os.makedirs(template_filestore_path, exist_ok=True)
+                if without_filestore:
+                    logger.info("Skipped filestore extraction for %s", template_name)
+                else:
+                    # Extract filestore
+                    if os.path.exists(template_filestore_path):
+                        shutil.rmtree(template_filestore_path)
+                    os.makedirs(template_filestore_path, exist_ok=True)
 
-                fs_prefix = "filestore/"
-                for member in zf.namelist():
-                    if not member.startswith(fs_prefix):
-                        continue
-                    rel = member[len(fs_prefix) :]
-                    if not rel:
-                        continue
-                    # Skip checklist/ symlink-like entries
-                    if rel.startswith("checklist/"):
-                        continue
-                    target = os.path.join(template_filestore_path, rel)
-                    # Reject any member that escapes the filestore dir (zip-slip).
-                    if not _is_within_directory(template_filestore_path, target):
-                        logger.warning(
-                            "Skipping unsafe archive member outside filestore: %s",
-                            member,
-                        )
-                        continue
-                    if member.endswith("/"):
-                        os.makedirs(target, exist_ok=True)
-                    else:
-                        os.makedirs(os.path.dirname(target), exist_ok=True)
-                        with zf.open(member) as src, open(target, "wb") as dst:
-                            shutil.copyfileobj(src, dst)
+                    fs_prefix = "filestore/"
+                    for member in zf.namelist():
+                        if not member.startswith(fs_prefix):
+                            continue
+                        rel = member[len(fs_prefix) :]
+                        if not rel:
+                            continue
+                        # Skip checklist/ symlink-like entries
+                        if rel.startswith("checklist/"):
+                            continue
+                        target = os.path.join(template_filestore_path, rel)
+                        # Reject any member that escapes the filestore dir (zip-slip).
+                        if not _is_within_directory(template_filestore_path, target):
+                            logger.warning(
+                                "Skipping unsafe archive member outside filestore: %s",
+                                member,
+                            )
+                            continue
+                        if member.endswith("/"):
+                            os.makedirs(target, exist_ok=True)
+                        else:
+                            os.makedirs(os.path.dirname(target), exist_ok=True)
+                            with zf.open(member) as src, open(target, "wb") as dst:
+                                shutil.copyfileobj(src, dst)
 
-                fs_count = sum(
-                    1
-                    for f in pathlib.Path(template_filestore_path).rglob("*")
-                    if f.is_file()
-                )
-                logger.info(
-                    "Extracted filestore to %s (%d files)",
-                    template_filestore_path,
-                    fs_count,
-                )
+                    fs_count = sum(
+                        1
+                        for f in pathlib.Path(template_filestore_path).rglob("*")
+                        if f.is_file()
+                    )
+                    logger.info(
+                        "Extracted filestore to %s (%d files)",
+                        template_filestore_path,
+                        fs_count,
+                    )
 
             # chown the new lower layer so the odoo user can read it through the
             # overlay once it is remounted.
             major = manifest.get("major_version", "")
-            if major:
+            if major and not without_filestore:
                 try:
                     uid_gid = get_odoo_uid_gid(client, f"odoo:{major}")
                     uid_str, gid_str = uid_gid.split(":")
@@ -1695,6 +1712,7 @@ def import_from_odoo(
         "odoo_version": manifest.get("version", ""),
         "pg_version": manifest.get("pg_version", ""),
         "modules": manifest.get("modules", {}),
+        "includes_filestore": not without_filestore,
     }
     _update_template_sizes(team, settings, template_name, metadata)
     logger.info("Metadata saved for template %s", template_name)
@@ -1712,6 +1730,7 @@ def import_from_odoo(
         "template_db": result["template_db"],
         "restore_seconds": result.get("restore_seconds", 0),
         "zip_size_mb": round(zip_size_mb, 1),
+        "includes_filestore": not without_filestore,
         "affected_envs": affected_envs,
         "remount_failures": remount_failures,
     }

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1556,11 +1556,11 @@ def import_from_odoo(
     assert_allowed_url(base, allow_private=False)
 
     if os.path.exists(template_dir):
-        raise ConflictError(f"Template '{template_name}' already exists.")
+        raise ConflictError(f"Template directory already exists: {template_dir}")
 
     client = get_client()
     if _db_exists(client, settings, tpl_db):
-        raise ConflictError(f"Template '{template_name}' already exists.")
+        raise ConflictError(f"Template database already exists: {tpl_db}")
 
     # Gate on the DB quota before downloading a potentially huge backup.
     check_db_quota(client, settings, team)
@@ -2264,8 +2264,14 @@ def delete_template(
         )
 
     tpl_db = get_template_db_name(template_name, team.team_id)
+    db_exists = _db_exists(client, settings, tpl_db)
+    template_dir_path = team.get_template_dir(template_name)
+    dir_exists = os.path.isdir(template_dir_path)
 
-    if _db_exists(client, settings, tpl_db):
+    if not db_exists and not dir_exists:
+        raise NotFoundError(f"Template '{template_name}' not found.")
+
+    if db_exists:
         _wait_pg_ready(client, settings)
         _exec_sql(
             client,
@@ -2275,8 +2281,7 @@ def delete_template(
         _exec_sql(client, settings, f'DROP DATABASE IF EXISTS "{tpl_db}" WITH (FORCE);')
         logger.info("Dropped template DB %s", tpl_db)
 
-    template_dir_path = team.get_template_dir(template_name)
-    if os.path.isdir(template_dir_path):
+    if dir_exists:
         shutil.rmtree(template_dir_path)
         logger.info("Removed template directory %s", template_dir_path)
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import contextlib
 import gzip
 import json
 import logging
 import os
 import pathlib
+import shlex
 import shutil
 import subprocess
 import tarfile
@@ -37,6 +39,7 @@ _PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _BUNDLED_PG_CONF = _PACKAGE_ROOT / "templates" / "postgresql.conf"
 _BUNDLED_ODOO_CONF = _PACKAGE_ROOT / "templates" / "odoo.conf"
 _BUNDLED_SANITIZE_DIR = _PACKAGE_ROOT / "templates"
+_PG_RESTORE_HELPER_IMAGE = "postgres:17"
 
 
 def _is_within_directory(directory: str, target: str) -> bool:
@@ -522,6 +525,75 @@ def _copy_file_to_container(
         os.remove(tmp_path)
 
 
+def _restore_custom_dump_with_helper(
+    client: DockerClient,
+    settings: Settings,
+    dump_path: str,
+    template_db: str,
+    *,
+    is_gzipped: bool,
+) -> tuple[int, str]:
+    """Run a newer pg_restore client from a temporary helper container."""
+    dump_dir = os.path.abspath(os.path.dirname(dump_path))
+    dump_name = os.path.basename(dump_path)
+    container_path = f"/backup/{dump_name}"
+    if is_gzipped:
+        command = [
+            "bash",
+            "-c",
+            "set -o pipefail; "
+            f"gunzip -c {shlex.quote(container_path)} | "
+            "pg_restore --no-owner "
+            f"-h {shlex.quote(settings.shared_db_container)} "
+            f"-U {shlex.quote(settings.db_user)} "
+            f"-d {shlex.quote(template_db)}",
+        ]
+    else:
+        command = [
+            "pg_restore",
+            "--no-owner",
+            "-h",
+            settings.shared_db_container,
+            "-U",
+            settings.db_user,
+            "-d",
+            template_db,
+            container_path,
+        ]
+
+    with contextlib.suppress(Exception):
+        client.images.pull(_PG_RESTORE_HELPER_IMAGE)
+
+    helper_name = f"{settings.prefix}pg-restore-helper-{time.time_ns()}"
+    helper = None
+    try:
+        helper = client.containers.run(
+            _PG_RESTORE_HELPER_IMAGE,
+            name=helper_name,
+            detach=True,
+            network=settings.shared_network,
+            environment={"PGPASSWORD": settings.db_password},
+            volumes={dump_dir: {"bind": "/backup", "mode": "ro"}},
+            command=command,
+            labels={settings.managed_label: "true", settings.system_label: "true"},
+        )
+        wait_result = helper.wait()
+        exit_code = int(wait_result.get("StatusCode", -1))
+        logs = helper.logs(stdout=True, stderr=True).decode("utf-8", errors="replace")
+        return exit_code, logs
+    except docker.errors.APIError as exc:
+        return -1, str(exc)
+    finally:
+        if helper is not None:
+            with contextlib.suppress(Exception):
+                helper.remove(force=True)
+
+
+def _is_pg_restore_archive_version_error(output: str) -> bool:
+    output = output.lower()
+    return "unsupported version" in output and "file header" in output
+
+
 def _copy_file_from_container(
     container: docker.models.containers.Container, container_path: str, dest_path: str
 ) -> None:
@@ -895,8 +967,34 @@ def reload_template(
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
     if exit_code != 0:
-        logger.error("DB restore failed after %.1fs: %s", restore_elapsed, output_str)
-        raise ExternalCommandError(restore_tool, exit_code, output_str)
+        if (
+            restore_tool == "pg_restore"
+            and _is_pg_restore_archive_version_error(output_str)
+        ):
+            logger.warning(
+                "pg_restore in %s cannot read dump archive; retrying with %s helper",
+                settings.shared_db_container,
+                _PG_RESTORE_HELPER_IMAGE,
+            )
+            _exec_sql(
+                client,
+                settings,
+                f'DROP DATABASE IF EXISTS "{tpl_db}" WITH (FORCE);',
+            )
+            _exec_sql(
+                client, settings, f'CREATE DATABASE "{tpl_db}" TABLESPACE "{ts_name}";'
+            )
+            helper_start = time.monotonic()
+            exit_code, output_str = _restore_custom_dump_with_helper(
+                client, settings, resolved_dump, tpl_db, is_gzipped=is_gzipped
+            )
+            restore_elapsed += time.monotonic() - helper_start
+
+        if exit_code != 0:
+            logger.error(
+                "DB restore failed after %.1fs: %s", restore_elapsed, output_str
+            )
+            raise ExternalCommandError(restore_tool, exit_code, output_str)
 
     if output_str.strip():
         logger.info("DB restore output: %s", output_str)

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -6,8 +6,10 @@ import json
 import logging
 import os
 import pathlib
+import re
 import shlex
 import shutil
+import stat
 import subprocess
 import tarfile
 import time
@@ -40,6 +42,17 @@ _BUNDLED_PG_CONF = _PACKAGE_ROOT / "templates" / "postgresql.conf"
 _BUNDLED_ODOO_CONF = _PACKAGE_ROOT / "templates" / "odoo.conf"
 _BUNDLED_SANITIZE_DIR = _PACKAGE_ROOT / "templates"
 _PG_RESTORE_HELPER_IMAGE = "postgres:17"
+_FILESTORE_HASH_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+_ARCHIVE_SUFFIXES = (
+    ".zip",
+    ".tar",
+    ".tar.gz",
+    ".tgz",
+    ".tar.bz2",
+    ".tbz2",
+    ".tar.xz",
+    ".txz",
+)
 
 
 def _is_within_directory(directory: str, target: str) -> bool:
@@ -116,6 +129,256 @@ def _normalize_extra_addons(raw_addons) -> dict[str, str]:
         )
         return {}
     return {}
+
+
+def _is_filestore_relpath(rel_path: str) -> bool:
+    parts = rel_path.strip("/").split("/")
+    if len(parts) != 2:
+        return False
+    chunk, filename = parts
+    return (
+        len(chunk) == 2
+        and all(c in "0123456789abcdefABCDEF" for c in chunk)
+        and bool(_FILESTORE_HASH_RE.match(filename))
+        and filename[:2].lower() == chunk.lower()
+    )
+
+
+def _clean_archive_member_name(name: str) -> str:
+    normalized = name.replace("\\", "/").strip("/")
+    if (
+        not normalized
+        or normalized.startswith("../")
+        or "/../" in normalized
+        or normalized == ".."
+    ):
+        return ""
+    return normalized
+
+
+def _detect_filestore_strip_prefix(paths: list[str]) -> str:
+    candidates: dict[str, int] = {}
+    for path in paths:
+        clean = _clean_archive_member_name(path)
+        if not clean:
+            continue
+        parts = clean.split("/")
+        for idx in range(len(parts) - 1):
+            rel = "/".join(parts[idx : idx + 2])
+            if _is_filestore_relpath(rel):
+                prefix = "/".join(parts[:idx])
+                candidates[prefix] = candidates.get(prefix, 0) + 1
+                break
+    if not candidates:
+        raise PrerequisiteNotMetError(
+            "Could not detect an Odoo filestore layout. Expected files like "
+            "'60/609e7ca59cc05bf0de7233c6781a381b742a2931'. "
+            "Use --strip-prefix if the archive has an unusual wrapper path."
+        )
+    best_count = max(candidates.values())
+    best = sorted(prefix for prefix, count in candidates.items() if count == best_count)
+    if len(best) > 1:
+        shown = ", ".join(prefix or "<none>" for prefix in best[:5])
+        raise PrerequisiteNotMetError(
+            "Could not choose a unique filestore prefix; candidates: "
+            f"{shown}. Pass --strip-prefix explicitly."
+        )
+    return best[0]
+
+
+def _normalize_strip_prefix(strip_prefix: str, paths: list[str]) -> str:
+    value = (strip_prefix or "auto").strip().strip("/")
+    if value == "auto":
+        return _detect_filestore_strip_prefix(paths)
+    if value in {"", ".", "none"}:
+        return ""
+    return value
+
+
+def _strip_filestore_prefix(path: str, prefix: str) -> str:
+    clean = _clean_archive_member_name(path)
+    if not clean:
+        return ""
+    if not prefix:
+        return clean
+    if clean == prefix:
+        return ""
+    prefix_slash = prefix.rstrip("/") + "/"
+    if not clean.startswith(prefix_slash):
+        return ""
+    return clean[len(prefix_slash) :]
+
+
+def _copy_normalized_filestore_tree(
+    source_dir: str, dest_dir: str, strip_prefix: str = "auto"
+) -> tuple[int, str]:
+    file_paths: list[str] = []
+    for root, _dirs, files in os.walk(source_dir):
+        for name in files:
+            path = os.path.join(root, name)
+            rel = os.path.relpath(path, source_dir).replace(os.sep, "/")
+            file_paths.append(rel)
+    prefix = _normalize_strip_prefix(strip_prefix, file_paths)
+    written = 0
+    for rel in file_paths:
+        stripped = _strip_filestore_prefix(rel, prefix)
+        if not stripped or not _is_filestore_relpath(stripped):
+            continue
+        src = os.path.join(source_dir, rel.replace("/", os.sep))
+        if os.path.islink(src):
+            logger.warning("Skipping symlink in filestore source: %s", rel)
+            continue
+        target = os.path.join(dest_dir, stripped)
+        if not _is_within_directory(dest_dir, target):
+            continue
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        shutil.copy2(src, target)
+        written += 1
+    if written == 0:
+        raise PrerequisiteNotMetError(
+            "No filestore files were copied. Check the source path or pass "
+            "--strip-prefix explicitly."
+        )
+    return written, prefix
+
+
+def _is_archive_source(source: str) -> bool:
+    return source.lower().endswith(_ARCHIVE_SUFFIXES)
+
+
+def _zip_member_is_symlink(info) -> bool:
+    return stat.S_IFMT(info.external_attr >> 16) == stat.S_IFLNK
+
+
+def _extract_zip_filestore(
+    archive_path: str, dest_dir: str, strip_prefix: str = "auto"
+) -> tuple[int, str]:
+    import zipfile
+
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        file_infos = [
+            info
+            for info in zf.infolist()
+            if not info.is_dir() and not _zip_member_is_symlink(info)
+        ]
+        prefix = _normalize_strip_prefix(
+            strip_prefix, [info.filename for info in file_infos]
+        )
+        written = 0
+        for info in file_infos:
+            stripped = _strip_filestore_prefix(info.filename, prefix)
+            if not stripped or not _is_filestore_relpath(stripped):
+                continue
+            target = os.path.join(dest_dir, stripped)
+            if not _is_within_directory(dest_dir, target):
+                logger.warning(
+                    "Skipping unsafe archive member outside filestore: %s",
+                    info.filename,
+                )
+                continue
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with zf.open(info) as src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            written += 1
+    if written == 0:
+        raise PrerequisiteNotMetError(
+            "No filestore files were extracted. Check the archive or pass "
+            "--strip-prefix explicitly."
+        )
+    return written, prefix
+
+
+def _extract_tar_filestore(
+    archive_path: str, dest_dir: str, strip_prefix: str = "auto"
+) -> tuple[int, str]:
+    with tarfile.open(archive_path, "r:*") as tf:
+        members = [member for member in tf.getmembers() if member.isfile()]
+        prefix = _normalize_strip_prefix(
+            strip_prefix, [member.name for member in members]
+        )
+        written = 0
+        for member in members:
+            stripped = _strip_filestore_prefix(member.name, prefix)
+            if not stripped or not _is_filestore_relpath(stripped):
+                continue
+            target = os.path.join(dest_dir, stripped)
+            if not _is_within_directory(dest_dir, target):
+                logger.warning(
+                    "Skipping unsafe tar member outside filestore: %s", member.name
+                )
+                continue
+            src = tf.extractfile(member)
+            if src is None:
+                continue
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            written += 1
+    if written == 0:
+        raise PrerequisiteNotMetError(
+            "No filestore files were extracted. Check the archive or pass "
+            "--strip-prefix explicitly."
+        )
+    return written, prefix
+
+
+def _extract_archive_filestore(
+    archive_path: str, dest_dir: str, strip_prefix: str = "auto"
+) -> tuple[int, str]:
+    if archive_path.lower().endswith(".zip"):
+        return _extract_zip_filestore(archive_path, dest_dir, strip_prefix)
+    return _extract_tar_filestore(archive_path, dest_dir, strip_prefix)
+
+
+def _is_remote_rsync_source(source: str) -> bool:
+    if source.startswith("rsync://"):
+        return True
+    if os.path.exists(source):
+        return False
+    return bool(re.match(r"^[^/\s:]+:.+", source))
+
+
+def _run_rsync_source(source: str, dest: str) -> None:
+    source_arg = source.rstrip("/") + "/"
+    dest_arg = dest.rstrip("/") + "/"
+    logger.info("Rsync filestore source: %s -> %s", source_arg, dest_arg)
+    subprocess.run(
+        ["rsync", "-a", "--delete", source_arg, dest_arg],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _stage_filestore_source(
+    source: str,
+    raw_dir: str,
+    prepared_dir: str,
+    strip_prefix: str = "auto",
+) -> tuple[int, str, str]:
+    if os.path.isfile(source):
+        if not _is_archive_source(source):
+            raise PrerequisiteNotMetError(
+                "Filestore source file must be a supported archive: "
+                ".zip, .tar, .tar.gz, .tgz, .tar.bz2, .tbz2, .tar.xz, or .txz."
+            )
+        files, prefix = _extract_archive_filestore(source, prepared_dir, strip_prefix)
+        return files, prefix, "archive"
+
+    if os.path.isdir(source):
+        _run_rsync_source(source, raw_dir)
+        files, prefix = _copy_normalized_filestore_tree(
+            raw_dir, prepared_dir, strip_prefix
+        )
+        return files, prefix, "rsync"
+
+    if _is_remote_rsync_source(source):
+        _run_rsync_source(source, raw_dir)
+        files, prefix = _copy_normalized_filestore_tree(
+            raw_dir, prepared_dir, strip_prefix
+        )
+        return files, prefix, "rsync"
+
+    raise NotFoundError(f"Filestore source not found: {source}")
 
 
 def _odoo_major_from_module_version(module_version: str) -> str:
@@ -960,9 +1223,8 @@ def reload_template(
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
     if exit_code != 0:
-        if (
-            restore_tool == "pg_restore"
-            and _is_pg_restore_archive_version_error(output_str)
+        if restore_tool == "pg_restore" and _is_pg_restore_archive_version_error(
+            output_str
         ):
             logger.warning(
                 "pg_restore in %s cannot read dump archive; retrying with %s helper",
@@ -1009,10 +1271,9 @@ def reload_template(
                 template_dir = os.path.abspath(team.get_template_dir(template_name))
                 if (
                     dump_path is None
-                    and os.path.abspath(resolved_dump).startswith(
-                        template_dir + os.sep
-                    )
-                    and os.path.abspath(helper_sql_path) != os.path.abspath(resolved_dump)
+                    and os.path.abspath(resolved_dump).startswith(template_dir + os.sep)
+                    and os.path.abspath(helper_sql_path)
+                    != os.path.abspath(resolved_dump)
                 ):
                     with contextlib.suppress(OSError):
                         os.remove(resolved_dump)
@@ -1543,6 +1804,107 @@ def refresh_template(
         "remount_failures": remount.failures,
         "reset_env_changes": reset_env_changes,
     }
+
+
+def attach_filestore(
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str,
+    source: str,
+    *,
+    reset_env_changes: bool = False,
+    strip_prefix: str = "auto",
+) -> dict[str, object]:
+    """Attach or replace a template filestore from a directory, rsync source, or archive."""
+    from oduflow.docker_ops import env_ops
+
+    validate_template_name(template_name)
+    client = get_client()
+    tpl_dir = team.get_template_dir(template_name)
+    tpl_db = get_template_db_name(template_name, team.team_id)
+    if not os.path.isdir(tpl_dir) and not _db_exists(client, settings, tpl_db):
+        raise NotFoundError(f"Template '{template_name}' not found.")
+    os.makedirs(tpl_dir, exist_ok=True)
+
+    staging_root = os.path.join(
+        team.data_dir,
+        ".attach_filestore",
+        template_name.replace("/", "-"),
+        str(time.time_ns()),
+    )
+    raw_dir = os.path.join(staging_root, "raw")
+    prepared_dir = os.path.join(staging_root, "prepared")
+    os.makedirs(raw_dir, exist_ok=True)
+    os.makedirs(prepared_dir, exist_ok=True)
+
+    try:
+        try:
+            file_count, detected_prefix, source_kind = _stage_filestore_source(
+                source, raw_dir, prepared_dir, strip_prefix
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
+            stdout = exc.stdout.decode("utf-8", errors="replace") if exc.stdout else ""
+            raise ExternalCommandError("rsync", exc.returncode, stderr or stdout)
+
+        metadata_path = team.get_template_metadata_path(template_name)
+        metadata: dict[str, object] = {}
+        if os.path.isfile(metadata_path):
+            try:
+                with open(metadata_path) as f:
+                    metadata = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                metadata = {}
+
+        target_filestore = team.get_template_filestore_path(template_name)
+        with env_ops.remount_template_overlays(
+            client,
+            settings,
+            team,
+            template_name,
+            reset_upper=reset_env_changes,
+        ) as remount:
+            if os.path.exists(target_filestore):
+                shutil.rmtree(target_filestore)
+            os.makedirs(os.path.dirname(target_filestore), exist_ok=True)
+            os.rename(prepared_dir, target_filestore)
+
+            odoo_image = str(metadata.get("odoo_image") or "")
+            if odoo_image:
+                try:
+                    uid_gid = get_odoo_uid_gid(client, odoo_image)
+                    uid_str, gid_str = uid_gid.split(":")
+                    chown_recursive(
+                        target_filestore,
+                        int(uid_str),
+                        int(gid_str),
+                        client,
+                        odoo_image,
+                    )
+                    logger.info("Template filestore chowned to %s", uid_gid)
+                except Exception as exc:  # noqa: BLE001 - chown is best-effort
+                    logger.warning("Could not chown template filestore: %s", exc)
+
+        metadata["includes_filestore"] = True
+        metadata["use_overlay"] = None
+        metadata = _update_template_sizes(team, settings, template_name, metadata)
+
+        return {
+            "status": "attached",
+            "template_name": template_name,
+            "source": source,
+            "source_kind": source_kind,
+            "strip_prefix": detected_prefix,
+            "filestore": target_filestore,
+            "filestore_files": file_count,
+            "filestore_size_mb": metadata.get("filestore_size_mb", 0.0),
+            "use_overlay": metadata.get("use_overlay"),
+            "affected_envs": remount.affected,
+            "remount_failures": remount.failures,
+            "reset_env_changes": reset_env_changes,
+        }
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
 
 
 def destroy_system(settings: Settings) -> dict[str, str]:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -525,18 +525,19 @@ def _copy_file_to_container(
         os.remove(tmp_path)
 
 
-def _restore_custom_dump_with_helper(
+def _convert_custom_dump_to_sql_with_helper(
     client: DockerClient,
     settings: Settings,
     dump_path: str,
-    template_db: str,
     *,
     is_gzipped: bool,
-) -> tuple[int, str]:
-    """Run a newer pg_restore client from a temporary helper container."""
+) -> tuple[int, str, str]:
+    """Convert a custom dump to plain SQL with a newer pg_restore client."""
     dump_dir = os.path.abspath(os.path.dirname(dump_path))
     dump_name = os.path.basename(dump_path)
     container_path = f"/backup/{dump_name}"
+    sql_path = os.path.join(dump_dir, "dump.sql")
+    container_sql_path = "/backup/dump.sql"
     if is_gzipped:
         command = [
             "bash",
@@ -544,20 +545,14 @@ def _restore_custom_dump_with_helper(
             "set -o pipefail; "
             f"gunzip -c {shlex.quote(container_path)} | "
             "pg_restore --no-owner "
-            f"-h {shlex.quote(settings.shared_db_container)} "
-            f"-U {shlex.quote(settings.db_user)} "
-            f"-d {shlex.quote(template_db)}",
+            f"-f {shlex.quote(container_sql_path)}",
         ]
     else:
         command = [
             "pg_restore",
             "--no-owner",
-            "-h",
-            settings.shared_db_container,
-            "-U",
-            settings.db_user,
-            "-d",
-            template_db,
+            "-f",
+            container_sql_path,
             container_path,
         ]
 
@@ -571,18 +566,16 @@ def _restore_custom_dump_with_helper(
             _PG_RESTORE_HELPER_IMAGE,
             name=helper_name,
             detach=True,
-            network=settings.shared_network,
-            environment={"PGPASSWORD": settings.db_password},
-            volumes={dump_dir: {"bind": "/backup", "mode": "ro"}},
+            volumes={dump_dir: {"bind": "/backup", "mode": "rw"}},
             command=command,
             labels={settings.managed_label: "true", settings.system_label: "true"},
         )
         wait_result = helper.wait()
         exit_code = int(wait_result.get("StatusCode", -1))
         logs = helper.logs(stdout=True, stderr=True).decode("utf-8", errors="replace")
-        return exit_code, logs
+        return exit_code, logs, sql_path
     except docker.errors.APIError as exc:
-        return -1, str(exc)
+        return -1, str(exc), sql_path
     finally:
         if helper is not None:
             with contextlib.suppress(Exception):
@@ -985,10 +978,44 @@ def reload_template(
                 client, settings, f'CREATE DATABASE "{tpl_db}" TABLESPACE "{ts_name}";'
             )
             helper_start = time.monotonic()
-            exit_code, output_str = _restore_custom_dump_with_helper(
-                client, settings, resolved_dump, tpl_db, is_gzipped=is_gzipped
+            helper_exit, helper_output, helper_sql_path = (
+                _convert_custom_dump_to_sql_with_helper(
+                    client, settings, resolved_dump, is_gzipped=is_gzipped
+                )
             )
             restore_elapsed += time.monotonic() - helper_start
+            if helper_exit != 0:
+                exit_code = helper_exit
+                output_str = helper_output
+            else:
+                helper_tmp_name = os.path.basename(helper_sql_path)
+                _copy_file_to_container(db_container, helper_sql_path, "/tmp")
+                psql_cmd = [
+                    "psql",
+                    "-U",
+                    settings.db_user,
+                    "-d",
+                    tpl_db,
+                    "-f",
+                    f"/tmp/{helper_tmp_name}",
+                ]
+                psql_start = time.monotonic()
+                exit_code, output = db_container.exec_run(psql_cmd)
+                restore_elapsed += time.monotonic() - psql_start
+                output_str = (
+                    output.decode("utf-8") if isinstance(output, bytes) else str(output)
+                )
+                restore_tool = "psql"
+                template_dir = os.path.abspath(team.get_template_dir(template_name))
+                if (
+                    dump_path is None
+                    and os.path.abspath(resolved_dump).startswith(
+                        template_dir + os.sep
+                    )
+                    and os.path.abspath(helper_sql_path) != os.path.abspath(resolved_dump)
+                ):
+                    with contextlib.suppress(OSError):
+                        os.remove(resolved_dump)
 
         if exit_code != 0:
             logger.error(

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1270,7 +1270,8 @@ def reload_template(
                 restore_tool = "psql"
                 template_dir = os.path.abspath(team.get_template_dir(template_name))
                 if (
-                    dump_path is None
+                    exit_code == 0
+                    and dump_path is None
                     and os.path.abspath(resolved_dump).startswith(template_dir + os.sep)
                     and os.path.abspath(helper_sql_path)
                     != os.path.abspath(resolved_dump)

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -115,6 +115,48 @@ def _normalize_extra_addons(raw_addons) -> dict[str, str]:
     return {}
 
 
+def _odoo_major_from_module_version(module_version: str) -> str:
+    parts = module_version.split(".")
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+        return f"{parts[0]}.{parts[1]}"
+    return ""
+
+
+def _read_template_manifest_from_db(
+    client: DockerClient, settings: Settings, template_db: str
+) -> dict[str, object]:
+    """Build Odoo backup-like manifest metadata from a restored database."""
+    version = _exec_sql(
+        client,
+        settings,
+        "SELECT COALESCE(latest_version, '') FROM ir_module_module "
+        "WHERE name='base' AND state='installed' LIMIT 1;",
+        db=template_db,
+    ).strip()
+    major_version = _odoo_major_from_module_version(version)
+    pg_version = _exec_sql(client, settings, "SHOW server_version;", db=template_db)
+    modules_raw = _exec_sql(
+        client,
+        settings,
+        "SELECT COALESCE(json_object_agg(name, latest_version), '{}'::json)::text "
+        "FROM ir_module_module WHERE state='installed';",
+        db=template_db,
+    )
+    try:
+        modules = json.loads(modules_raw) if modules_raw else {}
+    except json.JSONDecodeError:
+        logger.warning(
+            "Could not parse module manifest from %s: %s", template_db, modules_raw
+        )
+        modules = {}
+    return {
+        "version": version,
+        "major_version": major_version,
+        "pg_version": pg_version,
+        "modules": modules,
+    }
+
+
 def _resolve_conf(name: str) -> pathlib.Path:
     """Return /etc/oduflow/{name} if present, otherwise the bundled copy."""
     etc_path = _get_etc_dir() / name
@@ -1496,9 +1538,8 @@ def import_from_odoo(
 ) -> dict[str, object]:
     """Import a template from a running Odoo instance via its database manager API.
 
-    Downloads a ZIP backup, extracts it into the template
-    directory, reads manifest.json to determine the Odoo version, saves
-    metadata.json, and loads the dump into PostgreSQL as a template DB.
+    Downloads a full ZIP backup or DB-only custom dump, saves metadata.json,
+    and loads the dump into PostgreSQL as a template DB.
     """
     import urllib.request
     import zipfile
@@ -1549,22 +1590,17 @@ def import_from_odoo(
     # 2. Download backup
     logger.info("Downloading backup from %s (db=%s)...", base, db_name)
     boundary = "----OduflowBoundary"
+    backup_format = "dump" if without_filestore else "zip"
     parts = []
     for field_name, field_value in [
         ("master_pwd", master_pwd),
         ("name", db_name),
-        ("backup_format", "zip"),
+        ("backup_format", backup_format),
     ]:
         parts.append(
             f"--{boundary}\r\n"
             f'Content-Disposition: form-data; name="{field_name}"\r\n\r\n'
             f"{field_value}\r\n"
-        )
-    if without_filestore:
-        parts.append(
-            f"--{boundary}\r\n"
-            f'Content-Disposition: form-data; name="filestore"\r\n\r\n'
-            "false\r\n"
         )
     parts.append(f"--{boundary}--\r\n")
     multipart_body = "".join(parts).encode("utf-8")
@@ -1577,7 +1613,7 @@ def import_from_odoo(
     )
 
     download_start = time.monotonic()
-    tmp_zip = os.path.join(team.data_dir, "tmp_odoo_backup.zip")
+    tmp_backup = os.path.join(team.data_dir, f"tmp_odoo_backup.{backup_format}")
     os.makedirs(team.data_dir, exist_ok=True)
     try:
         with urllib.request.urlopen(req, timeout=600) as resp:
@@ -1589,7 +1625,7 @@ def import_from_odoo(
                     -1,
                     f"Unexpected response (Content-Type: {content_type}): {body}",
                 )
-            with open(tmp_zip, "wb") as f:
+            with open(tmp_backup, "wb") as f:
                 while True:
                     chunk = resp.read(1024 * 1024)
                     if not chunk:
@@ -1600,13 +1636,17 @@ def import_from_odoo(
         raise ExternalCommandError("odoo backup", e.code, f"HTTP {e.code}: {body}")
 
     download_elapsed = time.monotonic() - download_start
-    zip_size_mb = os.path.getsize(tmp_zip) / (1024 * 1024)
-    logger.info("Backup downloaded in %.1fs (%.1f MB)", download_elapsed, zip_size_mb)
+    backup_size_mb = os.path.getsize(tmp_backup) / (1024 * 1024)
+    logger.info(
+        "Backup downloaded in %.1fs (%.1f MB)", download_elapsed, backup_size_mb
+    )
 
-    # 3. Extract ZIP
+    # 3. Stage dump/filestore files
     from oduflow.docker_ops import env_ops
 
-    template_sql_path = os.path.join(template_dir, "dump.sql")
+    template_sql_path = os.path.join(
+        template_dir, "dump.pgdump" if without_filestore else "dump.sql"
+    )
     template_filestore_path = team.get_template_filestore_path(template_name)
 
     os.makedirs(template_dir, exist_ok=True)
@@ -1621,20 +1661,24 @@ def import_from_odoo(
         with env_ops.remount_template_overlays(
             client, settings, team, template_name
         ) as remount:
-            with zipfile.ZipFile(tmp_zip, "r") as zf:
-                # Extract manifest.json
-                if "manifest.json" in zf.namelist():
-                    with zf.open("manifest.json") as mf:
-                        manifest = json.load(mf)
+            if without_filestore:
+                shutil.copy2(tmp_backup, template_sql_path)
+                logger.info("Saved DB-only dump to %s", template_sql_path)
+            else:
+                with zipfile.ZipFile(tmp_backup, "r") as zf:
+                    # Extract manifest.json
+                    if "manifest.json" in zf.namelist():
+                        with zf.open("manifest.json") as mf:
+                            manifest = json.load(mf)
 
-                # Extract dump.sql
-                with zf.open("dump.sql") as src, open(template_sql_path, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
-                logger.info("Extracted dump.sql to %s", template_sql_path)
+                    # Extract dump.sql
+                    with (
+                        zf.open("dump.sql") as src,
+                        open(template_sql_path, "wb") as dst,
+                    ):
+                        shutil.copyfileobj(src, dst)
+                    logger.info("Extracted dump.sql to %s", template_sql_path)
 
-                if without_filestore:
-                    logger.info("Skipped filestore extraction for %s", template_name)
-                else:
                     # Extract filestore
                     if os.path.exists(template_filestore_path):
                         shutil.rmtree(template_filestore_path)
@@ -1679,7 +1723,7 @@ def import_from_odoo(
             # chown the new lower layer so the odoo user can read it through the
             # overlay once it is remounted.
             major = manifest.get("major_version", "")
-            if major and not without_filestore:
+            if major:
                 try:
                     uid_gid = get_odoo_uid_gid(client, f"odoo:{major}")
                     uid_str, gid_str = uid_gid.split(":")
@@ -1696,8 +1740,8 @@ def import_from_odoo(
         affected_envs = remount.affected
         remount_failures = remount.failures
     finally:
-        if os.path.exists(tmp_zip):
-            os.remove(tmp_zip)
+        if os.path.exists(tmp_backup):
+            os.remove(tmp_backup)
 
     # 4. Determine Odoo image from manifest
     major_version = manifest.get("major_version", "")
@@ -1719,6 +1763,24 @@ def import_from_odoo(
 
     # 6. Load dump into PostgreSQL
     result = reload_template(settings, team, template_name=template_name)
+    if without_filestore:
+        manifest = _read_template_manifest_from_db(
+            client, settings, str(result["template_db"])
+        )
+        major_version = manifest.get("major_version", "")
+        odoo_image = f"odoo:{major_version}" if major_version else ""
+        metadata.update(
+            {
+                "odoo_image": odoo_image,
+                "odoo_version": manifest.get("version", ""),
+                "pg_version": manifest.get("pg_version", ""),
+                "modules": manifest.get("modules", {}),
+            }
+        )
+        _update_template_sizes(team, settings, template_name, metadata)
+        logger.info(
+            "Metadata updated from restored template DB %s", result["template_db"]
+        )
 
     return {
         "status": "imported",
@@ -1729,7 +1791,7 @@ def import_from_odoo(
         "odoo_version": manifest.get("version", ""),
         "template_db": result["template_db"],
         "restore_seconds": result.get("restore_seconds", 0),
-        "zip_size_mb": round(zip_size_mb, 1),
+        "zip_size_mb": round(backup_size_mb, 1),
         "includes_filestore": not without_filestore,
         "affected_envs": affected_envs,
         "remount_failures": remount_failures,

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -817,6 +817,56 @@ def refresh_template(
     return "\n".join(lines)
 
 
+@mcp.tool()
+@handle_errors
+@with_team_lock
+def attach_filestore(
+    template_name: str,
+    source: str,
+    reset_env_changes: bool = False,
+    strip_prefix: str = "auto",
+    ctx: Context = None,
+) -> str:
+    """
+    Attach or replace a template filestore from a directory, rsync/ssh source, or archive.
+
+    The source may be a local directory, a local .zip/.tar/.tar.gz archive, an
+    rsync:// URL, or an SSH-style rsync source such as user@host:/path. Archive
+    and directory sources are normalized to the Odoo filestore layout
+    (XX/<sha1>). strip_prefix="auto" detects a wrapper directory such as the
+    database name; pass an explicit prefix when auto-detection is ambiguous.
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    result = system_ops.attach_filestore(
+        settings,
+        team,
+        template_name,
+        source,
+        reset_env_changes=reset_env_changes,
+        strip_prefix=strip_prefix,
+    )
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    lines = [
+        f"Filestore attached to template '{result['template_name']}'.",
+        f"Source: {result['source']} ({result['source_kind']})",
+        f"Strip prefix: {result.get('strip_prefix') or '<none>'}",
+        f"Files: {result['filestore_files']}",
+        f"Filestore size: {result['filestore_size_mb']} MB",
+        f"Mode: {'overlay' if result.get('use_overlay') else 'copy'}",
+    ]
+    if affected:
+        verb = "Reset" if reset_env_changes else "Remounted (changes preserved)"
+        lines.append(f"{verb} filestore overlays for: {', '.join(affected)}")
+    if failures:
+        lines.append(
+            "⚠️ Remount issues:\n"
+            + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
+    return "\n".join(lines)
+
+
 # =============================================================================
 # MCP Tools — Agent guides
 # =============================================================================
@@ -3018,6 +3068,42 @@ def _run_refresh_template(
     print("\n".join(lines))
 
 
+def _run_attach_filestore(
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str,
+    source: str,
+    reset_env_changes: bool = False,
+    strip_prefix: str = "auto",
+) -> None:
+    result = system_ops.attach_filestore(
+        settings,
+        team,
+        template_name,
+        source,
+        reset_env_changes=reset_env_changes,
+        strip_prefix=strip_prefix,
+    )
+    lines = [
+        f"Filestore attached to template '{result['template_name']}'.",
+        f"Source: {result['source']} ({result['source_kind']})",
+        f"Strip prefix: {result.get('strip_prefix') or '<none>'}",
+        f"Files: {result['filestore_files']}",
+        f"Filestore size: {result['filestore_size_mb']} MB",
+        f"Mode: {'overlay' if result.get('use_overlay') else 'copy'}",
+    ]
+    affected = cast("list[str]", result.get("affected_envs", []))
+    failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))
+    if affected:
+        verb = "Reset" if reset_env_changes else "Remounted (changes preserved)"
+        lines.append(f"{verb} filestore overlays for: {', '.join(affected)}")
+    if failures:
+        lines.append(
+            "Remount issues:\n" + "\n".join(f"- {env}: {msg}" for env, msg in failures)
+        )
+    print("\n".join(lines))
+
+
 def _run_delete_template(
     settings: Settings, team: TeamSettings, template_name: str
 ) -> None:
@@ -3359,6 +3445,28 @@ def _run_cli() -> None:
     )
     p_refresh.add_argument("--team", default="1", help="Team ID (default: 1)")
 
+    p_attach_fs = sub.add_parser(
+        "attach-filestore",
+        help="Attach or replace a template filestore from a directory, rsync/ssh source, or archive",
+    )
+    p_attach_fs.add_argument("template_name", help="Template profile name")
+    p_attach_fs.add_argument(
+        "source",
+        help="Local dir/archive, rsync:// source, or SSH rsync source user@host:/path",
+    )
+    p_attach_fs.add_argument(
+        "--strip-prefix",
+        default="auto",
+        help='Archive/source wrapper prefix to strip; "auto" detects it, "none" strips nothing',
+    )
+    p_attach_fs.add_argument(
+        "--reset-env-changes",
+        action="store_true",
+        help="Discard environments' filestore changes (destructive). "
+        "Default: preserve them.",
+    )
+    p_attach_fs.add_argument("--team", default="1", help="Team ID (default: 1)")
+
     p_drop_tpl = sub.add_parser(
         "delete-template", help="Delete a template profile (template DB + files)"
     )
@@ -3599,6 +3707,17 @@ def _run_cli() -> None:
             _cli_team(),
             template_name=args.template_name,
             reset_env_changes=args.reset_env_changes,
+        )
+        return
+
+    if args.command == "attach-filestore":
+        _run_attach_filestore(
+            _settings,
+            _cli_team(),
+            template_name=args.template_name,
+            source=args.source,
+            reset_env_changes=args.reset_env_changes,
+            strip_prefix=args.strip_prefix,
         )
         return
 

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -721,16 +721,15 @@ def import_template_from_odoo(
     """
     Import a template from a running Odoo instance via its database manager API.
 
-    Downloads a ZIP backup, extracts it into the template
-    directory, detects the Odoo version from the backup manifest, and loads
-    the dump into PostgreSQL as a template database.
+    Downloads a full ZIP backup or database-only PostgreSQL custom dump and
+    loads it into PostgreSQL as a template database.
 
     Args:
         odoo_url: Base URL of the Odoo instance (e.g. "https://my-odoo.example.com").
         master_pwd: Odoo master password (database manager password).
         db_name: Name of the database to back up. If empty, auto-detected (fails if multiple DBs exist).
         template_name: Name of the template profile to create.
-        without_filestore: If true, request a ZIP backup without filestore files.
+        without_filestore: If true, request a database-only PostgreSQL custom dump.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -3383,7 +3382,7 @@ def _run_cli() -> None:
     p_import.add_argument(
         "--without-filestore",
         action="store_true",
-        help="Request a database-only ZIP backup without filestore files",
+        help="Request a database-only PostgreSQL custom dump",
     )
     p_import.add_argument("--team", default="1", help="Team ID (default: 1)")
 

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -68,9 +68,7 @@ editing code.
 # handle_errors wraps FlowError into one) reach the client. Any other exception
 # is returned as a generic "Error calling tool" without its text, so internal
 # paths, container/DB names and stack detail are not disclosed to MCP callers.
-mcp = FastMCP(
-    "Oduflow", instructions=_MCP_INSTRUCTIONS, mask_error_details=True
-)
+mcp = FastMCP("Oduflow", instructions=_MCP_INSTRUCTIONS, mask_error_details=True)
 _locks = LockManager()
 _settings: Settings | None = None
 _instance_id: str = ""
@@ -717,12 +715,13 @@ def import_template_from_odoo(
     master_pwd: str,
     db_name: str = "",
     template_name: str = "default",
+    without_filestore: bool = False,
     ctx: Context = None,
 ) -> str:
     """
     Import a template from a running Odoo instance via its database manager API.
 
-    Downloads a full backup (SQL + filestore), extracts it into the template
+    Downloads a ZIP backup, extracts it into the template
     directory, detects the Odoo version from the backup manifest, and loads
     the dump into PostgreSQL as a template database.
 
@@ -731,6 +730,7 @@ def import_template_from_odoo(
         master_pwd: Odoo master password (database manager password).
         db_name: Name of the database to back up. If empty, auto-detected (fails if multiple DBs exist).
         template_name: Name of the template profile to create.
+        without_filestore: If true, request a ZIP backup without filestore files.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -741,6 +741,7 @@ def import_template_from_odoo(
         master_pwd=master_pwd,
         db_name=db_name,
         template_name=template_name,
+        without_filestore=without_filestore,
     )
     lines = [
         f"Template '{result['template_name']}' imported successfully!",
@@ -748,6 +749,8 @@ def import_template_from_odoo(
         f"Odoo version: {result['odoo_version']}",
         f"Odoo image: {result['odoo_image']}",
         f"Template DB: {result['template_db']}",
+        "Filestore: "
+        + ("included" if result.get("includes_filestore") else "not included"),
         f"Backup size: {result['zip_size_mb']} MB",
         f"DB restore time: {result['restore_seconds']}s",
     ]
@@ -3032,6 +3035,7 @@ def _run_import_template(
     master_pwd: str,
     db_name: str = "",
     template_name: str = "",
+    without_filestore: bool = False,
 ) -> None:
     result = system_ops.import_from_odoo(
         settings,
@@ -3040,6 +3044,7 @@ def _run_import_template(
         master_pwd=master_pwd,
         db_name=db_name,
         template_name=template_name,
+        without_filestore=without_filestore,
     )
     lines = [
         f"Template '{result['template_name']}' imported successfully!",
@@ -3047,6 +3052,8 @@ def _run_import_template(
         f"Odoo version: {result['odoo_version']}",
         f"Odoo image: {result['odoo_image']}",
         f"Template DB: {result['template_db']}",
+        "Filestore: "
+        + ("included" if result.get("includes_filestore") else "not included"),
         f"Backup size: {result['zip_size_mb']} MB",
         f"DB restore time: {result['restore_seconds']}s",
     ]
@@ -3373,6 +3380,11 @@ def _run_cli() -> None:
     p_import.add_argument(
         "--template-name", required=True, help="Template profile name"
     )
+    p_import.add_argument(
+        "--without-filestore",
+        action="store_true",
+        help="Request a database-only ZIP backup without filestore files",
+    )
     p_import.add_argument("--team", default="1", help="Team ID (default: 1)")
 
     p_lt = sub.add_parser("list-templates", help="List available template profiles")
@@ -3603,6 +3615,7 @@ def _run_cli() -> None:
             master_pwd=args.master_pwd,
             db_name=args.db_name,
             template_name=args.template_name,
+            without_filestore=args.without_filestore,
         )
         return
 

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -160,6 +160,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 | `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?, without_filestore=False)` | Import a template from a running Odoo instance via its database manager API. Set `without_filestore=True` for a database-only PostgreSQL custom dump. Requires explicit user permission |
 | `save_as_template(env_name, reset_env_changes=False)` | Make a branch the new template baseline. Other overlay environments on this template are remounted against the new baseline, **keeping their filestore changes by default** (non-destructive); `reset_env_changes=True` discards them. The source env is always reset. Requires explicit user permission |
 | `refresh_template(template_name, reset_env_changes=False)` | Re-apply a template's current filestore to live overlay environments, keeping their changes (non-destructive); `reset_env_changes=True` resets them to the template baseline. Use after the template filestore changed on disk or to re-sync a skipped env. Requires explicit user permission |
+| `attach_filestore(template_name, source, reset_env_changes=False, strip_prefix="auto")` | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source such as `user@host:/path`. It normalizes paths to `XX/<sha1>` and preserves live env changes by default. Requires explicit user permission |
 | `delete_template(template_name)` | ⚠️ **Destructive**. Remove a template profile. Requires explicit user permission |
 
 ### Reference & Guides

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -157,7 +157,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 | Tool | When to use |
 |---|---|
 | `list_templates` | List available database template profiles |
-| `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?, without_filestore=False)` | Import a template from a running Odoo instance via its database manager API. Set `without_filestore=True` for a database-only ZIP backup. Requires explicit user permission |
+| `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?, without_filestore=False)` | Import a template from a running Odoo instance via its database manager API. Set `without_filestore=True` for a database-only PostgreSQL custom dump. Requires explicit user permission |
 | `save_as_template(env_name, reset_env_changes=False)` | Make a branch the new template baseline. Other overlay environments on this template are remounted against the new baseline, **keeping their filestore changes by default** (non-destructive); `reset_env_changes=True` discards them. The source env is always reset. Requires explicit user permission |
 | `refresh_template(template_name, reset_env_changes=False)` | Re-apply a template's current filestore to live overlay environments, keeping their changes (non-destructive); `reset_env_changes=True` resets them to the template baseline. Use after the template filestore changed on disk or to re-sync a skipped env. Requires explicit user permission |
 | `delete_template(template_name)` | ⚠️ **Destructive**. Remove a template profile. Requires explicit user permission |

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -157,7 +157,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 | Tool | When to use |
 |---|---|
 | `list_templates` | List available database template profiles |
-| `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?)` | Import a template from a running Odoo instance via its database manager API (downloads a full backup and restores it as a new template). Requires explicit user permission |
+| `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?, without_filestore=False)` | Import a template from a running Odoo instance via its database manager API. Set `without_filestore=True` for a database-only ZIP backup. Requires explicit user permission |
 | `save_as_template(env_name, reset_env_changes=False)` | Make a branch the new template baseline. Other overlay environments on this template are remounted against the new baseline, **keeping their filestore changes by default** (non-destructive); `reset_env_changes=True` discards them. The source env is always reset. Requires explicit user permission |
 | `refresh_template(template_name, reset_env_changes=False)` | Re-apply a template's current filestore to live overlay environments, keeping their changes (non-destructive); `reset_env_changes=True` resets them to the template baseline. Use after the template filestore changed on disk or to re-sync a skipped env. Requires explicit user permission |
 | `delete_template(template_name)` | ⚠️ **Destructive**. Remove a template profile. Requires explicit user permission |

--- a/tests/test_attach_filestore.py
+++ b/tests/test_attach_filestore.py
@@ -1,0 +1,166 @@
+import json
+import os
+import shutil
+import zipfile
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+
+HASH_60 = "609e7ca59cc05bf0de7233c6781a381b742a2931"
+HASH_61 = "61dde68eefc2d6823b1243e482f522de8f9a8f32"
+
+
+def _team_and_settings(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    return team, settings
+
+
+@contextmanager
+def _remount():
+    remount = MagicMock()
+    remount.affected = []
+    remount.failures = []
+    yield remount
+
+
+def _patch_attach_dependencies(monkeypatch):
+    monkeypatch.setattr(system_ops, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(system_ops, "_db_exists", lambda *a, **k: True)
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.remount_template_overlays",
+        lambda *a, **k: _remount(),
+    )
+    monkeypatch.setattr(system_ops, "get_odoo_uid_gid", lambda *a, **k: "100:100")
+    monkeypatch.setattr(system_ops, "chown_recursive", lambda *a, **k: None)
+
+
+def _write_metadata(team, template_name="prod"):
+    tpl_dir = team.get_template_dir(template_name)
+    os.makedirs(tpl_dir, exist_ok=True)
+    with open(team.get_template_metadata_path(template_name), "w") as f:
+        json.dump({"odoo_image": "odoo:19.0", "includes_filestore": False}, f)
+
+
+def _zip(path, members):
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, body in members.items():
+            zf.writestr(name, body)
+
+
+def test_attach_filestore_zip_auto_strips_database_prefix(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    _write_metadata(team)
+    _patch_attach_dependencies(monkeypatch)
+    archive = tmp_path / "filestore.zip"
+    _zip(
+        archive,
+        {
+            f"odoo19-mirage/60/{HASH_60}": b"one",
+            f"odoo19-mirage/61/{HASH_61}": b"two",
+        },
+    )
+
+    result = system_ops.attach_filestore(settings, team, "prod", str(archive))
+
+    fs = team.get_template_filestore_path("prod")
+    assert result["status"] == "attached"
+    assert result["strip_prefix"] == "odoo19-mirage"
+    assert result["filestore_files"] == 2
+    assert open(os.path.join(fs, "60", HASH_60), "rb").read() == b"one"
+    assert not os.path.exists(os.path.join(fs, "odoo19-mirage"))
+    with open(team.get_template_metadata_path("prod")) as f:
+        metadata = json.load(f)
+    assert metadata["includes_filestore"] is True
+    assert metadata["filestore_size_mb"] >= 0.0
+
+
+def test_attach_filestore_zip_without_prefix(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    _write_metadata(team)
+    _patch_attach_dependencies(monkeypatch)
+    archive = tmp_path / "filestore.zip"
+    _zip(archive, {f"60/{HASH_60}": b"one"})
+
+    result = system_ops.attach_filestore(settings, team, "prod", str(archive))
+
+    assert result["strip_prefix"] == ""
+    assert os.path.isfile(
+        os.path.join(team.get_template_filestore_path("prod"), "60", HASH_60)
+    )
+
+
+def test_attach_filestore_ambiguous_archive_prefix_fails(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    _write_metadata(team)
+    _patch_attach_dependencies(monkeypatch)
+    archive = tmp_path / "filestore.zip"
+    _zip(
+        archive,
+        {
+            f"db-a/60/{HASH_60}": b"one",
+            f"db-b/61/{HASH_61}": b"two",
+        },
+    )
+
+    with pytest.raises(PrerequisiteNotMetError, match="unique filestore prefix"):
+        system_ops.attach_filestore(settings, team, "prod", str(archive))
+
+
+def test_attach_filestore_rsync_source_uses_rsync_and_normalizes(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    _write_metadata(team)
+    _patch_attach_dependencies(monkeypatch)
+    source = tmp_path / "source"
+    os.makedirs(source / "odoo19-mirage" / "60")
+    (source / "odoo19-mirage" / "60" / HASH_60).write_bytes(b"one")
+    calls = []
+
+    def fake_run(cmd, check, capture_output):
+        calls.append(cmd)
+        src = cmd[-2].rstrip("/")
+        dest = cmd[-1].rstrip("/")
+        shutil.copytree(src, dest, dirs_exist_ok=True)
+
+    monkeypatch.setattr(system_ops.subprocess, "run", fake_run)
+
+    result = system_ops.attach_filestore(settings, team, "prod", str(source))
+
+    assert calls[0][:3] == ["rsync", "-a", "--delete"]
+    assert result["source_kind"] == "rsync"
+    assert result["strip_prefix"] == "odoo19-mirage"
+    assert os.path.isfile(
+        os.path.join(team.get_template_filestore_path("prod"), "60", HASH_60)
+    )
+
+
+def test_attach_filestore_remote_source_builds_rsync_command(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    _write_metadata(team)
+    _patch_attach_dependencies(monkeypatch)
+    calls = []
+
+    def fake_run(cmd, check, capture_output):
+        calls.append(cmd)
+        dest = cmd[-1].rstrip("/")
+        os.makedirs(os.path.join(dest, "60"))
+        with open(os.path.join(dest, "60", HASH_60), "wb") as f:
+            f.write(b"one")
+
+    monkeypatch.setattr(system_ops.subprocess, "run", fake_run)
+
+    system_ops.attach_filestore(
+        settings, team, "prod", "odoo@example.com:/srv/filestore/odoo19-mirage"
+    )
+
+    assert calls[0][-2] == "odoo@example.com:/srv/filestore/odoo19-mirage/"

--- a/tests/test_import_template_from_odoo.py
+++ b/tests/test_import_template_from_odoo.py
@@ -41,6 +41,10 @@ def _zip_backup() -> bytes:
     return payload.getvalue()
 
 
+def _dump_backup() -> bytes:
+    return b"PGDMP custom dump bytes"
+
+
 class _Response:
     def __init__(self, body: bytes, content_type: str = "application/octet-stream"):
         self._body = io.BytesIO(body)
@@ -84,9 +88,23 @@ def _patch_import_dependencies(monkeypatch, backup_requests):
         },
     )
 
+    def fake_exec_sql(_client, _settings, sql, db="postgres"):
+        if "name='base'" in sql:
+            return "18.0.1.0"
+        if "SHOW server_version" in sql:
+            return "16"
+        if "json_object_agg" in sql:
+            return json.dumps({"base": "18.0.1.0", "web": "18.0.1.0"})
+        raise AssertionError(f"Unexpected SQL against {db}: {sql}")
+
+    monkeypatch.setattr(system_ops, "_exec_sql", fake_exec_sql)
+
     def fake_urlopen(req, timeout=0):
         if req.full_url.endswith("/web/database/backup"):
-            backup_requests.append(req.data.decode("utf-8"))
+            body = req.data.decode("utf-8")
+            backup_requests.append(body)
+            if "dump" in body:
+                return _Response(_dump_backup())
             return _Response(_zip_backup(), "application/zip")
         raise AssertionError(f"Unexpected request: {req.full_url}")
 
@@ -117,7 +135,7 @@ def test_import_from_odoo_default_zip_omits_filestore_field(monkeypatch, tmp_pat
     )
 
 
-def test_import_from_odoo_without_filestore_sends_false_and_skips_files(
+def test_import_from_odoo_without_filestore_uses_custom_dump_and_skips_files(
     monkeypatch, tmp_path
 ):
     team, settings = _team_and_settings(tmp_path)
@@ -135,14 +153,18 @@ def test_import_from_odoo_without_filestore_sends_false_and_skips_files(
     )
 
     assert result["includes_filestore"] is False
-    assert 'name="filestore"' in backup_requests[0]
-    assert "false" in backup_requests[0]
+    assert 'name="backup_format"' in backup_requests[0]
+    assert "dump" in backup_requests[0]
+    assert 'name="filestore"' not in backup_requests[0]
     assert os.path.isfile(team.get_template_sql_path("dbonly"))
+    assert os.path.basename(team.get_template_sql_path("dbonly")) == "dump.pgdump"
     assert not os.path.exists(team.get_template_filestore_path("dbonly"))
     with open(team.get_template_metadata_path("dbonly")) as f:
         metadata = json.load(f)
     assert metadata["includes_filestore"] is False
     assert metadata["filestore_size_mb"] == 0.0
+    assert metadata["odoo_image"] == "odoo:18.0"
+    assert metadata["modules"] == {"base": "18.0.1.0", "web": "18.0.1.0"}
 
 
 def test_import_from_odoo_existing_template_dir_fails_before_network(

--- a/tests/test_import_template_from_odoo.py
+++ b/tests/test_import_template_from_odoo.py
@@ -178,7 +178,7 @@ def test_import_from_odoo_existing_template_dir_fails_before_network(
     get_client = MagicMock()
     monkeypatch.setattr(system_ops, "get_client", get_client)
 
-    with pytest.raises(ConflictError, match="already exists"):
+    with pytest.raises(ConflictError, match="Template directory already exists"):
         system_ops.import_from_odoo(
             settings,
             team,
@@ -204,7 +204,7 @@ def test_import_from_odoo_existing_template_db_fails_before_network(
     monkeypatch.setattr(system_ops, "_db_exists", lambda *a, **k: True)
     monkeypatch.setattr(system_ops, "check_db_quota", quota)
 
-    with pytest.raises(ConflictError, match="already exists"):
+    with pytest.raises(ConflictError, match="Template database already exists"):
         system_ops.import_from_odoo(
             settings,
             team,

--- a/tests/test_import_template_from_odoo.py
+++ b/tests/test_import_template_from_odoo.py
@@ -1,0 +1,196 @@
+import io
+import json
+import os
+import zipfile
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ConflictError
+from oduflow.settings import Settings, TeamSettings
+
+
+def _team_and_settings(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    return team, settings
+
+
+def _zip_backup() -> bytes:
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps(
+                {
+                    "major_version": "19.0",
+                    "version": "19.0+e",
+                    "pg_version": "16",
+                    "modules": {"base": "19.0.1.0"},
+                }
+            ),
+        )
+        zf.writestr("dump.sql", "SELECT 1;")
+        zf.writestr("filestore/ab/abcdef", b"file")
+    return payload.getvalue()
+
+
+class _Response:
+    def __init__(self, body: bytes, content_type: str = "application/octet-stream"):
+        self._body = io.BytesIO(body)
+        self.headers = {"Content-Type": content_type}
+
+    def read(self, size: int = -1) -> bytes:
+        return self._body.read(size)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@contextmanager
+def _remount():
+    remount = MagicMock()
+    remount.affected = []
+    remount.failures = []
+    yield remount
+
+
+def _patch_import_dependencies(monkeypatch, backup_requests):
+    monkeypatch.setattr("oduflow.url_safety.assert_allowed_url", lambda *a, **k: None)
+    monkeypatch.setattr(system_ops, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(system_ops, "_db_exists", lambda *a, **k: False)
+    monkeypatch.setattr(system_ops, "check_db_quota", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.remount_template_overlays",
+        lambda *a, **k: _remount(),
+    )
+    monkeypatch.setattr(system_ops, "get_odoo_uid_gid", lambda *a, **k: "100:100")
+    monkeypatch.setattr(system_ops, "chown_recursive", lambda *a, **k: None)
+    monkeypatch.setattr(
+        system_ops,
+        "reload_template",
+        lambda *a, **k: {
+            "template_db": "oduflow_template_1_imported",
+            "restore_seconds": 0.1,
+        },
+    )
+
+    def fake_urlopen(req, timeout=0):
+        if req.full_url.endswith("/web/database/backup"):
+            backup_requests.append(req.data.decode("utf-8"))
+            return _Response(_zip_backup(), "application/zip")
+        raise AssertionError(f"Unexpected request: {req.full_url}")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+
+def test_import_from_odoo_default_zip_omits_filestore_field(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    backup_requests = []
+    _patch_import_dependencies(monkeypatch, backup_requests)
+
+    result = system_ops.import_from_odoo(
+        settings,
+        team,
+        odoo_url="https://odoo.example.com",
+        master_pwd="master",
+        db_name="prod",
+        template_name="imported",
+    )
+
+    assert result["includes_filestore"] is True
+    assert 'name="backup_format"' in backup_requests[0]
+    assert "zip" in backup_requests[0]
+    assert 'name="filestore"' not in backup_requests[0]
+    assert os.path.isfile(team.get_template_sql_path("imported"))
+    assert os.path.isfile(
+        os.path.join(team.get_template_filestore_path("imported"), "ab", "abcdef")
+    )
+
+
+def test_import_from_odoo_without_filestore_sends_false_and_skips_files(
+    monkeypatch, tmp_path
+):
+    team, settings = _team_and_settings(tmp_path)
+    backup_requests = []
+    _patch_import_dependencies(monkeypatch, backup_requests)
+
+    result = system_ops.import_from_odoo(
+        settings,
+        team,
+        odoo_url="https://odoo.example.com",
+        master_pwd="master",
+        db_name="prod",
+        template_name="dbonly",
+        without_filestore=True,
+    )
+
+    assert result["includes_filestore"] is False
+    assert 'name="filestore"' in backup_requests[0]
+    assert "false" in backup_requests[0]
+    assert os.path.isfile(team.get_template_sql_path("dbonly"))
+    assert not os.path.exists(team.get_template_filestore_path("dbonly"))
+    with open(team.get_template_metadata_path("dbonly")) as f:
+        metadata = json.load(f)
+    assert metadata["includes_filestore"] is False
+    assert metadata["filestore_size_mb"] == 0.0
+
+
+def test_import_from_odoo_existing_template_dir_fails_before_network(
+    monkeypatch, tmp_path
+):
+    team, settings = _team_and_settings(tmp_path)
+    os.makedirs(team.get_template_dir("existing"))
+    urlopen = MagicMock()
+    monkeypatch.setattr("oduflow.url_safety.assert_allowed_url", lambda *a, **k: None)
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    get_client = MagicMock()
+    monkeypatch.setattr(system_ops, "get_client", get_client)
+
+    with pytest.raises(ConflictError, match="already exists"):
+        system_ops.import_from_odoo(
+            settings,
+            team,
+            odoo_url="https://odoo.example.com",
+            master_pwd="master",
+            db_name="prod",
+            template_name="existing",
+        )
+
+    urlopen.assert_not_called()
+    get_client.assert_not_called()
+
+
+def test_import_from_odoo_existing_template_db_fails_before_network(
+    monkeypatch, tmp_path
+):
+    team, settings = _team_and_settings(tmp_path)
+    urlopen = MagicMock()
+    quota = MagicMock()
+    monkeypatch.setattr("oduflow.url_safety.assert_allowed_url", lambda *a, **k: None)
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    monkeypatch.setattr(system_ops, "get_client", lambda: MagicMock())
+    monkeypatch.setattr(system_ops, "_db_exists", lambda *a, **k: True)
+    monkeypatch.setattr(system_ops, "check_db_quota", quota)
+
+    with pytest.raises(ConflictError, match="already exists"):
+        system_ops.import_from_odoo(
+            settings,
+            team,
+            odoo_url="https://odoo.example.com",
+            master_pwd="master",
+            db_name="prod",
+            template_name="existingdb",
+        )
+
+    urlopen.assert_not_called()
+    quota.assert_not_called()

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -541,10 +541,10 @@ class TestReloadTemplate:
 
     def test_restore_retries_unsupported_archive_with_helper(self, mock_docker_client):
         db_container = MagicMock()
-        db_container.exec_run.return_value = (
-            1,
-            b"pg_restore: error: unsupported version (1.16) in file header",
-        )
+        db_container.exec_run.side_effect = [
+            (1, b"pg_restore: error: unsupported version (1.16) in file header"),
+            (0, b"helper sql restored"),
+        ]
         mock_docker_client.containers.get.return_value = db_container
 
         with (
@@ -557,17 +557,20 @@ class TestReloadTemplate:
                 return_value="oduflow_team_1",
             ),
             patch("oduflow.docker_ops.system_ops._is_text_dump", return_value=False),
-            patch("oduflow.docker_ops.system_ops._copy_file_to_container"),
+            patch("oduflow.docker_ops.system_ops._copy_file_to_container") as copy_file,
             patch("oduflow.docker_ops.system_ops._update_template_sizes"),
             patch(
-                "oduflow.docker_ops.system_ops._restore_custom_dump_with_helper",
-                return_value=(0, "helper restored"),
+                "oduflow.docker_ops.system_ops._convert_custom_dump_to_sql_with_helper",
+                return_value=(0, "converted", "/tmp/flow-test/templates/mytpl/dump.sql"),
             ) as helper,
         ):
             result = system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
 
         assert result["status"] == "reloaded"
         helper.assert_called_once()
+        assert copy_file.call_args_list[-1].args[1].endswith("dump.sql")
+        psql_cmd = db_container.exec_run.call_args_list[-1].args[0]
+        assert psql_cmd[0] == "psql"
         assert any(
             'DROP DATABASE IF EXISTS "oduflow_template_1_mytpl"' in call.args[2]
             for call in sql.call_args_list

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -539,6 +539,44 @@ class TestReloadTemplate:
         assert "pg_restore" in joined
         assert "--no-owner" in joined
 
+    def test_restore_retries_unsupported_archive_with_helper(self, mock_docker_client):
+        db_container = MagicMock()
+        db_container.exec_run.return_value = (
+            1,
+            b"pg_restore: error: unsupported version (1.16) in file header",
+        )
+        mock_docker_client.containers.get.return_value = db_container
+
+        with (
+            patch("oduflow.docker_ops.system_ops.os.path.isfile", return_value=True),
+            patch("oduflow.docker_ops.system_ops._wait_pg_ready"),
+            patch("oduflow.docker_ops.system_ops._exec_sql", return_value="5") as sql,
+            patch("oduflow.docker_ops.system_ops._db_exists", return_value=False),
+            patch(
+                "oduflow.docker_ops.system_ops.ensure_team_tablespace",
+                return_value="oduflow_team_1",
+            ),
+            patch("oduflow.docker_ops.system_ops._is_text_dump", return_value=False),
+            patch("oduflow.docker_ops.system_ops._copy_file_to_container"),
+            patch("oduflow.docker_ops.system_ops._update_template_sizes"),
+            patch(
+                "oduflow.docker_ops.system_ops._restore_custom_dump_with_helper",
+                return_value=(0, "helper restored"),
+            ) as helper,
+        ):
+            result = system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
+
+        assert result["status"] == "reloaded"
+        helper.assert_called_once()
+        assert any(
+            'DROP DATABASE IF EXISTS "oduflow_template_1_mytpl"' in call.args[2]
+            for call in sql.call_args_list
+        )
+        assert any(
+            'CREATE DATABASE "oduflow_template_1_mytpl"' in call.args[2]
+            for call in sql.call_args_list
+        )
+
 
 class TestPullEnvironmentLocal:
     def test_local_snapshot_detects_added_modified_deleted(self, tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,6 +63,58 @@ class TestCLIInitDestroy:
         mock_destroy.assert_called_once_with(TEST_SETTINGS)
 
 
+class TestImportTemplateFromOdoo:
+    def _result(self, includes_filestore: bool = False):
+        return {
+            "template_name": "prod",
+            "source_url": "https://odoo.example.com",
+            "source_db": "db",
+            "odoo_version": "19.0",
+            "odoo_image": "odoo:19.0",
+            "template_db": "oduflow_template_1_prod",
+            "zip_size_mb": 1.2,
+            "restore_seconds": 0.3,
+            "includes_filestore": includes_filestore,
+            "affected_envs": [],
+            "remount_failures": [],
+        }
+
+    @patch("oduflow.docker_ops.system_ops.import_from_odoo")
+    def test_cli_import_passes_without_filestore(self, mock_import, capsys):
+        from oduflow.server import _run_import_template
+
+        mock_import.return_value = self._result(includes_filestore=False)
+
+        _run_import_template(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            odoo_url="https://odoo.example.com",
+            master_pwd="master",
+            db_name="db",
+            template_name="prod",
+            without_filestore=True,
+        )
+
+        assert mock_import.call_args.kwargs["without_filestore"] is True
+        assert "Filestore: not included" in capsys.readouterr().out
+
+    @patch("oduflow.docker_ops.system_ops.import_from_odoo")
+    def test_mcp_import_passes_without_filestore(self, mock_import):
+        mock_import.return_value = self._result(includes_filestore=False)
+
+        result = _call_tool(
+            "import_template_from_odoo",
+            odoo_url="https://odoo.example.com",
+            master_pwd="master",
+            db_name="db",
+            template_name="prod",
+            without_filestore=True,
+        )
+
+        assert mock_import.call_args.kwargs["without_filestore"] is True
+        assert "Filestore: not included" in result
+
+
 class TestCreateEnvironmentTool:
     @patch("oduflow.docker_ops.env_ops.create_environment")
     def test_create(self, mock_create):

--- a/tests/test_template_delete.py
+++ b/tests/test_template_delete.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from oduflow.docker_ops import system_ops
-from oduflow.errors import ConflictError
+from oduflow.errors import ConflictError, NotFoundError
 from oduflow.settings import Settings, TeamSettings
 
 
@@ -81,3 +81,14 @@ def test_ignores_envs_of_other_templates(settings, team):
 
     assert result["status"] == "dropped"
     assert not os.path.isdir(tpl_dir)
+
+
+def test_missing_template_raises_not_found(settings, team):
+    client = _client([])
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client", return_value=client),
+        patch("oduflow.docker_ops.system_ops._db_exists", return_value=False),
+    ):
+        with pytest.raises(NotFoundError, match="Template 'prod' not found"):
+            system_ops.delete_template(settings, team, "prod")


### PR DESCRIPTION
Adds `--without-filestore` to `oduflow import-template` and `without_filestore=True` to the MCP import tool, using Odoo's ZIP backup with `filestore=false` while preserving manifest-based version detection.

The import path now refuses an existing template directory or template database before listing/downloading, preventing accidental overwrites. Docs, agent guidance, changelog notes, and focused tests cover the new CLI/MCP behavior and conflict guards.

Validated with `ruff check src/oduflow tests`, targeted import/server tests, and `pytest -m "not integration and not heavyweight"`.