### PR TITLE
fix(env): targeted extra-repo fetch + surface real create errors

### DIFF
--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -361,8 +361,15 @@ def _get_branch_refs(repo_path: str) -> dict[str, str]:
     return refs
 
 
-def fetch_extra_repo(team: TeamSettings, name: str) -> dict:
+def fetch_extra_repo(team: TeamSettings, name: str, branch: str | None = None) -> dict:
     """Fetch latest changes and return a summary of what changed.
+
+    When *branch* is given, only that one branch is fetched (a targeted
+    ``git fetch origin +refs/heads/<branch>:refs/heads/<branch>``) instead of
+    ``--all``. Creating/updating a worktree needs just its own branch, and
+    fetching every branch of a large repo like Odoo Enterprise otherwise times
+    out (issue: "Fetch timed out"). The explicit "update repo" path passes no
+    branch and still fetches everything to report changes across all branches.
 
     Returns a dict with keys: name, up_to_date, new_branches,
     deleted_branches, updated_branches.
@@ -416,9 +423,35 @@ def fetch_extra_repo(team: TeamSettings, name: str) -> dict:
     refs_before = _get_branch_refs(path)
     cred_env = git_env_for_team(team.git_credentials_file())
 
+    if branch:
+        # Targeted single-branch fetch: pull only the requested branch's tip so
+        # a large repo doesn't time out fetching every version branch. The '+'
+        # forces the local ref to match after a rebase/force-push upstream.
+        fetch_args = [
+            "git",
+            "-C",
+            path,
+            "fetch",
+            "origin",
+            f"+refs/heads/{branch}:refs/heads/{branch}",
+            "--recurse-submodules=no",
+        ]
+        fetch_label = f"git fetch origin {branch}"
+    else:
+        fetch_args = [
+            "git",
+            "-C",
+            path,
+            "fetch",
+            "--all",
+            "--prune",
+            "--recurse-submodules=no",
+        ]
+        fetch_label = "git fetch --all --prune"
+
     try:
         subprocess.run(
-            ["git", "-C", path, "fetch", "--all", "--prune", "--recurse-submodules=no"],
+            fetch_args,
             check=True,
             capture_output=True,
             text=True,
@@ -426,13 +459,9 @@ def fetch_extra_repo(team: TeamSettings, name: str) -> dict:
             env=cred_env,
         )
     except subprocess.CalledProcessError as e:
-        raise ExternalCommandError(
-            "git fetch --all --prune", e.returncode, e.stderr or ""
-        )
+        raise ExternalCommandError(fetch_label, e.returncode, e.stderr or "")
     except subprocess.TimeoutExpired:
-        raise ExternalCommandError(
-            "git fetch --all --prune", -1, "Fetch timed out (120s)."
-        )
+        raise ExternalCommandError(fetch_label, -1, "Fetch timed out (120s).")
 
     refs_after = _get_branch_refs(path)
 
@@ -484,7 +513,7 @@ def create_worktree(
     if not os.path.isdir(bare_path):
         raise NotFoundError(f"Extra repo '{repo_name}' not found. Add it first.")
 
-    fetch_extra_repo(team, repo_name)
+    fetch_extra_repo(team, repo_name, branch=branch)
 
     subprocess.run(
         ["git", "-C", bare_path, "worktree", "prune"],
@@ -560,7 +589,7 @@ def pull_extra_worktree(
     commit hash before the pull and *changed_files* are paths relative
     to the worktree root.  Returns ``("", [])`` if already up to date.
     """
-    fetch_extra_repo(team, repo_name)
+    fetch_extra_repo(team, repo_name, branch=branch)
 
     old_head = subprocess.run(
         ["git", "-C", worktree_path, "rev-parse", "HEAD"],

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2447,6 +2447,26 @@ function escAttr(s) {
     .replace(/>/g, '&gt;');
 }
 
+// Reads a fetch Response without throwing on an empty / non-JSON body.
+// Always returns a {ok, error, ...} object. A non-2xx response whose body
+// isn't JSON (e.g. a reverse-proxy timeout page on a long request) yields a
+// legible "HTTP <status>: <body>" instead of a cryptic DOMException from
+// r.json() surfacing as "Connection error: The string did not match the
+// expected pattern.".
+async function readResult(r) {
+  var text = '';
+  try { text = await r.text(); } catch (e) { text = ''; }
+  try { return JSON.parse(text); }
+  catch (e) {
+    return {
+      ok: false,
+      error: (text && text.trim())
+        ? ('HTTP ' + r.status + ': ' + text.trim().slice(0, 300))
+        : ('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''))
+    };
+  }
+}
+
 // Plain-text relative time ("just now", "5m ago"). Safe for attribute
 // values (via esc); formatDate below wraps it in markup — never use
 // formatDate inside an attribute.
@@ -3263,13 +3283,13 @@ async function submitCreate() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)
     });
-    var data = await r.json();
-    if (data.ok) {
+    var data = await readResult(r);
+    if (r.ok && data.ok) {
       closeCreateModal();
       showToast('Environment "' + branch + '" created');
       await loadEnvironments(true);
     } else {
-      errEl.textContent = data.error || 'Creation failed';
+      errEl.textContent = data.error || ('Creation failed (HTTP ' + r.status + ')');
       errEl.style.display = 'block';
     }
   } catch (e) {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -803,6 +803,12 @@ def _build_routes(
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
+            # FlowError is an "expected" business error, but for create it is the
+            # only record of WHY the environment failed to build (overlay mount,
+            # disk/quota, git auth, …): the response often never reaches the
+            # browser on multi-minute creates, so log it here to keep the reason
+            # in the server journal.
+            logger.warning("create_environment failed for %s: %s", env_name, e)
             return _error_response(e)
         except Exception as e:
             logger.exception("Unexpected error in api_create")

--- a/tests/test_extra_addons_clone.py
+++ b/tests/test_extra_addons_clone.py
@@ -93,3 +93,35 @@ class TestCloneExtraRepoShallow:
 
         # views.xml only exists on the 18.0 branch.
         assert (wt / "sale_enterprise" / "views.xml").is_file()
+
+    def test_worktree_fetches_new_commits_on_branch(self, team, tmp_path):
+        """create_worktree's targeted single-branch fetch pulls updates.
+
+        A commit added to 18.0 *after* the clone must land in the worktree,
+        proving the per-branch fetch runs instead of relying on stale clone
+        data (and without a slow ``--all`` over every branch).
+        """
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+
+        src = tmp_path / "source"
+
+        def _git(*args):
+            subprocess.run(
+                ["git", "-C", str(src), *args],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+        _git("checkout", "18.0")
+        (src / "sale_enterprise" / "new.xml").write_text("<odoo/>")
+        _git("add", "-A")
+        _git(*_GIT_ID, "commit", "-m", "18.0 update")
+        _git("checkout", "main")
+
+        wt = tmp_path / "wt"
+        create_worktree(team, "enterprise", "18.0", str(wt))
+
+        # new.xml was committed after the clone → only present if fetched.
+        assert (wt / "sale_enterprise" / "new.xml").is_file()


### PR DESCRIPTION
Creating an environment from a template could fail with `400` on the backend while the dashboard showed only a cryptic `Connection error: The string did not match the expected pattern.`, so neither the user nor the operator could see the cause.

**Root cause:** building an env ran `git fetch --all --prune` over every branch of each extra repo, which timed out (120s) on large repos like Odoo Enterprise and failed the whole create — now `fetch_extra_repo` takes a `branch` so `create_worktree`/`pull_extra_worktree` fetch only the branch they need, while the explicit "update repo" path still fetches `--all` for its cross-branch summary.

**Diagnosability:** `api_create` now logs the `FlowError` so the real reason lands in the server journal, and the dashboard reads responses via a `readResult()` helper that never throws on an empty/non-JSON body, showing the real backend error or a legible `HTTP <status>` instead of a DOMException.

Rebased on main (includes #118's shallow extra-repo clone) and covered by a new unit test asserting the targeted fetch picks up a commit pushed after the clone.