### PR TITLE
feat(extra-addons): shallow bare clone for extra repos

### DIFF
--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -55,12 +55,26 @@ def clone_extra_repo(
     cred_env = git_env_for_team(team.git_credentials_file())
 
     try:
+        # Shallow clone (--depth 1): drop history so large repos like Odoo
+        # Enterprise (years of commits) clone fast instead of timing out.
+        # --no-single-branch keeps the tip of *every* branch, so a single bare
+        # repo still serves worktrees for any branch/version (16.0, 17.0, 18.0,
+        # ...) exactly as the full clone did.
         subprocess.run(
-            ["git", "clone", "--bare", clone_url, target],
+            [
+                "git",
+                "clone",
+                "--bare",
+                "--depth",
+                "1",
+                "--no-single-branch",
+                clone_url,
+                target,
+            ],
             check=True,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=300,
             env=cred_env,
         )
     except subprocess.CalledProcessError as e:
@@ -72,7 +86,7 @@ def clone_extra_repo(
             )
         raise ExternalCommandError("git clone --bare", e.returncode, stderr)
     except subprocess.TimeoutExpired:
-        raise ExternalCommandError("git clone --bare", -1, "Clone timed out (120s).")
+        raise ExternalCommandError("git clone --bare", -1, "Clone timed out (300s).")
 
     # git clone --bare does not set a fetch refspec, so subsequent
     # git fetch --all would only write to FETCH_HEAD without updating

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -308,9 +308,11 @@ def add_extra_repo(name: str, repo_url: str, ctx: Context = None) -> str:
     """
     Clone an extra addons repository for use with environments.
 
-    The repository is cloned as a bare repo to the shared repos directory.
-    When creating an environment, reference it by name to mount it as
-    additional addons (e.g., Odoo Enterprise).
+    The repository is cloned as a shallow bare repo (only the latest commit of
+    each branch, no history) to the shared repos directory, so large repos like
+    Odoo Enterprise clone quickly. All branches are kept, so one repo serves any
+    Odoo version. When creating an environment, reference it by name to mount it
+    as additional addons (e.g., Odoo Enterprise).
 
     Args:
         name: Short name for the repo (e.g. "enterprise", "custom-themes").

--- a/tests/test_extra_addons_clone.py
+++ b/tests/test_extra_addons_clone.py
@@ -1,0 +1,95 @@
+"""Unit tests for cloning remote extra-addons repos (clone_extra_repo).
+
+These exercise real git (no network, no Docker): a local source repo with two
+branches is cloned via a file:// URL, and we assert the clone is shallow yet
+keeps every branch (--depth 1 --no-single-branch), so one bare repo still serves
+worktrees for any Odoo version.
+"""
+
+import subprocess
+
+import pytest
+
+from oduflow.extra_addons import clone_extra_repo, create_worktree, list_extra_repos
+from oduflow.settings import TeamSettings
+
+_GIT_ID = [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+]
+
+
+@pytest.fixture
+def team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path / "data"))
+
+
+def _make_git_source(tmp_path):
+    """Create a normal git repo with branches ``main`` and ``18.0``.
+
+    Returns a ``file://`` URL — git only honours ``--depth`` for remote-style
+    URLs; a plain local path is cloned in full (with a warning).
+    """
+    src = tmp_path / "source"
+    mod = src / "sale_enterprise"
+    mod.mkdir(parents=True)
+
+    def _git(*args):
+        subprocess.run(
+            ["git", "-C", str(src), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    _git("init", "-b", "main")
+    (mod / "__manifest__.py").write_text("{'name': 'Sale Enterprise'}")
+    _git("add", "-A")
+    _git(*_GIT_ID, "commit", "-m", "main commit")
+
+    _git("checkout", "-b", "18.0")
+    (mod / "views.xml").write_text("<odoo/>")
+    _git("add", "-A")
+    _git(*_GIT_ID, "commit", "-m", "18.0 commit")
+
+    _git("checkout", "main")
+    return f"file://{src}"
+
+
+def _is_shallow(bare_path):
+    out = subprocess.run(
+        ["git", "-C", bare_path, "rev-parse", "--is-shallow-repository"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return out.stdout.strip() == "true"
+
+
+class TestCloneExtraRepoShallow:
+    def test_clone_is_shallow(self, team, tmp_path):
+        url = _make_git_source(tmp_path)
+        result = clone_extra_repo(team, "enterprise", url)
+
+        assert _is_shallow(result["path"])
+
+    def test_clone_keeps_all_branches(self, team, tmp_path):
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+
+        repos = list_extra_repos(team)
+        assert len(repos) == 1
+        assert set(repos[0]["branches"]) == {"main", "18.0"}
+
+    def test_worktree_from_non_default_branch(self, team, tmp_path):
+        """A shallow, all-branches clone still checks out any branch's tip."""
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+
+        wt = tmp_path / "wt"
+        create_worktree(team, "enterprise", "18.0", str(wt))
+
+        # views.xml only exists on the 18.0 branch.
+        assert (wt / "sale_enterprise" / "views.xml").is_file()


### PR DESCRIPTION
Clone extra-addons repositories as a shallow bare repo (`git clone --bare --depth 1 --no-single-branch`) so large repos like Odoo Enterprise clone quickly instead of timing out, while keeping the tip of every branch so a single bare repo still serves worktrees for any Odoo version. The clone timeout is raised from 120s to 300s (with the timeout error message updated accordingly), and the `add_extra_repo` docstring now describes the shallow behavior. Adds unit tests exercising real git that assert the clone is shallow, keeps all branches, and can check out a worktree from a non-default branch.