### PR TITLE
Auto-install fuse-overlayfs; fall back to filestore copy off Linux

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@
 - **Docker** (Docker Engine or Docker Desktop)
 - **Python 3.10+**
 - **Git**
-- **fuse-overlayfs** (for filestore overlay mounting)
+- **fuse-overlayfs** (Linux only, for filestore overlay mounting) — auto-installed on first launch; see below
 
 !!! note "macOS support"
     On macOS, Docker Desktop runs containers inside a Linux VM and projects
@@ -16,6 +16,12 @@
     inside a throwaway container. No extra configuration is required.
 
 ### Install fuse-overlayfs
+
+On Linux, Oduflow **auto-installs `fuse-overlayfs` on first launch** if it is
+missing — it runs `apt-get install -y fuse-overlayfs` when it starts as **root**
+on a Debian/Ubuntu host (the Docker image already bundles it). This is
+best-effort: if Oduflow is not running as root, `apt-get` is unavailable, or the
+install fails, it logs a warning and you can install the package yourself:
 
 ```bash
 sudo apt install fuse-overlayfs

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,6 +140,11 @@ umount /srv/oduflow/team_1/workspaces/<env-slug>/filestore \
 
 ### fuse-overlayfs prerequisites
 
+On Linux, Oduflow auto-installs `fuse-overlayfs` on first launch when it starts
+as root on a Debian/Ubuntu host. If it is still missing (non-root, non-Debian, or
+no network), install it by hand. On macOS the binary is never needed — overlays
+fall back to a plain copy automatically.
+
 ```bash
 which fuse-overlayfs          # install: sudo apt install fuse-overlayfs
 ls -l /dev/fuse               # must exist (present by default on Ubuntu)

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import time
 from collections.abc import Iterator
 from typing import Any
@@ -198,6 +199,15 @@ def _mount_filestore(
         # Fallback for old templates without the flag
         size_mb = _dir_size_mb(template_filestore)
         use_overlay = size_mb >= settings.overlay_threshold_mb
+
+    # fuse-overlayfs is a Linux/FUSE binary; it cannot run on macOS. Off Linux,
+    # always fall back to a plain filestore copy instead of failing.
+    if use_overlay and not sys.platform.startswith("linux"):
+        logger.info(
+            "Non-Linux platform (%s): using filestore copy instead of overlay",
+            sys.platform,
+        )
+        use_overlay = False
 
     if not use_overlay:
         logger.info("Template use_overlay=False, using copy")

--- a/src/oduflow/prereqs.py
+++ b/src/oduflow/prereqs.py
@@ -1,0 +1,108 @@
+"""Best-effort host prerequisite provisioning, run once at server start.
+
+The only prerequisite handled here is ``fuse-overlayfs``, used to clone large
+template filestores copy-on-write instead of duplicating them (see
+``docker_ops/env_ops.py``). It is a Linux/FUSE binary — it does not exist on
+macOS, and the packaged Docker image (``oduist/oduflow``) already bundles it —
+so auto-install only matters for bare-metal Linux installs (``uv tool`` +
+systemd running as root).
+
+Every check is best-effort and idempotent: nothing here raises. When the binary
+cannot be provided (non-Linux, not root, non-Debian, no network), the reason is
+logged and env creation falls back to a plain filestore copy on macOS or surfaces
+a clear ``PrerequisiteNotMetError`` on Linux at mount time.
+
+Called from ``server._ensure_initialized`` on every server start.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+logger = logging.getLogger("oduflow")
+
+# Upper bound on any single apt-get invocation. Generous enough for a slow
+# mirror, but bounded so a hung download or a held apt lock cannot wedge the
+# server's startup path.
+_APT_TIMEOUT_SECONDS = 300
+
+
+def ensure_fuse_overlayfs() -> None:
+    """Install ``fuse-overlayfs`` via apt-get on Linux if it is missing.
+
+    No-op on non-Linux platforms, when the binary is already present, when not
+    running as root, or when ``apt-get`` is unavailable. Never raises — a failure
+    to install is logged and left for the mount-time check to surface.
+    """
+    if not sys.platform.startswith("linux"):
+        return  # macOS/other: overlay is unsupported, copy mode is used instead
+    if shutil.which("fuse-overlayfs"):
+        return  # already present (Docker image ships it, or installed earlier)
+    if os.geteuid() != 0:
+        logger.warning(
+            "fuse-overlayfs is missing and Oduflow is not running as root; "
+            "install it manually: sudo apt install fuse-overlayfs"
+        )
+        return
+    if shutil.which("apt-get") is None:
+        logger.warning(
+            "fuse-overlayfs is missing and apt-get was not found; install it "
+            "with your distribution's package manager (e.g. dnf install "
+            "fuse-overlayfs)"
+        )
+        return
+
+    logger.info("fuse-overlayfs is missing; installing via apt-get")
+    if _apt_install("fuse-overlayfs"):
+        logger.info("fuse-overlayfs installed successfully")
+        return
+
+    # Package index may be stale/empty (e.g. fresh minimal image); refresh once
+    # and retry a single time.
+    logger.info("fuse-overlayfs install failed; refreshing apt index and retrying")
+    _run_apt(["apt-get", "update"])
+    if _apt_install("fuse-overlayfs"):
+        logger.info("fuse-overlayfs installed successfully after apt-get update")
+    else:
+        logger.warning(
+            "Could not auto-install fuse-overlayfs; install it manually: "
+            "sudo apt install fuse-overlayfs"
+        )
+
+
+def _apt_install(package: str) -> bool:
+    """Run ``apt-get install -y <package>``; return True on success."""
+    return _run_apt(["apt-get", "install", "-y", package])
+
+
+def _run_apt(cmd: list[str]) -> bool:
+    """Run an apt command non-interactively; return True on exit code 0.
+
+    Best-effort: any failure (non-zero exit, timeout, missing binary, OS error)
+    is logged and reported as ``False`` rather than raised.
+
+    A timeout is enforced so a held dpkg/apt lock (e.g. a concurrent
+    apt-daily/unattended-upgrades run right after boot) or a stalled mirror
+    cannot block server startup indefinitely, since this runs synchronously in
+    ``_ensure_initialized``.
+    """
+    env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
+    try:
+        result = subprocess.run(
+            env=env, args=cmd, capture_output=True, timeout=_APT_TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("'%s' timed out after %ds", " ".join(cmd), _APT_TIMEOUT_SECONDS)
+        return False
+    except OSError as exc:
+        logger.warning("'%s' failed: %s", " ".join(cmd), exc)
+        return False
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        logger.warning("'%s' exited %d: %s", " ".join(cmd), result.returncode, stderr)
+        return False
+    return True

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2590,7 +2590,10 @@ def delete_file_in_volume(
 
 def _ensure_initialized(settings: Settings) -> None:
     """Ensure shared infrastructure and per-team directories exist (idempotent)."""
+    from oduflow import prereqs
+
     _copy_bundled_configs()
+    prereqs.ensure_fuse_overlayfs()
     system_ops.init_system(settings)
 
     import pathlib

--- a/tests/test_filestore_overlay.py
+++ b/tests/test_filestore_overlay.py
@@ -1,0 +1,89 @@
+"""Tests for the platform-aware filestore mount decision in ``_mount_filestore``.
+
+On macOS (and any non-Linux host) ``fuse-overlayfs`` cannot run, so an overlay
+template must transparently fall back to a plain copy. On Linux the historical
+hard error is preserved when the binary is missing.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow.docker_ops import env_ops
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+
+def _overlay_template(tmp_path, name="default"):
+    """Create a template whose metadata requests overlay mode."""
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+
+    fs_dir = tmp_path / "templates" / name / "filestore"
+    fs_dir.mkdir(parents=True)
+    (fs_dir / "a.txt").write_text("hello")
+
+    with open(team.get_template_metadata_path(name), "w") as f:
+        json.dump({"odoo_image": "odoo:17.0", "use_overlay": True}, f)
+
+    return team, settings
+
+
+def test_non_linux_falls_back_to_copy(tmp_path):
+    team, settings = _overlay_template(tmp_path)
+    odoo_volumes: dict = {}
+
+    with (
+        patch.object(env_ops.sys, "platform", "darwin"),
+        patch.object(env_ops, "get_odoo_uid_gid", return_value="0:0"),
+        patch.object(env_ops, "chown_recursive"),
+        patch.object(env_ops.subprocess, "run") as run,
+    ):
+        env_ops._mount_filestore(
+            MagicMock(),
+            settings,
+            team,
+            env_name="myenv",
+            env_db="myenv_db",
+            odoo_image="odoo:17.0",
+            odoo_volumes=odoo_volumes,
+            template_name="default",
+        )
+
+    # No fuse-overlayfs was invoked and the filestore was copied, not mounted.
+    run.assert_not_called()
+    merged = next(iter(odoo_volumes))
+    assert odoo_volumes[merged]["bind"].endswith("/filestore/myenv_db")
+    with open(f"{merged}/a.txt") as f:
+        assert f.read() == "hello"
+
+
+def test_linux_missing_binary_still_errors(tmp_path):
+    team, settings = _overlay_template(tmp_path)
+
+    with (
+        patch.object(env_ops.sys, "platform", "linux"),
+        patch.object(env_ops, "get_odoo_uid_gid", return_value="0:0"),
+        patch.object(env_ops, "chown_recursive"),
+        patch.object(env_ops.shutil, "which", return_value=None),
+        patch.object(env_ops.subprocess, "run") as run,
+    ):
+        with pytest.raises(
+            PrerequisiteNotMetError, match="fuse-overlayfs is not installed"
+        ):
+            env_ops._mount_filestore(
+                MagicMock(),
+                settings,
+                team,
+                env_name="myenv",
+                env_db="myenv_db",
+                odoo_image="odoo:17.0",
+                odoo_volumes={},
+                template_name="default",
+            )
+    run.assert_not_called()

--- a/tests/test_prereqs.py
+++ b/tests/test_prereqs.py
@@ -1,0 +1,131 @@
+"""Unit tests for the fuse-overlayfs startup preflight (``oduflow.prereqs``)."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from oduflow import prereqs
+
+
+def _completed(returncode: int) -> SimpleNamespace:
+    """A stand-in for ``subprocess.CompletedProcess``."""
+    return SimpleNamespace(returncode=returncode, stderr=b"boom")
+
+
+def _which(*present: str):
+    """Return a ``shutil.which`` fake where only ``present`` binaries resolve."""
+
+    def _lookup(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in present else None
+
+    return _lookup
+
+
+class TestEnsureFuseOverlayfs:
+    def test_non_linux_is_noop(self):
+        with (
+            patch.object(prereqs.sys, "platform", "darwin"),
+            patch.object(prereqs.subprocess, "run") as run,
+            patch.object(prereqs.shutil, "which") as which,
+        ):
+            prereqs.ensure_fuse_overlayfs()
+        run.assert_not_called()
+        which.assert_not_called()
+
+    def test_already_installed_is_noop(self):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("fuse-overlayfs")),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            prereqs.ensure_fuse_overlayfs()
+        run.assert_not_called()
+
+    def test_missing_but_not_root_warns_without_installing(self, caplog):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=1000),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_fuse_overlayfs()
+        run.assert_not_called()
+        assert "not running as root" in caplog.text
+
+    def test_missing_without_apt_get_warns(self, caplog):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which()),  # nothing resolves
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_fuse_overlayfs()
+        run.assert_not_called()
+        assert "apt-get was not found" in caplog.text
+
+    def test_installs_via_apt_get_when_root(self):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run", return_value=_completed(0)) as run,
+        ):
+            prereqs.ensure_fuse_overlayfs()
+        assert run.call_count == 1
+        cmd = run.call_args.kwargs["args"]
+        assert cmd == ["apt-get", "install", "-y", "fuse-overlayfs"]
+
+    def test_retries_after_apt_update_on_first_failure(self):
+        # First install fails, apt-get update succeeds, second install succeeds.
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(
+                prereqs.subprocess,
+                "run",
+                side_effect=[_completed(1), _completed(0), _completed(0)],
+            ) as run,
+        ):
+            prereqs.ensure_fuse_overlayfs()
+        commands = [call.kwargs["args"] for call in run.call_args_list]
+        assert commands == [
+            ["apt-get", "install", "-y", "fuse-overlayfs"],
+            ["apt-get", "update"],
+            ["apt-get", "install", "-y", "fuse-overlayfs"],
+        ]
+
+    def test_install_failure_never_raises(self, caplog):
+        # Every apt command fails; the function must swallow it and warn.
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run", return_value=_completed(100)),
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_fuse_overlayfs()  # must not raise
+        assert "Could not auto-install fuse-overlayfs" in caplog.text
+
+    def test_os_error_is_swallowed(self):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run", side_effect=OSError("nope")),
+        ):
+            prereqs.ensure_fuse_overlayfs()  # must not raise
+
+    def test_timeout_is_swallowed(self, caplog):
+        # A hung apt-get (held lock / stalled mirror) must not wedge startup.
+        timeout = prereqs.subprocess.TimeoutExpired(cmd="apt-get", timeout=1)
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run", side_effect=timeout),
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_fuse_overlayfs()  # must not raise
+        assert "timed out" in caplog.text


### PR DESCRIPTION
On Linux, Oduflow now provisions `fuse-overlayfs` at server start via a new best-effort, idempotent `prereqs.ensure_fuse_overlayfs()` (called from `_ensure_initialized`): it runs `apt-get install -y fuse-overlayfs` only when the binary is missing and Oduflow runs as root on a Debian/Ubuntu host, warning otherwise and never raising. Each `apt-get` call is bounded by a 300s timeout so a held dpkg lock or a stalled mirror cannot wedge startup. On macOS/non-Linux hosts, `_mount_filestore` now transparently falls back to a plain filestore copy instead of failing, while the historical hard error on Linux with a missing binary is preserved. Docs (installation, troubleshooting) are updated and new unit tests cover `prereqs` and the platform-aware mount decision.