### PR TITLE
Prevent Odoo restart loops from generated database passwords

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+- **Generated PostgreSQL passwords are safe for the Odoo entrypoint** — per-environment passwords that randomly began with `-` were parsed as another CLI option, leaving `--db_password` without a value and putting the Odoo container into a restart loop. Password generation now retries that rare token shape.
 - **Overlay filestore no longer duplicated into each environment** — `_ensure_user_site_packages` was recursively chowning `.local/share`, causing fuse-overlayfs to copy the entire template filestore (~10 GB) into each env's upper layer, defeating overlay space savings. Now chowns only the pip dirs non-recursively, keeping filestore overlay-bound. (#113)
 - **Overlay unmount now works on Ubuntu 24.04 with enforced fusermount AppArmor profile** — switched mount cleanup to try clean `umount` first (not mediated by the fusermount3 profile on Ubuntu 24.04+), falling back to `fusermount`/`fusermount3` helpers and lazy `umount -l` only as a last resort. (#113)
 - **Multi-team UI password provisioning for newly-added passwordless teams** — `_ensure_web_ui_password` was using `any()` so a multi-team config with one team already set would skip provisioning for others, locking them out. Now uses `all()` to provision every team and enforce that all are set at startup. (#114)

--- a/src/oduflow/env_credentials.py
+++ b/src/oduflow/env_credentials.py
@@ -18,7 +18,15 @@ def generate_pg_username(env_name: str, team_id: str) -> str:
 
 
 def generate_pg_password() -> str:
-    return secrets.token_urlsafe(18)
+    while True:
+        password = secrets.token_urlsafe(18)
+        # The official Odoo entrypoint passes this value as a separate
+        # ``--db_password`` argument. A leading dash is parsed as another CLI
+        # option, leaving --db_password without a value and crash-looping the
+        # container. Reject that rare token shape while keeping the same length
+        # and entropy for accepted passwords.
+        if not password.startswith("-"):
+            return password
 
 
 def create_credentials(

--- a/tests/test_env_credentials.py
+++ b/tests/test_env_credentials.py
@@ -1,5 +1,6 @@
 import json
 import os
+from unittest.mock import patch
 
 from oduflow.env_credentials import (
     create_credentials,
@@ -44,6 +45,17 @@ class TestGeneratePgPassword:
             pw = generate_pg_password()
             assert "'" not in pw
             assert '"' not in pw
+
+    @patch(
+        "oduflow.env_credentials.secrets.token_urlsafe",
+        side_effect=["-" + "a" * 23, "b" * 24],
+    )
+    def test_retries_when_password_starts_with_dash(self, mock_token_urlsafe):
+        pw = generate_pg_password()
+
+        assert pw == "b" * 24
+        assert mock_token_urlsafe.call_count == 2
+        mock_token_urlsafe.assert_called_with(18)
 
 
 class TestCreateLoadDeleteCredentials:


### PR DESCRIPTION
This retries per-environment PostgreSQL password generation when the random token begins with a dash, which Odoo's entrypoint misparses as a CLI option and otherwise causes a restart loop. It adds a deterministic regression test for the unsafe-first-token case and documents the fix in the current changelog. Validation: 14 credential tests and 781 non-integration, non-heavyweight tests passed; Ruff and diff checks are clean.