### PR TITLE
Mount Traefik ACME store into services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,38 @@ MCP Clients (Cursor, Claude, etc.)
 - Mocking pattern: patch `oduflow.docker_ops.*` functions, not Docker SDK directly
 - `conftest.py` at root ignores `src/**` for collection (tests live in `tests/`)
 
+### Testing the FreeSWITCH auxiliary service
+
+When Oduflow runs in Traefik TLS mode, every newly created or recreated
+auxiliary service automatically receives
+`oduflow-traefik-acme:/etc/traefik:ro`. Do not include that system volume in
+the MCP/CLI `volumes` argument; `/etc/traefik` is reserved. The implicit mount
+is not stored in the service preset, but `get_service_info` reports it from the
+live container.
+
+The test FreeSWITCH service must keep its own sounds volume and run in host
+mode. Use placeholders for deployment secrets — never commit the live values:
+
+```bash
+oduflow call create_service '{
+  "name": "fs",
+  "image": "oduist/freeswitch:latest",
+  "port": 8080,
+  "hostname": "fs",
+  "host_mode": true,
+  "volumes": "fs-sounds:/usr/share/freeswitch/sounds:rw",
+  "env_vars": "ODOO_URL=https://<environment-host>,FS_DOMAIN=<team-host>,FS_LOG_LEVEL=debug,FS_ESL_PASSWORD=<secret>,FS_SOFIA_LOG_LEVEL=2,SOUND_RATES=8000:16000:32000:48000,SOUND_TYPES=music:en-us-callie,EPMD=false,DUMPCAP=false,FS_WEBHOOK_TOKEN=<environment-token>"
+}'
+```
+
+`FS_WEBHOOK_TOKEN` must be the target environment's token. Before changing an
+existing `fs`, call `get_service_info`; `volumes` and `env_vars` overrides are
+full replacements. After deploying an Oduflow change, `update_service fs`
+recreates a legacy service that is missing the implicit ACME mount. Verify the
+result with `get_service_info fs`, confirm that `/etc/traefik/acme.json` is
+readable from the service, inspect the generated `wss.pem` issuer/dates, and
+then check the Odoo XML-RPC status.
+
 ## Plan First, Then Act
 
 Before making any code changes, always:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **Traefik certificates available to auxiliary services** — in Traefik TLS mode every created or recreated service receives the exact `oduflow-traefik-acme` volume at `/etc/traefik` read-only, with no per-service TLS flags or wildcard allowance for other system volumes. Existing services gain the mount on their next update.
 - **Per-team OAuth issuer with host-relative discovery** — in traefik mode, each team's OAuth Authorization Server derives its issuer from the incoming Host, so each team runs OAuth on its own already-certificated hostname with no need for a central `oauth_base_url`. `OduflowOAuthProvider` makes discovery metadata host-relative, `HostRelativeAuthChallenge` rewrites 401 challenge origins, and `[routing].hostname` is now validated per-mode (shared default deleted in traefik). (#112)
 - **Database-only Odoo template import** — `oduflow import-template` and `import_template_from_odoo` now accept `--without-filestore` / `without_filestore=True`, requesting a PostgreSQL custom-format dump without filestore files and deriving template metadata after restore.
 - **Attach separate template filestores** — new `oduflow attach-filestore` CLI and `attach_filestore` MCP tool attach or replace a template filestore after a database-only import. Sources can be local directories, zip/tar archives, `rsync://` URLs, or SSH rsync paths; wrapper directories such as the database name are auto-detected and live overlay env changes are preserved by default.
@@ -15,6 +16,7 @@
 
 ### Bug Fixes
 
+- **Invalid service volume updates are non-destructive** — `update_service` now resolves the complete candidate volume configuration before stopping the running container, so a missing or reserved volume no longer deletes the service before returning an error.
 - **Generated PostgreSQL passwords are safe for the Odoo entrypoint** — per-environment passwords that randomly began with `-` were parsed as another CLI option, leaving `--db_password` without a value and putting the Odoo container into a restart loop. Password generation now retries that rare token shape.
 - **Overlay filestore no longer duplicated into each environment** — `_ensure_user_site_packages` was recursively chowning `.local/share`, causing fuse-overlayfs to copy the entire template filestore (~10 GB) into each env's upper layer, defeating overlay space savings. Now chowns only the pip dirs non-recursively, keeping filestore overlay-bound. (#113)
 - **Overlay unmount now works on Ubuntu 24.04 with enforced fusermount AppArmor profile** — switched mount cleanup to try clean `umount` first (not mediated by the fusermount3 profile on Ubuntu 24.04+), falling back to `fusermount`/`fusermount3` helpers and lazy `umount -l` only as a last resort. (#113)
@@ -26,6 +28,7 @@
 
 ### Documentation & Testing
 
+- **Implicit service certificate-store decision record** — specs/0032 records the deliberate shared-read, read-only ACME mount and its trust-boundary consequences.
 - **Per-team OAuth decision record** — specs/0020 captures the evolution from a static `oauth_base_url` to host-relative issuer discovery. (#112)
 
 ## v1.64.0

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1490,7 +1490,17 @@ Services are:
 - Attached to the shared `oduflow-net` network (accessible by all Odoo containers)
 - Given an `unless-stopped` restart policy
 - Automatically routed through Traefik with HTTPS when in traefik mode
+- In Traefik TLS mode, automatically given the exact system mount `oduflow-traefik-acme:/etc/traefik:ro`
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
+
+### Traefik Certificate Store
+
+When Oduflow terminates TLS through Traefik, every auxiliary service can read
+Traefik's certificate store at `/etc/traefik/acme.json`. The mount is implicit:
+do not pass or override that system volume. It is always read-only and is not
+stored in service presets. This places all service images and operators inside
+the certificate-store trust boundary: read-only prevents modification, not
+disclosure of certificate private keys.
 
 ### Linux Capabilities
 
@@ -1533,13 +1543,14 @@ The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
 2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
-3. Pulls the target image (the override, or the current one)
-4. Decides whether to recreate:
+3. Resolves candidate volumes before touching the running container
+4. Pulls the target image (the override, or the current one)
+5. Decides whether to recreate:
     - If neither the image digest nor any setting changed → reports "already up-to-date"
-    - If the image digest changed or any setting was overridden → stops the old container, removes it, and creates a new one with the merged settings
-5. Updates the saved preset so subsequent `restore_service` calls use the new configuration
+    - If the image digest changed, any setting was overridden, or the implicit ACME mount is missing → stops the old container, removes it, and creates a new one with the merged settings
+6. Updates the saved preset so subsequent `restore_service` calls use the new configuration
 
-Overrides are optional: calling `update_service` with only `name` preserves the previous behaviour (pull and recreate only on digest change).
+Overrides are optional: calling `update_service` with only `name` pulls the current image and recreates only when its digest changed or the implicit ACME mount is missing.
 
 ## Service Presets
 
@@ -1830,10 +1841,10 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
+| `create_service` | ✓ | Create a managed service container; Traefik TLS mode implicitly mounts the exact ACME store at `/etc/traefik:ro` |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Pull latest image and/or change any service setting (env vars, image, port, hostname, host_mode, volumes, privileged, net_admin); recreates the container when anything changes and preserves the rest |
+| `update_service` | ✓ | Preflight volumes, pull/update settings, and recreate when needed, including to add a missing implicit ACME mount |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -168,6 +168,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `read_output` — read from a cached tool output by ID (paginate, grep, errors, tail)
 - `list_environments` / `get_environment_info` — inspect environments
 - `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_info` / `get_service_logs` / `run_service_command` — manage auxiliary services
+  - In Traefik TLS mode every service implicitly receives the exact `oduflow-traefik-acme:/etc/traefik:ro` mount; do not pass or override that system volume
 - `create_volume` / `list_volumes` / `inspect_volume` / `delete_volume` — manage Docker volumes
 - `read_file_in_volume` / `write_file_in_volume` / `search_in_volume` / `delete_file_in_volume` — manage files inside Docker volumes
 - `list_service_presets` / `restore_service` / `delete_service_preset` — manage service presets

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -41,10 +41,10 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin` (adds `NET_ADMIN` capability for VPN/tun/iptables) |
+| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin`; Traefik TLS mode implicitly mounts the exact ACME store at `/etc/traefik:ro` |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Pull latest image and/or change any service setting (env vars, image, port, hostname, host_mode, volumes, privileged, net_admin); recreates the container when anything changes and preserves the rest |
+| `update_service` | ✓ | Preflight volumes, pull the latest image and/or change any service setting; recreates when needed, including to add a missing implicit Traefik ACME mount |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
 | `get_service_logs` | | Retrieve service container logs |

--- a/docs/services.md
+++ b/docs/services.md
@@ -25,8 +25,24 @@ Services are:
 - Attached to the shared `oduflow-net` network (accessible by all Odoo containers)
 - Given an `unless-stopped` restart policy
 - Automatically routed through Traefik with HTTPS when in traefik mode
+- In Traefik TLS mode, automatically given the exact system mount `oduflow-traefik-acme:/etc/traefik:ro`
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
 - Always created from a freshly pulled image — `create_service` and `restore_service` explicitly pull before running, so mutable tags like `:latest` get the current published version instead of a stale local cache
+
+### Traefik Certificate Store
+
+When Oduflow terminates TLS through Traefik, every auxiliary service can read
+Traefik's certificate store at `/etc/traefik/acme.json`. The mount is implicit:
+do not add `oduflow-traefik-acme` to the `volumes` argument, and do not mount a
+different volume at `/etc/traefik`. Oduflow always mounts the exact system
+volume read-only; there is no wildcard allowance for other `oduflow-*` volumes.
+The implicit mount is runtime configuration and is not saved in the service
+preset.
+
+This deliberately makes the shared certificate and private-key material
+readable to every service container. Use only trusted service images and grant
+service-management access only to trusted operators. Read-only protects the
+store from modification, not from disclosure.
 
 ### Linux Capabilities
 
@@ -85,13 +101,14 @@ The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
 2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
-3. Pulls the target image (the override, or the current one)
-4. Decides whether to recreate:
+3. Resolves the complete candidate volume configuration before touching the running container; invalid or missing volumes fail without stopping it
+4. Pulls the target image (the override, or the current one)
+5. Decides whether to recreate:
     - If neither the image digest nor any setting changed → reports "already up-to-date"
-    - If the image digest changed or any setting was overridden → stops the old container, removes it, and creates a new one with the merged settings
-5. Updates the saved preset so subsequent `restore_service` calls use the new configuration
+    - If the image digest changed, any setting was overridden, or a legacy Traefik TLS service lacks the implicit ACME mount → stops the old container, removes it, and creates a new one with the merged settings
+6. Updates the saved preset so subsequent `restore_service` calls use the new configuration
 
-Overrides are optional: calling `update_service` with only `name` preserves the previous behaviour (pull and recreate only on digest change).
+Overrides are optional: calling `update_service` with only `name` pulls the current image and recreates only when its digest changed or the implicit ACME mount is missing.
 
 ## Service Presets
 

--- a/specs/0032-implicit-traefik-acme-mount-for-services.md
+++ b/specs/0032-implicit-traefik-acme-mount-for-services.md
@@ -1,0 +1,74 @@
+# 0032 — Auxiliary services receive the Traefik ACME store read-only
+
+**Status:** Adopted (still in force)
+**Type:** Architecture / Security boundary
+**First introduced:** `litnimax/whitelist-traefik-acme-volume` branch (2026-07-13)
+**Key code today:** `docker_ops/service_ops.py` (implicit mount and update preflight), service guidance in `templates/agent_guides/agent_instructions.md`
+
+## Context
+
+Some auxiliary services terminate their own TLS rather than leaving termination
+to Traefik. FreeSWITCH is the concrete case: its Verto/WSS startup needs the
+certificate material that Traefik has already obtained from Let's Encrypt and
+stored in `acme.json`.
+
+Oduflow's hard tenant-isolation pass deliberately rejected every raw
+`oduflow-*` volume supplied through the public service `volumes` argument. That
+closed access to the shared database, other teams' managed volumes, and system
+volumes, but also made Traefik's ACME store unavailable. Attempting to add it to
+an existing service exposed a second problem: `update_service` validated the
+volume only while recreating, after the old container had already been removed.
+
+Per-service certificate projection, new TLS flags, and a certificate-delivery
+API were considered. They add lifecycle and renewal machinery that is not
+needed for the operating model: services are trusted containers, and whether a
+service consumes the mounted store is the service's concern.
+
+## Decision
+
+In Traefik TLS mode, mount the exact deployment ACME volume into **every**
+auxiliary service at `/etc/traefik`, always read-only. The mount is platform
+configuration: callers neither request nor override it, and it is not persisted
+in service presets. There is no prefix or wildcard allowance for raw system
+volumes; all user-supplied `oduflow-*` mounts remain forbidden.
+
+Also preflight the complete candidate volume configuration in `update_service`
+before stopping or removing the current container. This addresses configuration
+errors such as missing or reserved volumes; it is not a general transactional
+rollback for arbitrary Docker failures after recreation begins.
+
+## How it works (macro)
+
+- `create_service` resolves caller-supplied volumes normally, verifies the exact
+  configured Traefik ACME volume exists, then adds
+  `volume:/etc/traefik:ro` to the Docker run configuration.
+- `/etc/traefik` is reserved while the implicit mount is active, so a caller
+  cannot obscure it with another volume. Port mode and Traefik installations
+  where Oduflow does not terminate TLS do not receive the mount.
+- `update_service` resolves the resulting mounts before pulling or deleting.
+  A legacy service whose live container lacks the implicit mount is treated as
+  configuration drift and recreated on an otherwise ordinary update.
+- Presets continue to describe only user-controlled service configuration.
+  Live inspection reports the implicit mount from Docker's actual mount list.
+
+## Consequences
+
+- FreeSWITCH and similar trusted services can consume `acme.json` without a
+  special public API, custom TLS parameters, or manual raw system-volume access.
+- Read-only protects certificate-store integrity and Traefik availability, but
+  not confidentiality. Every service can read and exfiltrate all certificate
+  and private-key material in the shared store; service images and operators
+  are therefore inside the deployment trust boundary.
+- This intentionally weakens the cross-service and cross-team confidentiality
+  guarantee established by [[0027-hard-tenant-isolation]], while preserving the
+  prohibition on database volumes, other teams' managed volumes, and arbitrary
+  system-volume name patterns.
+- Invalid volume overrides no longer reproduce the observed delete-then-fail
+  path. Failures after destructive recreation begins remain outside this narrow
+  guardrail.
+
+## History
+
+- `litnimax/whitelist-traefik-acme-volume` (2026-07-13) — implicit exact
+  read-only ACME mount for all Traefik TLS auxiliary services, legacy drift
+  detection, and pre-removal volume validation.

--- a/specs/README.md
+++ b/specs/README.md
@@ -50,6 +50,7 @@ precursors).
 | [0029](0029-agent-console-and-chat.md) | 2026-07-03 | Per-team coding agent: browser console and ACP chat |
 | [0030](0030-odoo-sh-addons-import.md) | 2026-07-04 | Odoo.sh import brings the addons-path (Enterprise/Themes/extra) + local extra-addons + template rename |
 | [0031](0031-connect-as-user-impersonation.md) | 2026-07-09 | Passwordless "Connect as user" session minting (`connect_as_user`) for agent browser testing |
+| [0032](0032-implicit-traefik-acme-mount-for-services.md) | 2026-07-13 | Auxiliary services receive the Traefik ACME store read-only |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import datetime
 import logging
+import posixpath
 import re
+from typing import Any
 
 import docker
 
@@ -14,6 +16,8 @@ from oduflow.naming import get_service_container_name
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
+
+_TRAEFIK_ACME_MOUNT_PATH = "/etc/traefik"
 
 _SYSTEM_ENV_KEYS = {
     "PATH",
@@ -48,6 +52,69 @@ _SYSTEM_ENV_KEYS = {
     "SSH_AGENT_PID",
     "DBUS_SESSION_BUS_ADDRESS",
 }
+
+
+def _resolve_service_volume_binds(
+    settings: Settings,
+    team: TeamSettings,
+    volumes: list[dict[str, str]] | None,
+    *,
+    client: Any = None,
+) -> dict[str, dict[str, str]]:
+    """Resolve user mounts and add the implicit Traefik ACME mount.
+
+    The ACME store is platform-owned rather than part of the user-supplied
+    service configuration. Every service created while Oduflow terminates TLS
+    through Traefik sees the exact store at ``/etc/traefik`` read-only.
+    """
+    volume_binds: dict[str, dict[str, str]] = volume_ops.resolve_volume_binds(
+        team, volumes or []
+    )
+
+    if settings.routing_mode != "traefik" or not settings.routing_tls:
+        return volume_binds
+
+    for mount in volumes or []:
+        mount_path = posixpath.normpath(mount.get("mount_path", ""))
+        if mount_path == _TRAEFIK_ACME_MOUNT_PATH or mount_path.startswith(
+            f"{_TRAEFIK_ACME_MOUNT_PATH}/"
+        ):
+            raise ConflictError(
+                f"Mount path '{mount.get('mount_path')}' is inside reserved "
+                f"'{_TRAEFIK_ACME_MOUNT_PATH}', which Oduflow uses for "
+                "the read-only Traefik certificate store."
+            )
+
+    docker_client = client or get_client()
+    try:
+        docker_client.volumes.get(settings.traefik_acme_volume)
+    except docker.errors.NotFound:
+        raise NotFoundError(
+            f"Traefik ACME volume '{settings.traefik_acme_volume}' not found. "
+            "Run init_system before creating services in Traefik TLS mode."
+        )
+
+    volume_binds[settings.traefik_acme_volume] = {
+        "bind": _TRAEFIK_ACME_MOUNT_PATH,
+        "mode": "ro",
+    }
+    return volume_binds
+
+
+def _needs_traefik_acme_mount(settings: Settings, container: Any) -> bool:
+    """Whether a Traefik TLS service is missing the implicit ACME mount."""
+    if settings.routing_mode != "traefik" or not settings.routing_tls:
+        return False
+
+    for mount in container.attrs.get("Mounts", []):
+        if (
+            mount.get("Type") == "volume"
+            and mount.get("Name") == settings.traefik_acme_volume
+            and mount.get("Destination") == _TRAEFIK_ACME_MOUNT_PATH
+            and not mount.get("RW", True)
+        ):
+            return False
+    return True
 
 
 def create_service(
@@ -136,10 +203,9 @@ def create_service(
     if env_vars:
         run_kwargs["environment"] = env_vars
 
-    if volumes:
-        vol_binds = volume_ops.resolve_volume_binds(team, volumes)
-        if vol_binds:
-            run_kwargs["volumes"] = vol_binds
+    vol_binds = _resolve_service_volume_binds(settings, team, volumes, client=client)
+    if vol_binds:
+        run_kwargs["volumes"] = vol_binds
 
     if privileged:
         run_kwargs["privileged"] = True
@@ -533,7 +599,10 @@ def update_service(
         raise NotFoundError(f"Cannot determine port for service '{name}'.")
 
     # Apply overrides and track whether config changed
-    config_changed = False
+    # Services created before the implicit ACME mount was introduced are
+    # brought forward by an ordinary update, even when the image digest and
+    # user-controlled settings are otherwise unchanged.
+    config_changed = _needs_traefik_acme_mount(settings, container)
     if env_override is not None and env_override != (env_vars or {}):
         env_vars = env_override or None
         config_changed = True
@@ -560,6 +629,11 @@ def update_service(
     target_image = image_override if image_override else old_image
     if image_override and image_override != old_image:
         config_changed = True
+
+    # Validate the complete candidate volume configuration before any
+    # destructive action. In particular, a missing/reserved volume override
+    # must not stop and remove the currently running service.
+    _resolve_service_volume_binds(settings, team, old_volumes or None, client=client)
 
     # Capture old image digest
     old_digest = container.image.id  # e.g. sha256:abc...

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2036,7 +2036,7 @@ def create_service(
         hostname: Custom hostname for traefik routing (optional, traefik mode only).
         env_vars: Comma-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production").
         host_mode: Run the container in host network mode instead of the shared Docker network. Use when the service needs direct host network access. Traefik routing still works.
-        volumes: Comma-separated volume mounts (e.g. "mydata:/data,config:/etc/app:ro"). Each entry is volume_name:/container/path[:ro|rw]. Volumes must be created first via create_volume.
+        volumes: Comma-separated volume mounts (e.g. "mydata:/data,config:/etc/app:ro"). Each entry is volume_name:/container/path[:ro|rw]. Volumes must be created first via create_volume. In Traefik TLS mode the system ACME volume is mounted automatically at /etc/traefik:ro; do not include it here.
         privileged: Run the container in privileged mode (full host access). Use with care — implies all Linux capabilities. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
         net_admin: Add the NET_ADMIN Linux capability. Required for VPN/WireGuard, tun/tap devices, and iptables manipulation inside the container.
     """
@@ -2107,7 +2107,7 @@ def update_service(
         port: New container port. Pass 0 to keep current port.
         hostname: New hostname for traefik routing. Leave empty to keep current hostname.
         host_mode: Run in host network mode. Leave unset (null) to keep current mode.
-        volumes: Comma-separated volume mounts that fully replace existing volumes (e.g. "mydata:/data,config:/etc/app:ro"). Leave empty to keep current volumes.
+        volumes: Comma-separated volume mounts that fully replace existing user volumes (e.g. "mydata:/data,config:/etc/app:ro"). Leave empty to keep current volumes. The implicit Traefik TLS mount at /etc/traefik:ro is preserved separately.
         privileged: Run the container in privileged mode (full host access). Leave unset (null) to keep current mode. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
         net_admin: Add (True) or remove (False) the NET_ADMIN Linux capability — required for VPN/WireGuard, tun/tap, and iptables. Leave unset (null) to keep current capabilities.
     """
@@ -2227,12 +2227,28 @@ def get_service_info(name: str, ctx: Context = None) -> str:
         lines.append("Privileged: true")
     if info.get("cap_add"):
         lines.append(f"Capabilities: {','.join(info['cap_add'])}")
-    if info.get("volumes"):
+    user_volumes = []
+    system_volumes = []
+    for volume in info.get("volumes") or []:
+        if (
+            volume.get("volume") == settings.traefik_acme_volume
+            and volume.get("mount_path") == "/etc/traefik"
+        ):
+            system_volumes.append(volume)
+        else:
+            user_volumes.append(volume)
+    if user_volumes:
         vol_str = ", ".join(
             f"{v['volume']}:{v['mount_path']}:{v.get('mode', 'rw')}"
-            for v in info["volumes"]
+            for v in user_volumes
         )
         lines.append(f"Volumes: {vol_str}")
+    if system_volumes:
+        system_str = ", ".join(
+            f"{v['volume']}:{v['mount_path']}:{v.get('mode', 'rw')}"
+            for v in system_volumes
+        )
+        lines.append(f"System mounts: {system_str} (implicit; do not pass as volumes)")
     if info.get("env_vars"):
         env_str = ", ".join(f"{k}={v}" for k, v in info["env_vars"].items())
         lines.append(f"Env: {env_str}")

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -128,7 +128,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 
 | Tool | When to use |
 |---|---|
-| `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access. The image is always pulled fresh, so mutable tags like `:latest` get the current version |
+| `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access. The image is always pulled fresh, so mutable tags like `:latest` get the current version. In Traefik TLS mode Oduflow automatically mounts `oduflow-traefik-acme:/etc/traefik:ro`; do not pass that system volume yourself |
 | `get_service_info(name)` | **Use this before recreating a service.** Returns full live state: image + digest, port, hostname, URL, `host_mode`, `volumes`, env vars, `cap_add`, `privileged`, restart count, started_at, whether a preset exists |
 | `update_service(name, env_vars?, image?, port?, hostname?, host_mode?, volumes?, privileged?, net_admin?)` | Change **any** setting on a running service. Without overrides, pulls the latest image. With any override, fully replaces that setting and recreates the container, preserving everything else. `env_vars` and `volumes` are full replacements, not merges. This is the preferred way to change a service |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
@@ -137,7 +137,9 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 | `delete_service_preset(name)` | Remove a saved service preset |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 
-> **Changing a service:** use `update_service` for **any** change — image, env vars, port, hostname, host_mode, volumes, privileged, or net_admin. It recreates the container automatically and preserves every setting you don't override, so you almost never need to `delete_service` + `create_service` by hand. (If you do recreate manually — e.g. to rename a service — call `get_service_info(name)` first and replay its `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged` in the new `create_service` call, otherwise you'll silently drop them.)
+> **Changing a service:** use `update_service` for **any** change — image, env vars, port, hostname, host_mode, volumes, privileged, or net_admin. It recreates the container automatically and preserves every setting you don't override, so you almost never need to `delete_service` + `create_service` by hand. (If you do recreate manually — e.g. to rename a service — call `get_service_info(name)` first and replay its `image`, `port`, `hostname`, `env_vars`, `host_mode`, user `volumes`, `cap_add`, `privileged` in the new `create_service` call, otherwise you'll silently drop them. Omit any `System mounts` such as the implicit Traefik ACME mount; Oduflow adds those itself.)
+
+> **Traefik TLS certificate store:** every service receives the exact system volume at `/etc/traefik` read-only. It is implicit and not part of the preset or the user-supplied `volumes` replacement. `/etc/traefik` is reserved, and all other raw `oduflow-*` volumes remain forbidden. `update_service` validates candidate volumes before stopping the current container.
 
 ### Volumes
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -525,6 +525,39 @@ class TestListServicesTool:
         assert "No active services" in result
 
 
+class TestGetServiceInfoTool:
+    @patch("oduflow.docker_ops.service_ops.get_service_info")
+    def test_system_acme_mount_is_not_reported_as_replayable_volume(self, mock_info):
+        mock_info.return_value = {
+            "name": "fs",
+            "container_name": "oduflow-1-svc-fs",
+            "status": "running",
+            "image": "oduist/freeswitch:latest",
+            "image_digest": "sha256:abc123",
+            "port": 8080,
+            "url": "https://fs.example.com",
+            "host_mode": True,
+            "volumes": [
+                {"volume": "fs-sounds", "mount_path": "/sounds", "mode": "rw"},
+                {
+                    "volume": "oduflow-traefik-acme",
+                    "mount_path": "/etc/traefik",
+                    "mode": "ro",
+                },
+            ],
+            "has_preset": True,
+        }
+
+        result = _get_tool_fn("get_service_info")(name="fs")
+
+        assert "Volumes: fs-sounds:/sounds:rw" in result
+        assert "Volumes: fs-sounds:/sounds:rw, oduflow-traefik-acme" not in result
+        assert (
+            "System mounts: oduflow-traefik-acme:/etc/traefik:ro "
+            "(implicit; do not pass as volumes)"
+        ) in result
+
+
 class TestGetServiceLogsTool:
     @patch("oduflow.docker_ops.service_ops.get_service_logs")
     def test_logs(self, mock_logs):

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -56,10 +56,12 @@ def mock_docker_client():
     with (
         patch("oduflow.docker_ops.service_ops.get_client") as svc_mock,
         patch("oduflow.docker_ops.system_ops.get_client") as sys_mock,
+        patch("oduflow.docker_ops.volume_ops.get_client") as vol_mock,
     ):
         client_instance = MagicMock()
         svc_mock.return_value = client_instance
         sys_mock.return_value = client_instance
+        vol_mock.return_value = client_instance
         yield client_instance
 
 
@@ -129,6 +131,95 @@ class TestCreateService:
             labels["traefik.http.routers.oduflow-1-svc-meilisearch.tls.certresolver"]
             == "letsencrypt"
         )
+        assert run_kwargs[1]["volumes"] == {
+            "oduflow-traefik-acme": {"bind": "/etc/traefik", "mode": "ro"}
+        }
+
+    def test_create_traefik_mounts_acme_with_user_volumes(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        service_ops.create_service(
+            TRAEFIK_SETTINGS,
+            TRAEFIK_TEAM,
+            "meilisearch",
+            "getmeili/meilisearch:v1.6",
+            7700,
+            volumes=[{"volume": "data", "mount_path": "/data", "mode": "rw"}],
+        )
+
+        assert mock_docker_client.containers.run.call_args[1]["volumes"] == {
+            "oduflow-vol-1-data": {"bind": "/data", "mode": "rw"},
+            "oduflow-traefik-acme": {"bind": "/etc/traefik", "mode": "ro"},
+        }
+
+    def test_create_traefik_host_mode_mounts_acme(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        service_ops.create_service(
+            TRAEFIK_SETTINGS,
+            TRAEFIK_TEAM,
+            "fs",
+            "oduist/freeswitch:latest",
+            8080,
+            host_mode=True,
+            volumes=[
+                {
+                    "volume": "fs-sounds",
+                    "mount_path": "/usr/share/freeswitch/sounds",
+                    "mode": "rw",
+                }
+            ],
+        )
+
+        run_kwargs = mock_docker_client.containers.run.call_args[1]
+        assert run_kwargs["network_mode"] == "host"
+        assert run_kwargs["volumes"] == {
+            "oduflow-vol-1-fs-sounds": {
+                "bind": "/usr/share/freeswitch/sounds",
+                "mode": "rw",
+            },
+            "oduflow-traefik-acme": {"bind": "/etc/traefik", "mode": "ro"},
+        }
+
+    def test_create_traefik_rejects_user_mount_at_reserved_path(
+        self, mock_docker_client
+    ):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(ConflictError, match="inside reserved '/etc/traefik'"):
+            service_ops.create_service(
+                TRAEFIK_SETTINGS,
+                TRAEFIK_TEAM,
+                "meilisearch",
+                "getmeili/meilisearch:v1.6",
+                7700,
+                volumes=[
+                    {
+                        "volume": "config",
+                        "mount_path": "/etc/traefik",
+                        "mode": "rw",
+                    }
+                ],
+            )
+
+        mock_docker_client.images.pull.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
+
+    def test_create_traefik_requires_acme_volume(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        with pytest.raises(NotFoundError, match="Traefik ACME volume.*not found"):
+            service_ops.create_service(
+                TRAEFIK_SETTINGS,
+                TRAEFIK_TEAM,
+                "meilisearch",
+                "getmeili/meilisearch:v1.6",
+                7700,
+            )
+
+        mock_docker_client.images.pull.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
 
     def test_create_traefik_no_tls(self, mock_docker_client):
         # tls=false (e.g. behind a Cloudflare tunnel): router on the plain-HTTP
@@ -159,6 +250,7 @@ class TestCreateService:
             "traefik.http.routers.oduflow-1-svc-meilisearch.tls.certresolver"
             not in labels
         )
+        assert "volumes" not in mock_docker_client.containers.run.call_args[1]
 
     def test_create_traefik_custom_hostname(self, mock_docker_client):
         mock_docker_client.networks.get.return_value = MagicMock()
@@ -471,7 +563,8 @@ class TestUpdateService:
             ) as mock_resolve,
         ):
             service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
-            mock_resolve.assert_called_once_with(TEST_TEAM, volumes)
+            assert mock_resolve.call_count == 2
+            mock_resolve.assert_any_call(TEST_TEAM, volumes)
 
     def test_update_port_mode_legacy_no_preset(self, mock_docker_client):
         """Legacy fallback: extract settings from container when no preset exists."""
@@ -630,7 +723,17 @@ class TestUpdateService:
         container = self._make_container(
             image_tags=["getmeili/meilisearch:v1.6"],
             labels={"oduflow.managed": "true", "oduflow.service": "meili"},
-            attrs={"Config": {"Env": []}},
+            attrs={
+                "Config": {"Env": []},
+                "Mounts": [
+                    {
+                        "Type": "volume",
+                        "Name": "oduflow-traefik-acme",
+                        "Destination": "/etc/traefik",
+                        "RW": False,
+                    }
+                ],
+            },
         )
         container.image.id = "sha256:same"
 
@@ -660,11 +763,88 @@ class TestUpdateService:
         container.remove.assert_not_called()
         mock_docker_client.containers.run.assert_not_called()
 
+    def test_update_adds_missing_implicit_traefik_acme_mount(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["getmeili/meilisearch:v1.6"],
+            labels={"oduflow.managed": "true", "oduflow.service": "meili"},
+            attrs={"Config": {"Env": []}, "Mounts": []},
+        )
+        container.image.id = "sha256:same"
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        pulled = MagicMock()
+        pulled.id = "sha256:same"
+        mock_docker_client.images.pull.return_value = pulled
+        preset = {
+            "name": "meili",
+            "image": "getmeili/meilisearch:v1.6",
+            "port": 7700,
+            "hostname": "meili",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(TRAEFIK_SETTINGS, TRAEFIK_TEAM, "meili")
+
+        assert result["image_updated"] is False
+        assert result["config_updated"] is True
+        container.stop.assert_called_once()
+        container.remove.assert_called_once_with(v=True)
+        assert mock_docker_client.containers.run.call_args[1]["volumes"] == {
+            "oduflow-traefik-acme": {"bind": "/etc/traefik", "mode": "ro"}
+        }
+
     def test_update_not_found(self, mock_docker_client):
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
         with pytest.raises(NotFoundError, match="Service 'redis' not found"):
             service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+
+    def test_update_reserved_volume_preflight_does_not_remove_running_service(
+        self, mock_docker_client
+    ):
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        mock_docker_client.containers.get.return_value = container
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            with pytest.raises(NotFoundError, match="reserved"):
+                service_ops.update_service(
+                    TEST_SETTINGS,
+                    TEST_TEAM,
+                    "redis",
+                    volume_override=[
+                        {
+                            "volume": "oduflow-traefik-acme",
+                            "mount_path": "/data",
+                            "mode": "rw",
+                        }
+                    ],
+                )
+
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+        mock_docker_client.images.pull.assert_not_called()
 
     def test_update_image_fallback_to_config(self, mock_docker_client):
         """When image.tags is empty, fall back to Config.Image."""


### PR DESCRIPTION
## Summary
- mount the Traefik ACME volume into auxiliary services read-only in Traefik TLS mode
- preflight service volume resolution before destructive update/recreate operations
- separate implicit system mounts from replayable volumes in get_service_info output and update agent guidance
- document the architecture decision and service behavior

## Tests
- source .venv/bin/activate && pytest tests/test_server.py tests/test_service_ops.py tests/test_volume_ops.py -q
- source .venv/bin/activate && pytest -m "not integration and not heavyweight" -q
- source .venv/bin/activate && ruff check src/oduflow/docker_ops/service_ops.py src/oduflow/server.py tests/test_service_ops.py tests/test_server.py
- git diff HEAD --check

Note: full default pytest also runs integration tests here and currently errors in tests/conftest.py because get_resource_name() is called without team_id; that fixture path is outside this change.