### PR TITLE
Bound MCP HTTP graceful shutdown

### DIFF
--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3946,7 +3946,18 @@ def _start_http() -> None:
 
         served = HostRelativeAuthChallenge(served, settings)
 
-    uvicorn.run(served, host=host, port=port, ws="websockets-sansio")
+    # Bound the graceful-shutdown window: MCP clients hold long-lived
+    # StreamableHTTP streams (SSE GET/keep-alive) that never close on their own,
+    # so without a cap uvicorn waits indefinitely on SIGTERM and systemd escalates
+    # to SIGKILL after TimeoutStopSec (~90s). Force-close lingering connections
+    # after 10s so a stop/restart completes cleanly instead of being killed.
+    uvicorn.run(
+        served,
+        host=host,
+        port=port,
+        ws="websockets-sansio",
+        timeout_graceful_shutdown=10,
+    )
 
 
 def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
- Add a 10s Uvicorn graceful-shutdown timeout for HTTP transport so long-lived MCP StreamableHTTP streams do not keep restarts waiting indefinitely.

## Validation
- .venv/bin/python -m pytest tests/test_server.py::TestHttpFailClosed::test_start_http_allows_insecure_with_flag -q