### PR TITLE
Log real client IPs behind Traefik

### DIFF
--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3946,6 +3946,13 @@ def _start_http() -> None:
 
         served = HostRelativeAuthChallenge(served, settings)
 
+    # Behind Traefik every request arrives from the proxy's container IP, so
+    # uvicorn's access log and the login rate-limiter would see one shared peer
+    # instead of the real client. Trust X-Forwarded-For only in traefik mode
+    # (uvicorn rewrites scope["client"] from it); in port mode the peer is the
+    # real client and trusting forwarded headers would let it spoof its IP.
+    forwarded_allow_ips = "*" if settings.routing_mode == "traefik" else None
+
     # Bound the graceful-shutdown window: MCP clients hold long-lived
     # StreamableHTTP streams (SSE GET/keep-alive) that never close on their own,
     # so without a cap uvicorn waits indefinitely on SIGTERM and systemd escalates
@@ -3957,6 +3964,8 @@ def _start_http() -> None:
         port=port,
         ws="websockets-sansio",
         timeout_graceful_shutdown=10,
+        proxy_headers=True,
+        forwarded_allow_ips=forwarded_allow_ips,
     )
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -893,3 +893,53 @@ class TestHttpFailClosed:
         ):
             server._start_http()
             mock_uvicorn.assert_called_once()
+
+    def test_port_mode_does_not_trust_forwarded_ips(self):
+        # In port mode the TCP peer is the real client; trusting X-Forwarded-For
+        # would let it spoof its IP, so uvicorn keeps the default trust list.
+        from oduflow import server
+
+        settings = Settings(
+            host="127.0.0.1",
+            teams={"1": TeamSettings(team_id="1")},
+            allow_insecure_http=True,
+            routing_mode="port",
+        )
+        with (
+            patch.object(server, "_get_settings", return_value=settings),
+            patch.object(server, "_build_auth", return_value=None),
+            patch("fastmcp.server.http.create_streamable_http_app"),
+            patch("oduflow.web_ui.mount_web_ui"),
+            patch("oduflow.reaper.start_reaper"),
+            patch("uvicorn.run") as mock_uvicorn,
+        ):
+            server._start_http()
+            _, kwargs = mock_uvicorn.call_args
+            assert kwargs["proxy_headers"] is True
+            assert kwargs["forwarded_allow_ips"] is None
+
+    def test_traefik_mode_trusts_forwarded_ips(self):
+        # Behind Traefik the peer is always the proxy, so uvicorn must read the
+        # real client IP from X-Forwarded-For for the access log and login
+        # rate-limiter.
+        from oduflow import server
+
+        settings = Settings(
+            host="0.0.0.0",
+            teams={"1": TeamSettings(team_id="1", hostname="t1.example.com")},
+            allow_insecure_http=True,
+            routing_mode="traefik",
+            routing_tls=False,
+        )
+        with (
+            patch.object(server, "_get_settings", return_value=settings),
+            patch.object(server, "_build_auth", return_value=None),
+            patch("fastmcp.server.http.create_streamable_http_app"),
+            patch("oduflow.web_ui.mount_web_ui"),
+            patch("oduflow.reaper.start_reaper"),
+            patch("uvicorn.run") as mock_uvicorn,
+        ):
+            server._start_http()
+            _, kwargs = mock_uvicorn.call_args
+            assert kwargs["proxy_headers"] is True
+            assert kwargs["forwarded_allow_ips"] == "*"


### PR DESCRIPTION
## Problem

Access logs (and the login rate-limiter) recorded the Traefik container IP (`172.19.0.3`) for every request instead of the real client, because uvicorn logs the direct TCP peer and behind Traefik that peer is always the proxy. uvicorn only trusts `X-Forwarded-For` from `127.0.0.1` by default, so Traefik's forwarded header was ignored.

## Fix

Pass `proxy_headers=True` and `forwarded_allow_ips` to `uvicorn.run`. The trust list is `"*"` **only** in `routing_mode == "traefik"`; in `port` mode it stays `None` (default) so a direct client can't spoof its IP via `X-Forwarded-For`. uvicorn's `ProxyHeadersMiddleware` then rewrites `scope["client"]` to the real client IP.

Side benefit: the login rate-limiter (`web_ui.py`) now throttles per real client instead of lumping every client behind Traefik under one shared IP.

## Notes

- The unrelated "302 Found on `/.env`, `/xmlrpc.php`, …" log lines are just `BasicAuthMiddleware` redirecting unauthenticated scanners to `/login` before routing — expected, not a bug.
- No new `oduflow.toml` knobs.

## Tests

Added `test_port_mode_does_not_trust_forwarded_ips` and `test_traefik_mode_trusts_forwarded_ips`; full `TestHttpFailClosed` passes. `ruff`/`format` clean.