### PR TITLE
Resolve Greptile follow-ups from PRs 114-123

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -84,6 +84,15 @@ def _normalize_extra_addons(raw_addons) -> dict[str, str]:
     return {}
 
 
+def _redact_repo_urls(text: str, *urls: str) -> str:
+    """Remove embedded credentials from known repository URLs in output."""
+    redacted = text
+    for url in urls:
+        if url:
+            redacted = redacted.replace(url, sanitize_repo_url(url))
+    return redacted
+
+
 def _get_used_ports(
     client: DockerClient,
     settings: Settings,
@@ -907,7 +916,11 @@ def create_environment(
                     f"Git authentication failed for {sanitize_repo_url(repo_url)}. "
                     f"Call 'setup_repo_auth' first to cache credentials."
                 )
-            raise ExternalCommandError("git clone", e.returncode, error_msg)
+            raise ExternalCommandError(
+                "git clone",
+                e.returncode,
+                _redact_repo_urls(error_msg, clone_url, repo_url),
+            )
         except subprocess.TimeoutExpired:
             raise ExternalCommandError(
                 "git clone",

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1858,6 +1858,7 @@ def attach_filestore(
                 metadata = {}
 
         target_filestore = team.get_template_filestore_path(template_name)
+        previous_filestore = os.path.join(staging_root, "previous")
         with env_ops.remount_template_overlays(
             client,
             settings,
@@ -1865,10 +1866,21 @@ def attach_filestore(
             template_name,
             reset_upper=reset_env_changes,
         ) as remount:
-            if os.path.exists(target_filestore):
-                shutil.rmtree(target_filestore)
+            had_previous = os.path.exists(target_filestore)
             os.makedirs(os.path.dirname(target_filestore), exist_ok=True)
-            os.rename(prepared_dir, target_filestore)
+            if had_previous:
+                # Keep the old lower layer until the prepared replacement is
+                # installed. Removing it first turns an otherwise recoverable
+                # rename error into a template with no filestore at all.
+                os.replace(target_filestore, previous_filestore)
+            if os.path.exists(target_filestore):
+                shutil.rmtree(target_filestore, ignore_errors=True)
+            try:
+                os.replace(prepared_dir, target_filestore)
+            except BaseException:
+                if had_previous and os.path.exists(previous_filestore):
+                    os.replace(previous_filestore, target_filestore)
+                raise
 
             odoo_image = str(metadata.get("odoo_image") or "")
             if odoo_image:
@@ -1885,6 +1897,9 @@ def attach_filestore(
                     logger.info("Template filestore chowned to %s", uid_gid)
                 except Exception as exc:  # noqa: BLE001 - chown is best-effort
                     logger.warning("Could not chown template filestore: %s", exc)
+
+            if os.path.exists(previous_filestore):
+                shutil.rmtree(previous_filestore, ignore_errors=True)
 
         metadata["includes_filestore"] = True
         metadata["use_overlay"] = None

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3835,27 +3835,27 @@ def _traefik_forwarded_allow_ips(settings: Settings) -> list[str]:
     Remote clients can reach the host-bound backend port directly, so trusting
     every peer (``*``) lets them spoof the client address used by login
     throttling. Trust only loopback (needed by Docker Desktop's forwarding) and
-    the live Traefik container's exact addresses.
+    the stable CIDRs of the Docker network that carries Traefik. A network CIDR
+    remains valid if Docker recreates Traefik with a different container IP.
     """
     trusted = {"127.0.0.1", "::1"}
-    try:
-        from oduflow.docker_ops.client import get_client
+    from oduflow.docker_ops.client import get_client
 
-        container = get_client().containers.get(settings.traefik_container)
-        container.reload()
-        network_settings = container.attrs.get("NetworkSettings", {})
-        candidates = [network_settings]
-        candidates.extend((network_settings.get("Networks") or {}).values())
-        for network in candidates:
-            for key in ("IPAddress", "GlobalIPv6Address"):
-                address = str(network.get(key) or "").strip()
-                if address:
-                    trusted.add(address)
-    except Exception as exc:  # noqa: BLE001 - fail closed to loopback-only trust
-        logger.warning(
-            "Could not resolve Traefik proxy addresses; forwarded headers will "
-            "be trusted from loopback only: %s",
-            exc,
+    try:
+        network = get_client().networks.get(settings.shared_network)
+        network.reload()
+        for config in network.attrs.get("IPAM", {}).get("Config", []):
+            subnet = str(config.get("Subnet") or "").strip()
+            if subnet:
+                trusted.add(subnet)
+    except Exception as exc:
+        raise PrerequisiteNotMetError(
+            f"Cannot resolve trusted proxy network '{settings.shared_network}': {exc}"
+        )
+    if len(trusted) == 2:
+        raise PrerequisiteNotMetError(
+            f"Docker network '{settings.shared_network}' has no IPAM subnet; "
+            "refusing wildcard or loopback-only proxy-header trust."
         )
     return sorted(trusted)
 
@@ -3979,8 +3979,8 @@ def _start_http() -> None:
 
     # Behind Traefik every request arrives from the proxy's container IP, so
     # uvicorn's access log and the login rate-limiter would see one shared peer
-    # instead of the real client. Trust X-Forwarded-For only from the exact
-    # Traefik peer addresses; wildcard trust lets a direct backend client spoof
+    # instead of the real client. Trust X-Forwarded-For only from Traefik's
+    # stable Docker network; wildcard trust lets a direct backend client spoof
     # its IP and bypass throttling. Port mode keeps Uvicorn's default trust.
     forwarded_allow_ips = (
         _traefik_forwarded_allow_ips(settings)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3829,6 +3829,37 @@ def _start_stdio() -> None:
         logger.info("Shutting down.")
 
 
+def _traefik_forwarded_allow_ips(settings: Settings) -> list[str]:
+    """TCP peers allowed to supply proxy headers to Uvicorn.
+
+    Remote clients can reach the host-bound backend port directly, so trusting
+    every peer (``*``) lets them spoof the client address used by login
+    throttling. Trust only loopback (needed by Docker Desktop's forwarding) and
+    the live Traefik container's exact addresses.
+    """
+    trusted = {"127.0.0.1", "::1"}
+    try:
+        from oduflow.docker_ops.client import get_client
+
+        container = get_client().containers.get(settings.traefik_container)
+        container.reload()
+        network_settings = container.attrs.get("NetworkSettings", {})
+        candidates = [network_settings]
+        candidates.extend((network_settings.get("Networks") or {}).values())
+        for network in candidates:
+            for key in ("IPAddress", "GlobalIPv6Address"):
+                address = str(network.get(key) or "").strip()
+                if address:
+                    trusted.add(address)
+    except Exception as exc:  # noqa: BLE001 - fail closed to loopback-only trust
+        logger.warning(
+            "Could not resolve Traefik proxy addresses; forwarded headers will "
+            "be trusted from loopback only: %s",
+            exc,
+        )
+    return sorted(trusted)
+
+
 def _start_http() -> None:
     """Start the MCP server (HTTP transport)."""
     from fastmcp.server.http import create_streamable_http_app
@@ -3870,8 +3901,8 @@ def _start_http() -> None:
     # ``all`` (not ``any``): a single passwordless team can never log in (auth is
     # global; empty passwords are skipped), so refuse rather than silently lock it
     # out.
-    if not settings.allow_insecure_http and not all(
-        t.ui_password for t in settings.teams.values()
+    if not settings.allow_insecure_http and (
+        not settings.teams or not all(t.ui_password for t in settings.teams.values())
     ):
         raise PrerequisiteNotMetError(
             "Refusing to start the HTTP transport with an unauthenticated web "
@@ -3948,10 +3979,14 @@ def _start_http() -> None:
 
     # Behind Traefik every request arrives from the proxy's container IP, so
     # uvicorn's access log and the login rate-limiter would see one shared peer
-    # instead of the real client. Trust X-Forwarded-For only in traefik mode
-    # (uvicorn rewrites scope["client"] from it); in port mode the peer is the
-    # real client and trusting forwarded headers would let it spoof its IP.
-    forwarded_allow_ips = "*" if settings.routing_mode == "traefik" else None
+    # instead of the real client. Trust X-Forwarded-For only from the exact
+    # Traefik peer addresses; wildcard trust lets a direct backend client spoof
+    # its IP and bypass throttling. Port mode keeps Uvicorn's default trust.
+    forwarded_allow_ips = (
+        _traefik_forwarded_allow_ips(settings)
+        if settings.routing_mode == "traefik"
+        else None
+    )
 
     # Bound the graceful-shutdown window: MCP clients hold long-lived
     # StreamableHTTP streams (SSE GET/keep-alive) that never close on their own,

--- a/tests/test_attach_filestore.py
+++ b/tests/test_attach_filestore.py
@@ -164,3 +164,36 @@ def test_attach_filestore_remote_source_builds_rsync_command(monkeypatch, tmp_pa
     )
 
     assert calls[0][-2] == "odoo@example.com:/srv/filestore/odoo19-mirage/"
+
+
+def test_attach_filestore_restores_previous_on_replace_failure(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    _write_metadata(team)
+    _patch_attach_dependencies(monkeypatch)
+    target = team.get_template_filestore_path("prod")
+    os.makedirs(os.path.join(target, "60"))
+    old_file = os.path.join(target, "60", HASH_60)
+    with open(old_file, "wb") as f:
+        f.write(b"old")
+    archive = tmp_path / "filestore.zip"
+    _zip(archive, {f"61/{HASH_61}": b"new"})
+
+    real_replace = os.replace
+    prepared_replace_seen = False
+
+    def fail_prepared_replace(src, dst):
+        nonlocal prepared_replace_seen
+        if os.path.basename(src) == "prepared":
+            prepared_replace_seen = True
+            raise OSError("replace failed")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(system_ops.os, "replace", fail_prepared_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        system_ops.attach_filestore(settings, team, "prod", str(archive))
+
+    assert prepared_replace_seen
+    assert os.path.isfile(old_file)
+    assert open(old_file, "rb").read() == b"old"
+    assert not os.path.exists(os.path.join(target, "61", HASH_61))

--- a/tests/test_extra_addons_clone.py
+++ b/tests/test_extra_addons_clone.py
@@ -44,7 +44,8 @@ def _make_git_source(tmp_path):
             text=True,
         )
 
-    _git("init", "-b", "main")
+    _git("init")
+    _git("checkout", "-b", "main")
     (mod / "__manifest__.py").write_text("{'name': 'Sale Enterprise'}")
     _git("add", "-A")
     _git(*_GIT_ID, "commit", "-m", "main commit")

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -204,6 +204,20 @@ class TestSetupRepoAuthSSRF:
         assert not os.path.exists(cred_file)
 
 
+class TestGitErrorRedaction:
+    def test_embedded_repo_credentials_are_removed_from_command_output(self):
+        from oduflow.docker_ops.env_ops import _redact_repo_urls
+
+        repo_url = "https://user:super-secret@example.com/acme/repo.git"
+        output = f"fatal: unable to access '{repo_url}': connection refused"
+
+        redacted = _redact_repo_urls(output, repo_url)
+
+        assert "super-secret" not in redacted
+        assert "user@" not in redacted
+        assert "https://example.com/acme/repo.git" in redacted
+
+
 class TestUiPasswordInjection:
     def test_injects_into_bootstrap_config(self):
         from oduflow.server import _inject_ui_password

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -957,31 +957,29 @@ class TestHttpFailClosed:
             patch.object(
                 server,
                 "_traefik_forwarded_allow_ips",
-                return_value=["127.0.0.1", "172.18.0.2"],
+                return_value=["127.0.0.1", "172.18.0.0/16"],
             ),
             patch("uvicorn.run") as mock_uvicorn,
         ):
             server._start_http()
             _, kwargs = mock_uvicorn.call_args
             assert kwargs["proxy_headers"] is True
-            assert kwargs["forwarded_allow_ips"] == ["127.0.0.1", "172.18.0.2"]
+            assert kwargs["forwarded_allow_ips"] == ["127.0.0.1", "172.18.0.0/16"]
 
-    def test_traefik_proxy_trust_uses_exact_container_addresses(self):
+    def test_traefik_proxy_trust_uses_stable_network_cidrs(self):
         from oduflow import server
 
-        settings = Settings(traefik_container="oduflow-traefik")
-        container = type(
-            "Container",
+        settings = Settings(shared_network="oduflow-net")
+        network = type(
+            "Network",
             (),
             {
                 "attrs": {
-                    "NetworkSettings": {
-                        "Networks": {
-                            "oduflow-net": {
-                                "IPAddress": "172.18.0.2",
-                                "GlobalIPv6Address": "fd00::2",
-                            }
-                        }
+                    "IPAM": {
+                        "Config": [
+                            {"Subnet": "172.18.0.0/16"},
+                            {"Subnet": "fd00::/64"},
+                        ]
                     }
                 },
                 "reload": lambda self: None,
@@ -990,15 +988,32 @@ class TestHttpFailClosed:
         client = type(
             "Client",
             (),
-            {
-                "containers": type(
-                    "Containers", (), {"get": lambda self, name: container}
-                )()
-            },
+            {"networks": type("Networks", (), {"get": lambda self, name: network})()},
         )()
 
         with patch("oduflow.docker_ops.client.get_client", return_value=client):
             trusted = server._traefik_forwarded_allow_ips(settings)
 
-        assert trusted == ["127.0.0.1", "172.18.0.2", "::1", "fd00::2"]
+        assert trusted == ["127.0.0.1", "172.18.0.0/16", "::1", "fd00::/64"]
         assert "*" not in trusted
+
+    def test_traefik_proxy_trust_fails_closed_without_network(self):
+        from oduflow import server
+        from oduflow.errors import PrerequisiteNotMetError
+
+        client = type(
+            "Client",
+            (),
+            {
+                "networks": type(
+                    "Networks",
+                    (),
+                    {"get": lambda self, name: (_ for _ in ()).throw(OSError("down"))},
+                )()
+            },
+        )()
+        with (
+            patch("oduflow.docker_ops.client.get_client", return_value=client),
+            pytest.raises(PrerequisiteNotMetError, match="trusted proxy network"),
+        ):
+            server._traefik_forwarded_allow_ips(Settings(shared_network="oduflow-net"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -894,6 +894,23 @@ class TestHttpFailClosed:
             server._start_http()
             mock_uvicorn.assert_called_once()
 
+    def test_start_http_refuses_empty_team_map(self):
+        from oduflow import server
+        from oduflow.errors import PrerequisiteNotMetError
+
+        settings = Settings(
+            host="127.0.0.1",
+            teams={},
+            allow_insecure_http=False,
+        )
+        with (
+            patch.object(server, "_get_settings", return_value=settings),
+            patch.object(server, "_ensure_web_ui_password", return_value=settings),
+            patch.object(server, "_build_auth", return_value=object()),
+        ):
+            with pytest.raises(PrerequisiteNotMetError, match="web dashboard"):
+                server._start_http()
+
     def test_port_mode_does_not_trust_forwarded_ips(self):
         # In port mode the TCP peer is the real client; trusting X-Forwarded-For
         # would let it spoof its IP, so uvicorn keeps the default trust list.
@@ -937,9 +954,51 @@ class TestHttpFailClosed:
             patch("fastmcp.server.http.create_streamable_http_app"),
             patch("oduflow.web_ui.mount_web_ui"),
             patch("oduflow.reaper.start_reaper"),
+            patch.object(
+                server,
+                "_traefik_forwarded_allow_ips",
+                return_value=["127.0.0.1", "172.18.0.2"],
+            ),
             patch("uvicorn.run") as mock_uvicorn,
         ):
             server._start_http()
             _, kwargs = mock_uvicorn.call_args
             assert kwargs["proxy_headers"] is True
-            assert kwargs["forwarded_allow_ips"] == "*"
+            assert kwargs["forwarded_allow_ips"] == ["127.0.0.1", "172.18.0.2"]
+
+    def test_traefik_proxy_trust_uses_exact_container_addresses(self):
+        from oduflow import server
+
+        settings = Settings(traefik_container="oduflow-traefik")
+        container = type(
+            "Container",
+            (),
+            {
+                "attrs": {
+                    "NetworkSettings": {
+                        "Networks": {
+                            "oduflow-net": {
+                                "IPAddress": "172.18.0.2",
+                                "GlobalIPv6Address": "fd00::2",
+                            }
+                        }
+                    }
+                },
+                "reload": lambda self: None,
+            },
+        )()
+        client = type(
+            "Client",
+            (),
+            {
+                "containers": type(
+                    "Containers", (), {"get": lambda self, name: container}
+                )()
+            },
+        )()
+
+        with patch("oduflow.docker_ops.client.get_client", return_value=client):
+            trusted = server._traefik_forwarded_allow_ips(settings)
+
+        assert trusted == ["127.0.0.1", "172.18.0.2", "::1", "fd00::2"]
+        assert "*" not in trusted


### PR DESCRIPTION
## Summary

- fail closed for empty team maps and trust forwarded headers only from loopback plus stable Traefik Docker-network CIDRs
- preserve the previous template filestore if installing a staged replacement fails
- redact embedded repository credentials from non-auth git clone failures
- keep the shallow-clone regression test compatible with older Git

## Validation

- `pytest -m "not integration and not heavyweight"` — 822 passed
- `ruff check src/oduflow tests`
- `git diff --check`
- `mypy src/oduflow` — baseline remains red with 393 pre-existing errors; not part of CI

Follow-ups for Greptile comments on #114, #115, #117, #118, and #123. The first Greptile review on this PR identified startup-computed container IP staleness; the follow-up commit uses stable network CIDRs and fails closed if Docker network trust cannot be established.