### PR TITLE
Make production restores atomic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ fastapi
 packaging
 cryptography
 itsdangerous
+boto3
+zstandard

--- a/src/oduflow/backup_ops.py
+++ b/src/oduflow/backup_ops.py
@@ -297,6 +297,83 @@ def _load_manifest(
     return manifest
 
 
+def _filestore_revision_from_manifest(manifest: dict[str, Any]) -> int:
+    """Validated filestore revision, where zero means an empty filestore."""
+    filestore = manifest.get("filestore")
+    if not isinstance(filestore, dict) or "revision" not in filestore:
+        raise PrerequisiteNotMetError(
+            "Snapshot manifest has no filestore revision; refusing to combine "
+            "its database with the current production filestore."
+        )
+    raw_revision = filestore["revision"]
+    try:
+        revision = int(raw_revision)
+    except (TypeError, ValueError):
+        raise PrerequisiteNotMetError(
+            "Snapshot manifest has an invalid filestore revision."
+        )
+    if (
+        isinstance(raw_revision, bool)
+        or (isinstance(raw_revision, float) and not raw_revision.is_integer())
+        or revision < 0
+    ):
+        raise PrerequisiteNotMetError(
+            "Snapshot manifest has an invalid filestore revision."
+        )
+    return revision
+
+
+def _swap_restored_filestore(
+    restore_dir: str, filestore_dir: str, old_dir: str
+) -> bool:
+    """Install a staged filestore, restoring the live directory on failure.
+
+    Return whether a previous live filestore was moved to ``old_dir``. The
+    caller removes that backup only after the database and filestore pair is
+    fully committed.
+    """
+    had_previous = os.path.isdir(filestore_dir)
+    if had_previous:
+        os.replace(filestore_dir, old_dir)
+    try:
+        os.replace(restore_dir, filestore_dir)
+    except BaseException:
+        if had_previous and os.path.isdir(old_dir):
+            os.replace(old_dir, filestore_dir)
+        raise
+    return had_previous
+
+
+def _rollback_database_swap(
+    client: Any,
+    settings: Settings,
+    db_name: str,
+    restore_db: str,
+    old_db: str,
+    pg_container: str,
+) -> None:
+    """Put the old live DB back and move the restored DB to scratch."""
+    _exec_sql(
+        client,
+        settings,
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+        f"WHERE datname = '{db_name}';",
+        container_name=pg_container,
+    )
+    _exec_sql(
+        client,
+        settings,
+        f'ALTER DATABASE "{db_name}" RENAME TO "{restore_db}";',
+        container_name=pg_container,
+    )
+    _exec_sql(
+        client,
+        settings,
+        f'ALTER DATABASE "{old_db}" RENAME TO "{db_name}";',
+        container_name=pg_container,
+    )
+
+
 def restore_production(
     settings: Settings,
     team: TeamSettings,
@@ -313,6 +390,7 @@ def restore_production(
     backup = _require_backup(settings)
     record = production_registry.get_production(team, name)
     manifest = _load_manifest(settings, team, name, snapshot_id)
+    fs_revision = _filestore_revision_from_manifest(manifest)
     client = get_client()
     env_name = prod_env_name(name)
     db_name = production_ops.prod_db_name(team, name)
@@ -332,13 +410,34 @@ def restore_production(
 
     container = production_ops._get_container(client, settings, team, name)
     was_running = container is not None and container.status == "running"
-    if container is not None and was_running:
-        container.stop()
 
     restore_db = f"{db_name}__restore"
     old_db = f"{db_name}__old"
+    filestore_parent = os.path.dirname(filestore_dir)
+    restore_dir = ""
+    old_dir = ""
+    container_stopped = False
     swapped = False
     try:
+        os.makedirs(filestore_parent, exist_ok=True)
+        restore_dir = tempfile.mkdtemp(
+            dir=filestore_parent, prefix=f".restore-{snapshot_id}-"
+        )
+        old_dir = tempfile.mkdtemp(dir=filestore_parent, prefix=f".old-{snapshot_id}-")
+        os.rmdir(old_dir)  # reserve a unique sibling path that does not yet exist
+
+        # Build the complete target filestore before the database is swapped.
+        # Revision zero is an exact empty-filestore snapshot, not an instruction
+        # to retain whatever happens to be live now.
+        if fs_revision > 0:
+            chunkstore.restore(
+                filestore_storage(settings, team), name, fs_revision, restore_dir
+            )
+        odoo_image = record.get("odoo_image", "")
+        if odoo_image:
+            uid_str, gid_str = get_odoo_uid_gid(client, odoo_image).split(":")
+            chown_recursive(restore_dir, int(uid_str), int(gid_str), client, odoo_image)
+
         # ------------------------ database ------------------------------
         with tempfile.TemporaryDirectory(dir=tmp_root) as tmpdir:
             dump_path = os.path.join(tmpdir, f"{snapshot_id}.pgdump")
@@ -397,6 +496,11 @@ def restore_production(
         )
 
         # Swap: terminate live connections, rename out, rename in.
+        # Everything above is prepared while Odoo remains available; downtime
+        # starts only for the paired database + filestore commit below.
+        if container is not None and was_running:
+            container.stop()
+            container_stopped = True
         _exec_sql(
             client,
             settings,
@@ -435,26 +539,22 @@ def restore_production(
             raise
 
         # ------------------------ filestore ------------------------------
-        fs_revision = int(manifest.get("filestore", {}).get("revision", 0) or 0)
-        if fs_revision > 0:
-            restore_dir = f"{filestore_dir}.restore-{snapshot_id}"
-            if os.path.isdir(restore_dir):
-                shutil.rmtree(restore_dir)
-            chunkstore.restore(
-                filestore_storage(settings, team), name, fs_revision, restore_dir
+        try:
+            had_previous_filestore = _swap_restored_filestore(
+                restore_dir, filestore_dir, old_dir
             )
-            odoo_image = record.get("odoo_image", "")
-            if odoo_image:
-                uid_str, gid_str = get_odoo_uid_gid(client, odoo_image).split(":")
-                chown_recursive(
-                    restore_dir, int(uid_str), int(gid_str), client, odoo_image
-                )
-            old_dir = f"{filestore_dir}.old-{snapshot_id}"
-            if os.path.isdir(filestore_dir):
-                os.replace(filestore_dir, old_dir)
-            os.replace(restore_dir, filestore_dir)
-            if os.path.isdir(old_dir):
-                shutil.rmtree(old_dir, ignore_errors=True)
+        except BaseException:
+            # The filesystem helper has already put the old filestore back.
+            # Compensate the successful database rename so callers never get a
+            # restored DB paired with stale/missing attachment files.
+            _rollback_database_swap(
+                client, settings, db_name, restore_db, old_db, pg_container
+            )
+            swapped = False
+            raise
+
+        if had_previous_filestore and os.path.isdir(old_dir):
+            shutil.rmtree(old_dir, ignore_errors=True)
 
         # Old database dropped only after everything else succeeded.
         _exec_sql(
@@ -464,6 +564,8 @@ def restore_production(
             container_name=pg_container,
         )
     finally:
+        if restore_dir and os.path.isdir(restore_dir):
+            shutil.rmtree(restore_dir, ignore_errors=True)
         if not swapped:
             # Failed before the swap: clean the half-restored database.
             try:
@@ -475,7 +577,7 @@ def restore_production(
                 )
             except Exception:
                 pass
-        if container is not None and was_running:
+        if container is not None and container_stopped:
             try:
                 container.start()
             except Exception:
@@ -532,7 +634,7 @@ def restore_production(
         "healthy": healthy,
         "warning": warning,
         "db_bytes": manifest["db"]["bytes"],
-        "filestore_revision": manifest.get("filestore", {}).get("revision", 0),
+        "filestore_revision": fs_revision,
     }
 
 

--- a/src/oduflow/backup_ops.py
+++ b/src/oduflow/backup_ops.py
@@ -417,6 +417,7 @@ def restore_production(
     restore_dir = ""
     old_dir = ""
     container_stopped = False
+    live_state_safe = True
     swapped = False
     try:
         os.makedirs(filestore_parent, exist_ok=True)
@@ -514,6 +515,11 @@ def restore_production(
             f"WHERE datname = '{db_name}';",
             container_name=pg_container,
         )
+        # From the first live rename until either the filestore commit or a
+        # complete rollback, an exception leaves the database name uncertain.
+        # Keep Odoo stopped unless one of those paths proves the live pair is
+        # coherent again.
+        live_state_safe = False
         _exec_sql(
             client,
             settings,
@@ -536,6 +542,7 @@ def restore_production(
                 f'ALTER DATABASE "{old_db}" RENAME TO "{db_name}";',
                 container_name=pg_container,
             )
+            live_state_safe = True
             raise
 
         # ------------------------ filestore ------------------------------
@@ -547,11 +554,14 @@ def restore_production(
             # The filesystem helper has already put the old filestore back.
             # Compensate the successful database rename so callers never get a
             # restored DB paired with stale/missing attachment files.
+            swapped = False
             _rollback_database_swap(
                 client, settings, db_name, restore_db, old_db, pg_container
             )
-            swapped = False
+            live_state_safe = True
             raise
+
+        live_state_safe = True
 
         if had_previous_filestore and os.path.isdir(old_dir):
             shutil.rmtree(old_dir, ignore_errors=True)
@@ -577,11 +587,19 @@ def restore_production(
                 )
             except Exception:
                 pass
-        if container is not None and container_stopped:
+        if container is not None and container_stopped and live_state_safe:
             try:
                 container.start()
             except Exception:
                 logger.exception("Could not restart production '%s'", name)
+        elif container is not None and container_stopped:
+            logger.error(
+                "Production '%s' remains stopped because database rollback "
+                "did not complete; inspect %s and %s before restarting",
+                name,
+                db_name,
+                old_db,
+            )
 
     healthy = production_ops.wait_production_healthy(
         client, settings, team, name, timeout=180

--- a/tests/test_backup_ops.py
+++ b/tests/test_backup_ops.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import hashlib
+import os
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from oduflow import backup_ops
-from oduflow.errors import ExternalCommandError
+from oduflow.docker_ops import production_ops
+from oduflow.errors import ExternalCommandError, PrerequisiteNotMetError
+from oduflow.settings import BackupSettings, Settings, TeamSettings
 
 
 class _FakeApi:
@@ -45,3 +52,185 @@ class TestDumpStream:
         assert next(gen) == b"partial"
         with pytest.raises(ExternalCommandError):
             next(gen)
+
+
+class TestFilestoreRestore:
+    def test_manifest_requires_explicit_revision(self):
+        with pytest.raises(PrerequisiteNotMetError, match="no filestore revision"):
+            backup_ops._filestore_revision_from_manifest({"filestore": {}})
+
+    def test_revision_zero_is_valid(self):
+        assert (
+            backup_ops._filestore_revision_from_manifest({"filestore": {"revision": 0}})
+            == 0
+        )
+
+    def test_empty_staged_filestore_replaces_old_files(self, tmp_path):
+        live = tmp_path / "filestore"
+        staged = tmp_path / "staged"
+        old = tmp_path / "old"
+        live.mkdir()
+        staged.mkdir()
+        (live / "attachment").write_text("old")
+
+        had_previous = backup_ops._swap_restored_filestore(
+            str(staged), str(live), str(old)
+        )
+
+        assert had_previous is True
+        assert list(live.iterdir()) == []
+        assert (old / "attachment").read_text() == "old"
+
+    def test_failed_filestore_swap_restores_old_files(self, tmp_path, monkeypatch):
+        live = tmp_path / "filestore"
+        staged = tmp_path / "staged"
+        old = tmp_path / "old"
+        live.mkdir()
+        staged.mkdir()
+        (live / "attachment").write_text("old")
+        (staged / "attachment").write_text("new")
+        real_replace = os.replace
+
+        def fail_staged(src, dst):
+            if src == str(staged):
+                raise OSError("swap failed")
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(backup_ops.os, "replace", fail_staged)
+
+        with pytest.raises(OSError, match="swap failed"):
+            backup_ops._swap_restored_filestore(str(staged), str(live), str(old))
+
+        assert (live / "attachment").read_text() == "old"
+        assert (staged / "attachment").read_text() == "new"
+
+
+def _restore_settings(tmp_path):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        db_user="odoo",
+        db_password="secret",
+        backup=BackupSettings(bucket="bucket", access_key="key", secret_key="secret"),
+        teams={"1": team},
+    )
+    return settings, team
+
+
+def _manifest(revision=1):
+    dump = b"database dump"
+    return {
+        "id": "snap",
+        "db": {
+            "bytes": len(dump),
+            "key": "db/snap.pgdump",
+            "sha256": hashlib.sha256(dump).hexdigest(),
+        },
+        "filestore": {"revision": revision},
+    }
+
+
+def _restore_patches(manifest, *, container=None):
+    client = MagicMock()
+    pg = MagicMock()
+    pg.exec_run.return_value = (0, b"")
+    client.containers.get.return_value = pg
+    s3 = MagicMock()
+
+    def download(_bucket, _key, destination):
+        with open(destination, "wb") as f:
+            f.write(b"database dump")
+
+    s3.download_file.side_effect = download
+    return (
+        client,
+        pg,
+        s3,
+        (
+            patch.object(
+                backup_ops.production_registry, "get_production", return_value={}
+            ),
+            patch.object(backup_ops, "_load_manifest", return_value=manifest),
+            patch.object(backup_ops, "get_client", return_value=client),
+            patch.object(production_ops, "_get_container", return_value=container),
+            patch.object(backup_ops.s3_client, "make_client", return_value=s3),
+            patch.object(backup_ops, "_copy_file_to_container"),
+            patch.object(
+                backup_ops,
+                "load_credentials",
+                return_value={"pg_user": "prod_user", "pg_password": "pw"},
+            ),
+            patch.object(backup_ops, "reassign_db_ownership"),
+            patch.object(backup_ops, "drop_signaling_sequences"),
+            patch.object(backup_ops, "filestore_storage", return_value=MagicMock()),
+        ),
+    )
+
+
+def test_chunk_restore_failure_happens_before_live_database_swap(tmp_path):
+    settings, team = _restore_settings(tmp_path)
+    manifest = _manifest()
+    _client, _pg, _s3, patches = _restore_patches(manifest)
+    with ExitStack() as stack:
+        for patcher in patches:
+            stack.enter_context(patcher)
+        stack.enter_context(
+            patch.object(
+                backup_ops.chunkstore, "restore", side_effect=OSError("chunk failed")
+            )
+        )
+        sql = stack.enter_context(patch.object(backup_ops, "_exec_sql"))
+        with pytest.raises(OSError, match="chunk failed"):
+            backup_ops.restore_production(settings, team, "erp", "snap")
+
+    statements = [call.args[2] for call in sql.call_args_list]
+    assert not any("ALTER DATABASE" in statement for statement in statements)
+
+
+def test_filestore_preparation_failure_does_not_stop_production(tmp_path):
+    settings, team = _restore_settings(tmp_path)
+    container = MagicMock(status="running")
+    manifest = _manifest()
+    _client, _pg, _s3, patches = _restore_patches(manifest, container=container)
+
+    with ExitStack() as stack:
+        for patcher in patches:
+            stack.enter_context(patcher)
+        stack.enter_context(
+            patch.object(
+                backup_ops.chunkstore, "restore", side_effect=OSError("chunk failed")
+            )
+        )
+        with pytest.raises(OSError, match="chunk failed"):
+            backup_ops.restore_production(settings, team, "erp", "snap")
+
+    container.stop.assert_not_called()
+    container.start.assert_not_called()
+
+
+def test_filestore_swap_failure_rolls_database_back(tmp_path):
+    settings, team = _restore_settings(tmp_path)
+    manifest = _manifest()
+    _client, _pg, _s3, patches = _restore_patches(manifest)
+    db_name = production_ops.prod_db_name(team, "erp")
+
+    with ExitStack() as stack:
+        for patcher in patches:
+            stack.enter_context(patcher)
+        stack.enter_context(patch.object(backup_ops.chunkstore, "restore"))
+        stack.enter_context(
+            patch.object(
+                backup_ops,
+                "_swap_restored_filestore",
+                side_effect=OSError("filestore swap failed"),
+            )
+        )
+        sql = stack.enter_context(patch.object(backup_ops, "_exec_sql"))
+        with pytest.raises(OSError, match="filestore swap failed"):
+            backup_ops.restore_production(settings, team, "erp", "snap")
+
+    statements = [call.args[2] for call in sql.call_args_list]
+    assert f'ALTER DATABASE "{db_name}" RENAME TO "{db_name}__old";' in statements
+    assert f'ALTER DATABASE "{db_name}__restore" RENAME TO "{db_name}";' in statements
+    assert f'ALTER DATABASE "{db_name}" RENAME TO "{db_name}__restore";' in statements
+    assert f'ALTER DATABASE "{db_name}__old" RENAME TO "{db_name}";' in statements

--- a/tests/test_backup_ops.py
+++ b/tests/test_backup_ops.py
@@ -234,3 +234,34 @@ def test_filestore_swap_failure_rolls_database_back(tmp_path):
     assert f'ALTER DATABASE "{db_name}__restore" RENAME TO "{db_name}";' in statements
     assert f'ALTER DATABASE "{db_name}" RENAME TO "{db_name}__restore";' in statements
     assert f'ALTER DATABASE "{db_name}__old" RENAME TO "{db_name}";' in statements
+
+
+def test_failed_database_compensation_keeps_production_stopped(tmp_path):
+    settings, team = _restore_settings(tmp_path)
+    container = MagicMock(status="running")
+    manifest = _manifest()
+    _client, _pg, _s3, patches = _restore_patches(manifest, container=container)
+
+    with ExitStack() as stack:
+        for patcher in patches:
+            stack.enter_context(patcher)
+        stack.enter_context(patch.object(backup_ops.chunkstore, "restore"))
+        stack.enter_context(
+            patch.object(
+                backup_ops,
+                "_swap_restored_filestore",
+                side_effect=OSError("filestore swap failed"),
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                backup_ops,
+                "_rollback_database_swap",
+                side_effect=OSError("database rollback failed"),
+            )
+        )
+        with pytest.raises(OSError, match="database rollback failed"):
+            backup_ops.restore_production(settings, team, "erp", "snap")
+
+    container.stop.assert_called_once_with()
+    container.start.assert_not_called()


### PR DESCRIPTION
Addresses the actionable restore feedback on #116.

- stage and validate the complete filestore before swapping the live database
- treat revision 0 as an exact empty filestore and reject missing/invalid revisions
- compensate the database rename if the filestore swap fails
- delay Odoo downtime until the final database/filestore swap
- include the backup runtime dependencies in requirements.txt
- add regression coverage for preparation and swap failures

Validation:
- `pytest -m "not integration and not heavyweight"` (945 passed, 14 deselected)
- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow tests`
- `git diff --check`