### PR TITLE
Add restricted HTTP path routing for services

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1483,6 +1483,9 @@ oduflow call create_service elasticsearch docker.elastic.co/elasticsearch/elasti
 
 # WireGuard VPN — needs NET_ADMIN to manage tun/iptables
 oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
+
+# Expose only selected HTTP path prefixes on different service ports
+oduflow call create_service '{"name":"fs","image":"oduist/freeswitch:latest","host_mode":true,"routes":[{"path":"/RPC2","port":8080,"strip_prefix":false}]}'
 ```
 
 Services are:
@@ -1492,6 +1495,15 @@ Services are:
 - Automatically routed through Traefik with HTTPS when in traefik mode
 - In Traefik TLS mode, automatically given the exact system mount `oduflow-traefik-acme:/etc/traefik:ro`
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
+
+### Restricted HTTP Path Routes
+
+In Traefik mode, `routes` can replace the single catch-all `port`. Each route
+targets an HTTP port on the same service and works for both bridge and host
+networking. `/api` matches `/api` and `/api/...`, but not `/apix`; when routes
+exist, unlisted paths receive Traefik's 404. `strip_prefix=true` removes the
+declared prefix before proxying. Routes cannot target arbitrary containers or
+URLs, and raw TCP/UDP protocols cannot be routed by HTTP path.
 
 ### Traefik Certificate Store
 
@@ -1542,7 +1554,7 @@ oduflow call delete_service redis
 The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
-2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
+2. Applies any overrides passed in (`env_vars`, `image`, `port`/`routes`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
 3. Resolves candidate volumes before touching the running container
 4. Pulls the target image (the override, or the current one)
 5. Decides whether to recreate:
@@ -1554,7 +1566,7 @@ Overrides are optional: calling `update_service` with only `name` pulls the curr
 
 ## Service Presets
 
-Every time a service is created, its configuration (image, port, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
+Every time a service is created, its configuration (image, port or restricted HTTP routes, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
 
 ```bash
 # List saved presets
@@ -1740,7 +1752,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/services` | List all managed services |
-| `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
+| `POST` | `/api/services/create` | Create a service with either `port` or restricted Traefik `routes: [{path, port, strip_prefix}]` |
 | `POST` | `/api/services/{name}/update` | Update (pull latest image & recreate) |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
@@ -1751,7 +1763,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/service-presets` | List saved service presets |
-| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
+| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset, including port or routes |
 | `POST` | `/api/service-presets/{name}/delete` | Delete a saved service preset |
 
 ### System
@@ -1846,7 +1858,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `restart_service` | | Restart a service container |
 | `update_service` | ✓ | Preflight volumes, pull/update settings, and recreate when needed, including to add a missing implicit ACME mount |
 | `list_services` | | List all managed service containers |
-| `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
+| `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset) |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |
 | **Volumes** | | |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -41,12 +41,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service container (e.g. Redis, Meilisearch). Supports `host_mode`, `volumes`, `privileged`, `net_admin`; Traefik TLS mode implicitly mounts the exact ACME store at `/etc/traefik:ro` |
+| `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | | Restart a service container |
-| `update_service` | ✓ | Preflight volumes, pull the latest image and/or change any service setting; recreates when needed, including to add a missing implicit Traefik ACME mount |
+| `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode |
 | `list_services` | | List all managed service containers |
-| `get_service_info` | | Full live state of a single service (image+digest, port, hostname, host_mode, volumes, env, cap_add, privileged, restart count, has_preset). Call before recreating a service to preserve all options |
+| `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | | Execute a shell command inside a service container |
 | **Volumes** | | |

--- a/docs/services.md
+++ b/docs/services.md
@@ -18,6 +18,18 @@ oduflow call create_service elasticsearch docker.elastic.co/elasticsearch/elasti
 
 # WireGuard VPN — needs NET_ADMIN to manage tun/iptables
 oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
+
+# Publish only selected HTTP prefixes, each on its own backend port
+oduflow call create_service '{
+  "name":"fs",
+  "image":"oduist/freeswitch:latest",
+  "hostname":"fs",
+  "host_mode":true,
+  "routes":[
+    {"path":"/RPC2","port":8080,"strip_prefix":false},
+    {"path":"/portal","port":8080,"strip_prefix":false}
+  ]
+}'
 ```
 
 Services are:
@@ -28,6 +40,27 @@ Services are:
 - In Traefik TLS mode, automatically given the exact system mount `oduflow-traefik-acme:/etc/traefik:ro`
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
 - Always created from a freshly pulled image — `create_service` and `restore_service` explicitly pull before running, so mutable tags like `:latest` get the current published version instead of a stale local cache
+
+### Restricted HTTP Path Routes
+
+In Traefik mode, `routes` can replace the single catch-all `port`. Each route
+publishes a URL prefix on the service's hostname and forwards it to another
+HTTP port of the **same service**. This works in both networking modes:
+
+- Bridge services are reached on their private IP in the team's Docker network.
+- `host_mode` services are reached through `host.docker.internal`.
+
+Routes are prefix matches on path-segment boundaries: `/api` accepts `/api` and
+`/api/...`, but not `/apix`. When routes are present Oduflow does not create the
+hostname-only catch-all router, so every unlisted path receives Traefik's 404
+without reaching the service. Set `strip_prefix=true` when the backend serves
+from `/`; Traefik then sends `/portal/assets/app.js` as `/assets/app.js` and
+adds `X-Forwarded-Prefix: /portal`.
+
+`routes` is intentionally not an arbitrary reverse-proxy configuration: a route
+contains only `path`, `port`, and optional `strip_prefix`, and always targets the
+same managed service. It is available only with `[routing].mode = "traefik"`.
+Raw TCP/UDP protocols cannot be routed by URL path.
 
 ### Traefik Certificate Store
 
@@ -59,8 +92,8 @@ Both can be enabled at the same time; on the Docker side, `privileged` implies a
 # List all services with status, ports, URLs, and env vars
 oduflow call list_services
 
-# Full state of a single service — image + digest, port, hostname, host_mode,
-# volumes, env vars, capabilities, restart count, started_at, has_preset
+# Full state of a single service — image + digest, port/routes, hostname,
+# host_mode, volumes, env vars, capabilities, restart count, started_at, preset
 oduflow call get_service_info redis
 
 # View service logs
@@ -91,16 +124,16 @@ oduflow call run_service_command redis "redis-cli ping"
 
 ### Changing a Service
 
-`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port, hostname, `host_mode`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand.
+`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
 
-If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
+If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
 
 ## Service Update Flow
 
 The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
-2. Applies any overrides passed in (`env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
+2. Applies any overrides passed in (`env_vars`, `image`, `port`/`routes`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
 3. Resolves the complete candidate volume configuration before touching the running container; invalid or missing volumes fail without stopping it
 4. Pulls the target image (the override, or the current one)
 5. Decides whether to recreate:
@@ -112,7 +145,7 @@ Overrides are optional: calling `update_service` with only `name` pulls the curr
 
 ## Service Presets
 
-Every time a service is created, its configuration (image, port, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
+Every time a service is created, its configuration (image, port or routes, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
 
 ```bash
 # List saved presets

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -48,8 +48,8 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/services` | List all managed services |
-| `POST` | `/api/services/create` | Create a service (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
-| `POST` | `/api/services/{name}/update` | Update a service — pull latest image and/or change settings (JSON body, all optional: `env_vars`, `image`, `port`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`); recreates on any change |
+| `POST` | `/api/services/create` | Create a service. Pass either `port` or Traefik `routes: [{path, port, strip_prefix}]`, plus optional `hostname`, `env_vars`, `host_mode`, volumes and capabilities |
+| `POST` | `/api/services/{name}/update` | Pull latest image and/or change settings. `routes` fully replaces the route list; `routes: []` plus `port` returns to catch-all mode |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
 | `GET` | `/api/services/{name}/logs?n=200` | Get service logs |
@@ -59,7 +59,7 @@ All endpoints return JSON with an `ok` field. Authentication via HTTP Basic auth
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/service-presets` | List saved service presets |
-| `POST` | `/api/service-presets/restore` | Restore a service from a saved preset (JSON body: `name`, `image`, `port`, `hostname`, `env_vars`, `host_mode`, `volumes`, `privileged`, `net_admin`) |
+| `POST` | `/api/service-presets/restore` | Restore a service configuration, including its single port or restricted HTTP routes |
 | `POST` | `/api/service-presets/{name}/delete` | Delete a saved service preset |
 
 ### System

--- a/specs/0033-restricted-http-path-routing-for-services.md
+++ b/specs/0033-restricted-http-path-routing-for-services.md
@@ -1,0 +1,70 @@
+# 0033 — Restricted HTTP path routing for auxiliary services
+
+**Status:** Adopted (still in force)
+**Type:** Architecture / Service exposure
+**First introduced:** `litnimax/service-route-architecture` branch (2026-07-14)
+**Key code today:** `docker_ops/service_ops.py` (validation and Traefik labels), service presets, MCP/REST/dashboard service surfaces
+
+## Context
+
+Auxiliary services originally exposed one HTTP port through a hostname-only
+Traefik router. That is adequate for Redis-like single-port services, but a
+service can host several HTTP interfaces on different ports. FreeSWITCH is the
+concrete case: its XML-RPC interface lives at `/RPC2` on port 8080, while other
+HTTP modules may use different paths and ports.
+
+A hostname-only router also forwards scanning and unrelated paths to the
+backend. Operators wanted the public surface to be an allowlist: only declared
+URL prefixes should reach the service, and all other paths should stop at
+Traefik. The capability must work for ordinary bridge services as well as
+`host_mode` services without opening arbitrary proxying across team networks.
+
+## Decision
+
+Let a managed service choose exactly one HTTP exposure model in Traefik mode:
+the existing single catch-all `port`, or a non-empty list of restricted
+`routes`. Each route contains a path prefix, a port on the same service, and an
+optional `strip_prefix` flag.
+
+- Prefixes match on path-segment boundaries (`/api` and `/api/...`, never
+  `/apix`). No hostname-only fallback router is generated when routes exist.
+- A bridge service is reached on its container IP and declared port. A
+  host-network service is reached through `host.docker.internal` and the
+  declared port.
+- Route targets cannot name another container, hostname, scheme, or URL. This
+  is service exposure, not a general reverse proxy or SSRF facility.
+- URL paths apply only to HTTP(S)/WebSocket traffic. Raw TCP/UDP services need a
+  future, separate entrypoint and exposure model.
+
+## How it works (macro)
+
+Each route becomes an explicit Traefik HTTP router and load-balancer service on
+the managed container. The router combines the service hostname with a
+segment-safe path rule and points to the route-specific backend port. Optional
+StripPrefix middleware adapts root-mounted applications and preserves the
+original prefix in `X-Forwarded-Prefix`.
+
+The canonical route list is kept in both the service preset and an Oduflow
+Docker label. Presets make restore/recreate durable; the label lets live
+inspection recover configuration when no preset exists. Updates replace the
+whole route list, matching the existing replacement semantics for env vars and
+volumes. Clearing routes requires a replacement catch-all port in the same
+update, so a service never enters an ambiguous exposure state.
+
+## Consequences
+
+- Multi-port HTTP services keep one hostname while exposing only their intended
+  path surface; unknown paths receive Traefik's 404 without touching backend
+  logs or handlers.
+- The same public model works across Docker networking modes; only backend
+  address resolution differs.
+- Existing services and presets need no data migration: absence of `routes`
+  retains the original single-port behavior.
+- This does not firewall a host-network process that binds directly to a public
+  host interface. Such a process must bind loopback or be protected by the host
+  firewall independently of Traefik routing.
+
+## History
+
+- `litnimax/service-route-architecture` (2026-07-14) — structured service
+  routes across core orchestration, presets, MCP, REST, dashboard and docs.

--- a/specs/README.md
+++ b/specs/README.md
@@ -51,6 +51,7 @@ precursors).
 | [0030](0030-odoo-sh-addons-import.md) | 2026-07-04 | Odoo.sh import brings the addons-path (Enterprise/Themes/extra) + local extra-addons + template rename |
 | [0031](0031-connect-as-user-impersonation.md) | 2026-07-09 | Passwordless "Connect as user" session minting (`connect_as_user`) for agent browser testing |
 | [0032](0032-implicit-traefik-acme-mount-for-services.md) | 2026-07-13 | Auxiliary services receive the Traefik ACME store read-only |
+| [0033](0033-restricted-http-path-routing-for-services.md) | 2026-07-14 | Restricted HTTP path routing for auxiliary services |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import logging
 import posixpath
 import re
@@ -18,6 +19,7 @@ from oduflow.settings import Settings, TeamSettings
 logger = logging.getLogger("oduflow")
 
 _TRAEFIK_ACME_MOUNT_PATH = "/etc/traefik"
+_HTTP_ROUTES_LABEL = "oduflow.http_routes"
 
 _SYSTEM_ENV_KEYS = {
     "PATH",
@@ -52,6 +54,121 @@ _SYSTEM_ENV_KEYS = {
     "SSH_AGENT_PID",
     "DBUS_SESSION_BUS_ADDRESS",
 }
+
+
+def normalize_http_routes(
+    routes: list[dict[str, object]] | None,
+) -> list[dict[str, object]] | None:
+    """Validate and canonicalize restricted HTTP path routes.
+
+    Routes are deliberately self-targeting: they expose another HTTP port of
+    the same auxiliary service, never an arbitrary hostname or URL.  This keeps
+    the tenant boundary intact even though Traefik is attached to every team
+    network.
+    """
+    if routes is None:
+        return None
+    if not isinstance(routes, list):
+        raise ValueError("routes must be a JSON array of route objects.")
+
+    normalized: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for index, route in enumerate(routes, start=1):
+        if not isinstance(route, dict):
+            raise ValueError(f"Route #{index} must be a JSON object.")
+        unknown_fields = set(route) - {"path", "port", "strip_prefix"}
+        if unknown_fields:
+            fields = ", ".join(sorted(unknown_fields))
+            raise ValueError(f"Route #{index} contains unsupported fields: {fields}.")
+
+        raw_path = route.get("path")
+        if not isinstance(raw_path, str) or not raw_path:
+            raise ValueError(f"Route #{index} path must be a non-empty string.")
+        if raw_path != raw_path.strip():
+            raise ValueError(
+                f"Route path '{raw_path}' must not contain outer whitespace."
+            )
+        if not raw_path.startswith("/"):
+            raise ValueError(f"Route path '{raw_path}' must start with '/'.")
+        if any(ch in raw_path for ch in ("?", "#", "`")) or any(
+            ord(ch) < 32 or ch.isspace() for ch in raw_path
+        ):
+            raise ValueError(
+                f"Route path '{raw_path}' contains unsupported URL characters."
+            )
+        if "//" in raw_path or any(part in (".", "..") for part in raw_path.split("/")):
+            raise ValueError(
+                f"Route path '{raw_path}' must not contain empty or dot segments."
+            )
+
+        path = raw_path.rstrip("/") or "/"
+        if path in seen:
+            raise ValueError(f"Duplicate route path '{path}'.")
+        seen.add(path)
+
+        raw_port = route.get("port")
+        if isinstance(raw_port, bool) or not isinstance(raw_port, int):
+            raise ValueError(f"Route '{path}' port must be an integer from 1 to 65535.")
+        port = raw_port
+        if not 1 <= port <= 65535:
+            raise ValueError(f"Route '{path}' port must be between 1 and 65535.")
+
+        raw_strip = route.get("strip_prefix", False)
+        if not isinstance(raw_strip, bool):
+            raise ValueError(f"Route '{path}' strip_prefix must be true or false.")
+        normalized.append({"path": path, "port": port, "strip_prefix": raw_strip})
+    return normalized
+
+
+def _validate_service_exposure(
+    settings: Settings,
+    port: int | None,
+    routes: list[dict[str, object]] | None,
+) -> None:
+    """Require exactly one supported public exposure model."""
+    if routes:
+        if settings.routing_mode != "traefik":
+            raise ValueError("HTTP path routes require routing.mode = 'traefik'.")
+        if port not in (None, 0):
+            raise ValueError("Pass either port or routes, not both.")
+        return
+    if port is None or isinstance(port, bool) or not 1 <= int(port) <= 65535:
+        raise ValueError("port must be between 1 and 65535 when routes are not set.")
+
+
+def _route_rule(hostname: str, path: str) -> str:
+    """Return a segment-safe prefix rule (/api and /api/*, never /apix)."""
+    if path == "/":
+        path_rule = "PathPrefix(`/`)"
+    else:
+        path_rule = f"(Path(`{path}`) || PathPrefix(`{path}/`))"
+    return f"Host(`{hostname}`) && {path_rule}"
+
+
+def _routes_from_labels(labels: dict[str, str]) -> list[dict[str, object]] | None:
+    raw = labels.get(_HTTP_ROUTES_LABEL)
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+        return normalize_http_routes(parsed)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        logger.warning("Ignoring invalid HTTP routes label", exc_info=True)
+        return None
+
+
+def _routes_with_urls(
+    routes: list[dict[str, object]] | None, hostname: str | None
+) -> list[dict[str, object]]:
+    if not routes:
+        return []
+    result: list[dict[str, object]] = []
+    for route in routes:
+        item = dict(route)
+        if hostname:
+            item["url"] = f"https://{hostname}{route['path']}"
+        result.append(item)
+    return result
 
 
 def _resolve_service_volume_binds(
@@ -122,16 +239,19 @@ def create_service(
     team: TeamSettings,
     name: str,
     image: str,
-    port: int,
+    port: int | None,
     hostname: str | None = None,
     env_vars: dict[str, str] | None = None,
     host_mode: bool = False,
     volumes: list[dict[str, str]] | None = None,
     cap_add: list[str] | None = None,
     privileged: bool = False,
-) -> dict[str, str]:
-    client = get_client()
+    routes: list[dict[str, object]] | None = None,
+) -> dict[str, Any]:
     container_name = get_service_container_name(name, settings.prefix, team.team_id)
+    routes = normalize_http_routes(routes)
+    _validate_service_exposure(settings, port, routes)
+    client = get_client()
 
     # Services join the team's isolated network (not needed for host mode).
     team_network = ""
@@ -175,25 +295,63 @@ def create_service(
         elif "." not in hostname:
             hostname = f"{hostname}.{team.hostname}"
         labels["traefik.enable"] = "true"
-        labels[f"traefik.http.routers.{container_name}.rule"] = f"Host(`{hostname}`)"
-        if settings.routing_tls:
-            labels[f"traefik.http.routers.{container_name}.entrypoints"] = "websecure"
-            labels[f"traefik.http.routers.{container_name}.tls.certresolver"] = (
-                "letsencrypt"
+        if routes:
+            labels[_HTTP_ROUTES_LABEL] = json.dumps(
+                routes, separators=(",", ":"), sort_keys=True
             )
+            for index, route in enumerate(routes, start=1):
+                route_name = f"{container_name}-route-{index}"
+                router_prefix = f"traefik.http.routers.{route_name}"
+                service_prefix = f"traefik.http.services.{route_name}"
+                labels[f"{router_prefix}.rule"] = _route_rule(
+                    hostname, str(route["path"])
+                )
+                labels[f"{router_prefix}.service"] = route_name
+                if settings.routing_tls:
+                    labels[f"{router_prefix}.entrypoints"] = "websecure"
+                    labels[f"{router_prefix}.tls.certresolver"] = "letsencrypt"
+                else:
+                    labels[f"{router_prefix}.entrypoints"] = "web"
+                if host_mode:
+                    labels[f"{service_prefix}.loadbalancer.server.url"] = (
+                        f"http://host.docker.internal:{route['port']}"
+                    )
+                else:
+                    labels[f"{service_prefix}.loadbalancer.server.port"] = str(
+                        route["port"]
+                    )
+                if route["strip_prefix"]:
+                    middleware_name = f"{route_name}-strip"
+                    labels[f"{router_prefix}.middlewares"] = middleware_name
+                    labels[
+                        f"traefik.http.middlewares.{middleware_name}.stripprefix.prefixes"
+                    ] = str(route["path"])
+            if not host_mode:
+                labels["traefik.docker.network"] = team_network
         else:
-            # Upstream terminates TLS (e.g. Cloudflare tunnel): plain HTTP on the
-            # web entrypoint. Public URL stays https:// below.
-            labels[f"traefik.http.routers.{container_name}.entrypoints"] = "web"
-        if host_mode:
-            labels[
-                f"traefik.http.services.{container_name}.loadbalancer.server.url"
-            ] = f"http://host.docker.internal:{port}"
-        else:
-            labels[
-                f"traefik.http.services.{container_name}.loadbalancer.server.port"
-            ] = str(port)
-            labels["traefik.docker.network"] = team_network
+            labels[f"traefik.http.routers.{container_name}.rule"] = (
+                f"Host(`{hostname}`)"
+            )
+            if settings.routing_tls:
+                labels[f"traefik.http.routers.{container_name}.entrypoints"] = (
+                    "websecure"
+                )
+                labels[f"traefik.http.routers.{container_name}.tls.certresolver"] = (
+                    "letsencrypt"
+                )
+            else:
+                # Upstream terminates TLS (e.g. Cloudflare tunnel): plain HTTP on
+                # the web entrypoint. Public URL stays https:// below.
+                labels[f"traefik.http.routers.{container_name}.entrypoints"] = "web"
+            if host_mode:
+                labels[
+                    f"traefik.http.services.{container_name}.loadbalancer.server.url"
+                ] = f"http://host.docker.internal:{port}"
+            else:
+                labels[
+                    f"traefik.http.services.{container_name}.loadbalancer.server.port"
+                ] = str(port)
+                labels["traefik.docker.network"] = team_network
         url = f"https://{hostname}"
     else:
         if not host_mode:
@@ -232,6 +390,7 @@ def create_service(
             volumes=volumes,
             cap_add=cap_add,
             privileged=privileged,
+            routes=routes,
         )
     except Exception:
         logger.warning("Failed to save service preset for %s", name, exc_info=True)
@@ -241,6 +400,7 @@ def create_service(
         "container_name": container_name,
         "image": image,
         "url": url,
+        "routes": _routes_with_urls(routes, hostname),
     }
 
 
@@ -321,6 +481,7 @@ def _describe_service_container(
     url: str | None = None
     hostname: str | None = None
     is_host_mode = container.labels.get("oduflow.host_mode") == "true"
+    routes = _routes_from_labels(container.labels)
 
     if settings.routing_mode == "traefik":
         rule_value = _traefik_label_by_suffix(container.labels, ".rule")
@@ -329,7 +490,9 @@ def _describe_service_container(
             hostname = match.group(1)
             url = f"https://{hostname}"
 
-        if is_host_mode:
+        if routes:
+            port_num = None
+        elif is_host_mode:
             url_value = _traefik_label_by_suffix(
                 container.labels, ".loadbalancer.server.url"
             )
@@ -399,6 +562,7 @@ def _describe_service_container(
         "port": port_num,
         "hostname": hostname,
         "url": url,
+        "routes": _routes_with_urls(routes, hostname),
         "env_vars": env_vars,
         "host_mode": is_host_mode,
         "volumes": svc_volumes,
@@ -482,7 +646,8 @@ def update_service(
     volume_override: list[dict[str, str]] | None = None,
     cap_add_override: list[str] | None = None,
     privileged_override: bool | None = None,
-) -> dict[str, str]:
+    routes_override: list[dict[str, object]] | None = None,
+) -> dict[str, Any]:
     """Pull the latest image for a service and re-create it with the same settings.
 
     Optional overrides replace the corresponding setting from the saved preset.
@@ -517,13 +682,14 @@ def update_service(
         pass
 
     if preset:
-        port = preset.get("port")
+        port = preset.get("port") or None
         hostname = preset.get("hostname") or None
         env_vars = preset.get("env_vars") or None
         is_host_mode = preset.get("host_mode", False)
         old_volumes = preset.get("volumes") or None
         cap_add = preset.get("cap_add") or None
         privileged = preset.get("privileged", False)
+        routes = normalize_http_routes(preset.get("routes"))
     else:
         # Legacy fallback: extract from running container
         raw_env = container.attrs.get("Config", {}).get("Env", [])
@@ -535,6 +701,7 @@ def update_service(
                     env_vars[key] = value
 
         is_host_mode = container.labels.get("oduflow.host_mode") == "true"
+        routes = _routes_from_labels(container.labels)
 
         host_config = container.attrs.get("HostConfig", {}) or {}
         cap_add = list(host_config.get("CapAdd") or []) or None
@@ -549,7 +716,9 @@ def update_service(
             if match:
                 hostname = match.group(1)
 
-            if is_host_mode:
+            if routes:
+                port = None
+            elif is_host_mode:
                 url_value = _traefik_label_by_suffix(
                     container.labels, ".loadbalancer.server.url"
                 )
@@ -595,7 +764,12 @@ def update_service(
 
         env_vars = env_vars or None
 
-    if port is None and port_override is None:
+    if (
+        port is None
+        and not routes
+        and port_override is None
+        and routes_override is None
+    ):
         raise NotFoundError(f"Cannot determine port for service '{name}'.")
 
     # Apply overrides and track whether config changed
@@ -624,6 +798,30 @@ def update_service(
     if privileged_override is not None and privileged_override != privileged:
         privileged = privileged_override
         config_changed = True
+    if routes_override is not None:
+        normalized_override = normalize_http_routes(routes_override)
+        if normalized_override:
+            if port_override is not None:
+                raise ValueError("Pass either port or routes, not both.")
+            port = None
+            new_routes = normalized_override
+        else:
+            new_routes = None
+            if port_override is None:
+                raise ValueError(
+                    "Removing routes requires a replacement port in the same update."
+                )
+        if new_routes != routes:
+            routes = new_routes
+            config_changed = True
+
+    if routes and port_override is not None and routes_override is None:
+        raise ValueError(
+            "A route-based service has no catch-all port; replace routes or clear "
+            "them with routes=[] and a replacement port."
+        )
+
+    _validate_service_exposure(settings, port, routes)
 
     # Determine the image to pull (override or current)
     target_image = image_override if image_override else old_image
@@ -665,6 +863,9 @@ def update_service(
             "config_updated": False,
             "old_digest": old_digest,
             "new_digest": new_digest,
+            "routes": _routes_with_urls(
+                routes, h if settings.routing_mode == "traefik" else None
+            ),
         }
 
     logger.info(
@@ -692,6 +893,7 @@ def update_service(
         volumes=old_volumes or None,
         cap_add=cap_add,
         privileged=privileged,
+        routes=routes,
     )
 
     result["image_updated"] = image_updated

--- a/src/oduflow/docker_ops/service_presets.py
+++ b/src/oduflow/docker_ops/service_presets.py
@@ -56,7 +56,7 @@ def save_preset(
     team: TeamSettings,
     name: str,
     image: str,
-    port: int,
+    port: int | None,
     hostname: str | None = None,
     env_vars: dict[str, str] | None = None,
     base_hostname: str = "",
@@ -64,6 +64,7 @@ def save_preset(
     volumes: list[dict[str, str]] | None = None,
     cap_add: list[str] | None = None,
     privileged: bool = False,
+    routes: list[dict[str, object]] | None = None,
 ) -> dict:
     """Save (or overwrite) a single service preset and return it."""
     short_hostname = hostname or ""
@@ -73,7 +74,7 @@ def save_preset(
             short_hostname = short_hostname[: -len(suffix)]
     preset: dict = {
         "image": image,
-        "port": port,
+        "port": port or 0,
         "hostname": short_hostname,
         "env_vars": env_vars if env_vars is not None else {},
     }
@@ -85,6 +86,8 @@ def save_preset(
         preset["cap_add"] = list(cap_add)
     if privileged:
         preset["privileged"] = True
+    if routes:
+        preset["routes"] = routes
     data = _load_presets(team)
     data[name] = preset
     _save_presets(team, data)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2017,13 +2017,14 @@ def run_db_query(
 def create_service(
     name: str,
     image: str,
-    port: int,
+    port: int = 0,
     hostname: str = "",
     env_vars: str = "",
     host_mode: bool = False,
     volumes: str = "",
     privileged: bool = False,
     net_admin: bool = False,
+    routes: list[dict[str, object]] | None = None,
     ctx: Context = None,
 ) -> str:
     """
@@ -2032,13 +2033,14 @@ def create_service(
     Args:
         name: Short name for the service (e.g. "redis", "meilisearch").
         image: Docker image with tag (e.g. "redis:7", "getmeili/meilisearch:v1.6").
-        port: The container port the service listens on.
+        port: Catch-all exposure mode: forward every path to this one container port. Required outside Traefik. Mutually exclusive with routes.
         hostname: Custom hostname for traefik routing (optional, traefik mode only).
         env_vars: Comma-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production").
         host_mode: Run the container in host network mode instead of the shared Docker network. Use when the service needs direct host network access. Traefik routing still works.
         volumes: Comma-separated volume mounts (e.g. "mydata:/data,config:/etc/app:ro"). Each entry is volume_name:/container/path[:ro|rw]. Volumes must be created first via create_volume. In Traefik TLS mode the system ACME volume is mounted automatically at /etc/traefik:ro; do not include it here.
         privileged: Run the container in privileged mode (full host access). Use with care — implies all Linux capabilities. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
         net_admin: Add the NET_ADMIN Linux capability. Required for VPN/WireGuard, tun/tap devices, and iptables manipulation inside the container.
+        routes: Alternative Traefik exposure mode. Each object has path, backend port, and optional strip_prefix. Routes target this same service and unlisted paths return Traefik 404. Mutually exclusive with the top-level port.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -2054,18 +2056,26 @@ def create_service(
         team,
         name,
         image,
-        port,
+        port or None,
         hostname=hostname or None,
         env_vars=parsed_env,
         host_mode=host_mode,
         volumes=parsed_volumes,
         cap_add=cap_add,
         privileged=privileged,
+        routes=routes,
     )
     vol_info = ""
     if parsed_volumes:
         vol_info = "\nVolumes: " + ", ".join(
             f"{v['volume']}:{v['mount_path']}:{v['mode']}" for v in parsed_volumes
+        )
+    route_info = ""
+    if result.get("routes"):
+        route_info = "\nRoutes:\n" + "\n".join(
+            f"- {route['path']} -> {route['port']}"
+            f"{' (strip prefix)' if route.get('strip_prefix') else ''}"
+            for route in result["routes"]
         )
     return (
         f"Service created successfully!\n"
@@ -2074,6 +2084,7 @@ def create_service(
         f"Image: {result['image']}\n"
         f"URL: {result['url']}"
         f"{vol_info}"
+        f"{route_info}"
     )
 
 
@@ -2090,12 +2101,13 @@ def update_service(
     volumes: str = "",
     privileged: bool | None = None,
     net_admin: bool | None = None,
+    routes: list[dict[str, object]] | None = None,
     ctx: Context = None,
 ) -> str:
     """
     Update a managed auxiliary service container. Pulls the latest image and
     optionally changes any setting (env vars, image, port, hostname, host_mode,
-    volumes, privileged, net_admin). The container is recreated when the image or
+    volumes, privileged, net_admin, routes). The container is recreated when the image or
     any setting changes; settings that are not overridden are preserved. This is
     the preferred way to change a service — you do not need to delete and
     recreate it manually.
@@ -2110,6 +2122,7 @@ def update_service(
         volumes: Comma-separated volume mounts that fully replace existing user volumes (e.g. "mydata:/data,config:/etc/app:ro"). Leave empty to keep current volumes. The implicit Traefik TLS mount at /etc/traefik:ro is preserved separately.
         privileged: Run the container in privileged mode (full host access). Leave unset (null) to keep current mode. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
         net_admin: Add (True) or remove (False) the NET_ADMIN Linux capability — required for VPN/WireGuard, tun/tap, and iptables. Leave unset (null) to keep current capabilities.
+        routes: Full replacement HTTP route list. Leave unset to preserve it. Pass [] together with port to return to a single catch-all port.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -2141,6 +2154,7 @@ def update_service(
         volume_override=parsed_volumes,
         cap_add_override=cap_add_override,
         privileged_override=privileged,
+        routes_override=routes,
     )
 
     if result.get("image_updated"):
@@ -2222,6 +2236,13 @@ def get_service_info(name: str, ctx: Context = None) -> str:
         lines.append(f"Hostname: {info['hostname']}")
     if info.get("url"):
         lines.append(f"URL: {info['url']}")
+    if info.get("routes"):
+        lines.append("Routes:")
+        for route in info["routes"]:
+            suffix = " (strip prefix)" if route.get("strip_prefix") else ""
+            lines.append(
+                f"  {route['path']} -> {route['port']}{suffix} [{route.get('url', '')}]"
+            )
     lines.append(f"Host mode: {'true' if info.get('host_mode') else 'false'}")
     if info.get("privileged"):
         lines.append("Privileged: true")
@@ -2275,7 +2296,9 @@ def list_service_presets(ctx: Context = None) -> str:
             if p.get("env_vars")
             else ""
         )
-        output += f"- {p['name']}: image={p['image']}, port={p['port']}"
+        output += f"- {p['name']}: image={p['image']}"
+        if not p.get("routes"):
+            output += f", port={p['port']}"
         if p.get("hostname"):
             output += f", hostname={p['hostname']}"
         if env_str:
@@ -2292,6 +2315,11 @@ def list_service_presets(ctx: Context = None) -> str:
                 for v in p["volumes"]
             )
             output += f", volumes=[{vol_str}]"
+        if p.get("routes"):
+            route_str = ",".join(
+                f"{route['path']}->{route['port']}" for route in p["routes"]
+            )
+            output += f", routes=[{route_str}]"
         output += "\n"
     return output
 
@@ -2324,6 +2352,7 @@ def restore_service(name: str, ctx: Context = None) -> str:
         volumes=preset_volumes,
         cap_add=preset_cap_add,
         privileged=preset_privileged,
+        routes=preset.get("routes") or None,
     )
     extra = ""
     if preset_volumes:
@@ -2335,6 +2364,10 @@ def restore_service(name: str, ctx: Context = None) -> str:
         extra += "\nPrivileged: true"
     elif preset_cap_add:
         extra += f"\nCapabilities: {','.join(preset_cap_add)}"
+    if result.get("routes"):
+        extra += "\nRoutes: " + ", ".join(
+            f"{route['path']}->{route['port']}" for route in result["routes"]
+        )
     return (
         f"Service restored from preset!\n"
         f"Name: {result['name']}\n"
@@ -2377,6 +2410,9 @@ def list_services(ctx: Context = None) -> str:
             output += f"  Port: {svc['port']}\n"
         if svc.get("url"):
             output += f"  URL: {svc['url']}\n"
+        if svc.get("routes"):
+            for route in svc["routes"]:
+                output += f"  Route: {route['path']} -> {route['port']}\n"
         if svc.get("env_vars"):
             env_str = ", ".join(f"{k}={v}" for k, v in svc["env_vars"].items())
             output += f"  Env: {env_str}\n"

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -128,16 +128,16 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 
 | Tool | When to use |
 |---|---|
-| `create_service(name, image, port, hostname?, env_vars?, host_mode?, volumes?, privileged?, net_admin?)` | Spin up a sidecar (Redis, Meilisearch, etc.). Accessible from Odoo containers via `oduflow-svc-{name}:{port}`. Set `net_admin=true` for VPN/tun/iptables; `privileged=true` for full host access. The image is always pulled fresh, so mutable tags like `:latest` get the current version. In Traefik TLS mode Oduflow automatically mounts `oduflow-traefik-acme:/etc/traefik:ro`; do not pass that system volume yourself |
-| `get_service_info(name)` | **Use this before recreating a service.** Returns full live state: image + digest, port, hostname, URL, `host_mode`, `volumes`, env vars, `cap_add`, `privileged`, restart count, started_at, whether a preset exists |
-| `update_service(name, env_vars?, image?, port?, hostname?, host_mode?, volumes?, privileged?, net_admin?)` | Change **any** setting on a running service. Without overrides, pulls the latest image. With any override, fully replaces that setting and recreates the container, preserving everything else. `env_vars` and `volumes` are full replacements, not merges. This is the preferred way to change a service |
+| `create_service(name, image, *, port=<catch-all> \| routes=[...], ...)` | Spin up a sidecar using exactly one exposure mode. `port=8080` publishes every path to one port and is required outside Traefik. Alternatively, Traefik `routes=[{"path":"/api","port":8080,"strip_prefix":false}]` publishes only those paths. Never pass `port` and `routes` together |
+| `get_service_info(name)` | **Use this before recreating a service.** Returns full live state, including whichever exposure model is active: `port` or `routes` |
+| `update_service(name, ..., port? \| routes?)` | Change any setting. `routes` is a full replacement; pass `routes=[]` together with `port` to switch back to catch-all mode. Otherwise never pass `port` and `routes` together. Unset settings are preserved |
 | `list_services` / `get_service_logs(name)` / `restart_service(name)` / `delete_service(name)` | Manage auxiliary services |
 | `restore_service(name)` | Recreate a service from its saved preset after deletion (volumes, host_mode, cap_add, env are all preserved) |
 | `list_service_presets` | List saved service presets (configurations that can be restored after a service is deleted) |
 | `delete_service_preset(name)` | Remove a saved service preset |
 | `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
 
-> **Changing a service:** use `update_service` for **any** change — image, env vars, port, hostname, host_mode, volumes, privileged, or net_admin. It recreates the container automatically and preserves every setting you don't override, so you almost never need to `delete_service` + `create_service` by hand. (If you do recreate manually — e.g. to rename a service — call `get_service_info(name)` first and replay its `image`, `port`, `hostname`, `env_vars`, `host_mode`, user `volumes`, `cap_add`, `privileged` in the new `create_service` call, otherwise you'll silently drop them. Omit any `System mounts` such as the implicit Traefik ACME mount; Oduflow adds those itself.)
+> **Changing a service:** use `update_service` for any change — image, env vars, port/routes, hostname, host mode, volumes or capabilities. If recreating manually, call `get_service_info` first and replay its complete user-controlled configuration. Omit implicit system mounts.
 
 > **Traefik TLS certificate store:** every service receives the exact system volume at `/etc/traefik` read-only. It is implicit and not part of the preset or the user-supplied `volumes` replacement. `/etc/traefik` is reserved, and all other raw `oduflow-*` volumes remain forbidden. `update_service` validates candidate volumes before stopping the current container.
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3624,7 +3624,10 @@ function renderServices(services) {
     if (svc.routes && svc.routes.length) {
       routesHtml = svc.routes.map(function(route) {
         var strip = route.strip_prefix ? ' · strip prefix' : '';
-        return '<div class="svc-meta"><span>Route: <a href="' + esc(route.url) + '" target="_blank">' + esc(route.path) + '</a>' +
+        var pathHtml = route.url
+          ? '<a href="' + esc(route.url) + '" target="_blank">' + esc(route.path) + '</a>'
+          : esc(route.path);
+        return '<div class="svc-meta"><span>Route: ' + pathHtml +
           ' <strong>→ ' + route.port + strip + '</strong></span></div>';
       }).join('');
     }

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -492,6 +492,15 @@
     border-top: 1px solid var(--border);
   }
   .form-error { color: var(--red); font-size: var(--text-xs); margin-bottom: 10px; display: none; }
+  .route-list { display: flex; flex-direction: column; gap: 8px; margin: 8px 0; }
+  .route-row { display: grid; grid-template-columns: minmax(0, 1fr) 92px auto auto; gap: 8px; align-items: center; }
+  .route-row input[type="text"], .route-row input[type="number"] {
+    width: 100%; padding: 7px 9px; font-family: var(--font-mono); font-size: var(--text-xs);
+    background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: var(--radius-sm);
+  }
+  .route-strip { display: inline-flex; align-items: center; gap: 5px; color: var(--text-dim); font-size: var(--text-xs); white-space: nowrap; }
+  .route-remove { padding: 5px 8px; }
+  .route-hint { color: var(--text-dim); font-size: var(--text-xs); line-height: 1.45; }
   .modal-overlay {
     position: fixed; top: 0; left: 0; right: 0; bottom: 0;
     background: var(--backdrop);
@@ -509,6 +518,7 @@
   }
   .modal-sm { max-width: 460px; }
   .modal-md { max-width: 520px; }
+  .modal-routes { max-width: 680px; max-height: 90vh; }
   /* Unified large modal size (chat / terminals) — almost fullscreen, with margins */
   .modal-terminal, .modal-chat { width: 92vw; max-width: 92vw; height: 90vh; max-height: 90vh; }
   /* --- ACP chat (chat.js) — Engineer's Console tokens only (DESIGN.md) --- */
@@ -1376,7 +1386,7 @@
 <div id="chat-dock" aria-label="Minimized chats"></div>
 <div id="chat-parking" hidden></div>
 <div class="modal-overlay" id="create-svc-modal" onclick="closeCreateServiceModal(event)">
-  <div class="modal modal-md">
+  <div class="modal modal-routes">
     <div class="modal-header">
       <h2>Create Service</h2>
       <button class="modal-close" onclick="closeCreateServiceModal()">&times;</button>
@@ -1392,8 +1402,21 @@
         <input type="text" id="svc-image" placeholder="e.g. redis:7, getmeili/meilisearch:v1.6">
       </div>
       <div class="form-group">
+        <label for="svc-exposure">Public exposure</label>
+        <select id="svc-exposure" onchange="toggleServiceExposure('svc')">
+          <option value="port">Single port (all paths)</option>
+          <option value="routes">Restricted path routes (Traefik)</option>
+        </select>
+      </div>
+      <div class="form-group" id="svc-port-group">
         <label for="svc-port">Container port</label>
-        <input type="number" id="svc-port" placeholder="e.g. 6379">
+        <input type="number" id="svc-port" placeholder="e.g. 6379" min="1" max="65535">
+      </div>
+      <div class="form-group" id="svc-routes-group" style="display:none;">
+        <label>Allowed path routes</label>
+        <div class="route-hint">Each prefix reaches a port on this service. Unknown paths return 404. “Strip” removes the prefix before proxying.</div>
+        <button class="btn btn-sm" type="button" onclick="addServiceRoute('svc')">Add route</button>
+        <div class="route-list" id="svc-routes"></div>
       </div>
       <div class="form-group">
         <label for="svc-hostname">Hostname (optional, traefik mode)</label>
@@ -1430,7 +1453,7 @@
   </div>
 </div>
 <div class="modal-overlay" id="restore-svc-modal" onclick="closeRestoreServiceModal(event)">
-  <div class="modal modal-md">
+  <div class="modal modal-routes">
     <div class="modal-header">
       <h2>Restore Service</h2>
       <button class="modal-close" onclick="closeRestoreServiceModal()">&times;</button>
@@ -1452,8 +1475,21 @@
         <input type="text" id="restore-svc-image" placeholder="e.g. redis:7">
       </div>
       <div class="form-group">
+        <label for="restore-svc-exposure">Public exposure</label>
+        <select id="restore-svc-exposure" onchange="toggleServiceExposure('restore-svc')">
+          <option value="port">Single port (all paths)</option>
+          <option value="routes">Restricted path routes (Traefik)</option>
+        </select>
+      </div>
+      <div class="form-group" id="restore-svc-port-group">
         <label for="restore-svc-port">Container port</label>
-        <input type="number" id="restore-svc-port" placeholder="e.g. 6379">
+        <input type="number" id="restore-svc-port" placeholder="e.g. 6379" min="1" max="65535">
+      </div>
+      <div class="form-group" id="restore-svc-routes-group" style="display:none;">
+        <label>Allowed path routes</label>
+        <div class="route-hint">Each prefix reaches a port on this service. Unknown paths return 404. “Strip” removes the prefix before proxying.</div>
+        <button class="btn btn-sm" type="button" onclick="addServiceRoute('restore-svc')">Add route</button>
+        <div class="route-list" id="restore-svc-routes"></div>
       </div>
       <div class="form-group">
         <label for="restore-svc-hostname">Hostname (optional, traefik mode)</label>
@@ -3526,6 +3562,53 @@ function maskValue(key, val) {
   return String(val).replace(/./g, '#');
 }
 
+function addServiceRoute(prefix, route) {
+  var list = document.getElementById(prefix + '-routes');
+  var row = document.createElement('div');
+  row.className = 'route-row';
+  row.innerHTML =
+    '<input type="text" class="route-path" placeholder="/RPC2" aria-label="Route path prefix">' +
+    '<input type="number" class="route-port" placeholder="8080" min="1" max="65535" aria-label="Route port">' +
+    '<label class="route-strip"><input type="checkbox" class="route-strip-input"> Strip</label>' +
+    '<button class="btn btn-sm btn-delete route-remove" type="button" aria-label="Remove route">Remove</button>';
+  row.querySelector('.route-path').value = route && route.path ? route.path : '';
+  row.querySelector('.route-port').value = route && route.port ? route.port : '';
+  row.querySelector('.route-strip-input').checked = !!(route && route.strip_prefix);
+  row.querySelector('.route-remove').onclick = function() { row.remove(); };
+  list.appendChild(row);
+}
+
+function toggleServiceExposure(prefix) {
+  var routeMode = document.getElementById(prefix + '-exposure').value === 'routes';
+  document.getElementById(prefix + '-port-group').style.display = routeMode ? 'none' : '';
+  document.getElementById(prefix + '-routes-group').style.display = routeMode ? '' : 'none';
+  if (routeMode && !document.querySelector('#' + prefix + '-routes .route-row')) {
+    addServiceRoute(prefix);
+  }
+}
+
+function setServiceRoutes(prefix, routes) {
+  var list = document.getElementById(prefix + '-routes');
+  list.innerHTML = '';
+  (routes || []).forEach(function(route) { addServiceRoute(prefix, route); });
+}
+
+function collectServiceRoutes(prefix) {
+  var routes = [];
+  document.querySelectorAll('#' + prefix + '-routes .route-row').forEach(function(row) {
+    var path = row.querySelector('.route-path').value.trim();
+    var port = parseInt(row.querySelector('.route-port').value, 10);
+    if (!path || !port) throw new Error('Every route requires a path and port.');
+    routes.push({
+      path: path,
+      port: port,
+      strip_prefix: row.querySelector('.route-strip-input').checked
+    });
+  });
+  if (!routes.length) throw new Error('Add at least one route.');
+  return routes;
+}
+
 function renderServices(services) {
   cachedServices = services || [];
   var el = document.getElementById('svc-list');
@@ -3534,9 +3617,17 @@ function renderServices(services) {
     return;
   }
   el.innerHTML = services.map(function(svc) {
-    var urlHtml = svc.url
+    var urlHtml = svc.url && !(svc.routes && svc.routes.length)
       ? '<div class="svc-meta"><span>URL: <a href="' + esc(svc.url) + '" target="_blank">' + esc(svc.url) + '</a></span></div>'
       : '';
+    var routesHtml = '';
+    if (svc.routes && svc.routes.length) {
+      routesHtml = svc.routes.map(function(route) {
+        var strip = route.strip_prefix ? ' · strip prefix' : '';
+        return '<div class="svc-meta"><span>Route: <a href="' + esc(route.url) + '" target="_blank">' + esc(route.path) + '</a>' +
+          ' <strong>→ ' + route.port + strip + '</strong></span></div>';
+      }).join('');
+    }
     var volHtml = '';
     if (svc.volumes && svc.volumes.length > 0) {
       var volStr = svc.volumes.map(function(v) { return esc(v.volume) + ':' + esc(v.mount_path) + (v.mode === 'ro' ? ':ro' : ''); }).join(', ');
@@ -3570,6 +3661,7 @@ function renderServices(services) {
         (svc.created_at ? '<span>Created: <strong>' + formatDate(svc.created_at) + '</strong></span>' : '') +
       '</div>' +
       urlHtml +
+      routesHtml +
       volHtml +
     '</div>';
   }).join('');
@@ -3685,6 +3777,9 @@ function openCreateServiceModal() {
    document.getElementById('svc-name').value = '';
    document.getElementById('svc-image').value = '';
    document.getElementById('svc-port').value = '';
+   document.getElementById('svc-exposure').value = 'port';
+   setServiceRoutes('svc', []);
+   toggleServiceExposure('svc');
    document.getElementById('svc-hostname').value = '';
    document.getElementById('svc-envvars').value = '';
    document.getElementById('svc-host-mode').checked = false;
@@ -3708,12 +3803,13 @@ async function submitCreateService() {
   var name = document.getElementById('svc-name').value.trim();
   var image = document.getElementById('svc-image').value.trim();
   var port = document.getElementById('svc-port').value.trim();
+  var routeMode = document.getElementById('svc-exposure').value === 'routes';
   var hostname = document.getElementById('svc-hostname').value.trim();
   var envvars = document.getElementById('svc-envvars').value.trim();
   var errEl = document.getElementById('create-svc-error');
 
-  if (!name || !image || !port) {
-    errEl.textContent = 'Service name, Docker image and port are required.';
+  if (!name || !image || (!routeMode && !port)) {
+    errEl.textContent = 'Service name, Docker image and exposure are required.';
     errEl.style.display = 'block';
     return;
   }
@@ -3728,7 +3824,9 @@ async function submitCreateService() {
     var svcVolumes = document.getElementById('svc-volumes').value.trim();
     var privileged = document.getElementById('svc-privileged').checked;
     var netAdmin = document.getElementById('svc-net-admin').checked;
-    var payload = { name: name, image: image, port: parseInt(port, 10), host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
+    var payload = { name: name, image: image, host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
+    if (routeMode) payload.routes = collectServiceRoutes('svc');
+    else payload.port = parseInt(port, 10);
     if (hostname) payload.hostname = hostname;
     if (envvars) payload.env_vars = envvars;
     if (svcVolumes) payload.volumes = svcVolumes;
@@ -3747,7 +3845,7 @@ async function submitCreateService() {
       errEl.style.display = 'block';
     }
   } catch (e) {
-    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.textContent = e.message.indexOf('route') !== -1 ? e.message : 'Connection error: ' + e.message;
     errEl.style.display = 'block';
   } finally {
     btn.disabled = false;
@@ -3796,7 +3894,9 @@ function renderPresetsList(presets) {
       '</div>' +
       '<div class="preset-meta">' +
         '<span>Image: <strong>' + esc(p.image) + '</strong></span>' +
-        '<span>Port: <strong>' + p.port + '</strong></span>' +
+        (p.routes && p.routes.length
+          ? '<span>Routes: <strong>' + p.routes.map(function(route) { return esc(route.path) + '→' + route.port; }).join(', ') + '</strong></span>'
+          : '<span>Port: <strong>' + p.port + '</strong></span>') +
         (p.hostname ? '<span>Host: <strong>' + esc(p.hostname) + '</strong></span>' : '') +
         envStr +
         (p.volumes && p.volumes.length ? '<span>Volumes: <strong>' + p.volumes.map(function(v) { return esc(v.volume) + ':' + esc(v.mount_path); }).join(', ') + '</strong></span>' : '') +
@@ -3833,7 +3933,10 @@ async function doDeletePreset(name) {
 function _fillRestoreFields(p) {
    document.getElementById('restore-svc-name').value = p.name || '';
    document.getElementById('restore-svc-image').value = p.image || '';
-   document.getElementById('restore-svc-port').value = p.port || '';
+   document.getElementById('restore-svc-port').value = p.routes && p.routes.length ? '' : (p.port || '');
+   document.getElementById('restore-svc-exposure').value = p.routes && p.routes.length ? 'routes' : 'port';
+   setServiceRoutes('restore-svc', p.routes || []);
+   toggleServiceExposure('restore-svc');
    document.getElementById('restore-svc-hostname').value = p.hostname || '';
    var envStr = '';
    if (p.env_vars && Object.keys(p.env_vars).length) {
@@ -3858,6 +3961,9 @@ function openRestoreServiceModal(preselect) {
    document.getElementById('restore-svc-name').value = '';
    document.getElementById('restore-svc-image').value = '';
    document.getElementById('restore-svc-port').value = '';
+   document.getElementById('restore-svc-exposure').value = 'port';
+   setServiceRoutes('restore-svc', []);
+   toggleServiceExposure('restore-svc');
    document.getElementById('restore-svc-hostname').value = '';
    document.getElementById('restore-svc-envvars').value = '';
    document.getElementById('restore-svc-host-mode').checked = false;
@@ -3902,12 +4008,13 @@ async function submitRestoreService() {
   var name = document.getElementById('restore-svc-name').value.trim();
   var image = document.getElementById('restore-svc-image').value.trim();
   var port = document.getElementById('restore-svc-port').value.trim();
+  var routeMode = document.getElementById('restore-svc-exposure').value === 'routes';
   var hostname = document.getElementById('restore-svc-hostname').value.trim();
   var envvars = document.getElementById('restore-svc-envvars').value.trim();
   var errEl = document.getElementById('restore-svc-error');
 
-  if (!name || !image || !port) {
-    errEl.textContent = 'Service name, Docker image and port are required.';
+  if (!name || !image || (!routeMode && !port)) {
+    errEl.textContent = 'Service name, Docker image and exposure are required.';
     errEl.style.display = 'block';
     return;
   }
@@ -3921,7 +4028,9 @@ async function submitRestoreService() {
     var restoreVolumes = document.getElementById('restore-svc-volumes').value.trim();
     var privileged = document.getElementById('restore-svc-privileged').checked;
     var netAdmin = document.getElementById('restore-svc-net-admin').checked;
-    var payload = { name: name, image: image, port: parseInt(port, 10), host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
+    var payload = { name: name, image: image, host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
+    if (routeMode) payload.routes = collectServiceRoutes('restore-svc');
+    else payload.port = parseInt(port, 10);
     if (hostname) payload.hostname = hostname;
     if (envvars) payload.env_vars = envvars;
     if (restoreVolumes) payload.volumes = restoreVolumes;
@@ -3941,7 +4050,7 @@ async function submitRestoreService() {
       errEl.style.display = 'block';
     }
   } catch (e) {
-    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.textContent = e.message.indexOf('route') !== -1 ? e.message : 'Connection error: ' + e.message;
     errEl.style.display = 'block';
   } finally {
     btn.disabled = false;

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1536,12 +1536,16 @@ def _build_routes(
             name = (body.get("name") or "").strip()
             image = (body.get("image") or "").strip()
             port = body.get("port")
+            routes = body.get("routes")
             hostname = (body.get("hostname") or "").strip() or None
             env_vars_raw = (body.get("env_vars") or "").strip()
             host_mode = bool(body.get("host_mode", False))
-            if not name or not image or not port:
+            if not name or not image or (not port and not routes):
                 return JSONResponse(
-                    {"ok": False, "error": "name, image and port are required."},
+                    {
+                        "ok": False,
+                        "error": "name, image and either port or routes are required.",
+                    },
                     status_code=400,
                 )
             env_vars = None
@@ -1565,15 +1569,18 @@ def _build_routes(
                 team,
                 name,
                 image,
-                int(port),
+                int(port) if port else None,
                 hostname=hostname,
                 env_vars=env_vars,
                 host_mode=host_mode,
                 volumes=parsed_volumes,
                 cap_add=cap_add,
                 privileged=privileged,
+                routes=routes,
             )
             return JSONResponse({"ok": True, "result": result})
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
         except Exception as e:
@@ -1618,6 +1625,7 @@ def _build_routes(
             )
             port_raw = body.get("port") if body else None
             port_override = int(port_raw) if port_raw else None
+            routes_override = body.get("routes") if body and "routes" in body else None
             host_mode_override = (
                 bool(body["host_mode"])
                 if body and "host_mode" in body and body["host_mode"] is not None
@@ -1644,8 +1652,11 @@ def _build_routes(
                 volume_override=volume_override,
                 cap_add_override=cap_add_override,
                 privileged_override=privileged_override,
+                routes_override=routes_override,
             )
             return JSONResponse({"ok": True, "result": result})
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
         except Exception as e:
@@ -1725,12 +1736,16 @@ def _build_routes(
             name = (body.get("name") or "").strip()
             image = (body.get("image") or "").strip()
             port = body.get("port")
+            routes = body.get("routes")
             hostname = (body.get("hostname") or "").strip() or None
             env_vars_raw = (body.get("env_vars") or "").strip()
             host_mode = bool(body.get("host_mode", False))
-            if not name or not image or not port:
+            if not name or not image or (not port and not routes):
                 return JSONResponse(
-                    {"ok": False, "error": "name, image and port are required."},
+                    {
+                        "ok": False,
+                        "error": "name, image and either port or routes are required.",
+                    },
                     status_code=400,
                 )
             env_vars = None
@@ -1754,15 +1769,18 @@ def _build_routes(
                 team,
                 name,
                 image,
-                int(port),
+                int(port) if port else None,
                 hostname=hostname,
                 env_vars=env_vars,
                 host_mode=host_mode,
                 volumes=parsed_volumes,
                 cap_add=cap_add,
                 privileged=privileged,
+                routes=routes,
             )
             return JSONResponse({"ok": True, "result": result})
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
         except Exception as e:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -421,6 +421,23 @@ class TestCreateServiceTool:
         call_kwargs = mock_create.call_args
         assert call_kwargs[1]["env_vars"] is None
 
+    @patch("oduflow.docker_ops.service_ops.create_service")
+    def test_create_with_routes(self, mock_create):
+        routes = [{"path": "/RPC2", "port": 8080, "strip_prefix": False}]
+        mock_create.return_value = {
+            "name": "fs",
+            "container_name": "oduflow-1-svc-fs",
+            "url": "https://fs.example.com",
+            "image": "fs:1",
+            "routes": routes,
+        }
+
+        result = _get_tool_fn("create_service")(name="fs", image="fs:1", routes=routes)
+
+        assert mock_create.call_args.args[4] is None
+        assert mock_create.call_args.kwargs["routes"] == routes
+        assert "- /RPC2 -> 8080" in result
+
 
 class TestUpdateServiceTool:
     @patch("oduflow.docker_ops.service_ops.update_service")
@@ -447,7 +464,20 @@ class TestUpdateServiceTool:
             volume_override=None,
             cap_add_override=None,
             privileged_override=None,
+            routes_override=None,
         )
+
+    @patch("oduflow.docker_ops.service_ops.update_service")
+    def test_update_routes_mapping(self, mock_update):
+        mock_update.return_value = {
+            "name": "fs",
+            "container_name": "oduflow-1-svc-fs",
+            "url": "https://fs.example.com",
+            "image": "fs:1",
+        }
+        routes = [{"path": "/RPC2", "port": 8080, "strip_prefix": False}]
+        _get_tool_fn("update_service")(name="fs", routes=routes)
+        assert mock_update.call_args.kwargs["routes_override"] == routes
 
     @patch("oduflow.docker_ops.service_ops.update_service")
     def test_update_net_admin_and_privileged_mapping(self, mock_update):

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -135,6 +135,100 @@ class TestCreateService:
             "oduflow-traefik-acme": {"bind": "/etc/traefik", "mode": "ro"}
         }
 
+    def test_create_traefik_bridge_with_restricted_routes(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        result = service_ops.create_service(
+            TRAEFIK_SETTINGS,
+            TRAEFIK_TEAM,
+            "gateway",
+            "example/gateway:1",
+            None,
+            routes=[
+                {"path": "/RPC2", "port": 8080},
+                {"path": "/admin/", "port": 8081, "strip_prefix": True},
+            ],
+        )
+
+        run_kwargs = mock_docker_client.containers.run.call_args[1]
+        labels = run_kwargs["labels"]
+        assert run_kwargs["network"] == "oduflow-1-net"
+        assert "traefik.http.routers.oduflow-1-svc-gateway.rule" not in labels
+        assert labels["traefik.http.routers.oduflow-1-svc-gateway-route-1.rule"] == (
+            "Host(`gateway.example.com`) && (Path(`/RPC2`) || PathPrefix(`/RPC2/`))"
+        )
+        assert (
+            labels[
+                "traefik.http.services.oduflow-1-svc-gateway-route-1.loadbalancer.server.port"
+            ]
+            == "8080"
+        )
+        assert labels[
+            "traefik.http.routers.oduflow-1-svc-gateway-route-2.middlewares"
+        ] == ("oduflow-1-svc-gateway-route-2-strip")
+        assert (
+            labels[
+                "traefik.http.middlewares.oduflow-1-svc-gateway-route-2-strip.stripprefix.prefixes"
+            ]
+            == "/admin"
+        )
+        assert result["routes"][0]["url"] == "https://gateway.example.com/RPC2"
+
+    def test_create_traefik_host_mode_routes_use_host_gateway(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+
+        service_ops.create_service(
+            TRAEFIK_SETTINGS,
+            TRAEFIK_TEAM,
+            "fs",
+            "oduist/freeswitch:latest",
+            None,
+            host_mode=True,
+            routes=[{"path": "/RPC2", "port": 8080}],
+        )
+
+        run_kwargs = mock_docker_client.containers.run.call_args[1]
+        assert run_kwargs["network_mode"] == "host"
+        assert (
+            run_kwargs["labels"][
+                "traefik.http.services.oduflow-1-svc-fs-route-1.loadbalancer.server.url"
+            ]
+            == "http://host.docker.internal:8080"
+        )
+
+    @pytest.mark.parametrize(
+        ("settings", "port", "routes", "message"),
+        [
+            (TEST_SETTINGS, None, [{"path": "/api", "port": 8080}], "traefik"),
+            (
+                TRAEFIK_SETTINGS,
+                8080,
+                [{"path": "/api", "port": 8080}],
+                "either port or routes",
+            ),
+            (
+                TRAEFIK_SETTINGS,
+                None,
+                [{"path": "/api", "port": 8080}, {"path": "/api/", "port": 8081}],
+                "Duplicate route",
+            ),
+            (
+                TRAEFIK_SETTINGS,
+                None,
+                [{"path": "/api", "port": 8080, "url": "http://other:80"}],
+                "unsupported fields: url",
+            ),
+        ],
+    )
+    def test_create_rejects_invalid_route_exposure(
+        self, mock_docker_client, settings, port, routes, message
+    ):
+        with pytest.raises(ValueError, match=message):
+            service_ops.create_service(
+                settings, TRAEFIK_TEAM, "svc", "example/svc:1", port, routes=routes
+            )
+        mock_docker_client.images.pull.assert_not_called()
+
     def test_create_traefik_mounts_acme_with_user_volumes(self, mock_docker_client):
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
 
@@ -648,6 +742,85 @@ class TestUpdateService:
             labels["traefik.http.routers.oduflow-1-svc-meili.rule"]
             == "Host(`meili.example.com`)"
         )
+
+    def test_update_replaces_legacy_port_with_routes(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["example/app:1"],
+            labels={
+                "oduflow.managed": "true",
+                "oduflow.service": "app",
+                "traefik.http.routers.oduflow-1-svc-app.rule": "Host(`app.example.com`)",
+                "traefik.http.services.oduflow-1-svc-app.loadbalancer.server.port": "8080",
+            },
+            attrs={"Config": {"Env": []}, "Mounts": []},
+        )
+        container.image.id = "sha256:old"
+        pulled = MagicMock(id="sha256:old")
+        mock_docker_client.images.pull.return_value = pulled
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        preset = {
+            "name": "app",
+            "image": "example/app:1",
+            "port": 8080,
+            "hostname": "app",
+            "env_vars": {},
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TRAEFIK_SETTINGS,
+                TRAEFIK_TEAM,
+                "app",
+                routes_override=[{"path": "/api", "port": 8081}],
+            )
+
+        assert result["config_updated"] is True
+        labels = mock_docker_client.containers.run.call_args[1]["labels"]
+        assert "traefik.http.routers.oduflow-1-svc-app.rule" not in labels
+        assert (
+            labels[
+                "traefik.http.services.oduflow-1-svc-app-route-1.loadbalancer.server.port"
+            ]
+            == "8081"
+        )
+
+    def test_update_clear_routes_requires_replacement_port(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["example/app:1"],
+            labels={
+                "oduflow.managed": "true",
+                "oduflow.service": "app",
+                "oduflow.http_routes": '[{"path":"/api","port":8080,"strip_prefix":false}]',
+            },
+            attrs={"Config": {"Env": []}, "Mounts": []},
+        )
+        preset = {
+            "name": "app",
+            "image": "example/app:1",
+            "port": 0,
+            "hostname": "app",
+            "env_vars": {},
+            "routes": [{"path": "/api", "port": 8080, "strip_prefix": False}],
+        }
+        mock_docker_client.containers.get.return_value = container
+
+        with (
+            patch(
+                "oduflow.docker_ops.service_ops.service_presets.get_preset",
+                return_value=preset,
+            ),
+            pytest.raises(ValueError, match="replacement port"),
+        ):
+            service_ops.update_service(
+                TRAEFIK_SETTINGS, TRAEFIK_TEAM, "app", routes_override=[]
+            )
+        container.stop.assert_not_called()
 
     def test_update_no_env_vars(self, mock_docker_client):
         """When the preset has no custom env vars, env_vars=None is passed to create."""
@@ -1319,6 +1492,43 @@ class TestGetServiceInfo:
         assert info["url"] == "https://meili.example.com"
         assert info["port"] == 7700
         assert info["has_preset"] is False
+
+    def test_get_service_info_reports_http_routes(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["example/app:1"],
+            image_id="sha256:app",
+            labels={
+                "__name": "oduflow-1-svc-app",
+                "oduflow.managed": "true",
+                "oduflow.service": "app",
+                "oduflow.http_routes": '[{"path":"/api","port":8080,"strip_prefix":false}]',
+                "traefik.http.routers.oduflow-1-svc-app-route-1.rule": (
+                    "Host(`app.example.com`) && (Path(`/api`) || PathPrefix(`/api/`))"
+                ),
+            },
+            attrs={
+                "Config": {"Env": []},
+                "Mounts": [],
+                "HostConfig": {},
+                "State": {},
+            },
+        )
+        mock_docker_client.containers.get.return_value = container
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=NotFoundError("no preset"),
+        ):
+            info = service_ops.get_service_info(TRAEFIK_SETTINGS, TRAEFIK_TEAM, "app")
+
+        assert info["port"] is None
+        assert info["routes"] == [
+            {
+                "path": "/api",
+                "port": 8080,
+                "strip_prefix": False,
+                "url": "https://app.example.com/api",
+            }
+        ]
 
     def test_get_service_info_not_found(self, mock_docker_client):
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")

--- a/tests/test_service_presets.py
+++ b/tests/test_service_presets.py
@@ -46,6 +46,15 @@ class TestSavePreset:
         preset = service_presets.get_preset(tmp_team, "redis")
         assert preset["hostname"] == "redis.local"
 
+    def test_save_preset_with_http_routes(self, tmp_team):
+        routes = [{"path": "/RPC2", "port": 8080, "strip_prefix": False}]
+        service_presets.save_preset(
+            tmp_team, "fs", "oduist/freeswitch:latest", None, routes=routes
+        )
+        preset = service_presets.get_preset(tmp_team, "fs")
+        assert preset["port"] == 0
+        assert preset["routes"] == routes
+
     def test_save_preset_overwrites(self, tmp_team):
         service_presets.save_preset(tmp_team, "redis", "redis:6", 6379)
         service_presets.save_preset(tmp_team, "redis", "redis:7", 6380)

--- a/tests/test_service_routes_web.py
+++ b/tests/test_service_routes_web.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path):
+    team = TeamSettings(team_id="1", hostname="example.com", data_dir=str(tmp_path))
+    settings = Settings(
+        routing_mode="traefik",
+        routing_tls=False,
+        base_data_dir=str(tmp_path),
+        teams={"1": team},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def test_create_service_accepts_structured_routes(tmp_path):
+    client = _client(tmp_path)
+    routes = [{"path": "/RPC2", "port": 8080, "strip_prefix": False}]
+    with patch("oduflow.web_ui.service_ops.create_service") as create:
+        create.return_value = {
+            "name": "fs",
+            "container_name": "oduflow-1-svc-fs",
+            "image": "fs:1",
+            "url": "https://fs.example.com",
+            "routes": routes,
+        }
+        response = client.post(
+            "/api/services/create",
+            json={"name": "fs", "image": "fs:1", "routes": routes},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert create.call_args.args[4] is None
+    assert create.call_args.kwargs["routes"] == routes
+
+
+def test_update_service_distinguishes_missing_and_empty_routes(tmp_path):
+    client = _client(tmp_path)
+    result = {
+        "name": "fs",
+        "container_name": "oduflow-1-svc-fs",
+        "image": "fs:1",
+        "url": "https://fs.example.com",
+    }
+    with patch(
+        "oduflow.web_ui.service_ops.update_service", return_value=result
+    ) as update:
+        response = client.post(
+            "/api/services/fs/update", json={"routes": [], "port": 8080}
+        )
+
+    assert response.status_code == 200
+    assert update.call_args.kwargs["routes_override"] == []
+    assert update.call_args.kwargs["port_override"] == 8080


### PR DESCRIPTION
Adds structured, mutually exclusive `routes` alongside the existing catch-all `port` exposure model for auxiliary services.
Restricted routes use segment-safe Traefik rules, work for both bridge and host networking, optionally strip prefixes, and leave undeclared paths at Traefik's 404.
The route configuration is preserved through presets, live inspection, updates, MCP, REST, and the dashboard, with an ADR and user documentation covering the security boundary and trade-offs.
Validated with Ruff, 830 non-integration tests plus 128 focused tests, JavaScript parsing, browser UI checks, strict MkDocs build, and `git diff --check`.
