### PR TITLE
Apply requirements.txt / apt_packages.txt changes on Sync

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **Dependency changes are applied on Sync** — a changed `requirements.txt`, `.oduflow/requirements.txt`, or `.oduflow/apt_packages.txt` during `pull_and_apply`/Sync now reinstalls the apt/pip dependencies into the running container and restarts it, instead of being misreported as an XML/JS-only browser refresh. The classifier previously ignored these files, so a dependency-only change silently did nothing. Reinstall runs before any module install/upgrade so new libraries are importable; packages *removed* from the file are not uninstalled until the container is rebuilt via `update_environment`.
+
 ## v1.66.0
 
 ### Features

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -2310,6 +2310,8 @@ def _apply_actions(
     do_restart: bool,
     changed_files: list[str],
     config_changed: bool = False,
+    deps_changed: bool = False,
+    repo_path: str = "",
 ) -> dict[str, Any]:
     """Run install/upgrade/restart and build the result dict (shared by the
     explicit and auto paths of :func:`pull_environment`)."""
@@ -2317,6 +2319,26 @@ def _apply_actions(
         install_odoo_modules,
         upgrade_odoo_modules,
     )
+
+    # Reinstall apt/pip deps up front so a subsequent module install/upgrade can
+    # import newly-added libs (same apt-then-pip order as create/update). Never
+    # restart here — a single restart happens in the branches below.
+    dep_logs: list[str] = []
+    dep_exit = 0
+    if deps_changed and repo_path:
+        dep_container = client.containers.get(odoo_container_name)
+        apt_log = _install_apt_packages(dep_container, repo_path)
+        if apt_log:
+            dep_logs.append(apt_log)
+            if "FAILED" in apt_log:
+                dep_exit = 1
+        pip_installed, pip_log = _install_pip_requirements(
+            dep_container, repo_path, restart=False
+        )
+        if pip_log:
+            dep_logs.append(pip_log)
+        if (not pip_installed) and pip_log:  # log present but not installed => FAILED
+            dep_exit = 1
 
     if to_install or to_upgrade:
         messages: list[str] = []
@@ -2334,6 +2356,8 @@ def _apply_actions(
             messages.append(f"Upgraded modules: {','.join(to_upgrade)}")
             if res.get("output"):
                 odoo_output_parts.append(res["output"])
+        if dep_logs:
+            messages.insert(0, "Reinstalled dependencies.")
         container = client.containers.get(odoo_container_name)
         if config_changed and _reapply_odoo_conf(settings, team, env_name, container):
             messages.append("Reapplied odoo.conf.")
@@ -2346,27 +2370,36 @@ def _apply_actions(
             "action": "install" if to_install else "upgrade",
             "modules_installed": to_install,
             "modules_upgraded": to_upgrade,
-            "exit_code": last_exit_code,
+            "exit_code": last_exit_code or dep_exit,
             "changed_files": changed_files,
             "message": " ".join(messages),
-            "output": "\n".join(odoo_output_parts),
+            "output": "\n".join(dep_logs + odoo_output_parts),
         }
 
-    if do_restart:
+    if do_restart or deps_changed:
         container = client.containers.get(odoo_container_name)
         reapplied = config_changed and _reapply_odoo_conf(
             settings, team, env_name, container
         )
         container.restart()
         logger.info("Container restarted", extra={"env_name": env_name})
+        parts: list[str] = []
+        if reapplied:
+            parts.append("Reapplied odoo.conf.")
+        if dep_logs:
+            parts.append("Reinstalled dependencies.")
+        elif deps_changed:
+            # A dependency file changed but nothing was installed (e.g. it was
+            # deleted, or only removed lines). Removed packages are not
+            # uninstalled until the container is rebuilt (update_environment).
+            parts.append("Dependencies changed.")
+        parts.append("Container restarted.")
         return {
             "action": "restart",
             "changed_files": changed_files,
-            "message": (
-                "Reapplied odoo.conf and restarted container."
-                if reapplied
-                else "Container restarted."
-            ),
+            "message": " ".join(parts),
+            "output": "\n".join(dep_logs),
+            "exit_code": dep_exit,
         }
 
     if changed_files:
@@ -2411,6 +2444,7 @@ def pull_environment(
       path-only ``shallow_classify`` in live-mount mode.
     """
     from oduflow.git_analysis import (
+        _is_dep_file,
         guardrail_warnings,
         merge_recommendations,
         recommend,
@@ -2447,6 +2481,7 @@ def pull_environment(
         _trace("pull_environment(%s): live-mount, detecting local changes", env_name)
         base_ref, all_changed = _detect_local_changes(repo_path, env_name, team)
         classify_units.append((repo_path, base_ref, all_changed))
+        main_changed_files = all_changed
     else:
         _trace("pull_environment(%s): git pull started", env_name)
         git_branch = container_obj.labels.get("oduflow.git_branch", env_name)
@@ -2481,6 +2516,9 @@ def pull_environment(
                     # Classify this worktree against its own path + old HEAD.
                     classify_units.append((wt_path, extra_old, extra_files))
         all_changed = changed_files + extra_changed_files
+        # Dependency reinstall keys off the MAIN repo only: the pip/apt install
+        # helpers read only the main repo_path, never the extra-addon worktrees.
+        main_changed_files = changed_files
 
     _trace(
         "pull_environment(%s): %d changed files: %s",
@@ -2502,6 +2540,11 @@ def pull_environment(
     # container before any restart (a plain restart reuses the stale copy).
     details = recommended.get("details")
     config_changed = isinstance(details, dict) and bool(details.get("restart_required"))
+    # A changed dependency descriptor (requirements.txt / apt_packages.txt) in the
+    # MAIN repo must reinstall apt/pip deps into the running container and restart.
+    # Scoped to the main repo because the install helpers only read its repo_path;
+    # applies to both explicit and auto modes (a prerequisite, not an agent action).
+    deps_changed = any(_is_dep_file(f) for f in main_changed_files)
 
     warnings: list[str] = []
     if explicit:
@@ -2547,6 +2590,8 @@ def pull_environment(
         do_restart=do_restart,
         changed_files=all_changed,
         config_changed=config_changed,
+        deps_changed=deps_changed,
+        repo_path=repo_path,
     )
     if warnings:
         result["warnings"] = warnings

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -20,6 +20,18 @@ def _trace(msg: str, *args: object) -> None:
 MANIFEST_KEYS_WITH_FILES = ("data", "demo", "assets", "qweb")
 RESTART_REQUIRED_PATHS = {".oduflow/odoo.conf"}
 
+# Dependency descriptors Oduflow actually reads into the container. A change to
+# any of these means Python/apt deps changed → reinstall + restart. Only these
+# exact repo-root-relative paths are installed (see
+# env_ops._install_pip_requirements / _install_apt_packages); a nested
+# ``foo/requirements.txt`` or a repo-root ``apt_packages.txt`` is intentionally
+# NOT a dependency descriptor.
+DEP_FILE_PATHS = {
+    "requirements.txt",
+    ".oduflow/requirements.txt",
+    ".oduflow/apt_packages.txt",
+}
+
 _FIELD_RE = re.compile(r"^\s*\w+\s*=\s*fields\..*", re.MULTILINE)
 _VIEW_TAG_RE = re.compile(r"<(tree|list|form)\b([^>]*)/?>")
 
@@ -149,6 +161,10 @@ def _requires_restart_path(file_path: str) -> bool:
     return file_path.replace(os.sep, "/") in RESTART_REQUIRED_PATHS
 
 
+def _is_dep_file(file_path: str) -> bool:
+    return file_path.replace(os.sep, "/") in DEP_FILE_PATHS
+
+
 def classify_changes(
     changed_files: list[str], repo_path: str, base_ref: str = "HEAD~1"
 ) -> dict:
@@ -167,6 +183,7 @@ def classify_changes(
                 "manifest_upgrade": [...], # modules needing upgrade due to manifest
                 "js_changed": [...],
                 "restart_required": [...],
+                "deps_changed": [...],   # dependency descriptors (requirements/apt)
             }
         }
     """
@@ -186,6 +203,7 @@ def classify_changes(
     xml_security = []
     js_changed = []
     restart_required = []
+    deps_changed: list[str] = []
     modules_to_upgrade: set[str] = set()
     modules_to_install: set[str] = set()
 
@@ -200,6 +218,14 @@ def classify_changes(
                 f,
                 ext,
                 module,
+            )
+            continue
+
+        if _is_dep_file(f):
+            deps_changed.append(f)
+            _trace(
+                "  file=%s -> dependency descriptor, reinstall + restart",
+                f,
             )
             continue
 
@@ -273,6 +299,7 @@ def classify_changes(
         "manifest_install": sorted(modules_to_install),
         "js_changed": js_changed,
         "restart_required": restart_required,
+        "deps_changed": deps_changed,
     }
 
     if modules_to_install or modules_to_upgrade:
@@ -290,10 +317,10 @@ def classify_changes(
             "details": details,
         }
 
-    if py_changed or restart_required:
+    if py_changed or restart_required or deps_changed:
         _trace(
             "classify_changes RESULT: action=restart "
-            "(Python or restart-required config changed)"
+            "(Python, restart-required config, or dependencies changed)"
         )
         return {
             "action": "restart",
@@ -389,6 +416,7 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
     xml_security: list[str] = []
     js_changed: list[str] = []
     restart_required: list[str] = []
+    deps_changed: list[str] = []
     modules_to_upgrade: set[str] = set()
 
     for f in changed_files:
@@ -397,6 +425,9 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
 
         if _requires_restart_path(f):
             restart_required.append(f)
+            continue
+        if _is_dep_file(f):
+            deps_changed.append(f)
             continue
         if os.path.basename(f) == "__manifest__.py" and module:
             modules_to_upgrade.add(module)
@@ -422,6 +453,7 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
         "manifest_install": [],
         "js_changed": js_changed,
         "restart_required": restart_required,
+        "deps_changed": deps_changed,
     }
 
     if modules_to_upgrade:
@@ -431,7 +463,7 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
             "modules_to_upgrade": sorted(modules_to_upgrade),
             "details": details,
         }
-    if py_changed or restart_required:
+    if py_changed or restart_required or deps_changed:
         return {
             "action": "restart",
             "modules_to_upgrade": [],

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1361,6 +1361,11 @@ def pull_and_apply(
       manifest data/depends changed → upgrade="module" (-u): these live in the
       database and a restart won't load them.
     - A brand-new module was added → install="module" (-i).
+    - Dependency files (`requirements.txt`, `.oduflow/requirements.txt`,
+      `.oduflow/apt_packages.txt`) changed → Oduflow reinstalls dependencies into
+      the running container and restarts automatically; no action needed. (Packages
+      removed from the file are not uninstalled until the container is rebuilt via
+      update_environment.)
 
     Errors and tracebacks are returned directly in this response — do NOT call
     get_environment_logs to check for them.

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -3,9 +3,12 @@ import textwrap
 
 from oduflow.git_analysis import (
     classify_changes,
+    shallow_classify,
+    merge_recommendations,
     _get_module_name,
     _is_security_path,
     _is_data_path,
+    _is_dep_file,
     _extract_field_lines,
     _extract_view_tag_attrs,
 )
@@ -44,6 +47,28 @@ class TestIsDataPath:
         assert _is_data_path("addons_ee/connect_elevenlabs/data/tools.xml") is True
 
 
+class TestIsDepFile:
+    def test_root_requirements(self):
+        assert _is_dep_file("requirements.txt") is True
+
+    def test_oduflow_requirements(self):
+        assert _is_dep_file(".oduflow/requirements.txt") is True
+
+    def test_oduflow_apt_packages(self):
+        assert _is_dep_file(".oduflow/apt_packages.txt") is True
+
+    def test_nested_requirements_is_not_a_dep_file(self):
+        # Only the repo-root / .oduflow requirements are installed.
+        assert _is_dep_file("sale/requirements.txt") is False
+
+    def test_requirements_dev_is_not_a_dep_file(self):
+        assert _is_dep_file("requirements-dev.txt") is False
+
+    def test_root_apt_packages_is_not_a_dep_file(self):
+        # apt_packages.txt is only read from .oduflow/, never the repo root.
+        assert _is_dep_file("apt_packages.txt") is False
+
+
 class TestClassifyChanges:
     def test_empty(self):
         result = classify_changes([], "/tmp")
@@ -74,6 +99,66 @@ class TestClassifyChanges:
         result = classify_changes(files, "/tmp")
         assert result["action"] == "restart"
         assert result["details"]["restart_required"] == [".oduflow/odoo.conf"]
+
+    def test_lone_requirements_txt_restart(self):
+        result = classify_changes(["requirements.txt"], "/tmp")
+        assert result["action"] == "restart"
+        assert result["details"]["deps_changed"] == ["requirements.txt"]
+        assert result["modules_to_upgrade"] == []
+
+    def test_oduflow_requirements_restart(self):
+        result = classify_changes([".oduflow/requirements.txt"], "/tmp")
+        assert result["action"] == "restart"
+        assert result["details"]["deps_changed"] == [".oduflow/requirements.txt"]
+
+    def test_apt_packages_restart(self):
+        result = classify_changes([".oduflow/apt_packages.txt"], "/tmp")
+        assert result["action"] == "restart"
+        assert result["details"]["deps_changed"] == [".oduflow/apt_packages.txt"]
+
+    def test_requirements_plus_hot_xml_restart(self):
+        # A dependency change beats a browser-only refresh.
+        files = ["requirements.txt", "sale/views/sale_order.xml"]
+        result = classify_changes(files, "/tmp")
+        assert result["action"] == "restart"
+        assert result["details"]["deps_changed"] == ["requirements.txt"]
+        assert result["details"]["xml_hot"] == ["sale/views/sale_order.xml"]
+
+    def test_requirements_plus_field_change_stays_upgrade(self, tmp_path):
+        # A field change still wins the action, but the dependency file is still
+        # recorded so the reinstall trigger survives the mixed case.
+        module_dir = tmp_path / "sale" / "models"
+        module_dir.mkdir(parents=True)
+        (tmp_path / "sale" / "__manifest__.py").write_text(
+            "{'name': 'Sale', 'version': '17.0.1.0.0'}"
+        )
+        (module_dir / "sale.py").write_text(
+            textwrap.dedent("""\
+            from odoo import fields, models
+
+            class SaleOrder(models.Model):
+                name = fields.Char(string='Name')
+                customer_code = fields.Char(string='Customer Code')
+        """)
+        )
+        (tmp_path / "requirements.txt").write_text("phonenumbers\n")
+
+        from unittest.mock import patch
+
+        old_source = textwrap.dedent("""\
+            from odoo import fields, models
+
+            class SaleOrder(models.Model):
+                name = fields.Char(string='Name')
+        """)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"stdout": old_source})()
+
+            files = ["requirements.txt", "sale/models/sale.py"]
+            result = classify_changes(files, str(tmp_path))
+            assert result["action"] == "upgrade"
+            assert "sale" in result["modules_to_upgrade"]
+            assert result["details"]["deps_changed"] == ["requirements.txt"]
 
     def test_security_xml(self):
         files = ["sale/security/ir.model.access.csv"]
@@ -540,6 +625,22 @@ class TestExtractFieldLines:
         assert _extract_field_lines(source) == set()
 
 
+class TestShallowClassify:
+    def test_lone_requirements_txt_restart(self):
+        result = shallow_classify(["requirements.txt"], "/tmp")
+        assert result["action"] == "restart"
+        assert result["details"]["deps_changed"] == ["requirements.txt"]
+
+    def test_apt_packages_restart(self):
+        result = shallow_classify([".oduflow/apt_packages.txt"], "/tmp")
+        assert result["action"] == "restart"
+        assert result["details"]["deps_changed"] == [".oduflow/apt_packages.txt"]
+
+    def test_only_xml_still_refresh(self):
+        result = shallow_classify(["sale/views/sale_order.xml"], "/tmp")
+        assert result["action"] == "refresh"
+
+
 class TestMergeRecommendations:
     def test_empty(self):
         from oduflow.git_analysis import merge_recommendations
@@ -585,3 +686,11 @@ class TestMergeRecommendations:
         merged = merge_recommendations([main, extra])
         assert merged["action"] == "upgrade"
         assert merged["modules_to_upgrade"] == ["sale_enterprise"]
+
+    def test_main_repo_dep_change_elevates_merged_action_to_restart(self):
+        # A main-repo requirements.txt change elevates its own unit to restart;
+        # merge takes the most-disruptive action across units.
+        main = classify_changes(["requirements.txt"], "/tmp")
+        extra = {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
+        merged = merge_recommendations([main, extra])
+        assert merged["action"] == "restart"

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -668,6 +668,35 @@ class TestPullEnvironmentLocal:
         assert env_ops._detect_local_changes(str(repo), "env", team)[1] == []
 
     @patch("oduflow.docker_ops.env_ops._apply_actions")
+    def test_local_requirements_change_passes_deps_changed(
+        self, mock_apply, mock_docker_client, tmp_path
+    ):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        req = repo / "requirements.txt"
+        req.write_text("phonenumbers\n")
+        env_ops._write_local_snapshot(str(repo), "env", team)
+
+        old_stat = req.stat()
+        req.write_text("phonenumbers\nqrcode\n")
+        os.utime(req, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000))
+
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": str(repo)}
+        mock_docker_client.containers.get.return_value = container
+        mock_apply.return_value = {
+            "action": "restart",
+            "changed_files": ["requirements.txt"],
+            "message": "Reinstalled dependencies. Container restarted.",
+        }
+
+        env_ops.pull_environment(TEST_SETTINGS, team, "env")
+
+        assert mock_apply.call_args.kwargs["deps_changed"] is True
+        assert mock_apply.call_args.kwargs["repo_path"] == str(repo)
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
     def test_local_failed_apply_does_not_advance_snapshot(
         self, mock_apply, mock_docker_client, tmp_path
     ):
@@ -1401,6 +1430,142 @@ class TestApplyActionsConf:
         container.restart.assert_called_once()
         assert result["action"] == "upgrade"
         assert "Reapplied odoo.conf." in result["message"]
+
+
+class TestApplyActionsDeps:
+    """A changed dependency descriptor must reinstall apt/pip deps into the
+    running container and restart it — not fall through to an XML/JS refresh."""
+
+    @staticmethod
+    def _client_with_container():
+        client = MagicMock()
+        container = MagicMock()
+        client.containers.get.return_value = container
+        return client, container
+
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements",
+        return_value=(True, "[PIP] Requirements installed successfully:\nok"),
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_apt_packages",
+        return_value="",
+    )
+    def test_deps_only_reinstalls_and_restarts(self, mock_apt, mock_pip):
+        client, container = self._client_with_container()
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-1-feature-x-odoo",
+            to_install=[],
+            to_upgrade=[],
+            do_restart=False,
+            changed_files=["requirements.txt"],
+            deps_changed=True,
+            repo_path="/repo",
+        )
+        # pip must run without restarting itself; the single restart is below.
+        mock_pip.assert_called_once()
+        assert mock_pip.call_args.kwargs["restart"] is False
+        container.restart.assert_called_once()
+        assert result["action"] == "restart"
+        assert "[PIP]" in result["output"]
+        assert "Reinstalled dependencies." in result["message"]
+        assert result["exit_code"] == 0
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.install_odoo_modules",
+        return_value={"exit_code": 0, "output": "installed"},
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements",
+        return_value=(True, "[PIP] Requirements installed successfully:\nok"),
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_apt_packages",
+        return_value="",
+    )
+    def test_deps_installed_before_module_install(
+        self, mock_apt, mock_pip, mock_install
+    ):
+        client, container = self._client_with_container()
+        # Route both patched calls through one parent so ordering is observable.
+        parent = MagicMock()
+        parent.attach_mock(mock_pip, "pip")
+        parent.attach_mock(mock_install, "install")
+
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-1-feature-x-odoo",
+            to_install=["sale"],
+            to_upgrade=[],
+            do_restart=False,
+            changed_files=["requirements.txt", "sale/__manifest__.py"],
+            deps_changed=True,
+            repo_path="/repo",
+        )
+        order = [name for name, _, _ in parent.mock_calls]
+        assert order.index("pip") < order.index("install")
+        container.restart.assert_called_once()
+        assert result["action"] == "install"
+        assert "[PIP]" in result["output"]
+        assert "installed" in result["output"]
+        assert result["message"].startswith("Reinstalled dependencies.")
+
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements",
+        return_value=(False, "[PIP] install FAILED (exit 1):\nboom"),
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_apt_packages",
+        return_value="",
+    )
+    def test_deps_pip_failure_surfaces_without_crashing(self, mock_apt, mock_pip):
+        client, container = self._client_with_container()
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-1-feature-x-odoo",
+            to_install=[],
+            to_upgrade=[],
+            do_restart=False,
+            changed_files=["requirements.txt"],
+            deps_changed=True,
+            repo_path="/repo",
+        )
+        assert result["action"] == "restart"
+        assert "FAILED" in result["output"]
+        assert result["exit_code"] == 1
+        container.restart.assert_called_once()
+
+    @patch("oduflow.docker_ops.env_ops._install_pip_requirements")
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages")
+    def test_deps_not_changed_skips_reinstall(self, mock_apt, mock_pip):
+        client, container = self._client_with_container()
+        result = env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-1-feature-x-odoo",
+            to_install=[],
+            to_upgrade=[],
+            do_restart=False,
+            changed_files=["sale/views/sale_order.xml"],
+            deps_changed=False,
+            repo_path="/repo",
+        )
+        mock_apt.assert_not_called()
+        mock_pip.assert_not_called()
+        container.restart.assert_not_called()
+        assert result["action"] == "refresh"
 
 
 class TestReapplyOdooConf:


### PR DESCRIPTION
## Problem

During `pull_and_apply` (Sync), a change to a dependency descriptor — `requirements.txt`, `.oduflow/requirements.txt`, or `.oduflow/apt_packages.txt` — was ignored by the change classifier and misreported as a browser-only XML/JS refresh. New pip/apt libraries were therefore never installed and the Sync silently did nothing useful.

## Fix

- **`git_analysis.py`** — adds `DEP_FILE_PATHS` + `_is_dep_file()`; both `classify_changes` and `shallow_classify` now record `deps_changed` and elevate the action to `restart` when a dependency descriptor changes. Only the exact repo-root-relative paths Oduflow actually installs count (a nested `foo/requirements.txt` or a repo-root `apt_packages.txt` intentionally does not).
- **`env_ops.py`** — `pull_environment` computes `deps_changed` from the **main repo** changed files (the pip/apt helpers only read the main `repo_path`, never extra-addon worktrees) and passes it plus `repo_path` to `_apply_actions`, which reinstalls apt-then-pip deps into the running container (same order as create/update) **before** any module install/upgrade, then performs a single restart.
- **`server.py`** — documents the behaviour in the `pull_and_apply` docstring.
- **`docs/changelog.md`** — Unreleased bugfix note.

Packages *removed* from a dependency file are not uninstalled until the container is rebuilt via `update_environment` — noted in both the changelog and the docstring.

## Tests

New unit tests:
- `test_git_analysis.py` — `_is_dep_file` matching; classifier for dep files alone, mixed with hot XML, mixed with a field change; `shallow_classify`; and merge elevation to `restart`.
- `test_odoo_manager.py` — `_apply_actions` reinstalls + restarts, installs deps before modules, surfaces a pip failure without crashing, and skips reinstall when unchanged; `pull_environment` passes `deps_changed`/`repo_path`.

Full unit suite: **842 passed** (`pytest -m "not integration and not heavyweight"`).