### PR TITLE
Cancel superseded test runs on PR pushes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a `concurrency` group to `tests.yml` so that pushing a new commit to an open PR cancels the still-running test workflow for that ref.

- Grouping key: `${{ github.workflow }}-${{ github.ref }}` — isolates branches, so only stale runs of the *same* PR/branch are cancelled.
- `cancel-in-progress: true` — saves CI minutes on rapid successive pushes.

Deliberately keeps the existing triggers unchanged: tests still run on push to `main`/`master` and on PRs into them, so `main` stays protected by pre-merge CI.