### PR TITLE
OAuth: fix claude.ai /mcp connector and split client_id from the secret

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- **claude.ai OAuth connector reaches the authorization endpoint** — a claude.ai custom connector derives its OAuth endpoints path-relative to the MCP URL (requesting `https://<host>/mcp/authorize` and `/mcp/token`) instead of following the root endpoints advertised by discovery. The outer scoped-access shim treated `authorize`/`token` as an environment name and rewrote the request onto the auth-protected `/mcp` endpoint, so the flow failed with `401 invalid_token` before it could start. Oduflow now routes the reserved OAuth/discovery sub-paths requested under `/mcp/` (`/mcp/authorize`, `/mcp/token`, `/mcp/register`, `/mcp/.well-known/*`) to the real root routes. Scoped `/mcp/<env>` connectors remain Bearer-only.
+
+### Security
+
+- **OAuth `client_id` is no longer the secret** — a team's OAuth `client_id` is now the non-secret identifier `team_<id>` (e.g. `team_1`); the team's `auth_token` is the `client_secret` and remains the issued access token. Previously `client_id == client_secret == auth_token`, so the secret appeared in the `/authorize` query string (and thus in server logs, browser history, and the `Referer`). The secret now travels only in the POST `/token` body. **Breaking:** re-enter any existing claude.ai connector as `Client ID = team_<id>`, `Client Secret = auth_token`.
+
 ## v1.67.0
 
 ### Features

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -132,7 +132,7 @@ mode = "port"               # "port" (direct host port) | "traefik" (reverse pro
 # automatically and runs on each team's own hostname (issuer derived per-request),
 # so oauth_base_url is NOT needed. Set it only to pin a fixed issuer, or in port
 # mode: the public URL of this instance (for Claude.ai and other OAuth MCP
-# clients). Each team's auth_token doubles as client_id, client_secret, and token.
+# clients). OAuth client_id = team_<id> (non-secret); auth_token = client_secret = token.
 [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 
@@ -201,7 +201,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 
 | Key | Default | Description |
 |---|---|---|
-| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only. See [Authentication & Security](security.md) |
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; the OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`) and each team's `auth_token` is the `client_secret` and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only. See [Authentication & Security](security.md) |
 
 ### Database settings
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -397,7 +397,7 @@ mode = "port"               # "port" (direct host port) | "traefik" (reverse pro
 # automatically and runs on each team's own hostname (issuer derived per-request),
 # so oauth_base_url is NOT needed. Set it only to pin a fixed issuer, or in port
 # mode: the public URL of this instance (for Claude.ai and other OAuth MCP
-# clients). Each team's auth_token doubles as client_id, client_secret, and token.
+# clients). OAuth client_id = team_<id> (non-secret); auth_token = client_secret = token.
 [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 
@@ -464,7 +464,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 
 | Key | Default | Description |
 |---|---|---|
-| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; each team's `auth_token` doubles as `client_id`, `client_secret`, and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only |
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; the OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`) and each team's `auth_token` is the `client_secret` and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only |
 
 ### Database settings
 
@@ -2224,16 +2224,16 @@ Dynamic Client Registration (`/register`) is **disabled** — clients must use t
 
 1. Go to Claude.ai Settings → Connectors → Add custom MCP
 2. Enter your Oduflow URL: `https://your-server.com/mcp` (in traefik mode, the team's own hostname, e.g. `https://team-a.example.com/mcp`)
-3. In the OAuth fields enter the team's `auth_token` as **both** `Client ID` **and** `Client Secret`:
+3. In the OAuth fields, use the team's id as `Client ID` and its `auth_token` as `Client Secret` (the `Client ID` is `team_<N>` for `[team.N]` — e.g. `team_1` for `[team.1]`):
 
    ```
-   Client ID     = secret-token-team-1
+   Client ID     = team_1
    Client Secret = secret-token-team-1
    ```
 
 4. Claude.ai performs the OAuth flow against your Oduflow instance, receives an access token, and connects.
 
-The team is identified by the `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
+The issued access token is the team's `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
 
 ### Bearer-only mode (CLI / automation)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -48,7 +48,7 @@ mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 # acme_email = "admin@example.com"    # required for traefik mode
 
 [oauth]
-# oauth_base_url = "https://oduflow.example.com"  # OAuth issuer; NOT needed in traefik (auto, per-team host). Set to pin an issuer or in port mode. auth_token = client_id = client_secret = access token
+# oauth_base_url = "https://oduflow.example.com"  # OAuth issuer; NOT needed in traefik (auto, per-team host). Set to pin an issuer or in port mode. OAuth client_id = team_<id> (non-secret); auth_token = client_secret = access token
 
 [database]
 user = "odoo"
@@ -141,7 +141,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 ### Claude.ai (self-hosted OAuth)
 
-For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAuth 2.1 Authorization Server (no external IdP). In **traefik mode** it is enabled automatically and runs on each team's own hostname (issuer derived per-request) — no `oauth_base_url` needed. In **port mode**, set `[oauth].oauth_base_url` to this instance's public URL. In Claude.ai add a custom MCP at `https://<team-hostname>/mcp` and enter the team's `auth_token` as **both** Client ID and Client Secret. The issued access token equals the `auth_token`, so the same value also works as a plain Bearer token.
+For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAuth 2.1 Authorization Server (no external IdP). In **traefik mode** it is enabled automatically and runs on each team's own hostname (issuer derived per-request) — no `oauth_base_url` needed. In **port mode**, set `[oauth].oauth_base_url` to this instance's public URL. In Claude.ai add a custom MCP at `https://<team-hostname>/mcp` and enter `Client ID = team_<id>` (e.g. `team_1`, non-secret) and `Client Secret = the team's auth_token`. The issued access token equals the `auth_token`, so the same value also works as a plain Bearer token.
 
 ## Core MCP Tools
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -90,7 +90,7 @@ Some MCP clients (e.g. Claude.ai Remote MCP) require an OAuth flow instead of a 
 oauth_base_url = "https://oduflow.example.com"
 ```
 
-Each team's `auth_token` then doubles as `client_id`, `client_secret`, and the issued access token. See [Authentication & Security](security.md#self-hosted-oauth-for-claudeai-and-other-mcp-clients) for the full setup and how to connect from Claude.ai.
+The OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`); each team's `auth_token` is the `client_secret` and the issued access token. See [Authentication & Security](security.md#self-hosted-oauth-for-claudeai-and-other-mcp-clients) for the full setup and how to connect from Claude.ai.
 
 ### MCP client configuration
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,7 +24,7 @@ The token is used to both authenticate and identify the team. This is implemente
 
 Oduflow can act as its own OAuth 2.1 Authorization Server, so MCP clients that require an OAuth flow (e.g. Claude.ai Remote MCP, MCP Inspector) can connect without any external identity provider.
 
-When the OAuth flow completes, the issued `access_token` is exactly the team's `auth_token` from `oduflow.toml` — so the same value works as a plain Bearer token for CLI clients.
+The team's OAuth **`client_id`** is a non-secret identifier, `team_<id>` (e.g. `team_1` for `[team.1]`); the **`client_secret`** is the team's `auth_token`. Only the `client_id` appears in the authorization URL — the secret is sent solely in the token request body, so it never leaks into logs or browser history. When the OAuth flow completes, the issued `access_token` is exactly the team's `auth_token` from `oduflow.toml` — so the same value works as a plain Bearer token for CLI clients.
 
 ### Setup
 
@@ -62,16 +62,16 @@ Dynamic Client Registration (`/register`) is **disabled** — clients must use t
 
 1. Go to Claude.ai Settings → Connectors → Add custom MCP
 2. Enter your Oduflow URL: `https://your-server.com/mcp` (in traefik mode, the team's own hostname, e.g. `https://team-a.example.com/mcp`)
-3. In the OAuth fields enter the team's `auth_token` as **both** `Client ID` **and** `Client Secret`:
+3. In the OAuth fields, use the team's id as `Client ID` and its `auth_token` as `Client Secret` (the `Client ID` is `team_<N>` for `[team.N]` — e.g. `team_1` for `[team.1]`):
 
    ```
-   Client ID     = secret-token-team-1
+   Client ID     = team_1
    Client Secret = secret-token-team-1
    ```
 
 4. Claude.ai performs the OAuth flow against your Oduflow instance, receives an access token, and connects.
 
-The team is identified by the `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
+The issued access token is the team's `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
 
 ### Bearer-only mode (CLI / automation)
 

--- a/specs/0020-authentication-oauth.md
+++ b/specs/0020-authentication-oauth.md
@@ -59,11 +59,14 @@ request context and threaded into per-team scoping.
   `oauth_base_url` is set, Oduflow serves the self-hosted Authorization Server;
   otherwise it falls back to validating static Bearer tokens directly from the
   `Authorization` header. Both reduce to the same per-team `auth_token`.
-- **One secret, three roles.** Because a team's `auth_token` is preregistered as
-  an OAuth client where `client_id == client_secret == auth_token` and the access
-  token equals it too, an OAuth client and a raw-curl client end up presenting
-  the *same* credential. After the OAuth dance the team resolves exactly as it
-  does for direct Bearer calls — no second identity system.
+- **One secret, one public id.** A team is preregistered as an OAuth client whose
+  `client_id` is the **non-secret** `team_<id>` (e.g. `team_1`) and whose
+  `client_secret` is the team's `auth_token`; the issued access token also equals
+  the `auth_token`. So an OAuth client and a raw-curl client present the *same*
+  secret, and after the OAuth dance the team resolves exactly as it does for
+  direct Bearer calls — no second identity system. Keeping the secret out of the
+  `client_id` matters because `client_id` travels in the `/authorize` query string
+  (see Evolution); the secret is sent only in the POST `/token` body.
 - **Scoping unchanged.** Once a request is authenticated to a team, the existing
   per-team resource scoping and locking apply; OAuth only changes *how the team
   is proven*, not what it can see.
@@ -112,6 +115,27 @@ request context and threaded into per-team scoping.
   port mode (in traefik every team must set its own hostname, so a shared default
   is dead and would collide two teams on one host).
 
+- **Non-secret `client_id` + OAuth sub-path routing (claude.ai custom
+  connector).** The self-hosted AS originally set `client_id == client_secret ==
+  auth_token`. But a claude.ai custom connector (manual client_id/secret) puts the
+  `client_id` in the `/authorize` **query string** and derives the OAuth endpoints
+  **path-relative to the connector URL** — it requests `https://<host>/mcp/authorize`
+  and `/mcp/token`, ignoring the (correct, root) endpoints from discovery. Two
+  problems followed: the secret leaked into URLs/logs, and the outer
+  `ScopedEnvASGI` shim (scoped `/mcp/<env>` access, [[0028-scoped-environment-mcp-access]])
+  treated `authorize`/`token` as an *environment name*, rewriting `/mcp/authorize`
+  onto the auth-protected `/mcp` route → `401 invalid_token`, so the flow never
+  started. Fixed by (a) **splitting the credential**: `client_id` becomes the
+  public `team_<id>`, `client_secret` stays the `auth_token`, and the issued access
+  token stays the `auth_token` (Bearer path unchanged; `team_<id>` alone is not a
+  valid token); and (b) teaching `ScopedEnvASGI` to **alias the reserved OAuth
+  sub-paths** under `/mcp/` (`authorize`, `token`, `register`, and the two
+  `.well-known/*` discovery docs) back to the real root routes instead of scoping
+  them as an env — mirroring the existing scoped-PRM alias. Scoped `/mcp/<env>`
+  connectors remain Bearer-only (ephemeral environments; no per-env OAuth).
+  Breaking: any already-configured claude.ai connector must be re-entered as
+  `client_id = team_<id>`, `client_secret = auth_token`.
+
 ## History
 
 - `97c3fc8` (2026-03-13) — GitHub OAuth 2.1 for MCP HTTP transport alongside
@@ -127,3 +151,10 @@ request context and threaded into per-team scoping.
   in traefik mode (host-relative discovery metadata); enable the Authorization
   Server automatically in traefik and make `oauth_base_url` optional there;
   restrict `[routing].hostname` to port mode.
+- `2026-07-15` — split the OAuth credential so the secret no longer travels in the
+  `/authorize` URL: `client_id = team_<id>` (public), `client_secret = auth_token`,
+  issued access token still `= auth_token`; route the reserved OAuth sub-paths a
+  path-relative client (claude.ai custom connector) requests under `/mcp/`
+  (`/mcp/authorize`, `/mcp/token`, `/mcp/register`, `/mcp/.well-known/*`) to the
+  real root routes so the flow reaches the AS instead of 401-ing on the scoped
+  `/mcp/<env>` shim (breaking: reconfigure existing connectors).

--- a/specs/0028-scoped-environment-mcp-access.md
+++ b/specs/0028-scoped-environment-mcp-access.md
@@ -3,7 +3,7 @@
 **Status:** Adopted
 **Type:** Architecture / MCP capability
 **First introduced:** scoped single-environment MCP access (this change)
-**Key code today:** `scoped_access.py` (`ScopedEnvASGI`, `ScopedAccessMiddleware`, `OduflowTokenVerifier`, allowlist), `env_tokens.py` (per-env token generation + resolution), `oauth_provider.py` (env tokens as OAuth clients), `server.py` (`_build_auth`, `_start_http` wiring), `docker_ops/env_ops.py` (`oduflow.mcp_token` label, `get_env_token`), `web_ui.py` + `templates/dashboard.html` (MCP Access modal)
+**Key code today:** `scoped_access.py` (`ScopedEnvASGI`, `ScopedAccessMiddleware`, `OduflowTokenVerifier`, allowlist), `env_tokens.py` (per-env token generation + resolution), `oauth_provider.py` (team OAuth clients plus env-token Bearer verification), `server.py` (`_build_auth`, `_start_http` wiring), `docker_ops/env_ops.py` (`oduflow.mcp_token` label, `get_env_token`), `web_ui.py` + `templates/dashboard.html` (MCP Access modal)
 
 ## Context
 
@@ -31,10 +31,9 @@ preserving the "no identity/target in tool signatures" invariant of
 [[0002-remote-multi-user-mcp-access]].
 
 - **Per-environment token.** `create_environment` mints a random token and stores
-  it in the container label `oduflow.mcp_token`. The token doubles as a Bearer
-  token and as an OAuth client credential, so the same Secret Key works for
-  curl/CLI clients and for OAuth clients (claude.ai) alike — mirroring how a team
-  `auth_token` already plays three roles in [[0020-authentication-oauth]].
+  it in the container label `oduflow.mcp_token`. The token is a Bearer credential
+  for the scoped endpoint. It is not accepted as an OAuth client_id because OAuth
+  authorization URLs expose client_id values in logs and browser history.
 - **Default-deny toolset.** The scoped endpoint exposes a curated allowlist (full
   dev loop + `restart`, plus read-only/diagnostic tools). Everything else —
   lifecycle, templates, services, volumes, repos, listing other environments — is
@@ -68,7 +67,7 @@ not merely pointed at a narrower endpoint.
   resolved `env_name` — so a tool can never target another environment, and a
   leaked listing can never enable a forbidden call.
 - **Operator UX.** Each environment card surfaces an **MCP Access** action showing
-  its `/mcp/<env>` URL and Secret Key (Bearer or OAuth).
+  its `/mcp/<env>` URL and Bearer Secret Key.
 
 ## Consequences
 
@@ -85,11 +84,12 @@ not merely pointed at a narrower endpoint.
   added to a live container: environments created before this feature carry no
   token until recreated — acceptable given environments are ephemeral and
   per-branch. Operators rotate a token by recreating the environment.
-- OAuth on the scoped URL reuses the env token as its client credential; the
-  reliable, always-available path is the Bearer Secret Key.
+- The scoped URL is Bearer-only. OAuth remains available for the team-wide
+  `/mcp` endpoint via the public `team_<id>` client_id and team `auth_token`
+  client_secret.
 
 ## History
 
 - (this change) — scoped single-environment MCP access: `/mcp/<env>` endpoint,
-  per-environment `oduflow.mcp_token` (Bearer + OAuth), default-deny allowlist
+  per-environment `oduflow.mcp_token` Bearer credential, default-deny allowlist
   middleware, and the dashboard MCP Access modal.

--- a/src/oduflow/env_tokens.py
+++ b/src/oduflow/env_tokens.py
@@ -2,8 +2,9 @@
 
 Each environment gets a personal token stored in the Docker label
 ``oduflow.mcp_token`` at creation time (see ``env_ops.create_environment``).
-The token doubles as a Bearer token and an OAuth client credential, and
-authorizes the scoped MCP endpoint ``/mcp/<env>`` (single-environment access).
+The token is a Bearer token authorizing the scoped MCP endpoint ``/mcp/<env>``
+(single-environment access). That endpoint is Bearer-only — the OAuth flow
+(client_id/secret) is wired only for the team-wide ``/mcp`` endpoint.
 
 ``resolve_token`` maps an incoming token to a ``(team_id, env_name)`` pair:
 

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -1,10 +1,13 @@
 """Self-hosted OAuth 2.1 Authorization Server for Oduflow.
 
-Each team's ``auth_token`` is preregistered as an OAuth client where
-``client_id == client_secret == auth_token``. After a successful
-Authorization Code + PKCE flow the issued ``access_token`` is the same
-``auth_token``, so the existing Bearer-token path in ``_resolve_team()``
-keeps working unchanged.
+Each team is preregistered as an OAuth client whose ``client_id`` is a public,
+non-secret identifier (``team_<id>``, e.g. ``team_1``) and whose
+``client_secret`` is the team's ``auth_token``. Keeping the secret out of the
+``client_id`` matters because ``client_id`` travels in the ``/authorize`` query
+string (logs, browser history, Referer); the secret is sent only in the POST
+``/token`` body. After a successful Authorization Code + PKCE flow the issued
+``access_token`` is the team ``auth_token``, so the existing Bearer-token path in
+``_resolve_team()`` keeps working unchanged.
 """
 
 from __future__ import annotations
@@ -47,6 +50,12 @@ _DANGEROUS_REDIRECT_SCHEMES = {"javascript", "data", "vbscript", "file"}
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
 
 _RESOURCE_METADATA_RE = re.compile(r'resource_metadata="([^"]+)"')
+
+
+def public_client_id(team_id: str) -> str:
+    """The non-secret OAuth ``client_id`` for a team, safe to appear in the
+    ``/authorize`` URL. The team's ``auth_token`` is the ``client_secret``."""
+    return f"team_{team_id}"
 
 
 def _forwarded_scheme_host(
@@ -200,8 +209,13 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
             token = team.auth_token
             if not token:
                 continue
+            # Public, non-secret client_id (e.g. "team_1"): it travels in the
+            # /authorize query string, so it must NOT be the secret. The secret
+            # lives only in client_secret (POST /token body) and is what the
+            # issued access_token equals.
+            client_id = public_client_id(team.team_id)
             client = _FlexibleClient(
-                client_id=token,
+                client_id=client_id,
                 client_secret=token,
                 redirect_uris=[placeholder_redirect],
                 grant_types=["authorization_code", "refresh_token"],
@@ -209,10 +223,12 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
                 token_endpoint_auth_method="client_secret_post",
                 scope=None,
             )
-            self.clients[token] = client
-            self._token_to_team[token] = team.team_id
-            # Preseed the access token so direct Bearer-token calls also work
-            # (curl/CLI clients that skip the OAuth dance entirely).
+            self.clients[client_id] = client
+            self._token_to_team[client_id] = team.team_id
+            # Preseed the access token — keyed by the SECRET auth_token, not the
+            # public client_id — so direct Bearer-token calls also work (curl/CLI
+            # clients that skip the OAuth dance). The public client_id is not a
+            # valid Bearer token on its own.
             self.access_tokens[token] = AccessToken(
                 token=token,
                 client_id=team.team_id,
@@ -371,8 +387,9 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         raise ValueError(
-            "Dynamic client registration is disabled. "
-            "Set client_id = client_secret = team.<id>.auth_token from oduflow.toml."
+            "Dynamic client registration is disabled. Use the preregistered "
+            "client: client_id = team_<id> (e.g. team_1), client_secret = that "
+            "team's auth_token from oduflow.toml."
         )
 
     async def exchange_authorization_code(
@@ -391,7 +408,10 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
 
             raise TokenError("invalid_client", "Unknown client.")
 
-        token = cid
+        # The issued access token is the client SECRET (the team auth_token, or
+        # the env token for a per-env client) — never the public client_id, which
+        # would not authenticate as a Bearer token downstream.
+        token = client.client_secret or cid
         scope = (
             " ".join(authorization_code.scopes) if authorization_code.scopes else None
         )
@@ -409,9 +429,11 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         refresh_token: str,
     ) -> RefreshToken | None:
         cid = client.client_id
+        # The refresh token we issue equals the client secret (team auth_token /
+        # env token), not the public client_id.
         if (
             cid is not None
-            and refresh_token == cid
+            and refresh_token == client.client_secret
             and (
                 cid in self._token_to_team or await self._env_identity(cid) is not None
             )

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -151,8 +151,7 @@ class _FlexibleClient(OAuthClientInformationFull):
     """Client info that accepts the varied callback URLs MCP clients use.
 
     Preregistered team clients have ``client_id = team_<id>`` (non-secret) and
-    ``client_secret = auth_token``; per-env clients keep ``client_id ==
-    client_secret == env_token``. The secret-bearing /token exchange proves
+    ``client_secret = auth_token``. The secret-bearing /token exchange proves
     identity, so we let MCP clients (claude.ai over https, IDEs over loopback or
     a custom scheme) bring their own callback — but we still reject callbacks that
     are never legitimate: dangerous schemes (javascript:, data:, …) and cleartext
@@ -354,21 +353,7 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         return (team_id, env_name)
 
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
-        client = await super().get_client(client_id)
-        if client is not None:
-            return client
-        # A per-environment token acts as its own OAuth client.
-        if await self._env_identity(client_id) is not None:
-            return _FlexibleClient(
-                client_id=client_id,
-                client_secret=client_id,
-                redirect_uris=[AnyUrl("https://claude.ai/")],
-                grant_types=["authorization_code", "refresh_token"],
-                response_types=["code"],
-                token_endpoint_auth_method="client_secret_post",
-                scope=None,
-            )
-        return None
+        return await super().get_client(client_id)
 
     async def load_access_token(  # type: ignore[override]
         self, token: str
@@ -403,16 +388,14 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         self.auth_codes.pop(authorization_code.code, None)
 
         cid = client.client_id
-        if cid is None or (
-            cid not in self._token_to_team and await self._env_identity(cid) is None
-        ):
+        if cid is None or cid not in self._token_to_team:
             from mcp.server.auth.provider import TokenError
 
             raise TokenError("invalid_client", "Unknown client.")
 
         # The issued access token is the client SECRET (the team auth_token, or
-        # the env token for a per-env client) — never the public client_id, which
-        # would not authenticate as a Bearer token downstream.
+        # never the public client_id, which would not authenticate as a Bearer
+        # token downstream.
         token = client.client_secret or cid
         scope = (
             " ".join(authorization_code.scopes) if authorization_code.scopes else None
@@ -431,14 +414,12 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         refresh_token: str,
     ) -> RefreshToken | None:
         cid = client.client_id
-        # The refresh token we issue equals the client secret (team auth_token /
-        # env token), not the public client_id.
+        # The refresh token we issue equals the client secret (team auth_token),
+        # not the public client_id.
         if (
             cid is not None
             and refresh_token == client.client_secret
-            and (
-                cid in self._token_to_team or await self._env_identity(cid) is not None
-            )
+            and cid in self._token_to_team
         ):
             return RefreshToken(
                 token=refresh_token,

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -150,12 +150,14 @@ class HostRelativeAuthChallenge:
 class _FlexibleClient(OAuthClientInformationFull):
     """Client info that accepts the varied callback URLs MCP clients use.
 
-    Preregistered clients have ``client_id == client_secret == auth_token``;
-    the secret-bearing /token exchange already proves identity, so we let MCP
-    clients (claude.ai over https, IDEs over loopback or a custom scheme) bring
-    their own callback — but we still reject callbacks that are never legitimate:
-    dangerous schemes (javascript:, data:, …) and cleartext http:// to a
-    non-loopback host (which would leak the authorization code in the clear).
+    Preregistered team clients have ``client_id = team_<id>`` (non-secret) and
+    ``client_secret = auth_token``; per-env clients keep ``client_id ==
+    client_secret == env_token``. The secret-bearing /token exchange proves
+    identity, so we let MCP clients (claude.ai over https, IDEs over loopback or
+    a custom scheme) bring their own callback — but we still reject callbacks that
+    are never legitimate: dangerous schemes (javascript:, data:, …) and cleartext
+    http:// to a non-loopback host (which would leak the authorization code in the
+    clear).
     """
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:

--- a/src/oduflow/scoped_access.py
+++ b/src/oduflow/scoped_access.py
@@ -192,14 +192,42 @@ class ScopedEnvASGI:
 
     _WELL_KNOWN_PREFIX = "/.well-known/oauth-protected-resource"
 
+    # OAuth/discovery endpoints that a *path-relative* MCP client (e.g. the
+    # claude.ai custom connector) requests under the ``/mcp`` mount instead of at
+    # the origin root — it appends ``/authorize`` etc. to the connector URL
+    # ``https://<host>/mcp`` rather than following the (correct, root) endpoints
+    # advertised by discovery. Without this table ``_scoped_env`` would treat
+    # ``authorize`` as an environment name and rewrite ``/mcp/authorize`` to the
+    # auth-protected ``/mcp`` route → ``401 invalid_token``. We alias them back to
+    # the real root routes the OAuth provider registers. Exact-match only, so an
+    # environment literally named e.g. ``token`` is a (negligible) blind spot;
+    # OAuth endpoints win.
+    _OAUTH_SUBPATHS = {
+        "/mcp/authorize": "/authorize",
+        "/mcp/token": "/token",
+        "/mcp/register": "/register",
+        "/mcp/.well-known/oauth-authorization-server": (
+            "/.well-known/oauth-authorization-server"
+        ),
+        "/mcp/.well-known/oauth-protected-resource": (
+            "/.well-known/oauth-protected-resource/mcp"
+        ),
+    }
+
     def __init__(self, app: Any) -> None:
         self.app = app
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope.get("type") == "http":
             path = scope.get("path", "")
-            env = self._scoped_env(path)
-            if env is not None:
+            oauth_path = self._OAUTH_SUBPATHS.get(path)
+            if oauth_path is not None:
+                # OAuth/discovery endpoint requested under /mcp/ — route it to the
+                # real root route (query string in scope["query_string"] is kept).
+                scope = dict(scope)
+                scope["path"] = oauth_path
+                scope["raw_path"] = oauth_path.encode()
+            elif (env := self._scoped_env(path)) is not None:
                 # ASGI ``path`` is already percent-decoded, so ``env`` is the
                 # plain environment name (slashes in branch names included).
                 scope = dict(scope)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4054,8 +4054,9 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
       /.well-known/oauth-authorization-server. In traefik mode the issuer is
       derived per-request from the team's own (TLS-terminated) hostname, so no
       central oauth_base_url is needed; each team's OAuth flow runs on its own
-      host. Each team's auth_token doubles as client_id, client_secret, and the
-      issued access token, so Bearer-token callers keep working unchanged.
+      host. Each team's client_id is public (team_<id>), while auth_token is the
+      client_secret and issued access token, so Bearer-token callers keep working
+      unchanged.
       Suitable for claude.ai and other MCP clients that require an OAuth flow.
     - Static Bearer tokens — port mode with no oauth_base_url: auth_token is
       consumed directly from the Authorization header. Suitable for curl, CLI
@@ -4064,8 +4065,8 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
     has_team_token = any(t.auth_token for t in settings.teams.values())
 
     if settings.oauth_enabled:
-        # oauth_enabled already implies a team auth_token (see Settings), which
-        # doubles as the OAuth client credential.
+        # oauth_enabled already implies a team auth_token (see Settings), used as
+        # the OAuth client_secret and issued access token.
         from oduflow.oauth_provider import OduflowOAuthProvider
 
         return OduflowOAuthProvider(settings)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -3717,7 +3717,7 @@ def _run_cli() -> None:
         )
         logger.info(
             "Generated MCP auth_token for team 1: %s "
-            "(use as Bearer token / OAuth client_id+secret)",
+            "(Bearer token / OAuth client_secret; OAuth client_id is 'team_1')",
             generated_token,
         )
         logger.info(

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -182,8 +182,8 @@ class Settings:
     # OAuth (self-hosted Authorization Server). Public base URL of this server,
     # used as the OAuth issuer and to advertise authorize/token endpoints.
     # When set, Oduflow exposes /.well-known/oauth-authorization-server,
-    # /authorize, and /token, and each team's auth_token doubles as
-    # client_id, client_secret, and the issued access token.
+    # /authorize, and /token. Each team's client_id is public (team_<id>), while
+    # auth_token is the client_secret and issued access token.
     # In traefik mode this is optional: the issuer is derived per-request from
     # the team's own hostname (already TLS-terminated), so OAuth works without a
     # central host. Set it only to pin a fixed issuer or in port mode.
@@ -305,7 +305,7 @@ class Settings:
             raise ValueError("Duplicate ui_password values across teams.")
 
         # Validate OAuth: when oauth_base_url is set, at least one team must
-        # have a non-empty auth_token (it doubles as OAuth client credentials).
+        # have a non-empty auth_token (used as OAuth client_secret/access token).
         if self.oauth_base_url and not any(t.auth_token for t in self.teams.values()):
             raise ValueError(
                 "oauth_base_url is set but no team has an auth_token. "

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1671,7 +1671,7 @@
       <button class="modal-close" onclick="closeMcpAccess()">&times;</button>
     </div>
     <div class="modal-body">
-      <p class="modal-note">Scoped MCP endpoint for this environment only. Use the Secret Key as a Bearer token or as an OAuth client credential. It exposes the in-environment tools (sync, install/upgrade, tests, shell, SQL, logs); it cannot create, delete or stop environments.</p>
+      <p class="modal-note">Scoped MCP endpoint for this environment only. Use the Secret Key as a Bearer token — this endpoint is Bearer-only and does not use the OAuth flow. It exposes the in-environment tools (sync, install/upgrade, tests, shell, SQL, logs); it cannot create, delete or stop environments.</p>
       <div class="form-group">
         <label for="mcp-access-url">Endpoint URL</label>
         <div class="copy-row">

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -59,7 +59,8 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 # is derived per-request), so you do NOT need oauth_base_url. Endpoints:
 #   /.well-known/oauth-authorization-server   /authorize   /token
 # For each team, claude.ai (and any OAuth-based MCP client) is configured with:
-#   client_id = client_secret = team.<id>.auth_token
+#   client_id = team_<id>  (for [team.1], use team_1)
+#   client_secret = team.<id>.auth_token
 # After the OAuth flow the issued access_token is also auth_token, so plain
 # Bearer-token clients keep working.
 #

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -81,15 +81,21 @@ class TestOduflowOAuthProvider:
 
     def test_preregistered_clients(self):
         provider = OduflowOAuthProvider(_settings())
-        client_a = _run(provider.get_client("tok-a"))
+        # client_id is the public, non-secret team identifier; the secret is the
+        # team's auth_token.
+        client_a = _run(provider.get_client("team_1"))
         assert client_a is not None
-        assert client_a.client_id == "tok-a"
+        assert client_a.client_id == "team_1"
         assert client_a.client_secret == "tok-a"
 
-        client_b = _run(provider.get_client("tok-b"))
+        client_b = _run(provider.get_client("team_2"))
         assert client_b is not None
+        assert client_b.client_id == "team_2"
         assert client_b.client_secret == "tok-b"
 
+        # The secret must NOT double as a client_id — otherwise it would leak
+        # into the /authorize URL.
+        assert _run(provider.get_client("tok-a")) is None
         assert _run(provider.get_client("unknown")) is None
 
     def test_register_client_disabled(self):
@@ -124,11 +130,11 @@ class TestOduflowOAuthProvider:
         from pydantic import AnyUrl
 
         provider = OduflowOAuthProvider(_settings())
-        client = _run(provider.get_client("tok-a"))
+        client = _run(provider.get_client("team_1"))
         assert client is not None
         code = AuthorizationCode(
             code="dummy",
-            client_id="tok-a",
+            client_id="team_1",
             redirect_uri=AnyUrl("https://claude.ai/cb"),
             redirect_uri_provided_explicitly=True,
             scopes=["mcp"],
@@ -136,15 +142,35 @@ class TestOduflowOAuthProvider:
             code_challenge="abc",
         )
         token = _run(provider.exchange_authorization_code(client, code))
+        # The issued access/refresh token is the SECRET auth_token, not the
+        # public client_id.
         assert token.access_token == "tok-a"
         assert token.refresh_token == "tok-a"
         assert token.token_type == "Bearer"
+
+    def test_bearer_invariant_and_refresh(self):
+        provider = OduflowOAuthProvider(_settings())
+        # The auth_token (the issued access token) still resolves to the team id
+        # via the preseeded, secret-keyed access token — the Bearer path is
+        # unchanged by the client_id/secret split.
+        access = _run(provider.load_access_token("tok-a"))
+        assert access is not None
+        assert access.client_id == "1"
+        # The public client_id is NOT a valid Bearer/access token on its own.
+        assert _run(provider.load_access_token("team_1")) is None
+        # Refresh token equals the secret (auth_token), not the client_id.
+        client = _run(provider.get_client("team_1"))
+        assert client is not None
+        rt = _run(provider.load_refresh_token(client, "tok-a"))
+        assert rt is not None
+        assert rt.client_id == "team_1"
+        assert _run(provider.load_refresh_token(client, "team_1")) is None
 
     def test_flexible_redirect_uri(self):
         from pydantic import AnyUrl
 
         provider = OduflowOAuthProvider(_settings())
-        client = _run(provider.get_client("tok-a"))
+        client = _run(provider.get_client("team_1"))
         assert client is not None
         # Legitimate MCP callbacks are accepted: https (claude.ai) and loopback
         # http (IDEs).
@@ -159,7 +185,7 @@ class TestOduflowOAuthProvider:
         from mcp.shared.auth import InvalidRedirectUriError
 
         provider = OduflowOAuthProvider(_settings())
-        client = _run(provider.get_client("tok-a"))
+        client = _run(provider.get_client("team_1"))
         # Cleartext http to a non-loopback host would leak the auth code.
         with pytest.raises(InvalidRedirectUriError):
             client.validate_redirect_uri(AnyUrl("http://evil.example/cb"))

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -190,7 +190,7 @@ class TestOduflowOAuthProvider:
         with pytest.raises(InvalidRedirectUriError):
             client.validate_redirect_uri(AnyUrl("http://evil.example/cb"))
 
-    def test_env_token_acts_as_client(self, monkeypatch):
+    def test_env_token_is_bearer_only(self, monkeypatch):
         from oduflow import oauth_provider as op
 
         mapping = {"env-secret": ("2", "feature/x"), "tok-a": ("1", None)}
@@ -201,11 +201,10 @@ class TestOduflowOAuthProvider:
         )
         provider = OduflowOAuthProvider(_settings())
 
-        # A per-env token resolves as its own OAuth client.
-        client = _run(provider.get_client("env-secret"))
-        assert client is not None
-        assert client.client_id == "env-secret"
-        assert client.client_secret == "env-secret"
+        # A per-env token must not be accepted as an OAuth client_id because it
+        # would put the secret in the /authorize URL. Scoped endpoints are
+        # Bearer-only.
+        assert _run(provider.get_client("env-secret")) is None
 
         # Its access token carries the team_id and an env-binding scope.
         access = _run(provider.verify_token("env-secret"))

--- a/tests/test_scoped_access.py
+++ b/tests/test_scoped_access.py
@@ -154,6 +154,42 @@ def test_asgi_rewrites_scoped_well_known():
     assert rec.scope["path"] == "/.well-known/oauth-protected-resource/mcp"
 
 
+@pytest.mark.parametrize(
+    "req_path,expected",
+    [
+        ("/mcp/authorize", "/authorize"),
+        ("/mcp/token", "/token"),
+        ("/mcp/register", "/register"),
+        (
+            "/mcp/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-authorization-server",
+        ),
+        (
+            "/mcp/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-protected-resource/mcp",
+        ),
+    ],
+)
+def test_asgi_routes_oauth_subpaths_to_root(req_path, expected):
+    # A path-relative MCP client (e.g. claude.ai) hits OAuth endpoints under the
+    # /mcp mount; they must reach the real root routes, NOT be treated as an
+    # environment named "authorize"/"token"/… (which would 401 on the protected
+    # /mcp endpoint).
+    rec = _Recorder()
+    _run(ScopedEnvASGI(rec)({"type": "http", "path": req_path}, None, None))
+    assert rec.scope["path"] == expected
+    assert rec.scope["raw_path"] == expected.encode()
+    assert scoped_access.SCOPE_KEY not in rec.scope
+
+
+def test_asgi_scoped_env_not_shadowed_by_oauth_names():
+    # Only exact reserved paths are aliased; a real /mcp/<env> still scopes.
+    rec = _Recorder()
+    _run(ScopedEnvASGI(rec)({"type": "http", "path": "/mcp/feature/x"}, None, None))
+    assert rec.scope["path"] == "/mcp"
+    assert rec.scope[scoped_access.SCOPE_KEY] == "feature/x"
+
+
 def test_asgi_non_http_untouched():
     rec = _Recorder()
     scope = {"type": "lifespan"}


### PR DESCRIPTION
Fixes the claude.ai custom OAuth connector, which failed with `401 invalid_token` because it requests OAuth endpoints path-relative to the MCP URL (`/mcp/authorize`, `/mcp/token`) that the outer scoped-access shim rewrote onto the auth-protected `/mcp` route — those reserved OAuth/discovery sub-paths under `/mcp/` now alias to the real root routes. Splits the credential so the secret no longer rides in the `/authorize` query string: `client_id` becomes the public `team_<id>` (e.g. `team_1`), `client_secret` is the team's `auth_token`, and the issued access token stays the `auth_token` (the plain Bearer path is unchanged; `team_<id>` alone is not a valid token). Scoped `/mcp/<env>` remains Bearer-only, and the MCP Access modal, the `env_tokens` docstring, the docs (security/quick-start/llms/changelog), ADR 0020, and the tests are updated accordingly. **Breaking:** re-enter any existing claude.ai connector as `Client ID = team_<id>`, `Client Secret = auth_token`.