### PR TITLE
Add dashboard new template creation

### DIFF
--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1588,6 +1588,7 @@ def publish_env_as_template(
     template_name: str,
     *,
     reset_env_changes: bool = False,
+    overwrite: bool = False,
 ) -> dict[str, object]:
     from oduflow.docker_ops import env_ops
     from oduflow.naming import get_db_name, get_filestore_paths, get_resource_name
@@ -1599,6 +1600,17 @@ def publish_env_as_template(
     if not _db_exists(client, settings, env_db):
         raise NotFoundError(
             f"Database '{env_db}' for environment '{env_name}' not found."
+        )
+
+    # Never silently clobber an existing template: publishing over one is a
+    # deliberate re-baseline, so it must be requested explicitly (overwrite=True).
+    if not overwrite and (
+        os.path.exists(team.get_template_dir(template_name))
+        or _db_exists(client, settings, tpl_db)
+    ):
+        raise ConflictError(
+            f"Template '{template_name}' already exists. Choose a new name "
+            f"(or pass overwrite=True to re-baseline it)."
         )
 
     # Republishing an existing template replaces it (no net growth); only a

--- a/src/oduflow/locking.py
+++ b/src/oduflow/locking.py
@@ -18,6 +18,9 @@ class LockManager:
     def __init__(self) -> None:
         self._env_locks: dict[str, threading.Lock] = {}
         self._team_locks: dict[str, threading.Lock] = {}
+        self._active_team_locks: set[str] = set()
+        self._env_lock_teams: dict[str, str] = {}
+        self._active_env_counts_by_team: dict[str, int] = {}
         self._system_lock = threading.Lock()
         self._map_lock = threading.Lock()  # protects dict access
 
@@ -29,20 +32,43 @@ class LockManager:
                 self._env_locks[env_name] = threading.Lock()
             return self._env_locks[env_name]
 
-    def acquire_env(self, env_name: str) -> None:
-        lock = self._get_env_lock(env_name)
-        if not lock.acquire(blocking=False):
-            raise BusyError(
-                f"Another operation on environment '{env_name}' is in progress. "
-                "Try again later."
-            )
+    def acquire_env(self, env_name: str, team_id: str | None = None) -> None:
+        with self._map_lock:
+            if team_id is not None and team_id in self._active_team_locks:
+                raise BusyError(
+                    f"Another team-level operation (team '{team_id}') is in progress. "
+                    "Try again later."
+                )
+            if env_name not in self._env_locks:
+                self._env_locks[env_name] = threading.Lock()
+            lock = self._env_locks[env_name]
+            if not lock.acquire(blocking=False):
+                raise BusyError(
+                    f"Another operation on environment '{env_name}' is in progress. "
+                    "Try again later."
+                )
+            if team_id is not None:
+                self._env_lock_teams[env_name] = team_id
+                self._active_env_counts_by_team[team_id] = (
+                    self._active_env_counts_by_team.get(team_id, 0) + 1
+                )
 
     def release_env(self, env_name: str) -> None:
-        lock = self._get_env_lock(env_name)
-        try:
-            lock.release()
-        except RuntimeError:
-            pass
+        with self._map_lock:
+            lock = self._env_locks.get(env_name)
+            if lock is None:
+                return
+            try:
+                lock.release()
+            except RuntimeError:
+                return
+            team_id = self._env_lock_teams.pop(env_name, None)
+            if team_id is not None:
+                count = self._active_env_counts_by_team.get(team_id, 0) - 1
+                if count > 0:
+                    self._active_env_counts_by_team[team_id] = count
+                else:
+                    self._active_env_counts_by_team.pop(team_id, None)
 
     # -- team locks --
 
@@ -53,19 +79,31 @@ class LockManager:
             return self._team_locks[team_id]
 
     def acquire_team(self, team_id: str) -> None:
-        lock = self._get_team_lock(team_id)
-        if not lock.acquire(blocking=False):
-            raise BusyError(
-                f"Another team-level operation (team '{team_id}') is in progress. "
-                "Try again later."
-            )
+        with self._map_lock:
+            if team_id not in self._team_locks:
+                self._team_locks[team_id] = threading.Lock()
+            lock = self._team_locks[team_id]
+            if (
+                team_id in self._active_team_locks
+                or self._active_env_counts_by_team.get(team_id, 0) > 0
+                or not lock.acquire(blocking=False)
+            ):
+                raise BusyError(
+                    f"Another team-level operation (team '{team_id}') is in progress. "
+                    "Try again later."
+                )
+            self._active_team_locks.add(team_id)
 
     def release_team(self, team_id: str) -> None:
-        lock = self._get_team_lock(team_id)
-        try:
-            lock.release()
-        except RuntimeError:
-            pass
+        with self._map_lock:
+            lock = self._team_locks.get(team_id)
+            if lock is None:
+                return
+            self._active_team_locks.discard(team_id)
+            try:
+                lock.release()
+            except RuntimeError:
+                pass
 
     # -- system lock --
 

--- a/src/oduflow/reaper.py
+++ b/src/oduflow/reaper.py
@@ -46,7 +46,7 @@ def _auto_stop(
     settings: Settings, team: TeamSettings, locks: LockManager, env_name: str
 ) -> None:
     try:
-        locks.acquire_env(env_name)
+        locks.acquire_env(env_name, team.team_id)
     except BusyError:
         return  # an operation is in flight; it counts as activity anyway
     try:
@@ -69,7 +69,7 @@ def _auto_delete(
     settings: Settings, team: TeamSettings, locks: LockManager, env_name: str
 ) -> None:
     try:
-        locks.acquire_env(env_name)
+        locks.acquire_env(env_name, team.team_id)
     except BusyError:
         return
     try:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -222,10 +222,11 @@ def with_env_lock(fn):
         env_name = kwargs.get("env_name") or (args[0] if args else None)
         if not env_name:
             raise ToolError("env_name is required")
-        _locks.acquire_env(env_name)
+        team = _resolve_team(kwargs.get("ctx"))
+        _locks.acquire_env(env_name, team.team_id)
         try:
             try:
-                activity.touch(_resolve_team(kwargs.get("ctx")), env_name)
+                activity.touch(team, env_name)
             except Exception:
                 pass  # activity tracking is best-effort
             return fn(*args, **kwargs)
@@ -452,10 +453,10 @@ def create_environment(
     from oduflow.naming import validate_env_name
 
     resolved_env_name = validate_env_name(env_name or branch)
-    _locks.acquire_env(resolved_env_name)
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    _locks.acquire_env(resolved_env_name, team.team_id)
     try:
-        settings = _get_settings()
-        team = _resolve_team(ctx)
         resolved_template: str | None
         if not template_name or template_name.lower() == "none":
             resolved_template = None
@@ -1142,6 +1143,7 @@ def get_environment_logs(
 
 @mcp.tool()
 @handle_errors
+@with_env_lock
 def restart_environment(env_name: str, wait: bool = True, ctx: Context = None) -> str:
     """
     Restart the Odoo container for a specific environment.
@@ -1284,6 +1286,7 @@ def get_environment_info(env_name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@with_env_lock
 def stop_environment(env_name: str, ctx: Context = None) -> str:
     """
     Stop the Odoo container for a specific environment.
@@ -1303,6 +1306,7 @@ def stop_environment(env_name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@with_env_lock
 def start_environment(env_name: str, wait: bool = True, ctx: Context = None) -> str:
     """
     Start all containers for a specific environment.

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -629,29 +629,34 @@ def save_as_template(
     env_name: str,
     template_name: str,
     reset_env_changes: bool = False,
+    overwrite: bool = False,
     ctx: Context = None,
 ) -> str:
     """
-    Save an environment as the new template (DB + filestore).
+    Save an environment as a template (DB + filestore).
 
-    Replaces the template database and filestore with the data from the specified
-    environment. Other environments that use this template with overlay-mounted
-    filestores are remounted against the new baseline: by default their filestore
-    changes (the overlay upper layer) are PRESERVED — non-destructive. Set
-    reset_env_changes=True to discard those changes and reset every affected
-    environment to the new baseline. The source environment itself is always
-    reset (its data just became the new template).
+    By default this creates a NEW template and REFUSES to overwrite an existing
+    one (raises an error) — pick a fresh template_name. Set overwrite=True to
+    deliberately re-baseline an existing template: its database and filestore are
+    replaced with the data from the specified environment, and other environments
+    that use this template with overlay-mounted filestores are remounted against
+    the new baseline. On re-baseline their filestore changes (the overlay upper
+    layer) are PRESERVED by default — non-destructive; set reset_env_changes=True
+    to discard those changes and reset every affected environment to the new
+    baseline. The source environment itself is always reset (its data just became
+    the new template).
 
     Requires EXPLICIT user permission and confirmation before execution.
     If the user has not clearly and unambiguously asked you to save
-    a specific environment as template, DO NOT call this tool. Setting
-    reset_env_changes=True is destructive for other environments — only do so
-    when the user explicitly asks to reset them.
+    a specific environment as template, DO NOT call this tool. Both
+    overwrite=True (re-baselines an existing template) and reset_env_changes=True
+    (destructive for other environments) require an explicit user request.
 
     Args:
         env_name: The name of the environment whose DB and filestore will become the new template.
         template_name: Name of the template profile to publish into.
         reset_env_changes: If True, discard other environments' filestore deltas (destructive). Default False (preserve).
+        overwrite: If True, allow re-baselining an existing template. Default False (refuse if the template already exists).
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -661,6 +666,7 @@ def save_as_template(
         env_name,
         template_name=template_name,
         reset_env_changes=reset_env_changes,
+        overwrite=overwrite,
     )
     affected = cast("list[str]", result.get("affected_envs", []))
     failures = cast("list[tuple[str, str]]", result.get("remount_failures", []))

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1622,6 +1622,26 @@
     </div>
   </div>
 </div>
+<div class="modal-overlay" id="new-tpl-modal" onclick="closeNewTemplateModal(event)">
+  <div class="modal">
+    <div class="modal-header">
+      <h2>New template</h2>
+      <button class="modal-close" onclick="closeNewTemplateModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-error" id="new-tpl-error"></div>
+      <div class="form-group">
+        <label for="new-tpl-name">Template name</label>
+        <input type="text" id="new-tpl-name" placeholder="new template name">
+        <div class="hint">Saves this environment's database and filestore as a new template. Refused if a template with this name already exists.</div>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeNewTemplateModal()">Cancel</button>
+        <button class="btn-create" id="new-tpl-submit" onclick="submitNewTemplate()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="system-bar" id="system-bar">
   <span><span class="sys-label">System</span></span>
   <span>CPU: <span class="sys-val" id="sys-cpu">—</span></span>
@@ -2344,6 +2364,8 @@ function renderEnvironments(envs, force) {
                 (env.protected ? 'disabled title="Environment is protected"' : 'title="Recreate the container, keep the database and filestore"') + '>Update</button>' +
               '<button role="menuitem" onclick="doRecreate(\'' + escAttr(env.branch) + '\')" ' + dis +
                 (env.protected ? 'disabled title="Environment is protected"' : 'title="Delete and rebuild from template: replaces the current database"') + '>Recreate</button>' +
+              '<button role="menuitem" onclick="doNewTemplate(\'' + escAttr(env.branch) + '\')" ' + dis +
+                'title="Save this environment (DB + filestore) as a new template">New Template</button>' +
               '<button role="menuitem" class="danger" onclick="doDelete(\'' + escAttr(env.branch) + '\')" ' + dis +
                 (env.protected ? 'disabled title="Environment is protected"' : '') + '>Delete</button>' +
             '</div>' +
@@ -3259,6 +3281,63 @@ async function submitRenameTemplate() {
   } finally {
     btn.disabled = false;
     btn.textContent = 'Rename';
+  }
+}
+
+var _newTplBranch = '';
+
+function doNewTemplate(branch) {
+  _newTplBranch = branch;
+  var errEl = document.getElementById('new-tpl-error');
+  errEl.style.display = 'none';
+  errEl.textContent = '';
+  var input = document.getElementById('new-tpl-name');
+  input.value = '';
+  document.getElementById('new-tpl-submit').disabled = false;
+  document.getElementById('new-tpl-submit').textContent = 'Create';
+  showModal('new-tpl-modal');
+  input.focus();
+}
+
+function closeNewTemplateModal(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('new-tpl-modal');
+}
+
+async function submitNewTemplate() {
+  var name = document.getElementById('new-tpl-name').value.trim();
+  var errEl = document.getElementById('new-tpl-error');
+  if (!name) {
+    errEl.textContent = 'Template name is required.';
+    errEl.style.display = 'block';
+    return;
+  }
+  errEl.style.display = 'none';
+  var btn = document.getElementById('new-tpl-submit');
+  btn.disabled = true;
+  btn.textContent = 'Creating...';
+  try {
+    var r = await fetch(API + '/' + encodeURIComponent(_newTplBranch) + '/save-as-template', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ template_name: name })
+    });
+    var data = await r.json();
+    if (data.ok) {
+      showToast('Saved "' + _newTplBranch + '" as template "' + name + '"');
+      hideModal('new-tpl-modal');
+      await loadTemplates();
+      await loadEnvironments(true);
+    } else {
+      errEl.textContent = data.error || 'Save as template failed';
+      errEl.style.display = 'block';
+    }
+  } catch (e) {
+    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Create';
   }
 }
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -51,6 +51,7 @@ from oduflow.docker_ops.stats import (
 )
 from oduflow.errors import BusyError, FlowError, NotFoundError
 from oduflow.locking import LockManager
+from oduflow.naming import validate_template_name
 from oduflow.settings import Settings, TeamSettings
 from oduflow.licensing import get_license_info, install_license_from_text
 
@@ -495,8 +496,12 @@ def _build_routes(
 
     def api_start(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
         try:
-            team = _get_ui_team(request)
+            locks.acquire_env(branch, team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
             result = env_ops.start_environment(get_settings(), branch, team)
             activity.mark_started(team, branch)
             return JSONResponse({"ok": True, "result": result})
@@ -505,12 +510,18 @@ def _build_routes(
         except Exception as e:
             logger.exception("Unexpected error in api_start")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_env(branch)
 
     def api_stop(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
+        try:
+            locks.acquire_env(branch, team.team_id)
+        except BusyError as e:
+            return _error_response(e)
         try:
             settings = get_settings()
-            team = _get_ui_team(request)
             result = env_ops.stop_environment(settings, team, branch)
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -518,11 +529,17 @@ def _build_routes(
         except Exception as e:
             logger.exception("Unexpected error in api_stop")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_env(branch)
 
     def api_restart(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
         try:
-            team = _get_ui_team(request)
+            locks.acquire_env(branch, team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
             result = env_ops.restart_environment(get_settings(), branch, team)
             activity.mark_started(team, branch)
             return JSONResponse({"ok": True, "result": result})
@@ -531,16 +548,18 @@ def _build_routes(
         except Exception as e:
             logger.exception("Unexpected error in api_restart")
             return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_env(branch)
 
     def api_sync(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
         try:
-            locks.acquire_env(branch)
+            locks.acquire_env(branch, team.team_id)
         except BusyError as e:
             return _error_response(e)
         try:
             settings = get_settings()
-            team = _get_ui_team(request)
             activity.touch(team, branch)
             result = env_ops.pull_environment(settings, team, branch)
             return JSONResponse({"ok": True, "result": result})
@@ -554,13 +573,13 @@ def _build_routes(
 
     def api_delete(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
         try:
-            locks.acquire_env(branch)
+            locks.acquire_env(branch, team.team_id)
         except BusyError as e:
             return _error_response(e)
         try:
             settings = get_settings()
-            team = _get_ui_team(request)
             env_ops.delete_environment(settings, team, branch)
             return JSONResponse({"ok": True, "result": {"deleted": branch}})
         except FlowError as e:
@@ -573,6 +592,7 @@ def _build_routes(
 
     async def api_update(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
         try:
             body = await request.json()
         except Exception:
@@ -589,12 +609,11 @@ def _build_routes(
                 if "=" in item
             )
         try:
-            locks.acquire_env(branch)
+            locks.acquire_env(branch, team.team_id)
         except BusyError as e:
             return _error_response(e)
         try:
             settings = get_settings()
-            team = _get_ui_team(request)
             activity.touch(team, branch)
             result = env_ops.update_environment(
                 settings,
@@ -614,8 +633,9 @@ def _build_routes(
 
     def api_recreate(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        team = _get_ui_team(request)
         try:
-            locks.acquire_env(branch)
+            locks.acquire_env(branch, team.team_id)
         except BusyError as e:
             return _error_response(e)
         try:
@@ -623,7 +643,6 @@ def _build_routes(
             from oduflow.docker_ops.client import get_client as _get_client
 
             settings = get_settings()
-            team = _get_ui_team(request)
             activity.touch(team, branch)
             client = _get_client()
             odoo_container_name = env_ops.get_resource_name(
@@ -685,6 +704,10 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "template_name is required"}, status_code=400
             )
+        try:
+            validate_template_name(template_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         # Team lock (not just the env): publishing can remount other envs' overlay
         # filestores, so it must serialize against the whole team like the MCP tool.
         try:
@@ -699,7 +722,18 @@ def _build_routes(
             result = system_ops.publish_env_as_template(
                 get_settings(), team, branch, template_name=template_name
             )
-            return JSONResponse({"ok": True, "result": result})
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "result": {
+                        "status": result.get("status"),
+                        "env_name": result.get("env_name"),
+                        "template_db": result.get("template_db"),
+                        "affected_envs": result.get("affected_envs", []),
+                        "remount_failures": result.get("remount_failures", []),
+                    },
+                }
+            )
         except ValueError as e:  # invalid template name
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
@@ -749,11 +783,12 @@ def _build_routes(
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
 
+        team = _get_ui_team(request)
         # Acquire the env lock in its own try so a BusyError returns WITHOUT
         # entering the try/finally below — otherwise the finally would release a
         # lock that another in-flight request holds (issue #42).
         try:
-            locks.acquire_env(env_name)
+            locks.acquire_env(env_name, team.team_id)
         except BusyError as e:
             return _error_response(e)
         try:
@@ -765,7 +800,6 @@ def _build_routes(
 
             # Load metadata from template
             settings = get_settings()
-            team = _get_ui_team(request)
             extra_dict = None
             if isinstance(extra_addons_raw, dict):
                 extra_dict = extra_addons_raw or None

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -671,6 +671,45 @@ def _build_routes(
         finally:
             locks.release_env(branch)
 
+    async def api_save_as_template(request: Request) -> JSONResponse:
+        branch = request.path_params["branch"]
+        team = _get_ui_team(request)
+        try:
+            body = await request.json()
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body"}, status_code=400
+            )
+        template_name = str((body or {}).get("template_name") or "").strip()
+        if not template_name:
+            return JSONResponse(
+                {"ok": False, "error": "template_name is required"}, status_code=400
+            )
+        # Team lock (not just the env): publishing can remount other envs' overlay
+        # filestores, so it must serialize against the whole team like the MCP tool.
+        try:
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            activity.touch(team, branch)
+            # No overwrite from the UI: publishing over an existing template is a
+            # deliberate re-baseline reserved for the MCP tool, so a duplicate name
+            # here raises ConflictError (surfaced to the client by _error_response).
+            result = system_ops.publish_env_as_template(
+                get_settings(), team, branch, template_name=template_name
+            )
+            return JSONResponse({"ok": True, "result": result})
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except FlowError as e:
+            return _error_response(e)
+        except Exception as e:
+            logger.exception("Unexpected error in api_save_as_template")
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+        finally:
+            locks.release_team(team.team_id)
+
     async def api_create(request: Request) -> JSONResponse:
         import json as _json
 
@@ -3076,6 +3115,11 @@ def _build_routes(
         Route("/api/environments/{branch:path}/update", api_update, methods=["POST"]),
         Route(
             "/api/environments/{branch:path}/recreate", api_recreate, methods=["POST"]
+        ),
+        Route(
+            "/api/environments/{branch:path}/save-as-template",
+            api_save_as_template,
+            methods=["POST"],
         ),
         Route("/api/environments/{branch:path}/delete", api_delete, methods=["POST"]),
         Route("/api/services", api_services, methods=["GET"]),

--- a/tests/test_save_as_template_web.py
+++ b/tests/test_save_as_template_web.py
@@ -1,0 +1,73 @@
+"""End-to-end web-route tests for POST /api/environments/{branch}/save-as-template.
+
+Drives the dashboard "New Template" action through the Starlette app: a valid
+name reaches system_ops.publish_env_as_template WITHOUT overwrite (so the UI can
+only create fresh templates), an empty name is rejected before any Docker call,
+and a duplicate name surfaces the backend ConflictError as a failed response.
+"""
+
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.errors import ConflictError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path):
+    team = TeamSettings(team_id="1", hostname="example.com", data_dir=str(tmp_path))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def test_save_as_template_creates_new(tmp_path):
+    client = _client(tmp_path)
+    result = {"env_name": "feature-x", "template_db": "oduflow_1_t_prod"}
+    with patch(
+        "oduflow.web_ui.system_ops.publish_env_as_template", return_value=result
+    ) as publish:
+        response = client.post(
+            "/api/environments/feature-x/save-as-template",
+            json={"template_name": "prod"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert publish.call_args.args[2] == "feature-x"
+    assert publish.call_args.kwargs["template_name"] == "prod"
+    # The UI never overwrites: no overwrite flag is passed (defaults to False).
+    assert publish.call_args.kwargs.get("overwrite") in (None, False)
+
+
+def test_save_as_template_requires_name(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.system_ops.publish_env_as_template") as publish:
+        response = client.post(
+            "/api/environments/feature-x/save-as-template",
+            json={"template_name": "   "},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    publish.assert_not_called()
+
+
+def test_save_as_template_rejects_duplicate(tmp_path):
+    client = _client(tmp_path)
+    with patch(
+        "oduflow.web_ui.system_ops.publish_env_as_template",
+        side_effect=ConflictError("Template 'prod' already exists."),
+    ):
+        response = client.post(
+            "/api/environments/feature-x/save-as-template",
+            json={"template_name": "prod"},
+        )
+
+    body = response.json()
+    assert body["ok"] is False
+    assert "already exists" in body["error"]

--- a/tests/test_save_as_template_web.py
+++ b/tests/test_save_as_template_web.py
@@ -8,26 +8,40 @@ and a duplicate name surfaces the backend ConflictError as a failed response.
 
 from unittest.mock import patch
 
+import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from oduflow.errors import ConflictError
+from oduflow.errors import BusyError, ConflictError
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import mount_web_ui
 
 
-def _client(tmp_path):
+def _client_with_locks(tmp_path):
     team = TeamSettings(team_id="1", hostname="example.com", data_dir=str(tmp_path))
     settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    locks = LockManager()
     app = Starlette()
-    mount_web_ui(app, lambda: settings, LockManager())
-    return TestClient(app)
+    mount_web_ui(app, lambda: settings, locks)
+    return TestClient(app), locks
+
+
+def _client(tmp_path):
+    return _client_with_locks(tmp_path)[0]
 
 
 def test_save_as_template_creates_new(tmp_path):
     client = _client(tmp_path)
-    result = {"env_name": "feature-x", "template_db": "oduflow_1_t_prod"}
+    result = {
+        "status": "promoted",
+        "env_name": "feature-x",
+        "template_db": "oduflow_1_t_prod",
+        "dump": "/srv/oduflow/templates/prod/dump.pgdump",
+        "filestore": "/srv/oduflow/templates/prod/filestore",
+        "affected_envs": [],
+        "remount_failures": [],
+    }
     with patch(
         "oduflow.web_ui.system_ops.publish_env_as_template", return_value=result
     ) as publish:
@@ -37,7 +51,11 @@ def test_save_as_template_creates_new(tmp_path):
         )
 
     assert response.status_code == 200
-    assert response.json()["ok"] is True
+    body = response.json()
+    assert body["ok"] is True
+    assert "dump" not in body["result"]
+    assert "filestore" not in body["result"]
+    assert body["result"]["template_db"] == "oduflow_1_t_prod"
     assert publish.call_args.args[2] == "feature-x"
     assert publish.call_args.kwargs["template_name"] == "prod"
     # The UI never overwrites: no overwrite flag is passed (defaults to False).
@@ -55,6 +73,41 @@ def test_save_as_template_requires_name(tmp_path):
     assert response.status_code == 400
     assert response.json()["ok"] is False
     publish.assert_not_called()
+
+
+def test_save_as_template_validates_name_before_team_lock(tmp_path):
+    client, locks = _client_with_locks(tmp_path)
+    locks.acquire_team("1")
+    try:
+        with patch("oduflow.web_ui.system_ops.publish_env_as_template") as publish:
+            response = client.post(
+                "/api/environments/feature-x/save-as-template",
+                json={"template_name": "../etc"},
+            )
+    finally:
+        locks.release_team("1")
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    publish.assert_not_called()
+
+
+def test_save_as_template_busy_when_env_operation_in_flight(tmp_path):
+    client, locks = _client_with_locks(tmp_path)
+    locks.acquire_env("feature-x", "1")
+    try:
+        with patch("oduflow.web_ui.system_ops.publish_env_as_template") as publish:
+            response = client.post(
+                "/api/environments/feature-x/save-as-template",
+                json={"template_name": "prod"},
+            )
+            publish.assert_not_called()
+
+        assert response.json()["ok"] is False
+        with pytest.raises(BusyError):
+            locks.acquire_env("feature-x", "1")
+    finally:
+        locks.release_env("feature-x")
 
 
 def test_save_as_template_rejects_duplicate(tmp_path):

--- a/tests/test_template_publish_overwrite.py
+++ b/tests/test_template_publish_overwrite.py
@@ -1,0 +1,92 @@
+"""Guard-path tests for system_ops.publish_env_as_template overwrite protection.
+
+Publishing an environment over an EXISTING template used to silently clobber it
+(its DB + filestore, remounting other envs). publish_env_as_template now refuses
+unless the caller explicitly opts in with overwrite=True, so the dashboard
+"New Template" action (which never sets overwrite) can only create fresh
+templates.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ConflictError
+from oduflow.naming import get_db_name, get_template_db_name
+from oduflow.settings import Settings, TeamSettings
+
+ENV = "feature-x"
+TPL = "prod"
+
+
+@pytest.fixture
+def settings():
+    return Settings()
+
+
+@pytest.fixture
+def team(tmp_path):
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _db_exists_map(existing):
+    """Return a _db_exists side_effect that reports only `existing` db names."""
+
+    def _fn(client, settings, db_name):
+        return db_name in existing
+
+    return _fn
+
+
+def test_refuses_overwrite_when_template_dir_exists(settings, team):
+    # Source env DB exists, template DB does not, but the template dir is on disk.
+    env_db = get_db_name(ENV, team.team_id)
+    os.makedirs(team.get_template_dir(TPL), exist_ok=True)
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client", return_value=MagicMock()),
+        patch(
+            "oduflow.docker_ops.system_ops._db_exists",
+            side_effect=_db_exists_map({env_db}),
+        ),
+    ):
+        with pytest.raises(ConflictError, match="already exists"):
+            system_ops.publish_env_as_template(settings, team, ENV, TPL)
+
+
+def test_refuses_overwrite_when_template_db_exists(settings, team):
+    # No template dir on disk, but the template DB is loaded in PostgreSQL.
+    env_db = get_db_name(ENV, team.team_id)
+    tpl_db = get_template_db_name(TPL, team.team_id)
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client", return_value=MagicMock()),
+        patch(
+            "oduflow.docker_ops.system_ops._db_exists",
+            side_effect=_db_exists_map({env_db, tpl_db}),
+        ),
+    ):
+        with pytest.raises(ConflictError, match="already exists"):
+            system_ops.publish_env_as_template(settings, team, ENV, TPL)
+
+
+def test_overwrite_true_bypasses_guard(settings, team):
+    # overwrite=True skips the ConflictError guard; execution then reaches the
+    # quota check (our sentinel), proving the guard did not fire on an existing
+    # template.
+    env_db = get_db_name(ENV, team.team_id)
+    os.makedirs(team.get_template_dir(TPL), exist_ok=True)
+    sentinel = RuntimeError("reached quota check")
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client", return_value=MagicMock()),
+        patch(
+            "oduflow.docker_ops.system_ops._db_exists",
+            side_effect=_db_exists_map({env_db}),
+        ),
+        patch("oduflow.docker_ops.system_ops.check_db_quota", side_effect=sentinel),
+    ):
+        with pytest.raises(RuntimeError, match="reached quota check"):
+            system_ops.publish_env_as_template(settings, team, ENV, TPL, overwrite=True)


### PR DESCRIPTION
Adds a dashboard New Template action that saves an environment database and filestore as a fresh template through a new web route. Updates save_as_template so overwriting an existing template is refused by default and requires an explicit overwrite=True opt-in for MCP callers. Adds focused route and publish guard tests for successful creation, missing names, duplicate rejection, and overwrite bypass.\n\nTests: source .venv/bin/activate && pytest tests/test_save_as_template_web.py tests/test_template_publish_overwrite.py