### PR TITLE
Make mypy strict pass and gate it in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,3 +30,25 @@ jobs:
 
       - name: Run tests
         run: pytest -m "not integration and not heavyweight"
+
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Editable install so the typed dependencies (fastmcp, cryptography,
+          # starlette, …) resolve for the type checker.
+          pip install -e .
+          pip install mypy==2.3.0
+
+      - name: Type check
+        run: mypy src/oduflow

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # Editable install so the typed dependencies (fastmcp, cryptography,
-          # starlette, …) resolve for the type checker.
-          pip install -e .
-          pip install mypy==2.3.0
+          # Editable install with the dev extra so the typed dependencies
+          # (fastmcp, cryptography, starlette, …) resolve for the type checker
+          # and mypy is pinned from pyproject.toml (single source of truth).
+          pip install -e ".[dev]"
 
       - name: Type check
         run: mypy src/oduflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ target-version = "py310"
 python_version = "3.10"
 strict = true
 ignore_missing_imports = true
+# The repo root has a non-Python `docker/` directory (docker/agent/ — Dockerfile
+# and shell scripts). With PEP 420 namespace packages enabled (mypy's default),
+# `import docker` resolves to that local dir instead of the docker SDK, producing
+# ~100 phantom "Module has no attribute" errors. All oduflow packages are regular
+# (they ship __init__.py), so turning namespace packages off is safe and makes
+# `import docker` resolve to site-packages.
+namespace_packages = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ dependencies = [
     "tomli>=2.0; python_version < '3.11'",
 ]
 
+[project.optional-dependencies]
+# Type checker pinned so a local `mypy src/oduflow` matches the CI gate exactly
+# (see .github/workflows/tests.yml). Install with: pip install -e ".[dev]"
+dev = ["mypy==2.3.0"]
+
 [project.urls]
 Homepage = "https://oduflow.dev"
 Documentation = "https://oduflow.dev"

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -71,7 +71,7 @@ def _trace(msg: str, *args: object) -> None:
 _PACKAGE_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
-def _normalize_extra_addons(raw_addons) -> dict[str, str]:
+def _normalize_extra_addons(raw_addons: object) -> dict[str, str]:
     """Convert old list format or new dict format to {name: branch} dict."""
     if isinstance(raw_addons, dict):
         return raw_addons
@@ -180,7 +180,7 @@ def _mount_filestore(
     env_name: str,
     env_db: str,
     odoo_image: str,
-    odoo_volumes: dict,
+    odoo_volumes: dict[str, Any],
     *,
     template_name: str,
 ) -> None:
@@ -474,7 +474,7 @@ def remount_template_overlays(
                 result.failures.append((env_name, f"remount: {exc}"))
 
 
-def _install_apt_packages(container, repo_path: str) -> str:
+def _install_apt_packages(container: Any, repo_path: str) -> str:
     """Install apt packages. Returns a human-readable log of what happened."""
     apt_file = os.path.join(repo_path, ".oduflow", "apt_packages.txt")
     if not os.path.isfile(apt_file):
@@ -506,7 +506,7 @@ def _install_apt_packages(container, repo_path: str) -> str:
         return f"[APT] Installed: {' '.join(packages)}"
 
 
-def _ensure_user_site_packages(container) -> None:
+def _ensure_user_site_packages(container: Any) -> None:
     """Create the user site-packages directory for the odoo user and fix ownership.
 
     This allows ``pip install --user`` to work inside containers where
@@ -539,7 +539,7 @@ def _ensure_user_site_packages(container) -> None:
 
 
 def _install_pip_requirements(
-    container, repo_path: str, *, restart: bool = True
+    container: Any, repo_path: str, *, restart: bool = True
 ) -> tuple[bool, str]:
     """Install pip requirements from repo.
 
@@ -639,8 +639,8 @@ def _init_empty_database(
     team: TeamSettings,
     odoo_image: str,
     env_db: str,
-    odoo_env: dict,
-    odoo_volumes: dict,
+    odoo_env: dict[str, Any],
+    odoo_volumes: dict[str, Any],
     env_name: str,
 ) -> str:
     """Initialize a fresh empty database with ``-i base`` in an isolated,
@@ -710,7 +710,7 @@ def create_environment(
     auto_install_modules: list[str] | None = None,
     env_vars: dict[str, str] | None = None,
     local_path: str = "",
-) -> dict[str, str]:
+) -> dict[str, Any]:
     env_name = env_name or branch
     start_time = time.time()
     try:
@@ -742,8 +742,8 @@ def create_environment(
                 url = f"https://{get_env_hostname(env_name, team.hostname)}"
             else:
                 ports = existing.ports.get("8069/tcp")
-                host_port = ports[0]["HostPort"] if ports else "?"
-                url = f"http://{team.hostname}:{host_port}"
+                existing_port = ports[0]["HostPort"] if ports else "?"
+                url = f"http://{team.hostname}:{existing_port}"
             raise ConflictError(
                 f"Environment '{env_name}' already exists and is running at {url}."
             )
@@ -1120,7 +1120,7 @@ def create_environment(
         "mode": "rw",
     }
 
-    run_kwargs: dict = dict(
+    run_kwargs: dict[str, Any] = dict(
         image=odoo_image,
         name=odoo_container_name,
         detach=True,
@@ -1276,7 +1276,7 @@ def create_environment(
         git_user,
     )
 
-    result = {
+    result: dict[str, Any] = {
         "url": url,
         "odoo_container": odoo_container_name,
         "database": env_db,
@@ -1966,7 +1966,7 @@ def restart_environment(
 
 def stop_environment(
     settings: Settings, team: TeamSettings, env_name: str
-) -> dict[str, str]:
+) -> dict[str, Any]:
     if is_protected(settings, team, env_name):
         raise ProtectedError(
             f"Environment '{env_name}' is protected. Unprotect it before stopping."
@@ -1992,7 +1992,7 @@ def stop_environment(
 
 def start_environment(
     settings: Settings, env_name: str, team: TeamSettings
-) -> dict[str, str]:
+) -> dict[str, Any]:
     client = get_client()
     odoo_container_name = get_resource_name(
         env_name, "odoo", settings.prefix, team.team_id
@@ -2731,7 +2731,7 @@ def update_environment(
         template_name = labels.get("oduflow.template", "none")
         if template_name and template_name != "none":
             try:
-                _tmp_vols: dict = {}
+                _tmp_vols: dict[str, Any] = {}
                 _mount_filestore(
                     client,
                     settings,
@@ -2788,7 +2788,7 @@ def update_environment(
     # ------------------------------------------------------------------
     # 4. Re-create the container with the same settings
     # ------------------------------------------------------------------
-    run_kwargs: dict = dict(
+    run_kwargs: dict[str, Any] = dict(
         image=odoo_image,
         name=odoo_container_name,
         detach=True,

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -810,7 +810,8 @@ def list_env_users(
     if exit_code != 0:
         raise ExternalCommandError("psql", exit_code, out)
     try:
-        return json.loads(out or "[]")
+        rows: list[dict[str, Any]] = json.loads(out or "[]")
+        return rows
     except json.JSONDecodeError:
         return []
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -275,7 +275,7 @@ def create_service(
         "oduflow.created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
 
-    run_kwargs: dict = {
+    run_kwargs: dict[str, Any] = {
         "image": image,
         "name": container_name,
         "detach": True,
@@ -458,8 +458,8 @@ def _traefik_label_by_suffix(labels: dict[str, str], suffix: str) -> str:
 
 
 def _describe_service_container(
-    settings: Settings, team: TeamSettings, container
-) -> dict:
+    settings: Settings, team: TeamSettings, container: Any
+) -> dict[str, Any]:
     """Extract a normalized state dict for a managed service container.
 
     Used by both ``list_services`` and ``get_service_info``.
@@ -573,7 +573,7 @@ def _describe_service_container(
     }
 
 
-def list_services(settings: Settings, team: TeamSettings) -> list[dict]:
+def list_services(settings: Settings, team: TeamSettings) -> list[dict[str, Any]]:
     client = get_client()
     containers = client.containers.list(
         all=True,
@@ -594,7 +594,9 @@ def list_services(settings: Settings, team: TeamSettings) -> list[dict]:
     return result
 
 
-def get_service_info(settings: Settings, team: TeamSettings, name: str) -> dict:
+def get_service_info(
+    settings: Settings, team: TeamSettings, name: str
+) -> dict[str, Any]:
     """Return full state and configuration of a single managed service.
 
     Combines live container state (image, digest, ports, volumes, env, caps,
@@ -681,6 +683,10 @@ def update_service(
     except Exception:
         pass
 
+    # Declared once so the preset and legacy-fallback branches agree on a type.
+    port: int | None
+    hostname: str | None
+    env_vars: dict[str, str] | None
     if preset:
         port = preset.get("port") or None
         hostname = preset.get("hostname") or None
@@ -693,7 +699,7 @@ def update_service(
     else:
         # Legacy fallback: extract from running container
         raw_env = container.attrs.get("Config", {}).get("Env", [])
-        env_vars: dict[str, str] = {}
+        env_vars = {}
         for entry in raw_env:
             if "=" in entry:
                 key, value = entry.split("=", 1)
@@ -707,8 +713,8 @@ def update_service(
         cap_add = list(host_config.get("CapAdd") or []) or None
         privileged = bool(host_config.get("Privileged", False))
 
-        port: int | None = None
-        hostname: str | None = None
+        port = None
+        hostname = None
 
         if settings.routing_mode == "traefik":
             rule_value = _traefik_label_by_suffix(container.labels, ".rule")
@@ -917,7 +923,8 @@ def get_service_logs(
         raise NotFoundError(f"Service '{name}' not found")
 
     output = container.logs(tail=lines, timestamps=True)
-    return output.decode("utf-8")
+    text: str = output.decode("utf-8")
+    return text
 
 
 def run_command_in_service(

--- a/src/oduflow/docker_ops/service_presets.py
+++ b/src/oduflow/docker_ops/service_presets.py
@@ -4,6 +4,7 @@ Presets are persisted as a single JSON file at ``{team.data_dir}/service_presets
 """
 
 from __future__ import annotations
+from typing import Any
 
 import json
 import logging
@@ -20,7 +21,7 @@ def _presets_path(team: TeamSettings) -> str:
     return os.path.join(team.data_dir, "service_presets.json")
 
 
-def _load_presets(team: TeamSettings) -> dict:
+def _load_presets(team: TeamSettings) -> dict[str, Any]:
     """Read and return all presets from disk.
 
     Returns an empty dict when the file does not exist or contains invalid JSON.
@@ -30,13 +31,14 @@ def _load_presets(team: TeamSettings) -> dict:
         return {}
     try:
         with open(path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
+            data: dict[str, Any] = json.load(fh)
+            return data
     except json.JSONDecodeError:
         logger.warning("Corrupt presets file at %s – returning empty dict", path)
         return {}
 
 
-def _save_presets(team: TeamSettings, data: dict) -> None:
+def _save_presets(team: TeamSettings, data: dict[str, Any]) -> None:
     """Persist *data* to the presets JSON file, creating parent dirs if needed.
 
     Writes atomically (temp file + os.replace) so a crash mid-write cannot leave
@@ -65,14 +67,14 @@ def save_preset(
     cap_add: list[str] | None = None,
     privileged: bool = False,
     routes: list[dict[str, object]] | None = None,
-) -> dict:
+) -> dict[str, Any]:
     """Save (or overwrite) a single service preset and return it."""
     short_hostname = hostname or ""
     if short_hostname and base_hostname:
         suffix = f".{base_hostname}"
         if short_hostname.endswith(suffix):
             short_hostname = short_hostname[: -len(suffix)]
-    preset: dict = {
+    preset: dict[str, Any] = {
         "image": image,
         "port": port or 0,
         "hostname": short_hostname,
@@ -94,7 +96,7 @@ def save_preset(
     return preset
 
 
-def list_presets(team: TeamSettings) -> list[dict]:
+def list_presets(team: TeamSettings) -> list[dict[str, Any]]:
     """Return all presets as a sorted list of dicts (each includes a ``name`` key)."""
     data = _load_presets(team)
     return sorted(
@@ -103,7 +105,7 @@ def list_presets(team: TeamSettings) -> list[dict]:
     )
 
 
-def get_preset(team: TeamSettings, name: str) -> dict:
+def get_preset(team: TeamSettings, name: str) -> dict[str, Any]:
     """Return a single preset dict (with ``name`` key) or raise :class:`NotFoundError`."""
     data = _load_presets(team)
     if name not in data:
@@ -111,7 +113,7 @@ def get_preset(team: TeamSettings, name: str) -> dict:
     return {"name": name, **data[name]}
 
 
-def delete_preset(team: TeamSettings, name: str) -> dict:
+def delete_preset(team: TeamSettings, name: str) -> dict[str, Any]:
     """Remove a preset from disk and return ``{"name": name}``.
 
     Raises :class:`NotFoundError` if the preset does not exist.

--- a/src/oduflow/docker_ops/stats.py
+++ b/src/oduflow/docker_ops/stats.py
@@ -18,7 +18,7 @@ from oduflow.settings import Settings, TeamSettings
 logger = logging.getLogger("oduflow")
 
 
-def _calc_cpu_percent(stats: dict) -> float:
+def _calc_cpu_percent(stats: dict[str, Any]) -> float:
     """Calculate CPU usage % from a single stats snapshot."""
     cpu = stats.get("cpu_stats", {})
     precpu = stats.get("precpu_stats", {})
@@ -34,10 +34,11 @@ def _calc_cpu_percent(stats: dict) -> float:
     num_cpus = cpu.get("online_cpus") or len(
         cpu.get("cpu_usage", {}).get("percpu_usage", []) or [1]
     )
-    return round((cpu_delta / system_delta) * num_cpus * 100.0, 1)
+    percent: float = round((cpu_delta / system_delta) * num_cpus * 100.0, 1)
+    return percent
 
 
-def _get_one_container_stats(container) -> dict[str, Any] | None:
+def _get_one_container_stats(container: Any) -> dict[str, Any] | None:
     """Get stats for a single container. Returns None on error."""
     try:
         if container.status != "running":

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 import contextlib
 import gzip
@@ -92,8 +93,8 @@ def _update_template_sizes(
     team: TeamSettings,
     settings: Settings,
     template_name: str,
-    metadata: dict | None = None,
-) -> dict:
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Compute filestore/dump sizes and persist them into template metadata."""
     from oduflow.docker_ops.env_ops import _dir_size_mb
 
@@ -118,7 +119,7 @@ def _update_template_sizes(
     return metadata
 
 
-def _normalize_extra_addons(raw_addons) -> dict[str, str]:
+def _normalize_extra_addons(raw_addons: object) -> dict[str, str]:
     """Convert old list format or new dict format to {name: branch} dict."""
     if isinstance(raw_addons, dict):
         return raw_addons
@@ -246,7 +247,7 @@ def _is_archive_source(source: str) -> bool:
     return source.lower().endswith(_ARCHIVE_SUFFIXES)
 
 
-def _zip_member_is_symlink(info) -> bool:
+def _zip_member_is_symlink(info: Any) -> bool:
     return stat.S_IFMT(info.external_attr >> 16) == stat.S_IFLNK
 
 
@@ -442,7 +443,7 @@ def _resolve_instance_conf(name: str, data_dir: str) -> pathlib.Path:
 
 def _write_traefik_dynamic_config(settings: Settings, config_path: str) -> None:
     """Generate traefik dynamic config that routes each team's hostname to oduflow."""
-    routers: dict = {}
+    routers: dict[str, Any] = {}
     for team_id, team in settings.teams.items():
         if not team.hostname:
             continue
@@ -1141,7 +1142,7 @@ def reload_template(
     team: TeamSettings,
     template_name: str,
     dump_path: str | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     client = get_client()
     tpl_db = get_template_db_name(template_name, team.team_id)
     resolved_dump = dump_path or team.get_template_sql_path(template_name)
@@ -1533,7 +1534,7 @@ def init_template(
     logger.info("Template generation complete, loading into template DB")
     result = reload_template(settings, team, template_name=template_name)
 
-    metadata = {"odoo_image": odoo_image}
+    metadata: dict[str, Any] = {"odoo_image": odoo_image}
     from oduflow.docker_ops.env_ops import _dir_size_mb
 
     fs_size = _dir_size_mb(template_filestore_path)
@@ -1553,7 +1554,7 @@ def init_template(
     return result
 
 
-def _source_env_metadata(settings: Settings, labels: dict) -> dict:
+def _source_env_metadata(settings: Settings, labels: dict[str, Any]) -> dict[str, Any]:
     """Template metadata describing the source environment's code origin.
 
     A live-mounted environment (``oduflow.local_path`` label) has no repo URL;
@@ -2389,7 +2390,7 @@ def extract_addon_dir(tar_path: str, addons_dir: str, name: str) -> int:
     tmp_root = os.path.join(addons_dir, f".incoming_{name}")
     if os.path.exists(tmp_root):
         shutil.rmtree(tmp_root)
-    cleanup = tmp_root
+    cleanup: str | None = tmp_root
     try:
         written = extract_filestore_tar(tar_path, tmp_root)
         entries = [e for e in os.listdir(tmp_root) if not e.startswith(".")]
@@ -2599,7 +2600,7 @@ def finalize_imported_template(
 
 def cleanup_orphans(
     settings: Settings, team: TeamSettings, dry_run: bool = True
-) -> dict:
+) -> dict[str, Any]:
     """Find and remove orphaned databases, workspaces, and port registry entries.
 
     An orphan is a resource whose branch has no corresponding Docker container.
@@ -2922,7 +2923,7 @@ def rename_template(
     }
 
 
-def list_templates(settings: Settings, team: TeamSettings) -> list[dict]:
+def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any]]:
     client = get_client()
     templates = team.list_templates()
     result = []

--- a/src/oduflow/docker_ops/volume_ops.py
+++ b/src/oduflow/docker_ops/volume_ops.py
@@ -5,6 +5,7 @@ They persist independently of services and can be mounted to any service.
 """
 
 from __future__ import annotations
+from typing import Any
 
 import logging
 import re
@@ -20,7 +21,7 @@ logger = logging.getLogger("oduflow")
 _VOLUME_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
 
-def _vol_labels(vol) -> dict[str, str]:
+def _vol_labels(vol: Any) -> dict[str, str]:
     """Return labels dict from a Docker Volume object.
 
     The Docker SDK Volume object stores labels in ``attrs['Labels']``
@@ -74,7 +75,7 @@ def create_volume(
     }
 
 
-def list_volumes(settings: Settings, team: TeamSettings) -> list[dict]:
+def list_volumes(settings: Settings, team: TeamSettings) -> list[dict[str, Any]]:
     """List all managed volumes for a team, including usage info."""
     client = get_client()
     volumes = client.volumes.list(
@@ -111,7 +112,7 @@ def list_volumes(settings: Settings, team: TeamSettings) -> list[dict]:
     return result
 
 
-def inspect_volume(settings: Settings, team: TeamSettings, name: str) -> dict:
+def inspect_volume(settings: Settings, team: TeamSettings, name: str) -> dict[str, Any]:
     """Return details for a single volume including usage."""
     client = get_client()
     docker_name = docker_volume_name(team, name)

--- a/src/oduflow/env_credentials.py
+++ b/src/oduflow/env_credentials.py
@@ -84,7 +84,8 @@ def load_credentials(
     creds_path = os.path.join(workspace_path, _CREDENTIALS_FILE)
     if os.path.isfile(creds_path):
         with open(creds_path) as f:
-            return json.load(f)
+            creds: dict[str, str] = json.load(f)
+            return creds
     if not allow_fallback:
         raise MissingCredentialsError(
             f"Environment '{env_name}' has no scoped database credentials. "

--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from typing import Any
 
 from oduflow.docker_ops.client import get_client
 from oduflow.errors import (
@@ -36,7 +37,7 @@ _AUTH_ERROR_KEYWORDS = (
 
 def clone_extra_repo(
     team: TeamSettings, name: str, repo_url: str, git_user: str = ""
-) -> dict:
+) -> dict[str, Any]:
     if not _NAME_RE.match(name):
         raise ValueError(
             f"Invalid repo name '{name}': only [a-zA-Z0-9_-] allowed, "
@@ -113,7 +114,7 @@ def clone_extra_repo(
 
 def create_local_repo(
     team: TeamSettings, name: str, source_dir: str, branch: str
-) -> dict:
+) -> dict[str, Any]:
     """Create an extra-addons repo from local files, with no remote origin.
 
     Used by the Odoo.sh import for addons that cannot be cloned (Enterprise,
@@ -217,7 +218,7 @@ def is_local_repo(team: TeamSettings, name: str) -> bool:
     return os.path.exists(os.path.join(team.shared_repos_dir, name, ".local"))
 
 
-def list_extra_repos(team: TeamSettings) -> list[dict]:
+def list_extra_repos(team: TeamSettings) -> list[dict[str, Any]]:
     repos_dir = team.shared_repos_dir
     if not os.path.isdir(repos_dir):
         return []
@@ -271,7 +272,7 @@ def is_extra_repo_protected(team: TeamSettings, name: str) -> bool:
     return os.path.exists(os.path.join(path, ".protected"))
 
 
-def protect_extra_repo(team: TeamSettings, name: str) -> dict:
+def protect_extra_repo(team: TeamSettings, name: str) -> dict[str, Any]:
     path = os.path.join(team.shared_repos_dir, name)
     if not os.path.isdir(path):
         raise NotFoundError(f"Extra repo '{name}' not found.")
@@ -281,7 +282,7 @@ def protect_extra_repo(team: TeamSettings, name: str) -> dict:
     return {"name": name, "protected": True}
 
 
-def unprotect_extra_repo(team: TeamSettings, name: str) -> dict:
+def unprotect_extra_repo(team: TeamSettings, name: str) -> dict[str, Any]:
     path = os.path.join(team.shared_repos_dir, name)
     if not os.path.isdir(path):
         raise NotFoundError(f"Extra repo '{name}' not found.")
@@ -292,7 +293,9 @@ def unprotect_extra_repo(team: TeamSettings, name: str) -> dict:
     return {"name": name, "protected": False}
 
 
-def delete_extra_repo(settings: Settings, team: TeamSettings, name: str) -> dict:
+def delete_extra_repo(
+    settings: Settings, team: TeamSettings, name: str
+) -> dict[str, Any]:
     path = os.path.join(team.shared_repos_dir, name)
     if not os.path.exists(path):
         raise NotFoundError(f"Extra repo '{name}' not found.")
@@ -361,7 +364,9 @@ def _get_branch_refs(repo_path: str) -> dict[str, str]:
     return refs
 
 
-def fetch_extra_repo(team: TeamSettings, name: str, branch: str | None = None) -> dict:
+def fetch_extra_repo(
+    team: TeamSettings, name: str, branch: str | None = None
+) -> dict[str, Any]:
     """Fetch latest changes and return a summary of what changed.
 
     When *branch* is given, only that one branch is fetched (a targeted
@@ -467,7 +472,7 @@ def fetch_extra_repo(team: TeamSettings, name: str, branch: str | None = None) -
 
     new_branches = sorted(set(refs_after) - set(refs_before))
     deleted_branches = sorted(set(refs_before) - set(refs_after))
-    updated_branches: list[dict] = []
+    updated_branches: list[dict[str, Any]] = []
     for branch_name in sorted(set(refs_before) & set(refs_after)):
         old_sha = refs_before[branch_name]
         new_sha = refs_after[branch_name]
@@ -657,7 +662,10 @@ def generate_odoo_conf(
     main_addons_path: str = "/mnt/extra-addons",
 ) -> str:
     parser = configparser.RawConfigParser()
-    parser.optionxform = str
+    # Preserve option case (Odoo config keys are case-sensitive); the default
+    # optionxform lowercases them. Assigning to this method is the documented
+    # configparser idiom but trips mypy's method-assignment check.
+    parser.optionxform = str  # type: ignore[method-assign,assignment]
     parser.read(base_conf_path)
 
     existing = parser.get("options", "addons_path", fallback="/mnt/extra-addons")

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 import ast
 import logging
@@ -36,9 +37,10 @@ _FIELD_RE = re.compile(r"^\s*\w+\s*=\s*fields\..*", re.MULTILINE)
 _VIEW_TAG_RE = re.compile(r"<(tree|list|form)\b([^>]*)/?>")
 
 
-def _parse_manifest(path: str) -> dict:
+def _parse_manifest(path: str) -> dict[str, Any]:
     with open(path, "r") as f:
-        return ast.literal_eval(f.read())
+        manifest: dict[str, Any] = ast.literal_eval(f.read())
+        return manifest
 
 
 def _get_module_name(file_path: str, repo_path: str = "") -> str | None:
@@ -167,7 +169,7 @@ def _is_dep_file(file_path: str) -> bool:
 
 def classify_changes(
     changed_files: list[str], repo_path: str, base_ref: str = "HEAD~1"
-) -> dict:
+) -> dict[str, Any]:
     """
     Classify changed files and determine required Odoo actions.
 
@@ -394,7 +396,7 @@ def _check_manifest_changes(
     return None
 
 
-def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
+def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict[str, Any]:
     """Path-only classification used when no git *base_ref* is available
     (a non-git live-mount).
 
@@ -478,7 +480,9 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict:
     }
 
 
-def recommend(changed_files: list[str], repo_path: str, base_ref: str | None) -> dict:
+def recommend(
+    changed_files: list[str], repo_path: str, base_ref: str | None
+) -> dict[str, Any]:
     """Recommended Odoo action for *changed_files*.
 
     Full :func:`classify_changes` (git-based deep checks) when a *base_ref* is
@@ -502,7 +506,7 @@ _DETAIL_LIST_KEYS = (
 )
 
 
-def merge_recommendations(recs: Iterable[dict]) -> dict:
+def merge_recommendations(recs: Iterable[dict[str, Any]]) -> dict[str, Any]:
     """Combine several :func:`recommend` results (one per repo/worktree).
 
     The main repo and each extra-addon worktree are classified against their own
@@ -521,7 +525,7 @@ def merge_recommendations(recs: Iterable[dict]) -> dict:
     install = sorted({m for r in recs for m in r.get("modules_to_install", []) or []})
     upgrade = sorted({m for r in recs for m in r.get("modules_to_upgrade", []) or []})
 
-    details: dict = {}
+    details: dict[str, Any] = {}
     for key in _DETAIL_LIST_KEYS:
         merged: list[str] = []
         for r in recs:
@@ -544,7 +548,7 @@ def merge_recommendations(recs: Iterable[dict]) -> dict:
 
 
 def guardrail_warnings(
-    recommended: dict,
+    recommended: dict[str, Any],
     to_install: list[str],
     to_upgrade: list[str],
     do_restart: bool,

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 from urllib.parse import urlparse
+from typing import Any
 
 from oduflow.errors import ExternalCommandError, FlowError
 
@@ -148,7 +149,7 @@ def inject_credential_user(repo_url: str, git_user: str) -> str:
     return parsed._replace(netloc=netloc).geturl()
 
 
-def list_credentials(cred_file: str) -> list[dict]:
+def list_credentials(cred_file: str) -> list[dict[str, Any]]:
     if not os.path.exists(cred_file):
         return []
 
@@ -338,9 +339,10 @@ def pull_repo(
     return old_head, [f for f in result.stdout.strip().splitlines() if f]
 
 
-def parse_manifest(manifest_path: str) -> dict:
+def parse_manifest(manifest_path: str) -> dict[str, Any]:
     """Parse an Odoo __manifest__.py file and return its dict."""
     import ast
 
     with open(manifest_path, "r") as f:
-        return ast.literal_eval(f.read())
+        manifest: dict[str, Any] = ast.literal_eval(f.read())
+        return manifest

--- a/src/oduflow/licensing.py
+++ b/src/oduflow/licensing.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger("oduflow")
 
@@ -57,7 +58,7 @@ class LicenseInfo:
         suffix = TYPE_SUFFIXES.get(self.type, "")
         return f"{base}: {self.name}{suffix}"
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "type": self.type,
             "name": self.name,
@@ -78,7 +79,7 @@ def get_license_path(etc_dir: str | None = None) -> str:
 
 
 def _verify_license_text(raw: str) -> LicenseInfo:
-    from cryptography.hazmat.primitives.asymmetric import padding
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
@@ -91,6 +92,8 @@ def _verify_license_text(raw: str) -> LicenseInfo:
     payload_bytes = base64.b64decode(payload_b64)
 
     pub_key = load_pem_public_key(_PUBLIC_KEY_PEM.encode())
+    if not isinstance(pub_key, rsa.RSAPublicKey):
+        raise ValueError("License public key must be an RSA key")
     pub_key.verify(
         signature,
         payload_bytes,

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4,10 +4,12 @@ import argparse
 import functools
 import logging
 import os
+import pathlib
 import re
 import sys
 import warnings
-from typing import Any, cast
+from collections.abc import Awaitable, Callable
+from typing import Any, ParamSpec, TypeVar, cast
 
 # Suppress a third-party deprecation warning emitted at import time by fastmcp's
 # JWT auth provider (it imports the deprecated authlib.jose module). This keeps
@@ -182,13 +184,16 @@ def _maybe_cache(output: str, header: str, source_tool: str, source_args: str) -
 
 # -- Decorators --
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def handle_errors(fn):
+
+def handle_errors(fn: Callable[P, R]) -> Callable[P, Awaitable[R]]:
     @functools.wraps(fn)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         import anyio
 
-        def _run():
+        def _run() -> R:
             try:
                 result = fn(*args, **kwargs)
                 preview = (
@@ -214,15 +219,19 @@ def handle_errors(fn):
     return wrapper
 
 
-def with_env_lock(fn):
+def with_env_lock(fn: Callable[P, R]) -> Callable[P, R]:
     """Acquire a per-environment lock before executing the tool function."""
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        env_name = kwargs.get("env_name") or (args[0] if args else None)
-        if not env_name:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        # Under ParamSpec, values pulled from *args/**kwargs are typed `object`;
+        # narrow them back to the concrete types these helpers expect.
+        raw_env_name = kwargs.get("env_name") or (args[0] if args else None)
+        if not raw_env_name:
             raise ToolError("env_name is required")
-        team = _resolve_team(kwargs.get("ctx"))
+        env_name = cast(str, raw_env_name)
+        ctx = cast("Context | None", kwargs.get("ctx"))
+        team = _resolve_team(ctx)
         _locks.acquire_env(env_name, team.team_id)
         try:
             try:
@@ -251,12 +260,12 @@ def _wake_for_work(
     return ""
 
 
-def with_team_lock(fn):
+def with_team_lock(fn: Callable[P, R]) -> Callable[P, R]:
     """Acquire a per-team lock before executing the tool function."""
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        ctx = kwargs.get("ctx")
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        ctx = cast("Context | None", kwargs.get("ctx"))
         team = _resolve_team(ctx)
         _locks.acquire_team(team.team_id)
         try:
@@ -275,7 +284,7 @@ def with_team_lock(fn):
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def setup_repo_auth(repo_url: str, ctx: Context = None) -> str:
+def setup_repo_auth(repo_url: str, ctx: Context | None = None) -> str:
     """
     Cache git credentials for a private repository.
 
@@ -305,7 +314,7 @@ def setup_repo_auth(repo_url: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def add_extra_repo(name: str, repo_url: str, ctx: Context = None) -> str:
+def add_extra_repo(name: str, repo_url: str, ctx: Context | None = None) -> str:
     """
     Clone an extra addons repository for use with environments.
 
@@ -329,7 +338,7 @@ def add_extra_repo(name: str, repo_url: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def list_extra_repos(ctx: Context = None) -> str:
+def list_extra_repos(ctx: Context | None = None) -> str:
     """List all cloned extra addons repositories."""
     from oduflow.extra_addons import list_extra_repos as _list
 
@@ -347,7 +356,7 @@ def list_extra_repos(ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def delete_extra_repo(name: str, ctx: Context = None) -> str:
+def delete_extra_repo(name: str, ctx: Context | None = None) -> str:
     """
     Delete a cloned extra addons repository.
 
@@ -365,7 +374,7 @@ def delete_extra_repo(name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def update_extra_repo(name: str, ctx: Context = None) -> str:
+def update_extra_repo(name: str, ctx: Context | None = None) -> str:
     """
     Pull latest changes from the remote for an extra addons repository.
 
@@ -381,7 +390,7 @@ def update_extra_repo(name: str, ctx: Context = None) -> str:
     return _format_fetch_summary(summary)
 
 
-def _format_fetch_summary(summary: dict) -> str:
+def _format_fetch_summary(summary: dict[str, Any]) -> str:
     name = summary["name"]
     if summary.get("local"):
         return f"Extra repo '{name}' is local (no remote) — nothing to pull."
@@ -431,7 +440,7 @@ def create_environment(
     auto_install_modules: str = "",
     env_vars: str = "",
     local_path: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Provision a new ephemeral Odoo environment.
@@ -606,7 +615,7 @@ def create_environment(
             lines.append(
                 "Env vars: " + ", ".join(f"{k}={v}" for k, v in parsed_env.items())
             )
-        setup_logs = result.get("setup_logs", [])
+        setup_logs: list[str] = result.get("setup_logs", [])
         if setup_logs:
             lines.append("\n--- Setup Log ---")
             lines.extend(setup_logs)
@@ -631,7 +640,7 @@ def save_as_template(
     template_name: str,
     reset_env_changes: bool = False,
     overwrite: bool = False,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Save an environment as a template (DB + filestore).
@@ -692,7 +701,7 @@ def save_as_template(
 
 @mcp.tool()
 @handle_errors
-def list_templates(ctx: Context = None) -> str:
+def list_templates(ctx: Context | None = None) -> str:
     """List available template profiles (database + filestore snapshots)."""
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -725,7 +734,7 @@ def import_template_from_odoo(
     db_name: str = "",
     template_name: str = "default",
     without_filestore: bool = False,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Import a template from a running Odoo instance via its database manager API.
@@ -783,7 +792,7 @@ def import_template_from_odoo(
 def refresh_template(
     template_name: str,
     reset_env_changes: bool = False,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Re-apply a template's current filestore to live overlay environments.
@@ -834,7 +843,7 @@ def attach_filestore(
     source: str,
     reset_env_changes: bool = False,
     strip_prefix: str = "auto",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Attach or replace a template filestore from a directory, rsync/ssh source, or archive.
@@ -883,7 +892,7 @@ def attach_filestore(
 
 @mcp.tool()
 @handle_errors
-def get_agent_instructions(ctx: Context = None) -> str:
+def get_agent_instructions(ctx: Context | None = None) -> str:
     """Get instructions for AI coding agents on how to use Oduflow MCP tools."""
     import pathlib
 
@@ -938,7 +947,7 @@ def get_agent_instructions(ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def get_odoo_development_guide(version: str, ctx: Context = None) -> str:
+def get_odoo_development_guide(version: str, ctx: Context | None = None) -> str:
     """
     Get Odoo development standards and constraints guide for a specific Odoo version.
 
@@ -983,7 +992,7 @@ def get_odoo_development_guide(version: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def delete_template(template_name: str, ctx: Context = None) -> str:
+def delete_template(template_name: str, ctx: Context | None = None) -> str:
     """
     DANGEROUS: Delete a template profile — permanently removes its template database and files from disk.
 
@@ -1006,7 +1015,9 @@ def delete_template(template_name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def rename_template(template_name: str, new_name: str, ctx: Context = None) -> str:
+def rename_template(
+    template_name: str, new_name: str, ctx: Context | None = None
+) -> str:
     """
     Rename a template profile — renames its directory and PostgreSQL template DB.
 
@@ -1035,7 +1046,7 @@ def rename_template(template_name: str, new_name: str, ctx: Context = None) -> s
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def delete_environment(env_name: str, ctx: Context = None) -> str:
+def delete_environment(env_name: str, ctx: Context | None = None) -> str:
     """
     Stop and remove all resources associated with an Odoo environment.
 
@@ -1053,7 +1064,7 @@ def delete_environment(env_name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def list_environments(ctx: Context = None) -> str:
+def list_environments(ctx: Context | None = None) -> str:
     """
     List all managed Odoo environments.
     """
@@ -1090,7 +1101,7 @@ def list_environments(ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def run_odoo_tests(env_name: str, modules: str, ctx: Context = None) -> str:
+def run_odoo_tests(env_name: str, modules: str, ctx: Context | None = None) -> str:
     """
     Run Odoo tests for specific modules in an environment.
 
@@ -1119,7 +1130,7 @@ def get_environment_logs(
     n_lines: int = 100,
     grep: str = "",
     level: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Get the last N lines of logs from the Odoo container for a specific environment.
@@ -1144,7 +1155,9 @@ def get_environment_logs(
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def restart_environment(env_name: str, wait: bool = True, ctx: Context = None) -> str:
+def restart_environment(
+    env_name: str, wait: bool = True, ctx: Context | None = None
+) -> str:
     """
     Restart the Odoo container for a specific environment.
 
@@ -1179,7 +1192,7 @@ def update_environment(
     env_name: str,
     env_vars: str = "",
     odoo_image: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Re-create the Odoo container for an environment without losing the database
@@ -1235,7 +1248,7 @@ def update_environment(
 
 @mcp.tool()
 @handle_errors
-def get_environment_info(env_name: str, ctx: Context = None) -> str:
+def get_environment_info(env_name: str, ctx: Context | None = None) -> str:
     """
     Get comprehensive information about an environment.
 
@@ -1287,7 +1300,7 @@ def get_environment_info(env_name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def stop_environment(env_name: str, ctx: Context = None) -> str:
+def stop_environment(env_name: str, ctx: Context | None = None) -> str:
     """
     Stop the Odoo container for a specific environment.
 
@@ -1307,7 +1320,9 @@ def stop_environment(env_name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def start_environment(env_name: str, wait: bool = True, ctx: Context = None) -> str:
+def start_environment(
+    env_name: str, wait: bool = True, ctx: Context | None = None
+) -> str:
     """
     Start all containers for a specific environment.
 
@@ -1343,7 +1358,7 @@ def pull_and_apply(
     upgrade: str = "",
     restart: bool = False,
     strict: bool = False,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Sync the latest code into an environment and apply the right Odoo action.
@@ -1413,7 +1428,7 @@ def pull_and_apply(
         return "\n".join(lines)
 
     if action == "none":
-        return woke_note + result["message"]
+        return cast(str, woke_note + result["message"])
 
     header_lines = [woke_note + result["message"]]
     if result.get("modules_installed"):
@@ -1449,7 +1464,7 @@ def read_output(
     start: int = 1,
     end: int = 0,
     grep: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Read from a cached tool output by its ID.
@@ -1549,7 +1564,9 @@ def read_output(
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def install_odoo_modules(env_name: str, modules: str, ctx: Context = None) -> str:
+def install_odoo_modules(
+    env_name: str, modules: str, ctx: Context | None = None
+) -> str:
     """
     Install Odoo modules in an environment.
 
@@ -1584,7 +1601,9 @@ def install_odoo_modules(env_name: str, modules: str, ctx: Context = None) -> st
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def upgrade_odoo_modules(env_name: str, modules: str, ctx: Context = None) -> str:
+def upgrade_odoo_modules(
+    env_name: str, modules: str, ctx: Context | None = None
+) -> str:
     """
     Upgrade Odoo modules in an environment.
 
@@ -1616,7 +1635,7 @@ def upgrade_odoo_modules(env_name: str, modules: str, ctx: Context = None) -> st
 @mcp.tool()
 @handle_errors
 def read_file_in_odoo(
-    env_name: str, path: str, read_range: str = "", ctx: Context = None
+    env_name: str, path: str, read_range: str = "", ctx: Context | None = None
 ) -> str:
     """
     Read a text file or list a directory inside the Odoo container for a specific environment.
@@ -1648,7 +1667,7 @@ def read_file_in_odoo(
     )
     if "error" in result:
         return f"{woke}Error: {result['error']}"
-    return woke + result["output"]
+    return cast(str, woke + result["output"])
 
 
 @mcp.tool()
@@ -1659,7 +1678,7 @@ def write_file_in_odoo(
     path: str,
     content: str,
     user: str = "odoo",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Write a text file inside the Odoo container.
@@ -1698,7 +1717,7 @@ def write_file_in_odoo(
 def run_odoo_shell(
     env_name: str,
     python_code: str,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Execute Python code in the Odoo shell context with full ORM access.
@@ -1742,7 +1761,7 @@ def http_request_to_odoo(
     body: str = "",
     headers: str = "",
     session_id: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Make an HTTP request to the running Odoo instance for a specific environment.
@@ -1800,7 +1819,7 @@ def search_in_odoo(
     path: str = "/mnt/extra-addons",
     glob: str = "*.py",
     max_results: int = 50,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Search for a pattern in files inside the Odoo container.
@@ -1843,7 +1862,7 @@ def list_installed_modules(
     env_name: str,
     name_filter: str = "",
     state_filter: str = "installed",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     List Odoo modules and their states in an environment.
@@ -1878,14 +1897,14 @@ def list_installed_modules(
     settings = _get_settings()
     team = _resolve_team(ctx)
     result = odoo_ops.run_db_query(settings, team, env_name, query, "csv")
-    return result["output"]
+    return cast(str, result["output"])
 
 
 @mcp.tool()
 @handle_errors
 @with_env_lock
 def run_odoo_command(
-    env_name: str, command: str, user: str = "odoo", ctx: Context = None
+    env_name: str, command: str, user: str = "odoo", ctx: Context | None = None
 ) -> str:
     """
     Execute an arbitrary shell command inside the Odoo container for a specific environment.
@@ -1917,7 +1936,7 @@ def run_odoo_command(
 @handle_errors
 @with_env_lock
 def reset_admin_password(
-    env_name: str, new_password: str = "test", ctx: Context = None
+    env_name: str, new_password: str = "test", ctx: Context | None = None
 ) -> str:
     """
     Reset the admin user password in the environment's Odoo database.
@@ -1939,7 +1958,7 @@ def reset_admin_password(
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def connect_as_user(env_name: str, user: str, ctx: Context = None) -> str:
+def connect_as_user(env_name: str, user: str, ctx: Context | None = None) -> str:
     """
     Mint a passwordless Odoo login session for a user and return its cookie.
 
@@ -1991,7 +2010,7 @@ def run_db_query(
     query: str,
     output_format: str = "csv",
     max_rows: int = 100,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Execute a SQL query against the environment's PostgreSQL database.
@@ -2040,7 +2059,7 @@ def create_service(
     privileged: bool = False,
     net_admin: bool = False,
     routes: list[dict[str, object]] | None = None,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Create a managed auxiliary service container (e.g. Redis, Meilisearch).
@@ -2117,7 +2136,7 @@ def update_service(
     privileged: bool | None = None,
     net_admin: bool | None = None,
     routes: list[dict[str, object]] | None = None,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Update a managed auxiliary service container. Pulls the latest image and
@@ -2194,7 +2213,7 @@ def update_service(
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def delete_service(name: str, ctx: Context = None) -> str:
+def delete_service(name: str, ctx: Context | None = None) -> str:
     """
     Stop and remove a managed auxiliary service container.
 
@@ -2207,7 +2226,7 @@ def delete_service(name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def restart_service(name: str, ctx: Context = None) -> str:
+def restart_service(name: str, ctx: Context | None = None) -> str:
     """
     Restart a managed auxiliary service container.
 
@@ -2220,7 +2239,7 @@ def restart_service(name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def get_service_info(name: str, ctx: Context = None) -> str:
+def get_service_info(name: str, ctx: Context | None = None) -> str:
     """
     Get full state and configuration of a managed auxiliary service.
 
@@ -2298,7 +2317,7 @@ def get_service_info(name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def list_service_presets(ctx: Context = None) -> str:
+def list_service_presets(ctx: Context | None = None) -> str:
     """List saved service presets (configurations that can be restored)."""
     team = _resolve_team(ctx)
     presets = service_presets.list_presets(team)
@@ -2342,7 +2361,7 @@ def list_service_presets(ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def restore_service(name: str, ctx: Context = None) -> str:
+def restore_service(name: str, ctx: Context | None = None) -> str:
     """
     Restore a service from a saved preset. Recreates the service container with the same configuration.
 
@@ -2396,7 +2415,7 @@ def restore_service(name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def delete_service_preset(name: str, ctx: Context = None) -> str:
+def delete_service_preset(name: str, ctx: Context | None = None) -> str:
     """
     Remove a saved service preset.
 
@@ -2410,7 +2429,7 @@ def delete_service_preset(name: str, ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def list_services(ctx: Context = None) -> str:
+def list_services(ctx: Context | None = None) -> str:
     """List all managed auxiliary service containers."""
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -2436,7 +2455,7 @@ def list_services(ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def get_service_logs(name: str, n_lines: int = 100, ctx: Context = None) -> str:
+def get_service_logs(name: str, n_lines: int = 100, ctx: Context | None = None) -> str:
     """
     Get logs from a managed auxiliary service container.
 
@@ -2453,7 +2472,7 @@ def get_service_logs(name: str, n_lines: int = 100, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 def run_service_command(
-    name: str, command: str, user: str = "root", ctx: Context = None
+    name: str, command: str, user: str = "root", ctx: Context | None = None
 ) -> str:
     """
     Execute an arbitrary shell command inside a managed auxiliary service container.
@@ -2467,7 +2486,7 @@ def run_service_command(
         _get_settings(), _resolve_team(ctx), name, command, user
     )
     exit_code = result["exit_code"]
-    output = result.get("output", "")
+    output = cast(str, result.get("output", ""))
     status = "Success" if exit_code == 0 else "Error"
     header = f"{status}. Exit code: {exit_code}."
     return _maybe_cache(
@@ -2489,7 +2508,7 @@ def run_service_command(
 def create_volume(
     name: str,
     description: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Create a named Docker volume for use with services.
@@ -2514,7 +2533,7 @@ def create_volume(
 
 @mcp.tool()
 @handle_errors
-def list_volumes(ctx: Context = None) -> str:
+def list_volumes(ctx: Context | None = None) -> str:
     """List all managed Docker volumes and their usage by services."""
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -2533,7 +2552,7 @@ def list_volumes(ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def inspect_volume(name: str, ctx: Context = None) -> str:
+def inspect_volume(name: str, ctx: Context | None = None) -> str:
     """
     Get detailed information about a specific volume, including which services use it.
 
@@ -2559,7 +2578,7 @@ def inspect_volume(name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_team_lock
-def delete_volume(name: str, ctx: Context = None) -> str:
+def delete_volume(name: str, ctx: Context | None = None) -> str:
     """
     Delete a managed Docker volume. Fails if the volume is in use by any service.
 
@@ -2583,7 +2602,7 @@ def read_file_in_volume(
     name: str,
     path: str,
     read_range: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Read a text file or list a directory inside a Docker volume.
@@ -2605,7 +2624,7 @@ def read_file_in_volume(
     result = volume_file_ops.read_file_in_volume(settings, team, name, path, read_range)
     if "error" in result:
         return f"Error: {result['error']}"
-    return result["output"]
+    return cast(str, result["output"])
 
 
 @mcp.tool()
@@ -2615,7 +2634,7 @@ def write_file_in_volume(
     name: str,
     path: str,
     content: str,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Write a text file inside a Docker volume.
@@ -2643,7 +2662,7 @@ def search_in_volume(
     path: str = "",
     glob: str = "*",
     max_results: int = 50,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Search for a pattern in files inside a Docker volume.
@@ -2678,7 +2697,7 @@ def search_in_volume(
 def delete_file_in_volume(
     name: str,
     path: str,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Delete a file or directory inside a Docker volume.
@@ -2909,7 +2928,7 @@ def _copy_bundled_configs() -> None:
             _copy_bundled_pg_conf(dest)
 
 
-def _write_tuned_pg_conf(dest) -> bool:
+def _write_tuned_pg_conf(dest: pathlib.Path) -> bool:
     """Generate a resource-tuned postgresql.conf at ``dest``. True on success."""
     try:
         from oduflow import pg_tune
@@ -2941,7 +2960,7 @@ def _write_tuned_pg_conf(dest) -> bool:
         return False
 
 
-def _copy_bundled_pg_conf(dest) -> None:
+def _copy_bundled_pg_conf(dest: pathlib.Path) -> None:
     """Fallback: copy the static bundled postgresql.conf to ``dest``."""
     import pathlib
     import shutil
@@ -3361,7 +3380,7 @@ def _print_tools(verbose: bool = False) -> None:
 
     print("Registered tools:")
     for name in sorted(mcp._tool_manager._tools.keys()):
-        tool_fn = mcp._tool_manager._tools[name].fn
+        tool_fn = cast(Any, mcp._tool_manager._tools[name]).fn
         sig = inspect.signature(tool_fn)
         params = []
         for p in sig.parameters.values():
@@ -3395,7 +3414,7 @@ def _run_call(argv: list[str]) -> None:
         print(f"Available: {', '.join(sorted(mcp._tool_manager._tools.keys()))}")
         sys.exit(1)
 
-    tool_fn = mcp._tool_manager._tools[tool_name].fn
+    tool_fn = cast(Any, mcp._tool_manager._tools[tool_name]).fn
     sig = inspect.signature(tool_fn)
 
     if tool_argv and tool_argv[0].startswith("{"):
@@ -3450,7 +3469,7 @@ def _run_call(argv: list[str]) -> None:
 
         result = tool_fn(**kwargs)
         if inspect.isawaitable(result):
-            result = asyncio.run(result)
+            result = asyncio.run(cast(Any, result))
         print(result)
     except Exception as e:
         print(f"ERROR: {e}", file=sys.stderr)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -2962,7 +2962,6 @@ def _write_tuned_pg_conf(dest: pathlib.Path) -> bool:
 
 def _copy_bundled_pg_conf(dest: pathlib.Path) -> None:
     """Fallback: copy the static bundled postgresql.conf to ``dest``."""
-    import pathlib
     import shutil
 
     bundled = pathlib.Path(__file__).resolve().parent / "templates" / "postgresql.conf"

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 try:
     import tomllib
 except ModuleNotFoundError:
-    import tomli as tomllib  # type: ignore[no-redef]
+    import tomli as tomllib
 
 logger = logging.getLogger("oduflow")
 

--- a/src/oduflow/url_safety.py
+++ b/src/oduflow/url_safety.py
@@ -24,7 +24,9 @@ class BlockedURLError(FlowError):
     """The URL resolves to a network location that is not allowed."""
 
 
-def _is_blocked(ip: ipaddress._BaseAddress, *, allow_private: bool) -> bool:
+def _is_blocked(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address, *, allow_private: bool
+) -> bool:
     # Never-legitimate remote targets, blocked even for internal git hosts.
     if (
         ip.is_loopback

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 import asyncio
 import base64
@@ -24,7 +25,8 @@ from starlette.responses import (
     RedirectResponse,
     Response,
 )
-from starlette.routing import Route, WebSocketRoute
+from starlette.applications import Starlette
+from starlette.routing import BaseRoute, Route, WebSocketRoute
 from starlette.types import ASGIApp, Receive, Scope, Send
 from starlette.websockets import WebSocket
 
@@ -290,7 +292,7 @@ def _error_response(e: FlowError) -> JSONResponse:
     return JSONResponse({"ok": False, "error": str(e)}, status_code=status)
 
 
-def _normalize_extra_addons(raw_addons) -> dict[str, str]:
+def _normalize_extra_addons(raw_addons: object) -> dict[str, str]:
     if isinstance(raw_addons, dict):
         return raw_addons
     if isinstance(raw_addons, list):
@@ -384,7 +386,7 @@ class _LoginRateLimiter:
 def _build_routes(
     get_settings: Callable[[], Settings],
     locks: LockManager,
-) -> list[Route]:
+) -> list[BaseRoute]:
     # Per-app so test apps and real deployments don't share failure counters.
     login_limiter = _LoginRateLimiter()
 
@@ -473,10 +475,15 @@ def _build_routes(
             headers={"Cache-Control": "public, max-age=86400"},
         )
 
-    def _get_ui_team(request: Request) -> TeamSettings:
-        """Get the team from request state (set by auth middleware) or fallback."""
+    def _get_ui_team(request: HTTPConnection) -> TeamSettings:
+        """Get the team from request state (set by auth middleware) or fallback.
+
+        Accepts any Starlette connection (HTTP ``Request`` or ``WebSocket``);
+        both carry the ``state`` populated by the auth middleware.
+        """
         if hasattr(request.state, "team"):
-            return request.state.team
+            team: TeamSettings = request.state.team
+            return team
         settings = get_settings()
         if len(settings.teams) == 1:
             return next(iter(settings.teams.values()))
@@ -641,11 +648,12 @@ def _build_routes(
         try:
             import docker as _docker
             from oduflow.docker_ops.client import get_client as _get_client
+            from oduflow.naming import get_resource_name
 
             settings = get_settings()
             activity.touch(team, branch)
             client = _get_client()
-            odoo_container_name = env_ops.get_resource_name(
+            odoo_container_name = get_resource_name(
                 branch, "odoo", settings.prefix, team.team_id
             )
             try:
@@ -1387,7 +1395,7 @@ def _build_routes(
         staging = team.get_import_staging_dir(template_name)  # validates name
         os.makedirs(staging, exist_ok=True)
         path = os.path.join(staging, "addons.json")
-        entries: list = []
+        entries: list[Any] = []
         if os.path.isfile(path):
             try:
                 with open(path) as f:
@@ -3199,7 +3207,7 @@ def _build_routes(
 
 
 def mount_web_ui(
-    app,
+    app: Starlette,
     get_settings: Callable[[], Settings],
     locks: LockManager,
 ) -> None:


### PR DESCRIPTION
mypy was configured `strict = true` from the first commit but never ran in CI and emitted 391 errors, so it gave no signal — this gets it to zero and wires it into CI. The biggest cause was `import docker` resolving to the repo-root `docker/` (docker/agent) directory instead of the SDK under PEP 420 namespace resolution, fixed with `namespace_packages = false` (~114 phantom errors); the rest is typing the tool decorators with `ParamSpec`, making `ctx` Optional, parametrizing bare `dict`/`list` generics, and targeted fixes. Along the way mypy surfaced real inaccuracies: several functions declared `dict[str, str]` returns while actually returning mixed dicts (`create_environment`, `reload_template`, `start_environment`, `stop_environment`), an imprecise `_BaseAddress` SSRF-guard parameter, and a union public-key `verify()` in `licensing`. A new `mypy` job (`pip install -e .` + `mypy==2.3.0`) runs `mypy src/oduflow` on every push/PR. `mypy src/oduflow` is green across 42 files, ruff is clean, and all 856 unit tests pass.