### PR TITLE
Add auto_commit to run_odoo_shell so changes persist by default

### DIFF
--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -539,14 +539,23 @@ def _finalize_shell_script(python_code: str, auto_commit: bool) -> str:
 
     ``odoo shell`` rolls back its cursor when the piped script finishes (see
     ``odoo/cli/shell.py``), so ORM writes are discarded unless the script
-    commits itself. Appending ``env.cr.commit()`` on the top level persists a
-    successful run; if the user code raises, execution never reaches the commit
-    and Odoo rolls back — matching the documented "exception → rollback"
-    contract. ``env`` is always in scope inside ``odoo shell``.
+    commits itself. The cursor is captured under a private name *before* the
+    user code runs and committed through that handle afterwards. Committing via
+    ``env.cr`` directly would break for an otherwise-valid script that rebinds
+    ``env`` (e.g. ``env = os.environ`` while writing through ``self.env``),
+    silently rolling the successful writes back; ``__oduflow_cr__`` is captured
+    up front and is unlikely to be shadowed. If the user code raises, execution
+    never reaches the commit and Odoo rolls back — matching the documented
+    "exception → rollback" contract. ``env`` is always in scope inside
+    ``odoo shell``.
     """
     if not auto_commit:
         return python_code
-    return python_code.rstrip("\n") + "\nenv.cr.commit()\n"
+    return (
+        "__oduflow_cr__ = env.cr\n"
+        + python_code.rstrip("\n")
+        + "\n__oduflow_cr__.commit()\n"
+    )
 
 
 def run_odoo_shell(

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -534,8 +534,27 @@ def write_file_in_environment(
     return {"path": path, "size": len(data)}
 
 
+def _finalize_shell_script(python_code: str, auto_commit: bool) -> str:
+    """Append an explicit commit to *python_code* when *auto_commit* is set.
+
+    ``odoo shell`` rolls back its cursor when the piped script finishes (see
+    ``odoo/cli/shell.py``), so ORM writes are discarded unless the script
+    commits itself. Appending ``env.cr.commit()`` on the top level persists a
+    successful run; if the user code raises, execution never reaches the commit
+    and Odoo rolls back — matching the documented "exception → rollback"
+    contract. ``env`` is always in scope inside ``odoo shell``.
+    """
+    if not auto_commit:
+        return python_code
+    return python_code.rstrip("\n") + "\nenv.cr.commit()\n"
+
+
 def run_odoo_shell(
-    settings: Settings, team: TeamSettings, env_name: str, python_code: str
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    python_code: str,
+    auto_commit: bool = True,
 ) -> dict[str, Any]:
     """Execute Python code in the Odoo shell context with full ORM access."""
     import io
@@ -564,7 +583,7 @@ def run_odoo_shell(
 
     # Write Python code to temp file via tar stream (avoids shell escaping)
     script_path = "/tmp/_oduflow_shell_script.py"
-    data = python_code.encode("utf-8")
+    data = _finalize_shell_script(python_code, auto_commit).encode("utf-8")
     tar_stream = io.BytesIO()
     with tarfile.open(fileobj=tar_stream, mode="w") as tar:
         info = tarfile.TarInfo(name="_oduflow_shell_script.py")

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1717,6 +1717,7 @@ def write_file_in_odoo(
 def run_odoo_shell(
     env_name: str,
     python_code: str,
+    auto_commit: bool = True,
     ctx: Context | None = None,
 ) -> str:
     """
@@ -1733,18 +1734,26 @@ def run_odoo_shell(
     - Debug business logic: check workflow transitions, access rights
     - Run data-fix scripts
 
-    The code is executed in a single transaction that is committed at the end.
-    If the code raises an exception, the transaction is rolled back and the
-    traceback is returned.
+    Transaction handling: `odoo shell` rolls back its cursor when the piped
+    script finishes, so ORM writes would otherwise be discarded. With
+    `auto_commit=True` (the default) an `env.cr.commit()` is appended, so a
+    successful run is persisted; if the code raises an exception, the commit is
+    never reached and the transaction is rolled back with the traceback
+    returned. Pass `auto_commit=False` for a read-only / dry-run inspection
+    where nothing should persist (Odoo rolls everything back at the end).
 
     Args:
         env_name: The name of the environment.
         python_code: Python code to execute. Use print() for output.
+        auto_commit: Commit the transaction after a successful run (default
+            True). Set to False to inspect without persisting any changes.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
     woke = _wake_for_work(settings, team, env_name)
-    result = odoo_ops.run_odoo_shell(settings, team, env_name, python_code)
+    result = odoo_ops.run_odoo_shell(
+        settings, team, env_name, python_code, auto_commit=auto_commit
+    )
     exit_code = result["exit_code"]
     output = result.get("output", "")
     status = "Success" if exit_code == 0 else "Error"

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1736,11 +1736,12 @@ def run_odoo_shell(
 
     Transaction handling: `odoo shell` rolls back its cursor when the piped
     script finishes, so ORM writes would otherwise be discarded. With
-    `auto_commit=True` (the default) an `env.cr.commit()` is appended, so a
-    successful run is persisted; if the code raises an exception, the commit is
-    never reached and the transaction is rolled back with the traceback
-    returned. Pass `auto_commit=False` for a read-only / dry-run inspection
-    where nothing should persist (Odoo rolls everything back at the end).
+    `auto_commit=True` (the default) the transaction is committed after your
+    code runs, so a successful run is persisted; if the code raises an
+    exception, the commit is never reached and the transaction is rolled back
+    with the traceback returned. Pass `auto_commit=False` for a read-only /
+    dry-run inspection where nothing should persist (Odoo rolls everything back
+    at the end).
 
     Args:
         env_name: The name of the environment.

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -83,7 +83,7 @@ In live-mount mode, you as the agent must track the intent of your own edits. If
 
 | Tool | When to use |
 |---|---|
-| `run_odoo_shell(env_name, python_code)` | Execute Python in Odoo shell with full ORM access (`self.env`, models, registry). Use `print()` to produce output. |
+| `run_odoo_shell(env_name, python_code, auto_commit?)` | Execute Python in Odoo shell with full ORM access (`self.env`, models, registry). Use `print()` to produce output. Commits on success by default; pass `auto_commit=false` for a read-only dry run (changes rolled back). |
 | `write_file_in_odoo(env_name, path, content, user?)` | Write a text file inside the container (CSV imports, scripts, configs). Uses tar stream — no shell escaping issues. Do NOT use for source code. |
 | `http_request_to_odoo(env_name, path, method?, body?, headers?, session_id?)` | HTTP request to the running Odoo instance. Test controllers, JSON-RPC, REST endpoints. |
 | `search_in_odoo(env_name, pattern, path?, glob?, max_results?)` | Grep for a pattern inside container files. Fixed-string search with file/line numbers. |

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1980,3 +1980,25 @@ class TestAgentContainer:
         )
 
         agent.exec_run.assert_not_called()
+
+
+class TestFinalizeShellScript:
+    """`odoo shell` rolls back at the end, so auto_commit must append a commit."""
+
+    def test_appends_commit_when_enabled(self):
+        out = odoo_ops._finalize_shell_script("x = 1", auto_commit=True)
+        assert out.splitlines()[-1] == "env.cr.commit()"
+        assert out.startswith("x = 1")
+
+    def test_no_commit_when_disabled(self):
+        out = odoo_ops._finalize_shell_script("x = 1\n", auto_commit=False)
+        assert "commit" not in out
+        assert out == "x = 1\n"
+
+    def test_trailing_newlines_normalized_before_commit(self):
+        # A dangling block or trailing blank lines must not push the commit
+        # off the top level or duplicate blank lines.
+        out = odoo_ops._finalize_shell_script(
+            "for i in range(3):\n    x = i\n\n\n", True
+        )
+        assert out == "for i in range(3):\n    x = i\nenv.cr.commit()\n"

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1985,15 +1985,25 @@ class TestAgentContainer:
 class TestFinalizeShellScript:
     """`odoo shell` rolls back at the end, so auto_commit must append a commit."""
 
-    def test_appends_commit_when_enabled(self):
+    def test_captures_cursor_and_commits_when_enabled(self):
         out = odoo_ops._finalize_shell_script("x = 1", auto_commit=True)
-        assert out.splitlines()[-1] == "env.cr.commit()"
-        assert out.startswith("x = 1")
+        lines = out.splitlines()
+        assert lines[0] == "__oduflow_cr__ = env.cr"
+        assert lines[-1] == "__oduflow_cr__.commit()"
+        assert "x = 1" in lines
 
     def test_no_commit_when_disabled(self):
         out = odoo_ops._finalize_shell_script("x = 1\n", auto_commit=False)
         assert "commit" not in out
         assert out == "x = 1\n"
+
+    def test_commit_survives_env_rebind(self):
+        # The cursor is captured before user code, so a script that rebinds
+        # `env` still commits through the private handle (not the rebound env).
+        out = odoo_ops._finalize_shell_script("env = object()", auto_commit=True)
+        lines = out.splitlines()
+        assert lines[0] == "__oduflow_cr__ = env.cr"
+        assert lines[-1] == "__oduflow_cr__.commit()"
 
     def test_trailing_newlines_normalized_before_commit(self):
         # A dangling block or trailing blank lines must not push the commit
@@ -2001,4 +2011,8 @@ class TestFinalizeShellScript:
         out = odoo_ops._finalize_shell_script(
             "for i in range(3):\n    x = i\n\n\n", True
         )
-        assert out == "for i in range(3):\n    x = i\nenv.cr.commit()\n"
+        assert out == (
+            "__oduflow_cr__ = env.cr\n"
+            "for i in range(3):\n    x = i\n"
+            "__oduflow_cr__.commit()\n"
+        )


### PR DESCRIPTION
`odoo shell` rolls back its cursor when the piped script finishes, so ORM writes made through `run_odoo_shell` were silently discarded — directly contradicting the tool's docstring, which claimed the transaction was committed at the end. This adds an `auto_commit` parameter (default `True`) that appends `env.cr.commit()` to the script so a successful run persists, while an exception still reaches Odoo's rollback and returns the traceback. Passing `auto_commit=False` keeps the previous read-only / dry-run behaviour where nothing is persisted. The docstring and the agent instructions guide are corrected to match, and a unit test covers the commit-appending helper (including trailing-newline normalization). No behavioural change to any other tool.