### PR TITLE
Harden secrets: DB password off the odoo CLI; scrub Web UI 500 error text (#84)

### DIFF
--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -89,11 +89,12 @@ def run_environment_tests(
         )
 
     _validate_module_names([m.strip() for m in modules.split(",") if m.strip()])
-    # allow_fallback=False: the creds are interpolated into the odoo CLI as
-    # `-r ... -w ...`, visible in the container's process argv, and tests run
-    # tenant-controlled code inside that container — the shared superuser
-    # password must never be exposed there (cross-tenant DB access on legacy
-    # environments predating per-env credentials).
+    # allow_fallback=False: tests run tenant-controlled code inside the odoo
+    # container, so the shared superuser password must never be exposed there
+    # (cross-tenant DB access on legacy environments predating per-env
+    # credentials). The per-env password itself is passed via the PGPASSWORD env
+    # var (see exec_run below), not on the odoo CLI, so it stays out of the
+    # container's process argv (`ps`).
     creds = load_credentials(
         env_name,
         team.workspaces_dir,
@@ -115,14 +116,16 @@ def run_environment_tests(
         f"odoo --test-enable --stop-after-init --workers 0 "
         f"--http-port 8089 {port_flag} 8090 -u {modules} "
         f"--db_host={settings.shared_db_container} "
-        f"-r {creds['pg_user']} -w {creds['pg_password']} "
+        f"-r {creds['pg_user']} "
         f"--database={env_db}"
     )
     logger.info(
         "Running tests",
         extra={"env_name": env_name, "modules": modules},
     )
-    exit_code, output = container.exec_run(cmd)
+    exit_code, output = container.exec_run(
+        cmd, environment={"PGPASSWORD": creds["pg_password"]}
+    )
 
     if isinstance(output, bytes):
         return output.decode("utf-8")
@@ -604,7 +607,7 @@ def run_odoo_shell(
     cmd = (
         f"odoo shell --no-http --stop-after-init "
         f"--db_host={settings.shared_db_container} "
-        f"-r {creds['pg_user']} -w {creds['pg_password']} "
+        f"-r {creds['pg_user']} "
         f"--database={env_db} "
         f"< {script_path}"
     )
@@ -613,7 +616,13 @@ def run_odoo_shell(
         "Running Odoo shell",
         extra={"env_name": env_name, "code_size": len(data)},
     )
-    exit_code, output = container.exec_run(["sh", "-c", cmd], user="odoo")
+    # Pass the per-env DB password via PGPASSWORD (libpq reads it) rather than
+    # `-w` on the odoo CLI, keeping it out of the container's process argv (`ps`).
+    exit_code, output = container.exec_run(
+        ["sh", "-c", cmd],
+        user="odoo",
+        environment={"PGPASSWORD": creds["pg_password"]},
+    )
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
     # Cleanup temp file

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -505,9 +505,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "environments": envs})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_list")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_start(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -522,9 +524,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_start")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -541,9 +545,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_stop")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -560,9 +566,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_restart")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -580,9 +588,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_sync")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -599,9 +609,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": {"deleted": branch}})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -640,9 +652,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_update")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -700,9 +714,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_recreate")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(branch)
 
@@ -754,9 +770,11 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_save_as_template")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -900,9 +918,11 @@ def _build_routes(
             # in the server journal.
             logger.warning("create_environment failed for %s: %s", env_name, e)
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_create")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(env_name)
 
@@ -924,9 +944,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "logs": logs})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_logs")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_stats(request: Request) -> JSONResponse:
         try:
@@ -945,9 +967,11 @@ def _build_routes(
                     "storage": storage,
                 }
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_stats")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_storage_refresh(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -956,9 +980,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "storage": entry})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_storage_refresh")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_usage(request: Request) -> JSONResponse:
         """Cached per-team usage + quotas — the read side for external
@@ -976,9 +1002,11 @@ def _build_routes(
                     "usage": read_storage_cache(team),
                 }
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_usage")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_usage_refresh(request: Request) -> JSONResponse:
         """Recompute storage for every environment plus team totals. Heavy
@@ -999,9 +1027,11 @@ def _build_routes(
             )
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_usage_refresh")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_templates(request: Request) -> JSONResponse:
         try:
@@ -1009,9 +1039,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "templates": templates})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_templates")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_template_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -1025,9 +1057,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_template_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1056,9 +1090,11 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_template_rename")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1187,9 +1223,11 @@ def _build_routes(
             record = import_tokens.create_token(team, template_name)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_import_token")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
         base = str(request.base_url).rstrip("/")
         # Behind a TLS-terminating proxy request.base_url is http://; honour
@@ -1315,11 +1353,13 @@ def _build_routes(
                     async for chunk in request.stream():
                         f.write(chunk)
                 os.replace(part, dest)
-            except Exception as e:
+            except Exception:
                 if os.path.exists(part):
                     os.remove(part)
                 logger.exception("Failed to receive dump for %s", template_name)
-                return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+                return JSONResponse(
+                    {"ok": False, "error": "Internal server error."}, status_code=500
+                )
             return JSONResponse({"ok": True})
 
         # Chunked upload: append at `offset`, complete when the part hits `total`.
@@ -1337,9 +1377,11 @@ def _build_routes(
             )
         try:
             state, size = await _receive_offset_chunk(request, part, offset)
-        except Exception as e:
+        except Exception:
             logger.exception("Failed to receive dump chunk for %s", template_name)
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         if state == "gap":
             return JSONResponse(
                 {
@@ -1381,11 +1423,13 @@ def _build_routes(
             # extracted, so a truncated upload is never mistaken for a complete
             # chunk on resume.
             system_ops.extract_filestore_chunk(tmp_tar, fs_dir, chunk)
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "Failed to receive filestore chunk %s for %s", chunk, template_name
             )
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             if os.path.exists(tmp_tar):
                 os.remove(tmp_tar)
@@ -1474,11 +1518,13 @@ def _build_routes(
                         f.write(data)
                 os.replace(part, final_tar)
                 _finish()
-            except Exception as e:
+            except Exception:
                 logger.exception(
                     "Failed to receive addon %s for %s", name, template_name
                 )
-                return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+                return JSONResponse(
+                    {"ok": False, "error": "Internal server error."}, status_code=500
+                )
             finally:
                 if os.path.exists(part):
                     os.remove(part)
@@ -1497,11 +1543,13 @@ def _build_routes(
             )
         try:
             state, size = await _receive_offset_chunk(request, part, offset)
-        except Exception as e:
+        except Exception:
             logger.exception(
                 "Failed to receive addon chunk %s for %s", name, template_name
             )
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         if state == "gap":
             return JSONResponse(
                 {
@@ -1516,11 +1564,13 @@ def _build_routes(
             try:
                 os.replace(part, final_tar)
                 _finish()
-            except Exception as e:
+            except Exception:
                 logger.exception(
                     "Failed to finalize addon %s for %s", name, template_name
                 )
-                return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+                return JSONResponse(
+                    {"ok": False, "error": "Internal server error."}, status_code=500
+                )
         return JSONResponse({"ok": True, "received": size, "complete": complete})
 
     async def api_import_addon_remote(request: Request) -> JSONResponse:
@@ -1598,9 +1648,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_import_finalize")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1610,9 +1662,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "services": services})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_services")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_service_create(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
@@ -1672,9 +1726,11 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_create")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1748,9 +1804,11 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_update")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1763,9 +1821,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_restart")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_service_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -1781,9 +1841,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1800,9 +1862,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "logs": logs})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_logs")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_service_presets(request: Request) -> JSONResponse:
         try:
@@ -1810,9 +1874,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "presets": presets})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_presets")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_service_restore(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
@@ -1872,9 +1938,11 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_restore")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1885,9 +1953,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": {"deleted": name}})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_service_preset_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_volumes(request: Request) -> JSONResponse:
         try:
@@ -1895,9 +1965,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "volumes": vols})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_volumes")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_volume_create(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
@@ -1920,9 +1992,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_volume_create")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1938,9 +2012,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_volume_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -1967,9 +2043,11 @@ def _build_routes(
                             {"filename": fpath.name, "title": _guide_title(str(fpath))}
                         )
             return JSONResponse({"ok": True, "guides": guides})
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_agent_guides_list")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_agent_guide_get(request: Request) -> JSONResponse:
         try:
@@ -1993,9 +2071,11 @@ def _build_routes(
                     {"ok": False, "error": "Guide not found"}, status_code=404
                 )
             return JSONResponse({"ok": True, "content": content, "filename": filename})
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_agent_guide_get")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_agent_info(request: Request) -> JSONResponse:
         """Whether the coding agent is enabled for this team, and its default
@@ -2011,9 +2091,11 @@ def _build_routes(
                     "default": agent_config.effective_agent_default(team),
                 }
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_agent_info")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_agent_acp_info(request: Request) -> JSONResponse:
         """Info the browser chat needs before connecting: the in-container
@@ -2036,9 +2118,11 @@ def _build_routes(
                     "session_id": agent_sessions.get_session(team, branch, agent_type),
                 }
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_agent_acp_info")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_agent_acp_session(request: Request) -> JSONResponse:
         """Persist (or clear) the durable session id for this environment+agent.
@@ -2057,9 +2141,11 @@ def _build_routes(
             else:
                 agent_sessions.clear_session(team, branch, agent_type)
             return JSONResponse({"ok": True})
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_agent_acp_session")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_license(request: Request) -> JSONResponse:
         settings = get_settings()
@@ -2079,9 +2165,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "license": info.to_dict()})
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_license_activate")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_extra_repos(request: Request) -> JSONResponse:
         from oduflow.extra_addons import list_extra_repos
@@ -2091,9 +2179,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "repos": repos})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_extra_repos")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_extra_repo_add(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
@@ -2117,9 +2207,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_extra_repo_add")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -2137,9 +2229,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": summary})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_extra_repo_pull")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -2153,9 +2247,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_extra_repo_protect")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_extra_repo_unprotect(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -2167,9 +2263,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_extra_repo_unprotect")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_extra_repo_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -2185,9 +2283,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": {"deleted": name}})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_extra_repo_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_team(team.team_id)
 
@@ -2198,9 +2298,11 @@ def _build_routes(
             team = _get_ui_team(request)
             creds = list_credentials(cred_file=team.git_credentials_file())
             return JSONResponse({"ok": True, "credentials": creds})
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_credentials")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_credential_add(request: Request) -> JSONResponse:
         try:
@@ -2220,9 +2322,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_credential_add")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_credential_delete(request: Request) -> JSONResponse:
         try:
@@ -2251,9 +2355,11 @@ def _build_routes(
             return JSONResponse(
                 {"ok": True, "result": {"host": host, "username": username}}
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_credential_delete")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_credential_validate(request: Request) -> JSONResponse:
         try:
@@ -2272,9 +2378,11 @@ def _build_routes(
                 host, username, cred_file=team.git_credentials_file()
             )
             return JSONResponse({"ok": True, "status": status})
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_credential_validate")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_protect(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -2284,9 +2392,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_protect")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_unprotect(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -2296,9 +2406,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_unprotect")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_set_note(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -2310,9 +2422,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_set_note")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_mcp_access(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -2332,9 +2446,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": {"url": url, "token": token}})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_mcp_access")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_env_users(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -2345,9 +2461,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "result": {"users": users}})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_env_users")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_connect_as(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -2377,9 +2495,11 @@ def _build_routes(
             )
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_connect_as")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def ws_terminal(websocket: WebSocket) -> None:
         branch = websocket.path_params["branch"]
@@ -3116,9 +3236,11 @@ def _build_routes(
             )
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_productions failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_production_create(request: Request) -> JSONResponse:
         settings = get_settings()
@@ -3155,9 +3277,11 @@ def _build_routes(
             return _error_response(e)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_create failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(_prod_lock_key(team, name))
 
@@ -3179,9 +3303,11 @@ def _build_routes(
             return _error_response(e)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
-        except Exception as e:
+        except Exception:
             logger.exception("production action failed for '%s'", name)
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(_prod_lock_key(team, name))
 
@@ -3203,9 +3329,11 @@ def _build_routes(
             return JSONResponse({"ok": True, **info})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_info failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_production_update(request: Request) -> JSONResponse:
         """Deploy in a background thread: deploys can run for minutes and
@@ -3251,9 +3379,11 @@ def _build_routes(
             return JSONResponse({"ok": True, **result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_rollback failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(_prod_lock_key(team, name))
 
@@ -3269,9 +3399,11 @@ def _build_routes(
             return JSONResponse({"ok": True})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_auto_update failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_production_logs(request: Request) -> JSONResponse:
         try:
@@ -3285,9 +3417,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "logs": logs})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_logs failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_production_deploys(request: Request) -> JSONResponse:
         try:
@@ -3298,9 +3432,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "deploys": deploys})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_deploys failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     async def api_production_delete(request: Request) -> JSONResponse:
         settings = get_settings()
@@ -3329,9 +3465,11 @@ def _build_routes(
             return JSONResponse({"ok": True, **result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_delete failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(_prod_lock_key(team, name))
 
@@ -3347,9 +3485,11 @@ def _build_routes(
             return JSONResponse({"ok": True, "snapshots": manifests})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_snapshots failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_production_snapshot_now(request: Request) -> JSONResponse:
         from oduflow import backup_ops
@@ -3391,9 +3531,11 @@ def _build_routes(
             return JSONResponse({"ok": True, **result})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_restore failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
         finally:
             locks.release_env(_prod_lock_key(team, name))
 
@@ -3415,9 +3557,11 @@ def _build_routes(
             return JSONResponse({"ok": True})
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_backup_schedule failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_production_backup_status(request: Request) -> JSONResponse:
         try:
@@ -3430,9 +3574,11 @@ def _build_routes(
             )
         except FlowError as e:
             return _error_response(e)
-        except Exception as e:
+        except Exception:
             logger.exception("api_production_backup_status failed")
-            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     # ------------------------------------------------------------------
     # Health + GitHub webhook (both PUBLIC paths with their own auth)

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1281,6 +1281,14 @@ class TestRunEnvironmentTests:
         # Odoo 17 → modern --gevent-port flag.
         assert "--gevent-port 8090" in args
         assert "--workers 0" in args
+        # Issue #84: the per-env DB password must never be interpolated onto the
+        # odoo CLI (it would show up in the container's `ps`); it is passed via
+        # the PGPASSWORD env var instead. The username (-r) is not secret.
+        assert "test-pw" not in args
+        assert "-w" not in args.split()
+        assert container.exec_run.call_args.kwargs["environment"] == {
+            "PGPASSWORD": "test-pw"
+        }
 
     @patch(
         "oduflow.docker_ops.odoo_ops.load_credentials",
@@ -1327,6 +1335,35 @@ class TestRunEnvironmentTests:
         assert "--gevent-port" not in test_cmd
 
 
+class TestRunOdooShell:
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_password_passed_via_pgpassword_env(
+        self, mock_load_creds, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"shell output")
+        mock_docker_client.containers.get.return_value = container
+
+        result = odoo_ops.run_odoo_shell(TEST_SETTINGS, TEST_TEAM, "main", "print(1)")
+
+        assert result["exit_code"] == 0
+        # First exec_run is the `sh -c "odoo shell ..."` invocation.
+        shell_call = container.exec_run.call_args_list[0]
+        sh_argv = shell_call[0][0]
+        assert sh_argv[:2] == ["sh", "-c"]
+        cmd = sh_argv[2]
+        assert "-r u_1_main" in cmd
+        assert "--database=oduflow_1_main" in cmd
+        # Issue #84: password goes through PGPASSWORD, never onto the odoo CLI.
+        assert "test-pw" not in cmd
+        assert "-w" not in cmd.split()
+        assert shell_call.kwargs["user"] == "odoo"
+        assert shell_call.kwargs["environment"] == {"PGPASSWORD": "test-pw"}
+
+
 class TestConnectAsUserScript:
     def test_numeric_user_lookup_preserves_active_filter(self):
         script = odoo_ops._build_connect_as_user_script("7")
@@ -1338,7 +1375,9 @@ class TestConnectAsUserScript:
         script = odoo_ops._build_connect_as_user_script("jane@acme.com")
 
         assert "user_env = env(user=u.id)" in script
-        assert "user_context = dict(user_env['res.users'].context_get() or {})" in script
+        assert (
+            "user_context = dict(user_env['res.users'].context_get() or {})" in script
+        )
         assert "user_context['uid'] = user.id" in script
         assert "'context': user_context" in script
         assert "'context': dict(u.context_get())" not in script

--- a/tests/test_web_ui_error_scrub.py
+++ b/tests/test_web_ui_error_scrub.py
@@ -1,0 +1,49 @@
+"""Regression test for issue #84 (item 2).
+
+The dashboard's HTTP-500 handlers returned ``str(e)`` in the JSON body, which
+could leak absolute paths / Docker internals to the browser. The handlers must
+now return a generic message and keep the detail server-side (logged only).
+
+MCP tool responses are intentionally left verbose and are out of scope here.
+"""
+
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _open_settings(tmp_path):
+    # No ui_password -> the UI mounts without auth, so the GET reaches api_list.
+    return Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1")},
+    )
+
+
+def test_unexpected_500_does_not_leak_exception_text(tmp_path):
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    # The handler catches the exception and returns 500 itself, so the test
+    # client must not re-raise it.
+    client = TestClient(app, raise_server_exceptions=False)
+
+    secret = "/srv/oduflow/data/team-1/secret-internal-path"
+    with patch(
+        "oduflow.web_ui.env_ops.list_environments",
+        side_effect=RuntimeError(secret),
+    ):
+        resp = client.get("/api/environments")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["ok"] is False
+    # Generic message only — the internal detail must not reach the browser.
+    assert body["error"] == "Internal server error."
+    assert secret not in resp.text


### PR DESCRIPTION
Resolves the two deferred hardening items in #84 (follow-up to #53).

**Item 1 — DB password off the CLI:** `run_environment_tests` and `run_odoo_shell` no longer interpolate `-w <password>` onto the `odoo` command line (where it was visible via `ps` inside the container); the per-env password is now passed through the `PGPASSWORD` env var, which libpq reads, leaving DB connectivity unchanged since `odoo.conf` already strips `db_password`.

**Item 2 — scrub Web UI error text:** the dashboard's 73 HTTP-500 handlers now return a generic `"Internal server error."` to the browser instead of `str(e)` (which could leak absolute paths / Docker internals), while still logging full detail server-side via `logger.exception`; scope is Web-UI-only, so MCP tool responses, `FlowError` messages, 400 client-validation errors, and interactive WebSocket terminals stay verbose by design.

Adds `tests/test_web_ui_error_scrub.py` and extends the `run_environment_tests` / `run_odoo_shell` unit tests; full unit suite passes (1051 passed).