### PR TITLE
OAuth: mint independent expiring tokens with rotation and revocation (#83)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@
 ### Security
 
 - **OAuth `client_id` is no longer the secret** — a team's OAuth `client_id` is now the non-secret identifier `team_<id>` (e.g. `team_1`); the team's `auth_token` is the `client_secret` and remains the issued access token. Previously `client_id == client_secret == auth_token`, so the secret appeared in the `/authorize` query string (and thus in server logs, browser history, and the `Referer`). The secret now travels only in the POST `/token` body. **Breaking:** re-enter any existing claude.ai connector as `Client ID = team_<id>`, `Client Secret = auth_token`.
+- **OAuth issues independent, expiring, revocable tokens** — completing the previous item, the OAuth Authorization Code / refresh exchange now mints an *independent, opaque* `access_token` (with a rotating refresh token) instead of handing back the team's `auth_token`. A minted access token expires (~1h) and can be revoked via the now-enabled `/revoke` endpoint; using a refresh token rotates the pair so a leaked refresh token is single-use. The OAuth client (claude.ai/IDE) therefore never stores the team's long-lived master secret. Minted tokens are persisted (`oauth_token_store.py`) so live connections survive an Oduflow restart. The `auth_token` still works as a non-expiring direct Bearer credential for curl/CLI, and per-environment tokens remain Bearer-only. (#83)
 
 ## v1.67.0
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2186,7 +2186,7 @@ The token is used to both authenticate and identify the team. This is implemente
 
 Oduflow can act as its own OAuth 2.1 Authorization Server, so MCP clients that require an OAuth flow (e.g. Claude.ai Remote MCP, MCP Inspector) can connect without any external identity provider.
 
-When the OAuth flow completes, the issued `access_token` is exactly the team's `auth_token` from `oduflow.toml` — so the same value works as a plain Bearer token for CLI clients.
+The OAuth `client_id` is the non-secret `team_<id>` and the `client_secret` is the team's `auth_token` (sent only in the token request body, never in the authorization URL). When the OAuth flow completes, Oduflow mints an **independent, opaque, expiring** `access_token` (with a rotating refresh token) — the client never receives the `auth_token`, and a minted token can be revoked. The `auth_token` itself stays valid as a plain Bearer token for CLI clients.
 
 ### Setup
 
@@ -2216,7 +2216,8 @@ Either way, Oduflow exposes:
 
 - `GET /.well-known/oauth-authorization-server` — discovery metadata
 - `GET /authorize` — authorization endpoint (Authorization Code + PKCE)
-- `POST /token` — token endpoint
+- `POST /token` — token endpoint (mints/rotates the access + refresh token pair)
+- `POST /revoke` — revoke a minted access or refresh token
 
 Dynamic Client Registration (`/register`) is **disabled** — clients must use the preregistered credentials.
 
@@ -2233,7 +2234,7 @@ Dynamic Client Registration (`/register`) is **disabled** — clients must use t
 
 4. Claude.ai performs the OAuth flow against your Oduflow instance, receives an access token, and connects.
 
-The issued access token is the team's `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
+The issued access token is an independent, expiring token bound to that team (not the `auth_token`), so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials without Claude ever storing the master secret; it refreshes transparently and survives an Oduflow restart (minted tokens are persisted).
 
 ### Bearer-only mode (CLI / automation)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,7 +24,7 @@ The token is used to both authenticate and identify the team. This is implemente
 
 Oduflow can act as its own OAuth 2.1 Authorization Server, so MCP clients that require an OAuth flow (e.g. Claude.ai Remote MCP, MCP Inspector) can connect without any external identity provider.
 
-The team's OAuth **`client_id`** is a non-secret identifier, `team_<id>` (e.g. `team_1` for `[team.1]`); the **`client_secret`** is the team's `auth_token`. Only the `client_id` appears in the authorization URL — the secret is sent solely in the token request body, so it never leaks into logs or browser history. When the OAuth flow completes, the issued `access_token` is exactly the team's `auth_token` from `oduflow.toml` — so the same value works as a plain Bearer token for CLI clients.
+The team's OAuth **`client_id`** is a non-secret identifier, `team_<id>` (e.g. `team_1` for `[team.1]`); the **`client_secret`** is the team's `auth_token`. Only the `client_id` appears in the authorization URL — the secret is sent solely in the token request body, so it never leaks into logs or browser history. When the OAuth flow completes, Oduflow issues an **independent, opaque access token that expires** (with a refresh token to obtain a new one) — the client never receives the `auth_token` itself, so a compromised OAuth token has a bounded lifetime and can be revoked. The `auth_token` stays valid as a plain Bearer token for CLI clients (see [Bearer-only mode](#bearer-only-mode-cli-automation)).
 
 ### Setup
 
@@ -54,7 +54,8 @@ Either way, Oduflow exposes:
 
 - `GET /.well-known/oauth-authorization-server` — discovery metadata
 - `GET /authorize` — authorization endpoint (Authorization Code + PKCE)
-- `POST /token` — token endpoint
+- `POST /token` — token endpoint (mints/rotates the access + refresh token pair)
+- `POST /revoke` — revoke a minted access or refresh token
 
 Dynamic Client Registration (`/register`) is **disabled** — clients must use the preregistered credentials.
 
@@ -71,7 +72,7 @@ Dynamic Client Registration (`/register`) is **disabled** — clients must use t
 
 4. Claude.ai performs the OAuth flow against your Oduflow instance, receives an access token, and connects.
 
-The issued access token is the team's `auth_token`, so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials.
+The issued access token is an independent, expiring token bound to that team (not the `auth_token`), so each team's claude.ai connector ends up scoped to its own workspaces, templates, and credentials while Claude never stores the master secret. Claude.ai transparently uses its refresh token to obtain a new access token when the old one expires; the connection also survives an Oduflow restart because minted tokens are persisted.
 
 ### Bearer-only mode (CLI / automation)
 

--- a/specs/0020-authentication-oauth.md
+++ b/specs/0020-authentication-oauth.md
@@ -1,9 +1,9 @@
 # 0020 — Authentication for MCP HTTP transport: GitHub OAuth → self-hosted OAuth Authorization Server
 
-**Status:** Adopted (self-hosted AS is current; traefik uses a per-team, host-relative issuer; static Bearer tokens retained)
+**Status:** Adopted (self-hosted AS is current; traefik uses a per-team, host-relative issuer; the OAuth flow mints independent expiring/rotating/revocable tokens with a persistent store; static Bearer tokens retained)
 **Type:** Architecture
 **First introduced:** `97c3fc8` "add GitHub OAuth support for MCP HTTP transport" (2026-03-13)
-**Key code today:** `server.py` (`_build_auth`, transport/auth wiring), `oauth_provider.py` (`OduflowOAuthProvider`, host-relative `get_routes`), `settings.py` (`oauth_base_url`, `oauth_enabled`, per-team `auth_token`/`hostname`)
+**Key code today:** `server.py` (`_build_auth`, transport/auth wiring), `oauth_provider.py` (`OduflowOAuthProvider`, host-relative `get_routes`), `oauth_token_store.py` (persistent minted-token store), `settings.py` (`oauth_base_url`, `oauth_enabled`, per-team `auth_token`/`hostname`)
 
 ## Context
 
@@ -61,12 +61,12 @@ request context and threaded into per-team scoping.
   `Authorization` header. Both reduce to the same per-team `auth_token`.
 - **One secret, one public id.** A team is preregistered as an OAuth client whose
   `client_id` is the **non-secret** `team_<id>` (e.g. `team_1`) and whose
-  `client_secret` is the team's `auth_token`; the issued access token also equals
-  the `auth_token`. So an OAuth client and a raw-curl client present the *same*
-  secret, and after the OAuth dance the team resolves exactly as it does for
-  direct Bearer calls — no second identity system. Keeping the secret out of the
-  `client_id` matters because `client_id` travels in the `/authorize` query string
-  (see Evolution); the secret is sent only in the POST `/token` body.
+  `client_secret` is the team's `auth_token`. The OAuth flow mints an independent,
+  opaque, expiring access token (see Evolution) that carries the team's numeric id,
+  so after the OAuth dance the team resolves exactly as it does for a direct Bearer
+  `auth_token` call — no second identity system. Keeping the secret out of the
+  `client_id` matters because `client_id` travels in the `/authorize` query string;
+  the secret is sent only in the POST `/token` body.
 - **Scoping unchanged.** Once a request is authenticated to a team, the existing
   per-team resource scoping and locking apply; OAuth only changes *how the team
   is proven*, not what it can see.
@@ -136,6 +136,29 @@ request context and threaded into per-team scoping.
   Breaking: any already-configured claude.ai connector must be re-entered as
   `client_id = team_<id>`, `client_secret = auth_token`.
 
+- **Independent, expiring, revocable minted tokens (#83).** The credential split
+  (above) kept the *issued* access token equal to the `auth_token`, so the OAuth
+  client (claude.ai/IDE) still stored the team's long-lived master secret, the
+  token never expired, and `revoke_token` was a no-op. The code/refresh exchange
+  now **mints an independent, opaque access token** (`secrets.token_urlsafe`) with
+  a rotating refresh token: the client never receives `auth_token`; a leaked minted
+  token expires (default 1h — a fixed sensible default, not a config knob); using a
+  refresh token rotates the pair (the old one is invalidated); and the enabled
+  `/revoke` endpoint really deletes a token. A minted token stores the **numeric
+  `team_id` as its `client_id`** with empty scope, so `_resolve_team` routes it
+  identically to the `auth_token` (full team access). Minted tokens are **persisted**
+  (`oauth_token_store.py`, mirroring `port_registry`'s per-path thread lock +
+  cross-process flock + atomic `os.replace`, mode `0o600`) and served from an
+  in-memory cache on the per-request verify path; persistence means a restart
+  (upgrade, config reload) does not drop live claude.ai/IDE OAuth sessions. The
+  **direct Bearer path is unchanged**: the `auth_token` remains a preseeded,
+  non-expiring, non-revocable credential (curl/CLI), and per-environment tokens
+  ([[0028-scoped-environment-mcp-access]]) stay Bearer-only. The secret still never
+  rides in the front channel — the MCP SDK validates `client_secret` at `/token`
+  (`client_secret_post`) — so this is a token-lifecycle change layered on the
+  credential split. Not covered by unit tests: validate against a live claude.ai
+  connect + at least one IDE before shipping.
+
 ## History
 
 - `97c3fc8` (2026-03-13) — GitHub OAuth 2.1 for MCP HTTP transport alongside
@@ -158,3 +181,8 @@ request context and threaded into per-team scoping.
   (`/mcp/authorize`, `/mcp/token`, `/mcp/register`, `/mcp/.well-known/*`) to the
   real root routes so the flow reaches the AS instead of 401-ing on the scoped
   `/mcp/<env>` shim (breaking: reconfigure existing connectors).
+- `2026-07-19` — finish #83: the OAuth code/refresh exchange mints independent,
+  opaque, **expiring** access tokens with rotating refresh tokens and a real
+  `/revoke`, persisted across restarts (`oauth_token_store.py`); the `auth_token`
+  stays a non-expiring direct Bearer credential and per-env tokens stay
+  Bearer-only.

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -5,14 +5,20 @@ non-secret identifier (``team_<id>``, e.g. ``team_1``) and whose
 ``client_secret`` is the team's ``auth_token``. Keeping the secret out of the
 ``client_id`` matters because ``client_id`` travels in the ``/authorize`` query
 string (logs, browser history, Referer); the secret is sent only in the POST
-``/token`` body. After a successful Authorization Code + PKCE flow the issued
-``access_token`` is the team ``auth_token``, so the existing Bearer-token path in
-``_resolve_team()`` keeps working unchanged.
+``/token`` body. A successful Authorization Code + PKCE flow mints an
+*independent*, opaque, expiring ``access_token`` (with a rotating
+``refresh_token``) — the OAuth client never receives the team ``auth_token``.
+Minted tokens are persisted (see :mod:`oduflow.oauth_token_store`) so they
+survive a restart, expire, and can be revoked. The team ``auth_token`` itself
+stays valid as a preseeded, non-expiring direct Bearer credential (curl/CLI),
+and a minted token carries the numeric ``team_id`` as its ``client_id`` so
+``_resolve_team()`` routes it exactly like the ``auth_token``.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -38,6 +44,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from oduflow import env_tokens
+from oduflow.oauth_token_store import OAuthTokenStore
 from oduflow.scoped_access import ENV_SCOPE_PREFIX
 from oduflow.settings import Settings
 
@@ -50,6 +57,12 @@ _DANGEROUS_REDIRECT_SCHEMES = {"javascript", "data", "vbscript", "file"}
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1", "[::1]"}
 
 _RESOURCE_METADATA_RE = re.compile(r'resource_metadata="([^"]+)"')
+
+# Minted OAuth access tokens expire after this many seconds; the client obtains
+# a fresh pair via its refresh token. Intentionally not a config knob — a
+# sensible default (matches the SDK's DEFAULT_ACCESS_TOKEN_EXPIRY_SECONDS).
+_ACCESS_TOKEN_TTL_SECONDS = 3600
+_TOKEN_STORE_FILENAME = "oauth_tokens.json"
 
 
 def public_client_id(team_id: str) -> str:
@@ -200,10 +213,20 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
                 "localhost",
             )
             base_url = f"https://{placeholder_host}"
-        super().__init__(base_url=base_url)
+        # Enable the /revoke endpoint so a client can really invalidate a minted
+        # token (revoke_token deletes it from the persistent store).
+        super().__init__(
+            base_url=base_url,
+            revocation_options=RevocationOptions(enabled=True),
+        )
 
         self._settings = settings
         self._token_to_team: dict[str, str] = {}
+        # Persistent store of minted (opaque, expiring) access/refresh tokens.
+        self._token_store = OAuthTokenStore(
+            os.path.join(settings.base_data_dir, _TOKEN_STORE_FILENAME),
+            access_ttl=_ACCESS_TOKEN_TTL_SECONDS,
+        )
         placeholder_redirect = AnyUrl("https://claude.ai/")
 
         for team in settings.teams.values():
@@ -358,9 +381,22 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
     async def load_access_token(  # type: ignore[override]
         self, token: str
     ) -> AccessToken | None:
+        # 1. Preseeded team auth_token (direct Bearer, non-expiring).
         existing = await super().load_access_token(token)
         if existing is not None:
             return existing
+        # 2. A minted OAuth access token from the persistent store. Its stored
+        # client_id is the numeric team_id, so it routes like the auth_token.
+        # get_access() drops the token and returns None once expired.
+        record = self._token_store.get_access(token)
+        if record is not None:
+            return AccessToken(
+                token=token,
+                client_id=str(record.get("client_id", "")),
+                scopes=list(record.get("scopes", [])),
+                expires_at=record.get("expires_at"),
+            )
+        # 3. A per-environment token (scoped Bearer).
         identity = await self._env_identity(token)
         if identity is None:
             return None
@@ -393,19 +429,21 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
 
             raise TokenError("invalid_client", "Unknown client.")
 
-        # The issued access token is the client SECRET (the team auth_token, or
-        # never the public client_id, which would not authenticate as a Bearer
-        # token downstream.
-        token = client.client_secret or cid
-        scope = (
-            " ".join(authorization_code.scopes) if authorization_code.scopes else None
+        # Mint an independent, opaque, expiring access token (+ refresh token)
+        # rather than handing back the team auth_token. The minted token's stored
+        # client_id is the numeric team_id, so a full-access (empty-scope) token
+        # routes exactly like the auth_token in _resolve_team().
+        team_id = self._token_to_team[cid]
+        scopes = list(authorization_code.scopes or [])
+        access, refresh, _expires_at = self._token_store.mint_pair(
+            client_id=team_id, scopes=scopes
         )
         return OAuthToken(
-            access_token=token,
+            access_token=access,
             token_type="Bearer",
-            expires_in=None,
-            refresh_token=token,
-            scope=scope,
+            expires_in=_ACCESS_TOKEN_TTL_SECONDS,
+            refresh_token=refresh,
+            scope=" ".join(scopes) if scopes else None,
         )
 
     async def load_refresh_token(
@@ -414,20 +452,18 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         refresh_token: str,
     ) -> RefreshToken | None:
         cid = client.client_id
-        # The refresh token we issue equals the client secret (team auth_token),
-        # not the public client_id.
-        if (
-            cid is not None
-            and refresh_token == client.client_secret
-            and cid in self._token_to_team
-        ):
-            return RefreshToken(
-                token=refresh_token,
-                client_id=cid,
-                scopes=[],
-                expires_at=None,
-            )
-        return None
+        if cid is None or cid not in self._token_to_team:
+            return None
+        record = self._token_store.get_refresh(refresh_token)
+        # The refresh token must belong to this client's team.
+        if record is None or record.get("client_id") != self._token_to_team[cid]:
+            return None
+        return RefreshToken(
+            token=refresh_token,
+            client_id=cid,
+            scopes=list(record.get("scopes", [])),
+            expires_at=None,
+        )
 
     async def exchange_refresh_token(
         self,
@@ -435,16 +471,24 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
         refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
-        token = refresh_token.token
+        # Rotate: the old access+refresh pair is invalidated and a new pair is
+        # minted with the refresh token's original team/scopes.
+        rotated = self._token_store.rotate(refresh_token.token)
+        if rotated is None:
+            from mcp.server.auth.provider import TokenError
+
+            raise TokenError("invalid_grant", "Unknown or already-used refresh token.")
+        access, refresh, _expires_at, _client_id, minted_scopes = rotated
         return OAuthToken(
-            access_token=token,
+            access_token=access,
             token_type="Bearer",
-            expires_in=None,
-            refresh_token=token,
-            scope=" ".join(scopes) if scopes else None,
+            expires_in=_ACCESS_TOKEN_TTL_SECONDS,
+            refresh_token=refresh,
+            scope=" ".join(minted_scopes) if minted_scopes else None,
         )
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
-        # Tokens are tied to oduflow.toml; runtime revocation would just
-        # break the next request. Operator should rotate auth_token instead.
-        return None
+        # Really delete the minted token (and its paired token) from the store.
+        # The preseeded auth_token and per-env tokens are not in the store, so
+        # revoking them is a no-op (rotate auth_token in oduflow.toml instead).
+        self._token_store.revoke(token.token)

--- a/src/oduflow/oauth_token_store.py
+++ b/src/oduflow/oauth_token_store.py
@@ -1,0 +1,283 @@
+"""Persistent store for minted OAuth access/refresh tokens.
+
+The self-hosted OAuth server (:mod:`oduflow.oauth_provider`) issues independent,
+opaque, expiring access tokens (with rotating refresh tokens) instead of handing
+the team ``auth_token`` to the OAuth client. Those minted tokens must survive a
+server restart — otherwise every restart (upgrade, config edit) would drop live
+claude.ai / IDE connections — so they are persisted to a JSON file, using the
+same lock + atomic-write pattern as :mod:`oduflow.port_registry`.
+
+``load_access_token`` runs on every authenticated request, so reads are served
+from an in-memory cache; the JSON file is the durable source of truth, read on
+startup and re-read on a cache miss (so a token minted or revoked by another
+worker process is eventually picked up). Writes (mint / rotate / revoke / expiry
+cleanup) run under a cross-thread + cross-process lock and rewrite the file
+atomically with ``0o600`` perms (the file holds bearer secrets).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import secrets
+import tempfile
+import threading
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, cast
+
+logger = logging.getLogger("oduflow")
+
+# {"access": {token: record}, "refresh": {token: record}}; records are plain
+# JSON dicts (see ``mint_pair`` for their shape).
+StoreData = dict[str, dict[str, Any]]
+
+# Bytes of entropy per opaque token (``secrets.token_urlsafe`` argument).
+_TOKEN_BYTES = 32
+
+
+# The store is process-shared state on the data dir: a per-path thread mutex
+# (parallel requests) plus an flock on a sidecar file (multiple oduflow
+# processes) guard every read-modify-write cycle. Mirrors ``port_registry``.
+_locks_guard = threading.Lock()
+_path_locks: dict[str, threading.Lock] = {}
+
+
+def _thread_lock(path: str) -> threading.Lock:
+    with _locks_guard:
+        lock = _path_locks.get(path)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[path] = lock
+        return lock
+
+
+@contextmanager
+def _file_lock(path: str) -> Iterator[None]:
+    """Serialize a read-modify-write across threads and processes."""
+    with _thread_lock(path):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        fd = os.open(path + ".lock", os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+
+def _empty() -> StoreData:
+    data: StoreData = {"access": {}, "refresh": {}}
+    return data
+
+
+def _load_file(path: str) -> StoreData:
+    """Load the store from disk; empty dict if missing or corrupt."""
+    if not os.path.isfile(path):
+        return _empty()
+    try:
+        with open(path) as f:
+            raw = json.load(f)
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        logger.warning("Could not load OAuth token store %s: %s", path, e)
+        return _empty()
+    if not isinstance(raw, dict):
+        return _empty()
+    access = raw.get("access", {})
+    refresh = raw.get("refresh", {})
+    if not isinstance(access, dict) or not isinstance(refresh, dict):
+        return _empty()
+    return cast(StoreData, {"access": access, "refresh": refresh})
+
+
+def _save_file(path: str, data: StoreData) -> None:
+    """Atomically save the store (mode ``0o600``). Callers hold ``_file_lock``."""
+    dir_name = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix="oauth_tokens.", suffix=".tmp", dir=dir_name)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _prune_expired(data: StoreData, now: float) -> bool:
+    """Drop expired access tokens and their refresh partners. Returns whether
+    anything was removed."""
+    removed = False
+    for token, rec in list(data["access"].items()):
+        expires_at = rec.get("expires_at")
+        if expires_at is not None and expires_at < now:
+            del data["access"][token]
+            partner = rec.get("refresh")
+            if partner:
+                data["refresh"].pop(partner, None)
+            removed = True
+    return removed
+
+
+class OAuthTokenStore:
+    """Persistent, in-memory-cached store of minted OAuth tokens.
+
+    A minted access token's stored ``client_id`` is the numeric ``team_id`` (the
+    key in ``settings.teams``), so a resolved :class:`AccessToken` routes to the
+    right team exactly like the preseeded ``auth_token`` does. ``scopes`` is
+    empty for team tokens (full access).
+    """
+
+    def __init__(self, path: str, access_ttl: int) -> None:
+        self._path = path
+        self._access_ttl = access_ttl
+        self._cache_lock = threading.Lock()
+        self._access: dict[str, Any] = {}
+        self._refresh: dict[str, Any] = {}
+        self._mtime: float | None = None
+        self._reload()
+
+    # -- cache management --
+
+    def _reload(self) -> None:
+        """Refresh the cache from disk, pruning expired access tokens."""
+        with _file_lock(self._path):
+            data = _load_file(self._path)
+            if _prune_expired(data, time.time()):
+                _save_file(self._path, data)
+            self._set_cache(data)
+
+    def _set_cache(self, data: StoreData) -> None:
+        with self._cache_lock:
+            self._access = data["access"]
+            self._refresh = data["refresh"]
+            try:
+                self._mtime = os.path.getmtime(self._path)
+            except OSError:
+                self._mtime = None
+
+    def _maybe_reload(self) -> None:
+        """Reload only if another process rewrote the file since our last read."""
+        try:
+            mtime: float | None = os.path.getmtime(self._path)
+        except OSError:
+            mtime = None
+        if mtime != self._mtime:
+            self._reload()
+
+    # -- reads (per-request hot path) --
+
+    def get_access(self, token: str) -> dict[str, Any] | None:
+        with self._cache_lock:
+            rec = self._access.get(token)
+        if rec is None:
+            self._maybe_reload()
+            with self._cache_lock:
+                rec = self._access.get(token)
+        if rec is None:
+            return None
+        expires_at = rec.get("expires_at")
+        if expires_at is not None and expires_at < time.time():
+            self.revoke(token)
+            return None
+        return dict(rec)
+
+    def get_refresh(self, token: str) -> dict[str, Any] | None:
+        with self._cache_lock:
+            rec = self._refresh.get(token)
+        if rec is None:
+            self._maybe_reload()
+            with self._cache_lock:
+                rec = self._refresh.get(token)
+        return dict(rec) if rec is not None else None
+
+    # -- writes --
+
+    def mint_pair(self, client_id: str, scopes: list[str]) -> tuple[str, str, int]:
+        """Mint a fresh opaque access+refresh pair. Returns
+        ``(access_token, refresh_token, expires_at)``."""
+        access = secrets.token_urlsafe(_TOKEN_BYTES)
+        refresh = secrets.token_urlsafe(_TOKEN_BYTES)
+        expires_at = int(time.time()) + self._access_ttl
+        with _file_lock(self._path):
+            data = _load_file(self._path)
+            _prune_expired(data, time.time())
+            data["access"][access] = {
+                "client_id": client_id,
+                "scopes": list(scopes),
+                "expires_at": expires_at,
+                "refresh": refresh,
+            }
+            data["refresh"][refresh] = {
+                "client_id": client_id,
+                "scopes": list(scopes),
+                "access": access,
+            }
+            _save_file(self._path, data)
+            self._set_cache(data)
+        return access, refresh, expires_at
+
+    def rotate(self, old_refresh: str) -> tuple[str, str, int, str, list[str]] | None:
+        """Consume ``old_refresh`` and its access partner, mint a new pair with
+        the same client_id/scopes. Returns
+        ``(access, refresh, expires_at, client_id, scopes)`` or ``None`` if the
+        refresh token is unknown (already rotated away / revoked)."""
+        access = secrets.token_urlsafe(_TOKEN_BYTES)
+        refresh = secrets.token_urlsafe(_TOKEN_BYTES)
+        expires_at = int(time.time()) + self._access_ttl
+        with _file_lock(self._path):
+            data = _load_file(self._path)
+            old = data["refresh"].get(old_refresh)
+            if old is None:
+                self._set_cache(data)
+                return None
+            client_id = str(old.get("client_id", ""))
+            scopes = [str(s) for s in old.get("scopes", [])]
+            # Invalidate the old pair (rotation).
+            data["refresh"].pop(old_refresh, None)
+            old_access = old.get("access")
+            if old_access:
+                data["access"].pop(old_access, None)
+            _prune_expired(data, time.time())
+            data["access"][access] = {
+                "client_id": client_id,
+                "scopes": scopes,
+                "expires_at": expires_at,
+                "refresh": refresh,
+            }
+            data["refresh"][refresh] = {
+                "client_id": client_id,
+                "scopes": scopes,
+                "access": access,
+            }
+            _save_file(self._path, data)
+            self._set_cache(data)
+        return access, refresh, expires_at, client_id, scopes
+
+    def revoke(self, token: str) -> None:
+        """Delete ``token`` (whether access or refresh) and its partner."""
+        with _file_lock(self._path):
+            data = _load_file(self._path)
+            changed = False
+            access_rec = data["access"].pop(token, None)
+            if access_rec is not None:
+                changed = True
+                partner = access_rec.get("refresh")
+                if partner:
+                    data["refresh"].pop(partner, None)
+            refresh_rec = data["refresh"].pop(token, None)
+            if refresh_rec is not None:
+                changed = True
+                partner = refresh_rec.get("access")
+                if partner:
+                    data["access"].pop(partner, None)
+            if changed:
+                _save_file(self._path, data)
+            self._set_cache(data)

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import tempfile
 
 import pytest
 
@@ -31,6 +32,9 @@ def _settings(**overrides):
     )
     return Settings(
         oauth_base_url=overrides.pop("oauth_base_url", "https://oduflow.example.com"),
+        # Minted-token store lives under base_data_dir; give each provider its own
+        # temp dir unless a test needs two providers to share one (persistence).
+        base_data_dir=overrides.pop("base_data_dir", tempfile.mkdtemp()),
         teams=teams,
         **overrides,
     )
@@ -40,10 +44,30 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
+def _mint(provider, client_id="team_1", scopes=None):
+    """Drive a code exchange and return the issued OAuthToken (opaque pair)."""
+    from mcp.server.auth.provider import AuthorizationCode
+    from pydantic import AnyUrl
+
+    client = _run(provider.get_client(client_id))
+    assert client is not None
+    code = AuthorizationCode(
+        code="dummy",
+        client_id=client_id,
+        redirect_uri=AnyUrl("https://claude.ai/cb"),
+        redirect_uri_provided_explicitly=True,
+        scopes=scopes if scopes is not None else [],
+        expires_at=9999999999,
+        code_challenge="abc",
+    )
+    return _run(provider.exchange_authorization_code(client, code))
+
+
 def _host_settings(*hostnames):
     """Host-relative Settings (no oauth_base_url) with a team per hostname."""
     return Settings(
         oauth_base_url="",
+        base_data_dir=tempfile.mkdtemp(),
         teams={
             str(i): TeamSettings(
                 team_id=str(i),
@@ -66,6 +90,7 @@ class TestOduflowOAuthProvider:
             routing_mode="traefik",
             acme_email="admin@example.com",
             oauth_base_url="",
+            base_data_dir=tempfile.mkdtemp(),
             teams={
                 "1": TeamSettings(
                     team_id="1",
@@ -125,46 +150,107 @@ class TestOduflowOAuthProvider:
 
         assert _run(provider.verify_token("nope")) is None
 
-    def test_exchange_authorization_code_returns_auth_token(self):
-        from mcp.server.auth.provider import AuthorizationCode
-        from pydantic import AnyUrl
-
+    def test_exchange_authorization_code_mints_opaque_token(self):
         provider = OduflowOAuthProvider(_settings())
-        client = _run(provider.get_client("team_1"))
-        assert client is not None
-        code = AuthorizationCode(
-            code="dummy",
-            client_id="team_1",
-            redirect_uri=AnyUrl("https://claude.ai/cb"),
-            redirect_uri_provided_explicitly=True,
-            scopes=["mcp"],
-            expires_at=9999999999,
-            code_challenge="abc",
-        )
-        token = _run(provider.exchange_authorization_code(client, code))
-        # The issued access/refresh token is the SECRET auth_token, not the
-        # public client_id.
-        assert token.access_token == "tok-a"
-        assert token.refresh_token == "tok-a"
+        token = _mint(provider, scopes=["mcp"])
+        # The issued tokens are independent, opaque, and NOT the auth_token or
+        # the public client_id.
+        assert token.access_token not in ("tok-a", "team_1")
+        assert token.refresh_token not in ("tok-a", "team_1")
+        assert token.access_token != token.refresh_token
+        assert len(token.access_token) >= 32
         assert token.token_type == "Bearer"
+        # The access token expires.
+        assert token.expires_in == 3600
+        # It resolves to the team (numeric team_id) so _resolve_team routes it
+        # exactly like the auth_token, preserving requested scopes.
+        access = _run(provider.load_access_token(token.access_token))
+        assert access is not None
+        assert access.client_id == "1"
+        assert access.scopes == ["mcp"]
+        assert access.expires_at is not None
 
-    def test_bearer_invariant_and_refresh(self):
+    def test_bearer_invariant(self):
         provider = OduflowOAuthProvider(_settings())
-        # The auth_token (the issued access token) still resolves to the team id
-        # via the preseeded, secret-keyed access token — the Bearer path is
-        # unchanged by the client_id/secret split.
+        # The auth_token still resolves to the team id via the preseeded,
+        # secret-keyed access token — the direct Bearer path is unchanged and
+        # never expires.
         access = _run(provider.load_access_token("tok-a"))
         assert access is not None
         assert access.client_id == "1"
+        assert access.expires_at is None
         # The public client_id is NOT a valid Bearer/access token on its own.
         assert _run(provider.load_access_token("team_1")) is None
-        # Refresh token equals the secret (auth_token), not the client_id.
+
+    def test_refresh_token_rotation(self):
+        provider = OduflowOAuthProvider(_settings())
+        token = _mint(provider)
         client = _run(provider.get_client("team_1"))
-        assert client is not None
-        rt = _run(provider.load_refresh_token(client, "tok-a"))
+
+        rt = _run(provider.load_refresh_token(client, token.refresh_token))
         assert rt is not None
         assert rt.client_id == "team_1"
+
+        rotated = _run(provider.exchange_refresh_token(client, rt, []))
+        # A brand-new pair is issued.
+        assert rotated.access_token != token.access_token
+        assert rotated.refresh_token != token.refresh_token
+        # The old pair is dead after rotation.
+        assert _run(provider.load_access_token(token.access_token)) is None
+        assert _run(provider.load_refresh_token(client, token.refresh_token)) is None
+        # The new access token still resolves to the team.
+        new_access = _run(provider.load_access_token(rotated.access_token))
+        assert new_access is not None
+        assert new_access.client_id == "1"
+        # A non-issued value is not a valid refresh token.
         assert _run(provider.load_refresh_token(client, "team_1")) is None
+
+    def test_minted_access_token_expires(self, monkeypatch):
+        from oduflow import oauth_token_store as store_mod
+
+        provider = OduflowOAuthProvider(_settings())
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(store_mod.time, "time", lambda: clock["t"])
+        token = _mint(provider)
+        assert _run(provider.load_access_token(token.access_token)) is not None
+        # Advance past the TTL: the token is rejected and purged.
+        clock["t"] = 1000.0 + 3600 + 1
+        assert _run(provider.load_access_token(token.access_token)) is None
+
+    def test_revoke_deletes_minted_token(self):
+        provider = OduflowOAuthProvider(_settings())
+        token = _mint(provider)
+        access = _run(provider.load_access_token(token.access_token))
+        assert access is not None
+
+        _run(provider.revoke_token(access))
+        # Both the access token and its paired refresh token are gone.
+        assert _run(provider.load_access_token(token.access_token)) is None
+        client = _run(provider.get_client("team_1"))
+        assert _run(provider.load_refresh_token(client, token.refresh_token)) is None
+
+        # The preseeded auth_token is NOT revocable at runtime (config-bound).
+        preseeded = _run(provider.load_access_token("tok-a"))
+        assert preseeded is not None
+        _run(provider.revoke_token(preseeded))
+        assert _run(provider.load_access_token("tok-a")) is not None
+
+    def test_minted_tokens_persist_across_restart(self):
+        data_dir = tempfile.mkdtemp()
+        provider = OduflowOAuthProvider(_settings(base_data_dir=data_dir))
+        token = _mint(provider)
+
+        # A fresh provider on the same data dir (simulated restart) still honors
+        # the minted token — connections survive an upgrade/config reload.
+        restarted = OduflowOAuthProvider(_settings(base_data_dir=data_dir))
+        access = _run(restarted.load_access_token(token.access_token))
+        assert access is not None
+        assert access.client_id == "1"
+
+        # A revoke persists too: a third instance sees it gone.
+        _run(restarted.revoke_token(access))
+        again = OduflowOAuthProvider(_settings(base_data_dir=data_dir))
+        assert _run(again.load_access_token(token.access_token)) is None
 
     def test_flexible_redirect_uri(self):
         from pydantic import AnyUrl
@@ -225,6 +311,8 @@ class TestOduflowOAuthProvider:
         assert "/.well-known/oauth-authorization-server" in paths
         assert "/authorize" in paths
         assert "/token" in paths
+        # Revocation is enabled so minted tokens can be invalidated at runtime.
+        assert "/revoke" in paths
 
     def test_metadata_via_test_client(self):
         from starlette.applications import Starlette
@@ -239,7 +327,8 @@ class TestOduflowOAuthProvider:
         assert meta["issuer"].rstrip("/") == "https://oduflow.example.com"
         assert "authorization_endpoint" in meta
         assert "token_endpoint" in meta
-        # DCR is disabled — endpoint must not be advertised.
+        # Revocation is advertised; DCR is disabled and must not be.
+        assert "revocation_endpoint" in meta
         assert "registration_endpoint" not in meta
 
     def test_metadata_host_relative(self):


### PR DESCRIPTION
Completes #83 on top of the `client_id`/secret split from #129: the self-hosted OAuth Authorization Code / refresh exchange now mints an independent, opaque, **expiring** access token (with a rotating refresh token) instead of returning the team `auth_token`, and enables the `/revoke` endpoint to really delete a token. Minted tokens are persisted across restarts via a new `oauth_token_store.py` (a `port_registry`-style thread+process lock and atomic `0o600` write, served from an in-memory cache on the per-request verify path), and each carries the numeric `team_id` as its `client_id` so `_resolve_team` routes it exactly like the `auth_token`. The `auth_token` remains a non-expiring direct Bearer credential for curl/CLI, and per-environment tokens stay Bearer-only. Also updates ADR 0020 (Evolution + History), the security/llms docs and changelog, and adds tests for minting, expiry, refresh rotation, revocation, and restart persistence. Not covered by unit tests — validate against a live claude.ai connect plus at least one IDE before merging (authorize → token → refresh → revoke must round-trip).