### PR TITLE
security: harden git credentials, import tokens, CSRF and web-UI auth

### DIFF
--- a/specs/0011-per-user-git-credentials.md
+++ b/specs/0011-per-user-git-credentials.md
@@ -73,6 +73,15 @@ URL** that is logged, labelled, or shown.
 - **Strip on the way out.** Any path that exposes a repo URL — startup logs, the
   environment list API, container labels — routes it through `sanitize_repo_url`
   first, so a token can be entered once but is never readable afterward.
+- **Never write the secret in the first place.** At `create_environment` time,
+  `extract_and_store_inline_credentials` moves any inline `user:PAT@host`
+  credential out of the URL into the team credential store and persists only the
+  sanitized URL in the `oduflow.repo` label (and thus in saved template
+  metadata). This closes a write-path gap where the label previously stored the
+  raw URL and only read/log paths sanitized it — a token was recoverable via
+  `docker inspect` until the environment was recreated. git stderr is likewise
+  scrubbed (`redact_url_credentials`) so a credential-bearing remote echoed in an
+  error never reaches the caller or the logs.
 
 ## Consequences
 
@@ -100,3 +109,10 @@ URL** that is logged, labelled, or shown.
   `git ls-remote` (replacing a shallow clone), list/validate/delete API + the
   dashboard Credentials tab, persistent `.git-credentials` store, and a
   credential helper configured at startup.
+- security audit hardening (2026-07-19) — enforced "creds never in labels" on the
+  **write** path: `extract_and_store_inline_credentials` moves inline
+  `user:PAT@host` credentials into the credential store at `create_environment`
+  time so the `oduflow.repo` label / template metadata only ever hold a sanitized
+  URL (previously the raw URL was stored and only read paths sanitized).
+  `redact_url_credentials` scrubs credential-bearing remotes from git stderr;
+  `.git-credentials` dir/file modes forced to `0o700`/`0o600`.

--- a/src/oduflow/activity.py
+++ b/src/oduflow/activity.py
@@ -53,9 +53,15 @@ def parse_ts(value: str | None) -> float | None:
     if not value:
         return None
     try:
-        return datetime.fromisoformat(value).timestamp()
+        dt = datetime.fromisoformat(value)
     except ValueError:
         return None
+    # Records written by _now_iso() are tz-aware; a legacy/hand-edited naive
+    # value would otherwise be read as host-local time, shifting reaper
+    # stop/delete decisions by the UTC offset. Treat naive as UTC.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
 
 
 def _thread_lock(path: str) -> threading.Lock:

--- a/src/oduflow/backup_ops.py
+++ b/src/oduflow/backup_ops.py
@@ -34,6 +34,7 @@ import logging
 import os
 import shutil
 import tempfile
+from collections.abc import Iterator
 from typing import Any
 
 from oduflow import chunkstore, production_registry, s3_client
@@ -96,7 +97,7 @@ def _snapshot_id(now: datetime.datetime | None = None) -> str:
     return (now or _now_utc()).strftime("%Y%m%dT%H%M%SZ")
 
 
-def _dump_stream(container: Any, db_user: str, db_name: str):
+def _dump_stream(container: Any, db_user: str, db_name: str) -> Iterator[bytes]:
     """Yield pg_dump -Fc stdout frames from a docker exec stream.
 
     Uses the low-level exec API so the command's exit code can be inspected

--- a/src/oduflow/backup_scheduler.py
+++ b/src/oduflow/backup_scheduler.py
@@ -177,7 +177,7 @@ def _run_snapshot_job(
     except BusyError:
         return  # deploy/restore in flight; still due next tick
     started = time.time()
-    backup_state = {
+    backup_state: dict[str, Any] = {
         "last_attempt_at": now.isoformat(),
     }
     try:

--- a/src/oduflow/chunkstore/backup.py
+++ b/src/oduflow/chunkstore/backup.py
@@ -358,6 +358,7 @@ def backup(
             and "sc" in prev_entry
         )
         if unchanged and st.st_size > 0:
+            assert prev_entry is not None
             # Splice the previous revision's chunks in: cut the new stream
             # first so chunks never mix new bytes and preserved refs.
             stream.flush()

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -96,6 +96,23 @@ def _redact_repo_urls(text: str, *urls: str) -> str:
     return redacted
 
 
+def _move_inline_repo_credentials(
+    repo_url: str, cred_file: str, git_user: str
+) -> tuple[str, str]:
+    """Store inline credentials and make their username authoritative."""
+    from oduflow.git_ops import extract_and_store_inline_credentials
+
+    clean_url, extracted_user = extract_and_store_inline_credentials(
+        repo_url, cred_file
+    )
+    if clean_url != repo_url:
+        # An explicit credential-bearing URL overrides template metadata. This
+        # also clears a stale username for token-as-username URLs, whose secret
+        # must not be copied into the Docker label.
+        git_user = extracted_user
+    return clean_url, git_user
+
+
 def _get_used_ports(
     client: DockerClient,
     settings: Settings,
@@ -910,13 +927,9 @@ def create_environment(
     # Clone/recreate/agent paths already authenticate via that store. No-op for
     # clean URLs and for live-mount (which never clones).
     if not local_mount and repo_url:
-        from oduflow.git_ops import extract_and_store_inline_credentials
-
-        repo_url, extracted_user = extract_and_store_inline_credentials(
-            repo_url, team.git_credentials_file()
+        repo_url, git_user = _move_inline_repo_credentials(
+            repo_url, team.git_credentials_file(), git_user
         )
-        if extracted_user and not git_user:
-            git_user = extracted_user
 
     labels = {
         settings.managed_label: "true",

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -904,6 +904,20 @@ def create_environment(
         )
     env_db = get_db_name(env_name, team.team_id)
 
+    # Keep inline git credentials (https://user:PAT@host/...) out of the Docker
+    # label (world-readable via `docker inspect`, copied into template metadata):
+    # move them into the team credential store, then persist only a sanitized URL.
+    # Clone/recreate/agent paths already authenticate via that store. No-op for
+    # clean URLs and for live-mount (which never clones).
+    if not local_mount and repo_url:
+        from oduflow.git_ops import extract_and_store_inline_credentials
+
+        repo_url, extracted_user = extract_and_store_inline_credentials(
+            repo_url, team.git_credentials_file()
+        )
+        if extracted_user and not git_user:
+            git_user = extracted_user
+
     labels = {
         settings.managed_label: "true",
         settings.team_label: team.team_id,

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -54,6 +54,7 @@ from oduflow.naming import (
     get_resource_name,
     get_template_db_name,
     get_workspace_path,
+    redact_url_credentials,
     sanitize_repo_url,
     slugify_branch,
 )
@@ -742,7 +743,9 @@ def _clone_repo(
             env=git_env,
         )
     except subprocess.CalledProcessError as e:
-        error_msg = e.stderr.decode("utf-8") if e.stderr else str(e)
+        error_msg = redact_url_credentials(
+            e.stderr.decode("utf-8") if e.stderr else str(e)
+        )
         if any(kw.lower() in error_msg.lower() for kw in auth_keywords):
             raise RepoAuthError(
                 f"Git authentication failed for {sanitize_repo_url(repo_url)}. "

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -2455,7 +2455,9 @@ def import_from_odoo(
 
     # SSRF guard: importing a DB from a URL is a clearly-external operation, so
     # block loopback, the cloud metadata endpoint, and internal RFC1918 hosts.
-    assert_allowed_url(base, allow_private=False)
+    # Require HTTPS: the request carries the Odoo master password (see below),
+    # which must never cross the wire in cleartext.
+    assert_allowed_url(base, require_https=True, allow_private=False)
 
     if os.path.exists(template_dir):
         raise ConflictError(f"Template directory already exists: {template_dir}")

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from typing import Any
 
 from oduflow.errors import ExternalCommandError, FlowError
-from oduflow.naming import redact_url_credentials
+from oduflow.naming import redact_url_credentials, sanitize_repo_url
 
 logger = logging.getLogger("oduflow")
 
@@ -99,6 +99,40 @@ def _store_git_credentials(
     except OSError:
         pass
     logger.info("Git credentials stored for host=%s user=%s", host, username)
+
+
+def extract_and_store_inline_credentials(
+    repo_url: str, cred_file: str
+) -> tuple[str, str]:
+    """Move inline URL credentials into the git credential store.
+
+    If *repo_url* embeds ``user:PAT@host`` credentials, store them in
+    *cred_file* (the team credential store that clone/pull already
+    authenticate against) and return ``(sanitized_url, username)``. Otherwise
+    return ``(repo_url, "")`` unchanged.
+
+    Purpose: keep the PAT out of the Docker ``oduflow.repo`` label, which is
+    world-readable via ``docker inspect`` and copied verbatim into saved
+    template metadata. This is a network-free move; SSRF at clone time is gated
+    separately by ``validate_repo_url`` at the tool layer.
+    """
+    if not repo_url:
+        return repo_url, ""
+    try:
+        parsed = urlparse(repo_url)
+    except Exception:
+        return repo_url, ""
+    if not parsed.username and not parsed.password:
+        return repo_url, ""
+    host = parsed.hostname or ""
+    if not host:
+        return repo_url, ""
+    _store_git_credentials(host, parsed.username or "", parsed.password or "", cred_file)
+    # Surface the username as the (non-secret) account name only when a separate
+    # password is present. For token-as-username forms (password empty, token in
+    # the username slot) keep it out of the label and rely on host-based matching.
+    label_user = parsed.username if (parsed.username and parsed.password) else ""
+    return sanitize_repo_url(repo_url), label_user or ""
 
 
 def setup_repo_auth(repo_url: str, cred_file: str) -> dict[str, str]:

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import subprocess
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 from typing import Any
 
 from oduflow.errors import ExternalCommandError, FlowError
@@ -34,6 +34,14 @@ class InvalidRepoURLError(FlowError):
 
 class RepoAuthError(FlowError):
     """Repository authentication failed. Call setup_repo_auth first."""
+
+
+def _credential_host(parsed: ParseResult) -> str:
+    """Git credential-store host key, including an explicit port."""
+    hostname = parsed.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    return f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
 
 
 def validate_repo_url(repo_url: str) -> None:
@@ -71,8 +79,8 @@ def _parse_authenticated_url(repo_url: str) -> tuple[str, str, str, str]:
         raise InvalidRepoURLError(
             "URL must contain credentials: https://user:PAT@github.com/owner/repo.git"
         )
-    clean_url = parsed._replace(netloc=parsed.hostname or "").geturl()
-    return clean_url, parsed.hostname or "", parsed.username, parsed.password
+    clean_url = sanitize_repo_url(repo_url)
+    return clean_url, _credential_host(parsed), parsed.username, parsed.password
 
 
 def _store_git_credentials(
@@ -98,7 +106,9 @@ def _store_git_credentials(
         os.chmod(cred_file, 0o600)
     except OSError:
         pass
-    logger.info("Git credentials stored for host=%s user=%s", host, username)
+    # A few providers accept token-as-username URLs. Never log this field: the
+    # caller cannot reliably distinguish an account name from a secret.
+    logger.info("Git credentials stored for host=%s", host)
 
 
 def extract_and_store_inline_credentials(
@@ -124,10 +134,12 @@ def extract_and_store_inline_credentials(
         return repo_url, ""
     if not parsed.username and not parsed.password:
         return repo_url, ""
-    host = parsed.hostname or ""
+    host = _credential_host(parsed)
     if not host:
         return repo_url, ""
-    _store_git_credentials(host, parsed.username or "", parsed.password or "", cred_file)
+    _store_git_credentials(
+        host, parsed.username or "", parsed.password or "", cred_file
+    )
     # Surface the username as the (non-secret) account name only when a separate
     # password is present. For token-as-username forms (password empty, token in
     # the username slot) keep it out of the label and rely on host-based matching.

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from typing import Any
 
 from oduflow.errors import ExternalCommandError, FlowError
+from oduflow.naming import redact_url_credentials
 
 logger = logging.getLogger("oduflow")
 
@@ -77,7 +78,8 @@ def _parse_authenticated_url(repo_url: str) -> tuple[str, str, str, str]:
 def _store_git_credentials(
     host: str, username: str, password: str, cred_file: str
 ) -> None:
-    os.makedirs(os.path.dirname(cred_file), exist_ok=True)
+    # Don't trust the process umask for the dir holding the plaintext PAT store.
+    os.makedirs(os.path.dirname(cred_file), mode=0o700, exist_ok=True)
     env = git_env_for_team(cred_file)
 
     credential_input = (
@@ -90,6 +92,12 @@ def _store_git_credentials(
         capture_output=True,
         env=env,
     )
+    # git's store helper defaults the file to 0600, but enforce it explicitly as
+    # defense-in-depth (and to harden a pre-existing file created under a laxer umask).
+    try:
+        os.chmod(cred_file, 0o600)
+    except OSError:
+        pass
     logger.info("Git credentials stored for host=%s user=%s", host, username)
 
 
@@ -117,7 +125,9 @@ def setup_repo_auth(repo_url: str, cred_file: str) -> dict[str, str]:
             env=env,
         )
     except subprocess.CalledProcessError as e:
-        error_msg = e.stderr.decode("utf-8") if e.stderr else str(e)
+        error_msg = redact_url_credentials(
+            e.stderr.decode("utf-8") if e.stderr else str(e)
+        )
         raise ExternalCommandError(
             "git ls-remote (auth test)",
             e.returncode,
@@ -306,7 +316,7 @@ def pull_repo(
             env=env,
         )
     except subprocess.CalledProcessError as e:
-        error_msg = e.stderr or str(e)
+        error_msg = redact_url_credentials(e.stderr or str(e))
         raise ExternalCommandError("git pull", e.returncode, error_msg)
     except subprocess.TimeoutExpired:
         raise ExternalCommandError("git pull", -1, "Fetch timed out (60s).")

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -69,6 +69,14 @@ def validate_env_name(env_name: str) -> str:
             f"Invalid environment name '{env_name}': '/'-separated segments must "
             "be non-empty and not '.' or '..'."
         )
+    # A name made up only of stripped characters (e.g. "@@@", non-ASCII) would
+    # slugify to "", producing a degenerate DB name ("oduflow_<team>_") that
+    # collides with every other such name. Require at least one slug char.
+    if not slugify_branch(name):
+        raise ValueError(
+            f"Invalid environment name '{env_name}': must contain at least one "
+            "alphanumeric, '_' or '-' character."
+        )
     return name
 
 
@@ -243,3 +251,16 @@ def sanitize_repo_url(url: str) -> str:
     except Exception:
         pass
     return url
+
+
+# Matches inline credentials embedded in any URL anywhere inside a larger string
+# (e.g. git's stderr, which frequently echoes the full remote incl. user:PAT@host).
+# sanitize_repo_url only handles a whole-string URL; this scrubs free text.
+_URL_CREDS_RE = re.compile(r"(\w+://)[^/\s@]+@")
+
+
+def redact_url_credentials(text: str) -> str:
+    """Redact ``scheme://user:pass@`` credentials embedded anywhere in text."""
+    if not text:
+        return text
+    return _URL_CREDS_RE.sub(r"\1***@", text)

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -246,7 +246,10 @@ def sanitize_repo_url(url: str) -> str:
     try:
         parsed = urlparse(url)
         if parsed.username or parsed.password:
-            clean = parsed._replace(netloc=parsed.hostname or "")
+            # Strip only userinfo.  Keep the original host spelling, IPv6
+            # brackets, and explicit port: this sanitized URL is also used for
+            # subsequent clones, not just display.
+            clean = parsed._replace(netloc=parsed.netloc.rsplit("@", 1)[-1])
             return urlunparse(clean)
     except Exception:
         pass

--- a/src/oduflow/output_cache.py
+++ b/src/oduflow/output_cache.py
@@ -45,13 +45,20 @@ class OutputCache:
     def __init__(self) -> None:
         self._store: dict[str, CachedOutput] = {}
         self._lock = threading.Lock()
+        self._seq = 0
 
     def store(self, output: str, source_tool: str, source_args: str) -> CachedOutput:
         """Cache output, return CachedOutput with generated ID."""
         if len(output) > _MAX_OUTPUT_SIZE:
             output = output[:_MAX_OUTPUT_SIZE]
 
-        raw = f"{output[:1000]}{time.time()}".encode()
+        # A process-wide sequence guarantees a unique id even when two outputs
+        # share the same 1000-char prefix within one clock tick (identical
+        # prefix + equal time.time() would otherwise collide and overwrite).
+        with self._lock:
+            self._seq += 1
+            seq = self._seq
+        raw = f"{output[:1000]}{time.time()}{seq}".encode()
         output_id = hashlib.sha256(raw).hexdigest()[:8]
 
         lines = output.splitlines()

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -293,15 +293,17 @@ def prod_lock_key(team_id: str, name: str) -> str:
     return f"prod:{team_id}:{name}"
 
 
-def with_prod_lock(fn):
+def with_prod_lock(fn: Callable[P, R]) -> Callable[P, R]:
     """Acquire the production's lock before executing the tool function."""
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        name = kwargs.get("name") or (args[0] if args else None)
-        if not name:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        raw_name = kwargs.get("name") or (args[0] if args else None)
+        if not raw_name:
             raise ToolError("name is required")
-        team = _resolve_team(kwargs.get("ctx"))
+        name = cast(str, raw_name)
+        ctx = cast("Context | None", kwargs.get("ctx"))
+        team = _resolve_team(ctx)
         key = prod_lock_key(team.team_id, name)
         _locks.acquire_env(key)
         try:
@@ -2782,7 +2784,7 @@ def create_production(
     extra_addons: dict[str, str] | None = None,
     auto_update: bool = False,
     template_name: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Create a PRODUCTION Odoo environment (long-lived, own domain, dedicated
@@ -2840,7 +2842,7 @@ def create_production(
 
 @mcp.tool()
 @handle_errors
-def list_productions(ctx: Context = None) -> str:
+def list_productions(ctx: Context | None = None) -> str:
     """
     List the team's production environments with status, domain, deployed
     commit, and last deploy result.
@@ -2857,7 +2859,7 @@ def list_productions(ctx: Context = None) -> str:
 
 @mcp.tool()
 @handle_errors
-def get_production_info(name: str, ctx: Context = None) -> str:
+def get_production_info(name: str, ctx: Context | None = None) -> str:
     """
     Detailed information about a production: status, health, deployed commit,
     recent branch commits, deploy history, and backup state.
@@ -2880,7 +2882,7 @@ def production_logs(
     n_lines: int = 100,
     grep: str = "",
     level: str = "",
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Fetch logs from a production's Odoo container.
@@ -2907,7 +2909,7 @@ def production_logs(
 @mcp.tool()
 @handle_errors
 @with_prod_lock
-def start_production(name: str, ctx: Context = None) -> str:
+def start_production(name: str, ctx: Context | None = None) -> str:
     """
     Start a stopped production environment.
 
@@ -2923,7 +2925,7 @@ def start_production(name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_prod_lock
-def stop_production(name: str, ctx: Context = None) -> str:
+def stop_production(name: str, ctx: Context | None = None) -> str:
     """
     Stop a production environment. WARNING: takes the production offline.
 
@@ -2939,7 +2941,7 @@ def stop_production(name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_prod_lock
-def restart_production(name: str, ctx: Context = None) -> str:
+def restart_production(name: str, ctx: Context | None = None) -> str:
     """
     Restart a production's Odoo container (brief downtime).
 
@@ -2955,7 +2957,9 @@ def restart_production(name: str, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_prod_lock
-def set_production_auto_update(name: str, enabled: bool, ctx: Context = None) -> str:
+def set_production_auto_update(
+    name: str, enabled: bool, ctx: Context | None = None
+) -> str:
     """
     Enable/disable automatic deployment of GitHub push webhooks for a
     production. When enabled, a push to the production's branch triggers
@@ -2981,7 +2985,7 @@ def update_production(
     install: str = "",
     upgrade: str = "",
     restart: bool = False,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Deploy the latest commits of a production's branch — with AUTOMATIC CODE
@@ -3032,7 +3036,9 @@ def update_production(
 @mcp.tool()
 @handle_errors
 @with_prod_lock
-def rollback_production(name: str, to_commit: str = "", ctx: Context = None) -> str:
+def rollback_production(
+    name: str, to_commit: str = "", ctx: Context | None = None
+) -> str:
     """
     Manually roll a production's CODE back to a previous commit and restart.
     (The database is not touched — restore a snapshot for data rollback.)
@@ -3047,12 +3053,12 @@ def rollback_production(name: str, to_commit: str = "", ctx: Context = None) -> 
     result = production_ops.rollback_production(
         settings, team, name, to_commit, trigger="mcp"
     )
-    return result["message"]
+    return str(result["message"])
 
 
 @mcp.tool()
 @handle_errors
-def production_deploys(name: str, limit: int = 20, ctx: Context = None) -> str:
+def production_deploys(name: str, limit: int = 20, ctx: Context | None = None) -> str:
     """
     Deploy history of a production (newest last): commits, actions, modules,
     status (success / rolled_back / rollback_failed), errors.
@@ -3074,7 +3080,7 @@ def production_deploys(name: str, limit: int = 20, ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_prod_lock
-def snapshot_production(name: str, note: str = "", ctx: Context = None) -> str:
+def snapshot_production(name: str, note: str = "", ctx: Context | None = None) -> str:
     """
     Take a snapshot of a production to S3: database dump + deduplicated
     filestore revision + manifest (with the deployed commit sha). Snapshots
@@ -3107,7 +3113,7 @@ def snapshot_production(name: str, note: str = "", ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 def list_production_snapshots(
-    name: str, refresh: bool = False, ctx: Context = None
+    name: str, refresh: bool = False, ctx: Context | None = None
 ) -> str:
     """
     List a production's snapshots (oldest first): id, created_at, sizes,
@@ -3136,7 +3142,7 @@ def list_production_snapshots(
 @handle_errors
 @with_prod_lock
 def restore_production(
-    name: str, snapshot_id: str, confirm: str = "", ctx: Context = None
+    name: str, snapshot_id: str, confirm: str = "", ctx: Context | None = None
 ) -> str:
     """
     Restore a production's DATABASE and FILESTORE from a snapshot.
@@ -3169,7 +3175,7 @@ def restore_production(
 
 @mcp.tool()
 @handle_errors
-def production_backup_status(ctx: Context = None) -> str:
+def production_backup_status(ctx: Context | None = None) -> str:
     """
     Backup posture for the team: per-production snapshot state (schedule,
     last snapshot, last error) and cluster WAL-G state (base backups, WAL
@@ -3189,7 +3195,7 @@ def production_backup_status(ctx: Context = None) -> str:
 @handle_errors
 @with_prod_lock
 def set_production_backup_schedule(
-    name: str, schedule: str, ctx: Context = None
+    name: str, schedule: str, ctx: Context | None = None
 ) -> str:
     """
     Override a production's daily snapshot time.
@@ -3211,7 +3217,7 @@ def set_production_backup_schedule(
 
 @mcp.tool()
 @handle_errors
-def prune_production_backups(ctx: Context = None) -> str:
+def prune_production_backups(ctx: Context | None = None) -> str:
     """
     Apply the retention policy ([backup] keep) to the team's snapshots and
     filestore chunk store now (runs weekly on schedule anyway). Uses safe
@@ -3235,7 +3241,7 @@ def prune_production_backups(ctx: Context = None) -> str:
 @mcp.tool()
 @handle_errors
 def restore_cluster_pitr(
-    target_time: str = "", confirm: str = "", ctx: Context = None
+    target_time: str = "", confirm: str = "", ctx: Context | None = None
 ) -> str:
     """
     DISASTER RECOVERY: restore the WHOLE production PostgreSQL cluster from
@@ -3264,7 +3270,9 @@ def restore_cluster_pitr(
     _resolve_team(ctx)  # authenticate the caller; PITR spans all teams
     _locks.acquire_env("prod:__cluster__")
     try:
-        client = system_ops.get_client()
+        from oduflow.docker_ops.client import get_client
+
+        client = get_client()
         # Stop every production Odoo container (all teams share the cluster).
         stopped: list[str] = []
         for team_cfg in settings.teams.values():
@@ -3301,7 +3309,7 @@ def delete_production(
     name: str,
     confirm: str = "",
     drop_database: bool = False,
-    ctx: Context = None,
+    ctx: Context | None = None,
 ) -> str:
     """
     Delete a production environment. The container and registry record are

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -3430,7 +3430,8 @@ def _build_routes(
             locks.release_env(_prod_lock_key(team, name))
 
     def _production_action(
-        request: Request, action: Callable[..., dict]
+        request: Request,
+        action: Callable[[Settings, TeamSettings, str], dict[str, Any]],
     ) -> JSONResponse:
         """Shared lock/error wrapper for simple per-production POST actions."""
         settings = get_settings()
@@ -3638,7 +3639,9 @@ def _build_routes(
     def api_production_snapshot_now(request: Request) -> JSONResponse:
         from oduflow import backup_ops
 
-        def _snapshot(settings: Settings, team: TeamSettings, name: str) -> dict:
+        def _snapshot(
+            settings: Settings, team: TeamSettings, name: str
+        ) -> dict[str, Any]:
             return backup_ops.snapshot_production(settings, team, name, trigger="ui")
 
         return _production_action(request, _snapshot)

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -15,9 +15,11 @@ import secrets
 import socket
 import threading
 import time
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from itsdangerous import BadData, URLSafeTimedSerializer
+from starlette.datastructures import Headers
+from starlette.exceptions import HTTPException
 from starlette.requests import HTTPConnection, Request
 from starlette.responses import (
     HTMLResponse,
@@ -200,6 +202,25 @@ def _check_cookie_token(token: str, settings: Settings) -> "TeamSettings | None"
     return team
 
 
+def _is_cross_origin(headers: Headers) -> bool:
+    """Whether Origin/Referer mark this as a cross-site request (CSRF).
+
+    Compares the Origin (or, absent that, Referer) host:port against the
+    request's own Host header. Returns False when neither header is present —
+    non-browser clients (curl, the import shell script) carry no ambient cookie
+    and cannot be driven cross-site by a victim's browser, so there is nothing
+    to forge."""
+    host = headers.get("host", "")
+    source = headers.get("origin", "") or headers.get("referer", "")
+    if not source:
+        return False
+    try:
+        netloc = urlsplit(source).netloc
+    except Exception:
+        return True
+    return netloc != host
+
+
 class BasicAuthMiddleware:
     def __init__(self, app: ASGIApp, get_settings: Callable[[], Settings]) -> None:
         self._app = app
@@ -224,6 +245,29 @@ class BasicAuthMiddleware:
             if token:
                 team = _check_cookie_token(token, self._get_settings())
         if team:
+            # CSRF: browsers authenticate with an ambient cookie, so reject
+            # cross-site state-changing requests (unsafe HTTP methods and every
+            # WebSocket handshake — cross-site WS hijacking targets the shell/SQL
+            # terminals). SameSite=Strict is the first line; this is the
+            # server-side backstop. Non-browser clients send no Origin/Referer
+            # and are unaffected.
+            method = scope.get("method", "")
+            is_unsafe = scope["type"] == "websocket" or method in (
+                "POST",
+                "PUT",
+                "PATCH",
+                "DELETE",
+            )
+            if is_unsafe and _is_cross_origin(conn.headers):
+                if scope["type"] == "websocket":
+                    await WebSocket(scope, receive, send).close(code=1008)
+                else:
+                    forbidden: Response = JSONResponse(
+                        {"ok": False, "error": "Cross-origin request blocked"},
+                        status_code=403,
+                    )
+                    await forbidden(scope, receive, send)
+                return
             scope.setdefault("state", {})["team"] = team
             await self._app(scope, receive, send)
             return
@@ -497,6 +541,13 @@ def _build_routes(
             team: TeamSettings = request.state.team
             return team
         settings = get_settings()
+        # When auth is enforced (any team has a ui_password), the middleware
+        # always populates request.state.team for non-public paths. Reaching
+        # here means the request bypassed auth — default-deny instead of silently
+        # acting as team "1" (tenant-isolation hazard). The single-team fallback
+        # is only for the open (auth-disabled) server.
+        if any(t.ui_password for t in settings.teams.values()):
+            raise HTTPException(status_code=401, detail="Unauthorized")
         if len(settings.teams) == 1:
             return next(iter(settings.teams.values()))
         return settings.get_team("1")

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1105,12 +1105,16 @@ def _build_routes(
     # --- Import from Odoo.sh (push-based template ingest) ------------------
 
     def _import_token_value(request: Request) -> str:
-        """Read the import token from an Authorization: Bearer header (preferred,
-        keeps it out of URLs/logs) or a ?token= query param as a fallback."""
+        """Read the import token from the Authorization: Bearer header only.
+
+        A ``?token=`` query param is deliberately NOT accepted: these endpoints
+        bypass Basic auth, so the token is the sole credential, and tokens in
+        URLs leak into reverse-proxy/CDN access logs and Referer headers. The
+        official ``import-odoo.sh`` client always sends the Bearer header."""
         auth = request.headers.get("authorization", "")
         if auth.startswith("Bearer "):
             return auth[len("Bearer ") :].strip()
-        return request.query_params.get("token", "").strip()
+        return ""
 
     def _resolve_import_token(
         request: Request,

--- a/src/oduflow/webhooks.py
+++ b/src/oduflow/webhooks.py
@@ -76,7 +76,9 @@ def verify_signature(secret: str, body: bytes, signature_header: str) -> bool:
     return hmac.compare_digest(expected, digest.strip().lower())
 
 
-def resolve_team(settings: Settings, body: bytes, signature_header: str):
+def resolve_team(
+    settings: Settings, body: bytes, signature_header: str
+) -> TeamSettings | None:
     """The team whose webhook secret signed this request (None = no match)."""
     for team in settings.teams.values():
         try:

--- a/tests/test_repo_credential_scrub.py
+++ b/tests/test_repo_credential_scrub.py
@@ -1,0 +1,56 @@
+"""Inline git credentials must not land in the Docker ``oduflow.repo`` label.
+
+``create_environment`` moves any ``https://user:PAT@host/...`` credentials into
+the team credential store and persists only a sanitized URL, because labels are
+world-readable via ``docker inspect`` and copied verbatim into saved template
+metadata.
+"""
+
+from __future__ import annotations
+
+import os
+
+from oduflow.git_ops import extract_and_store_inline_credentials
+
+
+def test_inline_creds_moved_to_store_and_url_sanitized(tmp_path):
+    cred = str(tmp_path / "sub" / ".git-credentials")
+    url, user = extract_and_store_inline_credentials(
+        "https://alice:ghp_SECRET123@github.com/o/r.git", cred
+    )
+    assert url == "https://github.com/o/r.git"  # no credentials in the label URL
+    assert user == "alice"  # non-secret account name, safe for the label
+    stored = open(cred).read()
+    assert "ghp_SECRET123" in stored  # secret lives in the credential store
+    assert oct(os.stat(cred).st_mode & 0o777) == "0o600"
+    assert oct(os.stat(os.path.dirname(cred)).st_mode & 0o777) == "0o700"
+
+
+def test_clean_url_is_untouched(tmp_path):
+    cred = str(tmp_path / ".git-credentials")
+    url, user = extract_and_store_inline_credentials(
+        "https://github.com/o/r.git", cred
+    )
+    assert url == "https://github.com/o/r.git"
+    assert user == ""
+    assert not os.path.exists(cred)  # nothing stored for a credential-free URL
+
+
+def test_token_as_username_kept_out_of_label(tmp_path):
+    # https://<TOKEN>@host (token in the username slot, no password) must not
+    # leak the token as the label's git_user; rely on host-based matching.
+    cred = str(tmp_path / ".git-credentials")
+    url, user = extract_and_store_inline_credentials(
+        "https://ghp_TOKENONLY@github.com/o/r.git", cred
+    )
+    assert url == "https://github.com/o/r.git"
+    assert user == ""
+    assert "ghp_TOKENONLY" in open(cred).read()
+
+
+def test_empty_url_noop(tmp_path):
+    cred = str(tmp_path / ".git-credentials")
+    url, user = extract_and_store_inline_credentials("", cred)
+    assert url == ""
+    assert user == ""
+    assert not os.path.exists(cred)

--- a/tests/test_repo_credential_scrub.py
+++ b/tests/test_repo_credential_scrub.py
@@ -8,9 +8,12 @@ metadata.
 
 from __future__ import annotations
 
+import logging
 import os
+import subprocess
 
-from oduflow.git_ops import extract_and_store_inline_credentials
+from oduflow.docker_ops.env_ops import _move_inline_repo_credentials
+from oduflow.git_ops import extract_and_store_inline_credentials, git_env_for_team
 
 
 def test_inline_creds_moved_to_store_and_url_sanitized(tmp_path):
@@ -28,17 +31,16 @@ def test_inline_creds_moved_to_store_and_url_sanitized(tmp_path):
 
 def test_clean_url_is_untouched(tmp_path):
     cred = str(tmp_path / ".git-credentials")
-    url, user = extract_and_store_inline_credentials(
-        "https://github.com/o/r.git", cred
-    )
+    url, user = extract_and_store_inline_credentials("https://github.com/o/r.git", cred)
     assert url == "https://github.com/o/r.git"
     assert user == ""
     assert not os.path.exists(cred)  # nothing stored for a credential-free URL
 
 
-def test_token_as_username_kept_out_of_label(tmp_path):
+def test_token_as_username_kept_out_of_label_and_logs(tmp_path, caplog):
     # https://<TOKEN>@host (token in the username slot, no password) must not
     # leak the token as the label's git_user; rely on host-based matching.
+    caplog.set_level(logging.INFO, logger="oduflow")
     cred = str(tmp_path / ".git-credentials")
     url, user = extract_and_store_inline_credentials(
         "https://ghp_TOKENONLY@github.com/o/r.git", cred
@@ -46,6 +48,43 @@ def test_token_as_username_kept_out_of_label(tmp_path):
     assert url == "https://github.com/o/r.git"
     assert user == ""
     assert "ghp_TOKENONLY" in open(cred).read()
+    assert "ghp_TOKENONLY" not in caplog.text
+
+
+def test_inline_creds_preserve_nondefault_port(tmp_path):
+    cred = str(tmp_path / ".git-credentials")
+    url, user = extract_and_store_inline_credentials(
+        "https://alice:secret@git.example.com:8443/o/r.git", cred
+    )
+    assert url == "https://git.example.com:8443/o/r.git"
+    assert user == "alice"
+    filled = subprocess.run(
+        ["git", "credential", "fill"],
+        input="protocol=https\nhost=git.example.com:8443\nusername=alice\n\n",
+        text=True,
+        capture_output=True,
+        check=True,
+        env=git_env_for_team(cred),
+    )
+    assert "password=secret" in filled.stdout
+
+
+def test_inline_creds_override_stale_template_user(tmp_path):
+    cred = str(tmp_path / ".git-credentials")
+    url, user = _move_inline_repo_credentials(
+        "https://alice:secret@git.example.com/o/r.git", cred, "old-template-user"
+    )
+    assert url == "https://git.example.com/o/r.git"
+    assert user == "alice"
+
+
+def test_token_as_username_clears_stale_template_user(tmp_path):
+    cred = str(tmp_path / ".git-credentials")
+    url, user = _move_inline_repo_credentials(
+        "https://ghp_TOKENONLY@github.com/o/r.git", cred, "old-template-user"
+    )
+    assert url == "https://github.com/o/r.git"
+    assert user == ""
 
 
 def test_empty_url_noop(tmp_path):

--- a/tests/test_web_ui_csrf.py
+++ b/tests/test_web_ui_csrf.py
@@ -1,0 +1,104 @@
+"""CSRF protection for the web dashboard.
+
+The dashboard authenticates browsers with an ambient session cookie / Basic
+auth, so cross-site state-changing requests must be rejected. ``SameSite=Strict``
+is the first line of defence; ``BasicAuthMiddleware`` adds a server-side
+Origin/Referer backstop for unsafe HTTP methods and WebSocket handshakes.
+Non-browser clients (curl, the import shell script) send no Origin/Referer and
+are unaffected.
+"""
+
+from __future__ import annotations
+
+import base64
+import tempfile
+
+from starlette.datastructures import Headers
+from starlette.responses import JSONResponse
+from starlette.routing import Route, Router
+from starlette.testclient import TestClient
+
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import BasicAuthMiddleware, _AUTH_USER, _is_cross_origin
+
+_PW = "s3cret"
+
+
+def _headers(**kw: str) -> Headers:
+    return Headers(raw=[(k.encode(), v.encode()) for k, v in kw.items()])
+
+
+def test_is_cross_origin_matches_host():
+    assert _is_cross_origin(_headers(host="h:8080", origin="https://h:8080")) is False
+    assert _is_cross_origin(_headers(host="h", origin="https://h")) is False
+
+
+def test_is_cross_origin_rejects_foreign_origin():
+    assert _is_cross_origin(_headers(host="h", origin="https://evil.example")) is True
+
+
+def test_is_cross_origin_referer_fallback():
+    assert _is_cross_origin(_headers(host="h", referer="https://evil.example/x")) is True
+    assert _is_cross_origin(_headers(host="h", referer="https://h/dash")) is False
+
+
+def test_is_cross_origin_allows_missing_headers():
+    # Native clients (curl) carry no ambient cookie -> nothing to forge.
+    assert _is_cross_origin(_headers(host="h")) is False
+
+
+def _client() -> TestClient:
+    settings = Settings(
+        routing_mode="port",
+        base_data_dir=tempfile.mkdtemp(prefix="oduflow-csrf-test-"),
+        teams={"1": TeamSettings(team_id="1", ui_password=_PW)},
+    )
+
+    async def ok(request):  # noqa: ANN001
+        return JSONResponse({"ok": True})
+
+    router = Router(
+        routes=[
+            Route("/api/dummy", ok, methods=["GET", "POST"]),
+        ]
+    )
+    app = BasicAuthMiddleware(router, lambda: settings)
+    return TestClient(app, base_url="http://testserver")
+
+
+def _basic() -> dict[str, str]:
+    blob = base64.b64encode(f"{_AUTH_USER}:{_PW}".encode()).decode()
+    return {"Authorization": f"Basic {blob}"}
+
+
+def test_cross_origin_post_blocked():
+    client = _client()
+    r = client.post(
+        "/api/dummy",
+        headers={**_basic(), "Origin": "https://evil.example"},
+    )
+    assert r.status_code == 403
+    assert "Cross-origin" in r.json()["error"]
+
+
+def test_same_origin_post_allowed():
+    client = _client()
+    r = client.post(
+        "/api/dummy",
+        headers={**_basic(), "Origin": "http://testserver"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+
+def test_post_without_origin_allowed():
+    client = _client()
+    r = client.post("/api/dummy", headers=_basic())
+    assert r.status_code == 200
+
+
+def test_safe_method_never_blocked_by_csrf():
+    # A cross-origin GET is not state-changing; the Origin check must not apply.
+    client = _client()
+    r = client.get("/api/dummy", headers={**_basic(), "Origin": "https://evil.example"})
+    assert r.status_code == 200


### PR DESCRIPTION
Security-audit hardening across the credential, web-UI and naming surfaces, in two commits.

Keeps inline git PATs out of the world-readable `oduflow.repo` Docker label by moving them into the team credential store at `create_environment` time (only a sanitized URL is persisted), redacts credentials echoed in git stderr, and forces `.git-credentials` dir/file modes to `0o700`/`0o600`. Tightens the import path — the import token is accepted via the `Authorization` header only (no `?token=` query fallback that leaks into proxy logs) and `import_from_odoo` now requires HTTPS so the Odoo master password never crosses the wire in cleartext. Adds a server-side CSRF backstop (Origin/Referer vs Host on unsafe methods and every WebSocket handshake) on top of `SameSite=Strict`, and makes `_get_ui_team` default-deny (401) instead of silently acting as team "1" when auth is enabled. Also fixes collision-prone `output_cache` ids, naive-timestamp handling in `activity.parse_ts`, and rejects environment names that slugify to an empty database name; ADR 0011 is updated and new tests cover the credential scrub and CSRF behavior.