### PR TITLE
Connect As: cross-subdomain login landing + env routing regeneration on update

### DIFF
--- a/specs/0036-cross-subdomain-connect-as-landing.md
+++ b/specs/0036-cross-subdomain-connect-as-landing.md
@@ -1,0 +1,107 @@
+# 0036 — Cross-subdomain "Connect as user" landing (token → env-host cookie)
+
+**Status:** Adopted
+**Type:** Routing / Web dashboard
+**First introduced:** `litnimax/connect-as-user-selects` branch (2026-07-19)
+**Key code today:** `connect_tokens.py` (one-time token store), `web_ui.py` (`api_connect_open` traefik branch, `api_connect_land`, `_PUBLIC_PATHS`), `docker_ops/system_ops.py` (`_write_traefik_dynamic_config` `oduflow-connect` router), `templates/dashboard.html` (Connect As modal)
+
+## Context
+
+[[0031-connect-as-user-impersonation]] mints a passwordless Odoo session
+server-side and hands back the `session_id` cookie + URL — enough for Playwright
+(which injects the cookie into its context) but not for a human clicking a
+dashboard button: a browser can't be handed a cookie for another host from
+JavaScript (Odoo issues `session_id` HttpOnly), and the dashboard's "Open" only
+worked when it shared a host with the env (port/local mode). 0031 explicitly
+deferred the "token-URL" convenience form and assumed its only clean home was an
+addon installed inside every Odoo env — the platform-layer approach exists
+precisely to avoid that.
+
+Under Traefik routing the env lives on its own subdomain (`<slug>.<team-host>`,
+[[0004-stable-addressing-port-registry-and-traefik]]) while the dashboard is on
+the parent host. Two "obvious" cross-domain cookie tricks both fail:
+
+- A **host-only** cookie set from the dashboard response is scoped to the
+  dashboard host; the browser never sends it to the env subdomain.
+- A **parent-domain** cookie (`Domain=<team-host>`) does reach the subdomain, but
+  per RFC 6265 it is a *distinct* cookie from any host-only `session_id` Odoo
+  already set on the env host — it does not override it, both are sent, and the
+  older (stale) one is sent first. So it is unreliable exactly when the user has
+  already opened the env, and it shares one session across all of a team's env
+  subdomains (one login at a time, sid broadcast to siblings).
+
+## Decision
+
+Set the env's session cookie **from the env's own host**, like odoo.sh — but
+without an Odoo addon. Reserve one path on every env host, intercept it at the
+Traefik layer, and route it to the Oduflow server, which sets the cookie
+host-only there.
+
+Flow:
+
+1. The dashboard's Connect action calls `api_connect_open`. In traefik mode it
+   mints the session (existing `connect_as_user`), stashes the `session_id`
+   behind a **one-time, short-lived, host-bound token** (`connect_tokens`), and
+   303-redirects the browser to `https://<env-host>/oduflow-connect?token=…`. No
+   cookie is set on the dashboard response.
+2. A file-provider Traefik router `PathPrefix(/oduflow-connect)` (high priority,
+   beating the env's docker `Host(...)` router for that path only) sends that
+   request to Oduflow — not Odoo.
+3. `api_connect_land` (public, authenticated solely by the token) consumes the
+   token and sets `session_id` **host-only** on the env host — which overrides
+   any stale host-only cookie Odoo left there — then 303s to `/web`, landing
+   authenticated.
+
+Port/same-host mode is unchanged (the dashboard sets the cookie directly and
+redirects). The `connect_as_user` cookie payload remains for Playwright/API
+callers; the dashboard's own cookie-copy affordances are retired in favour of the
+one-click open.
+
+## How it works (macro)
+
+- **One-time token store** (`connect_tokens`): in-process (single-process server,
+  like `agent_sessions`). `issue(env_host, sid)` returns a random
+  `token_urlsafe`; `consume(token, env_host)` returns the sid exactly once,
+  rejecting unknown/used/expired/host-mismatched tokens (120 s TTL). The token,
+  not a dashboard session, is the sole credential at the landing — so
+  `/oduflow-connect` is in `_PUBLIC_PATHS`.
+- **Traefik interception** reuses the dynamic-config machinery of
+  [[0034-external-traefik-routes]]: one extra router in `oduflow.yml`, service
+  `oduflow` (already `host.docker.internal:<port>`), `_route_entrypoint` for
+  web/websecure. Because it matches only `/oduflow-connect`, every other path on
+  the env host still reaches Odoo. A high explicit `priority` removes
+  cross-provider ambiguity with the docker `Host()` router.
+- **Host-only override is the crux.** The cookie is set on a response served *for
+  the env host*, so it shares the (name, host-only, path) identity of Odoo's own
+  `session_id` and replaces it — the reliability the parent-domain cookie can't
+  give.
+- **Dashboard UX**: Connect As becomes one action — pick a user, click Connect, a
+  new tab opens already logged in. The browser flow no longer needs the
+  `/connect-as` cookie round-trip, so the URL/cookie/Copy/Show fields and the
+  explanatory notes are dropped; programmatic callers use the `connect_as_user`
+  MCP tool instead.
+
+## Consequences
+
+- The human "Connect as user" loop works across env subdomains with a single
+  click, closing the gap 0031 left — and without the per-env Odoo addon 0031
+  assumed would be required.
+- **Per-host cookies**: each env host gets its own `session_id`, so multiple envs
+  can be open at once and no session token is broadcast to sibling subdomains —
+  strictly better than the parent-domain alternative that was considered and
+  rejected.
+- The token is a full session behind a 120 s one-time handle; it can appear in the
+  tab's URL/history but is single-use and host-bound, and only issued to an
+  already-authorized dashboard user. This narrows 0031's "session id is a live
+  credential" exposure for the browser path — the sid never rides in the URL,
+  only the one-time token does.
+- Adds one reserved path (`/oduflow-connect`) and one Traefik router; no new
+  config knobs. Traefik mode only — port/local mode keeps the shared-host cookie.
+
+## History
+
+- `litnimax/connect-as-user-selects` (2026-07-19) — one-time token store, traefik
+  branch in `api_connect_open`, public `api_connect_land` landing,
+  `oduflow-connect` high-priority PathPrefix router, and the simplified
+  single-click Connect As dialog. Realises the token-URL form deferred in
+  [[0031-connect-as-user-impersonation]].

--- a/specs/README.md
+++ b/specs/README.md
@@ -54,6 +54,7 @@ precursors).
 | [0033](0033-restricted-http-path-routing-for-services.md) | 2026-07-14 | Restricted HTTP path routing for auxiliary services |
 | [0034](0034-external-traefik-routes.md) | 2026-07-16 | External `[route.*]` domains → upstream URLs, plus operator drop-in Traefik dynamic files |
 | [0035](0035-production-hosting.md) | 2026-07-11 | Production hosting: dedicated PG cluster, WAL-G/S3 backups, snapshots, auto-rollback deploys |
+| [0036](0036-cross-subdomain-connect-as-landing.md) | 2026-07-19 | Cross-subdomain "Connect as user" landing: one-time token → env-host `/oduflow-connect` sets the session cookie host-only |
 
 ## Design docs
 

--- a/src/oduflow/connect_tokens.py
+++ b/src/oduflow/connect_tokens.py
@@ -1,0 +1,67 @@
+"""One-time, short-lived tokens for the cross-subdomain Connect As "Open" flow.
+
+Under traefik routing an environment lives on its own host
+(``<slug>.<team-host>``), so the dashboard cannot set the env's ``session_id``
+cookie directly: a parent-domain cookie would *not* override a stale host-only
+``session_id`` Odoo may have left on the env host (they are distinct cookies per
+RFC 6265, and the older one is sent first). Instead the dashboard mints the
+session, stashes the resulting ``session_id`` behind a one-time token here, and
+303-redirects the browser to ``https://<env-host>/oduflow-connect?token=...``.
+Traefik routes that path to Oduflow (not Odoo), which consumes the token and
+sets ``session_id`` HOST-ONLY on the env host — overriding any stale cookie.
+
+The store is in-process (the server is single-process, like ``agent_sessions``);
+entries are consumed exactly once and expire after a short TTL.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from oduflow.env_tokens import generate_token
+
+# Long enough to survive a couple of redirects and a slow tab open, short enough
+# that a leaked link is useless almost immediately.
+_TTL_SECONDS = 120.0
+
+_lock = threading.Lock()
+# token -> (env_host, session_id, expiry_monotonic)
+_store: dict[str, tuple[str, str, float]] = {}
+
+
+def _now(now: float | None) -> float:
+    return time.monotonic() if now is None else now
+
+
+def _prune(now: float) -> None:
+    for token in [t for t, (_, _, exp) in _store.items() if exp <= now]:
+        _store.pop(token, None)
+
+
+def issue(env_host: str, session_id: str, *, now: float | None = None) -> str:
+    """Store ``session_id`` bound to ``env_host`` and return a one-time token."""
+    ts = _now(now)
+    token = generate_token()
+    with _lock:
+        _prune(ts)
+        _store[token] = (env_host.lower(), session_id, ts + _TTL_SECONDS)
+    return token
+
+
+def consume(token: str, env_host: str, *, now: float | None = None) -> str | None:
+    """Return the ``session_id`` for a valid token, once.
+
+    Returns ``None`` if the token is unknown, already used, expired, or was
+    issued for a different host than the one now presenting it.
+    """
+    ts = _now(now)
+    with _lock:
+        _prune(ts)
+        entry = _store.pop(token, None)
+    if entry is None:
+        return None
+    stored_host, session_id, expiry = entry
+    if expiry <= ts or stored_host != env_host.lower():
+        return None
+    return session_id

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -758,6 +758,40 @@ def _clone_repo(
         )
 
 
+def build_env_traefik_labels(
+    settings: Settings, team: TeamSettings, env_name: str
+) -> dict[str, str]:
+    """Traefik docker-provider routing labels for an environment's Odoo container.
+
+    Empty in port mode. This is the single source of an environment's routing
+    labels, shared by :func:`create_environment` and :func:`update_environment`
+    so a container recreated by an update always reflects the *current*
+    ``routing_mode`` / ``routing_tls`` / team ``hostname`` — labels are frozen at
+    container creation, so this is what lets a mode/TLS/hostname switch be
+    repaired by a plain ``update_environment`` instead of a destroy+create.
+    """
+    if settings.routing_mode != "traefik":
+        return {}
+    slug = slugify_branch(env_name)
+    router = f"oduflow-{team.team_id}-{slug}"
+    host = get_env_hostname(env_name, team.hostname)
+    labels: dict[str, str] = {
+        "traefik.enable": "true",
+        f"traefik.http.routers.{router}.rule": f"Host(`{host}`)",
+        f"traefik.http.services.{router}.loadbalancer.server.port": "8069",
+        "traefik.docker.network": get_team_network_name(team.team_id, settings.prefix),
+    }
+    if settings.routing_tls:
+        labels[f"traefik.http.routers.{router}.entrypoints"] = "websecure"
+        labels[f"traefik.http.routers.{router}.tls"] = "true"
+        labels[f"traefik.http.routers.{router}.tls.certresolver"] = "letsencrypt"
+    else:
+        # Upstream (e.g. Cloudflare tunnel) terminates TLS; Traefik routes plain
+        # HTTP on the web entrypoint. Public URL stays https://.
+        labels[f"traefik.http.routers.{router}.entrypoints"] = "web"
+    return labels
+
+
 def create_environment(
     settings: Settings,
     team: TeamSettings,
@@ -891,32 +925,7 @@ def create_environment(
     if env_vars:
         labels["oduflow.env_vars"] = json.dumps(env_vars)
 
-    if settings.routing_mode == "traefik":
-        slug = slugify_branch(env_name)
-        traefik_router = f"oduflow-{team.team_id}-{slug}"
-        traefik_host = get_env_hostname(env_name, team.hostname)
-        labels.update(
-            {
-                "traefik.enable": "true",
-                f"traefik.http.routers.{traefik_router}.rule": f"Host(`{traefik_host}`)",
-                f"traefik.http.services.{traefik_router}.loadbalancer.server.port": "8069",
-                "traefik.docker.network": get_team_network_name(
-                    team.team_id, settings.prefix
-                ),
-            }
-        )
-        if settings.routing_tls:
-            labels.update(
-                {
-                    f"traefik.http.routers.{traefik_router}.entrypoints": "websecure",
-                    f"traefik.http.routers.{traefik_router}.tls": "true",
-                    f"traefik.http.routers.{traefik_router}.tls.certresolver": "letsencrypt",
-                }
-            )
-        else:
-            # Upstream (e.g. Cloudflare tunnel) terminates TLS; Traefik routes
-            # plain HTTP on the web entrypoint. Public URL stays https://.
-            labels[f"traefik.http.routers.{traefik_router}.entrypoints"] = "web"
+    labels.update(build_env_traefik_labels(settings, team, env_name))
 
     logger.info(
         "Creating environment",
@@ -2640,8 +2649,12 @@ def update_environment(
     raw_cmd = container.attrs["Config"].get("Cmd") or []
     command = " ".join(raw_cmd) if raw_cmd else None
 
-    # Port bindings (only relevant in port mode)
+    # Port bindings (only relevant in port mode). Only read here; a fresh
+    # allocation (when switching into port mode) is deferred until just before
+    # the container is recreated, so an earlier abort (e.g. image pull failure)
+    # does not leak a reserved port.
     host_port: int | None = None
+    port_newly_allocated = False
     if settings.routing_mode == "port":
         port_bindings = container.attrs.get("HostConfig", {}).get("PortBindings") or {}
         tcp_bindings = port_bindings.get("8069/tcp")
@@ -2742,6 +2755,18 @@ def update_environment(
     else:
         labels.pop("oduflow.env_vars", None)
 
+    # Recompute the Traefik routing labels from the CURRENT settings instead of
+    # copying the old container's: labels are frozen at creation, so this is what
+    # lets a routing-mode / TLS / hostname switch be repaired by a plain
+    # update_environment. Strip every stale ``traefik.*`` key first so a
+    # traefik→port switch drops them and a renamed router does not linger.
+    labels = {k: v for k, v in labels.items() if not k.startswith("traefik.")}
+    labels.update(build_env_traefik_labels(settings, team, env_name))
+    if settings.routing_mode == "traefik":
+        # No published port in traefik mode; drop any stale reservation left from
+        # a previous port-mode life so the slot is reusable.
+        release_port(team.port_registry_path, env_name)
+
     # Verify extra addons worktrees are intact
     extra_addons_json = labels.get("oduflow.extra_addons", "")
     if extra_addons_json:
@@ -2754,6 +2779,20 @@ def update_environment(
             wt = os.path.join(extra_dir, rn)
             if not os.path.isdir(wt):
                 logger.warning("Extra addons worktree missing: %s", wt)
+
+    # Switching into port mode (was traefik) or a legacy container that never
+    # published a port: allocate one now, right before recreation, so any
+    # earlier abort could not have leaked the reservation.
+    if settings.routing_mode == "port" and host_port is None:
+        used_ports = _get_used_ports(client, settings, team, exclude_env=env_name)
+        host_port = allocate_port(
+            team.port_registry_path,
+            env_name,
+            team.port_range_start,
+            team.port_range_end,
+            used_ports=used_ports,
+        )
+        port_newly_allocated = True
 
     # ------------------------------------------------------------------
     # 4. Re-create the container with the same settings
@@ -2774,7 +2813,14 @@ def update_environment(
     if settings.routing_mode == "port" and host_port is not None:
         run_kwargs["ports"] = {"8069/tcp": host_port}
 
-    new_container = client.containers.run(**run_kwargs)
+    try:
+        new_container = client.containers.run(**run_kwargs)
+    except Exception:
+        # The old container is already gone; at least don't leak a port slot we
+        # freshly reserved for this recreate.
+        if port_newly_allocated:
+            release_port(team.port_registry_path, env_name)
+        raise
 
     # Regenerate and copy odoo.conf into the new container (repo .oduflow/ takes
     # priority over the instance conf; extra-addons paths merged from labels).

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -813,12 +813,15 @@ def connect_as_user(
 def list_env_users(
     settings: Settings, team: TeamSettings, env_name: str
 ) -> list[dict[str, Any]]:
-    """Active login users of an environment (login, name, share).
+    """Active login users of an environment (login, name, share, portal).
 
     Powers the dashboard's "Connect as" picker. Reads the environment database
     directly via psql on the shared DB container (like ``reset_admin_password``),
-    so it works regardless of whether the Odoo HTTP server is up. ``share`` marks
-    portal users, letting the UI group internal vs. portal roles.
+    so it works regardless of whether the Odoo HTTP server is up. ``share`` is
+    True for both portal and public users; ``portal`` is True only for real
+    portal users (members of ``base.group_portal``). The UI uses this to offer
+    separate internal (``share`` False) and portal (``portal`` True) pickers and
+    to exclude the public/anonymous user from both.
     """
     import json
 
@@ -833,9 +836,17 @@ def list_env_users(
         )
     # json_agg → a single JSON array so the value parses cleanly without CSV
     # quoting concerns (partner names may contain commas).
+    # ``portal`` = membership in the base.group_portal user-type group, resolved
+    # by xml_id via ir_model_data so it is stable across Odoo versions/DBs. It
+    # is a strict subset of ``share`` (which also covers the public user).
     sql = (
         "SELECT COALESCE(json_agg(json_build_object("
-        "'login', u.login, 'name', p.name, 'share', u.share) "
+        "'login', u.login, 'name', p.name, 'share', u.share, "
+        "'portal', (u.id IN ("
+        "SELECT r.uid FROM res_groups_users_rel r "
+        "JOIN ir_model_data d ON d.model = 'res.groups' "
+        "AND d.module = 'base' AND d.name = 'group_portal' "
+        "WHERE r.gid = d.res_id))) "
         "ORDER BY u.share, lower(p.name)), '[]') "
         "FROM res_users u JOIN res_partner p ON p.id = u.partner_id "
         "WHERE u.active AND u.login IS NOT NULL AND u.login <> '__system__'"

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -495,6 +495,18 @@ def _write_traefik_dynamic_config(settings: Settings, config_path: str) -> None:
             **_route_entrypoint(settings),
         }
 
+    # Cross-subdomain Connect As landing: ``/oduflow-connect`` on any env host is
+    # routed to Oduflow (not the env's Odoo) so Oduflow can set the session
+    # cookie host-only on that host. High priority so it beats the env's docker
+    # ``Host(...)`` router for this path only; every other path still hits Odoo.
+    if routers:
+        routers["oduflow-connect"] = {
+            "rule": "PathPrefix(`/oduflow-connect`)",
+            "service": "oduflow",
+            "priority": 100000,
+            **_route_entrypoint(settings),
+        }
+
     # Static extra routes: an external hostname → an arbitrary upstream URL for a
     # service Oduflow does not manage (see [route.*] in oduflow.toml).
     for route in settings.extra_routes:

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2873,7 +2873,7 @@ async function submitConnect() {
       'Logged in as ' + res.login + ' (uid ' + res.uid + '). Session expires ' +
       res.expires_at + '. Cookie domain: ' + res.cookie.domain + ', path /.';
     var openBtn = document.getElementById('connect-open');
-    openBtn.onclick = function() { connectOpen(res.url, res.cookie); };
+    openBtn.onclick = function() { connectOpen(res.url, res.cookie, res.login); };
     document.getElementById('connect-result').style.display = '';
     showToast('Session minted for ' + res.login);
   } catch (e) {
@@ -2884,14 +2884,20 @@ async function submitConnect() {
   }
 }
 
-function connectOpen(url, cookie) {
-  // Same host (local/port mode): the dashboard and the env share a hostname —
-  // cookies are not port-scoped, so dropping session_id here reaches the env.
-  // A different host (traefik subdomain) can't be set from the dashboard
-  // origin, so we just open and the operator adds the cookie themselves.
+function connectOpen(url, cookie, login) {
+  // Same host (local/port mode): the dashboard and the env share a hostname, so
+  // a cookie set for that host reaches the env across ports. We can't set it
+  // from JS — Odoo issues session_id as HttpOnly, so a document.cookie write is
+  // silently dropped once any env session exists — so navigate through the
+  // connect-open bridge, which sets the cookie via an HTTP Set-Cookie (this
+  // overrides the HttpOnly one) and redirects into the env already logged in.
   if (cookie && cookie.domain === location.hostname) {
-    document.cookie = 'session_id=' + cookie.value + '; path=/';
+    window.open(API + '/' + encodeURIComponent(_connectBranch) +
+      '/connect-open?user=' + encodeURIComponent(login), '_blank', 'noopener');
+    return;
   }
+  // Different host (traefik subdomain): the cookie can't be set from the
+  // dashboard origin, so we just open and the operator adds the cookie.
   window.open(url, '_blank', 'noopener');
 }
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1788,7 +1788,6 @@
       <button class="modal-close" onclick="closeConnect()">&times;</button>
     </div>
     <div class="modal-body">
-      <p class="modal-note">Mint a passwordless login session for a user and get back the session_id cookie plus a URL. Add the cookie to your browser or Playwright context to land in an authenticated session as that user — no login form, no password. The session id is a live credential; treat it like a password.</p>
       <div class="form-group">
         <label for="connect-user-internal">Internal user</label>
         <select id="connect-user-internal" aria-label="Internal user to log in as"></select>
@@ -1798,30 +1797,8 @@
         <select id="connect-user-portal" aria-label="Portal user to log in as"></select>
       </div>
       <div class="form-actions">
-        <button class="btn btn-connect" id="connect-submit" onclick="submitConnect()">Connect</button>
-      </div>
-      <div id="connect-result" style="display:none;">
-        <div class="form-group">
-          <label for="connect-url">URL</label>
-          <div class="copy-row">
-            <input id="connect-url" class="mono-input" type="text" readonly>
-            <button class="btn" type="button" onclick="copyConnectField('connect-url', 'URL copied')">Copy</button>
-            <button class="btn" type="button" id="connect-open">Open</button>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="connect-cookie">Session cookie (session_id)</label>
-          <div class="copy-row">
-            <input id="connect-cookie" class="mono-input" type="password" readonly>
-            <button class="btn" type="button" id="connect-reveal" onclick="toggleConnectSecret()" aria-pressed="false">Show</button>
-            <button class="btn" type="button" onclick="copyConnectField('connect-cookie', 'Cookie copied')">Copy</button>
-          </div>
-        </div>
-        <p class="modal-note" id="connect-meta"></p>
-        <p class="modal-note">The Open button logs you in directly only when the dashboard shares the environment's host (local / port mode). On a separate host, add the cookie above to your browser (or Playwright) first.</p>
-      </div>
-      <div class="form-actions">
         <button class="btn" onclick="closeConnect()">Close</button>
+        <button class="btn btn-connect" id="connect-submit" onclick="submitConnect()">Connect</button>
       </div>
     </div>
   </div>
@@ -2818,13 +2795,6 @@ async function openConnect(branch) {
   internalSel.disabled = true;
   portalSel.disabled = true;
   submit.disabled = true;
-  document.getElementById('connect-result').style.display = 'none';
-  var ck = document.getElementById('connect-cookie');
-  ck.type = 'password';
-  ck.value = '';
-  var reveal = document.getElementById('connect-reveal');
-  reveal.textContent = 'Show';
-  reveal.setAttribute('aria-pressed', 'false');
   showModal('connect-modal');
   try {
     var r = await fetch(API + '/' + encodeURIComponent(branch) + '/users');
@@ -2845,74 +2815,19 @@ function closeConnect(event) {
   hideModal('connect-modal');
 }
 
-async function submitConnect() {
+// Pick a user and open the env in a new tab, already logged in. The
+// /connect-open bridge does everything server-side (mint the session, then in
+// port mode set the cookie on the shared host, or in traefik mode redirect to
+// the env's own /oduflow-connect which sets it host-only there). One synchronous
+// window.open in the click handler — no popup-blocker fight, no cookie handling
+// in the browser.
+function submitConnect() {
   var user = document.getElementById('connect-user-internal').value ||
     document.getElementById('connect-user-portal').value;
   if (!user) { showToast('Select an internal or portal user', true); return; }
-  var btn = document.getElementById('connect-submit');
-  var prev = btn.textContent;
-  btn.disabled = true;
-  btn.textContent = 'Connecting…';
-  try {
-    var r = await fetch(API + '/' + encodeURIComponent(_connectBranch) + '/connect-as', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ user: user })
-    });
-    var data = await r.json();
-    if (!data.ok) { showToast(data.error || 'Failed to connect', true); return; }
-    var res = data.result;
-    document.getElementById('connect-url').value = res.url || '';
-    var ck = document.getElementById('connect-cookie');
-    ck.type = 'password';
-    ck.value = (res.cookie && res.cookie.value) || '';
-    var reveal = document.getElementById('connect-reveal');
-    reveal.textContent = 'Show';
-    reveal.setAttribute('aria-pressed', 'false');
-    document.getElementById('connect-meta').textContent =
-      'Logged in as ' + res.login + ' (uid ' + res.uid + '). Session expires ' +
-      res.expires_at + '. Cookie domain: ' + res.cookie.domain + ', path /.';
-    var openBtn = document.getElementById('connect-open');
-    openBtn.onclick = function() { connectOpen(res.url, res.cookie, res.login); };
-    document.getElementById('connect-result').style.display = '';
-    showToast('Session minted for ' + res.login);
-  } catch (e) {
-    showToast('Connection error: ' + e.message, true);
-  } finally {
-    btn.disabled = false;
-    btn.textContent = prev;
-  }
-}
-
-function connectOpen(url, cookie, login) {
-  // Same host (local/port mode): the dashboard and the env share a hostname, so
-  // a cookie set for that host reaches the env across ports. We can't set it
-  // from JS — Odoo issues session_id as HttpOnly, so a document.cookie write is
-  // silently dropped once any env session exists — so navigate through the
-  // connect-open bridge, which sets the cookie via an HTTP Set-Cookie (this
-  // overrides the HttpOnly one) and redirects into the env already logged in.
-  if (cookie && cookie.domain === location.hostname) {
-    window.open(API + '/' + encodeURIComponent(_connectBranch) +
-      '/connect-open?user=' + encodeURIComponent(login), '_blank', 'noopener');
-    return;
-  }
-  // Different host (traefik subdomain): the cookie can't be set from the
-  // dashboard origin, so we just open and the operator adds the cookie.
-  window.open(url, '_blank', 'noopener');
-}
-
-function toggleConnectSecret() {
-  var el = document.getElementById('connect-cookie');
-  var btn = document.getElementById('connect-reveal');
-  var show = el.type === 'password';
-  el.type = show ? 'text' : 'password';
-  btn.textContent = show ? 'Hide' : 'Show';
-  btn.setAttribute('aria-pressed', show ? 'true' : 'false');
-}
-
-function copyConnectField(id, label) {
-  var val = document.getElementById(id).value;
-  if (val) copyToClipboard(val, label);
+  window.open(API + '/' + encodeURIComponent(_connectBranch) +
+    '/connect-open?user=' + encodeURIComponent(user), '_blank', 'noopener');
+  hideModal('connect-modal');
 }
 
 async function loadEnvironments(force) {

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1790,8 +1790,12 @@
     <div class="modal-body">
       <p class="modal-note">Mint a passwordless login session for a user and get back the session_id cookie plus a URL. Add the cookie to your browser or Playwright context to land in an authenticated session as that user — no login form, no password. The session id is a live credential; treat it like a password.</p>
       <div class="form-group">
-        <label for="connect-user">Log in as</label>
-        <select id="connect-user" aria-label="User to log in as"></select>
+        <label for="connect-user-internal">Internal user</label>
+        <select id="connect-user-internal" aria-label="Internal user to log in as"></select>
+      </div>
+      <div class="form-group">
+        <label for="connect-user-portal">Portal user</label>
+        <select id="connect-user-portal" aria-label="Portal user to log in as"></select>
       </div>
       <div class="form-actions">
         <button class="btn btn-connect" id="connect-submit" onclick="submitConnect()">Connect</button>
@@ -2766,13 +2770,53 @@ function copyMcpField(id, label) {
 
 var _connectBranch = '';
 
+// Populate the Internal and Portal selects. They are mutually exclusive:
+// picking a value in one clears the other; submitConnect uses whichever is set.
+function fillConnectSelects(users, errMsg) {
+  var internalSel = document.getElementById('connect-user-internal');
+  var portalSel = document.getElementById('connect-user-portal');
+  if (errMsg) showToast(errMsg, true);
+  var opt = function(u, selected) {
+    var label = u.name ? (u.name + ' — ' + u.login) : u.login;
+    return '<option value="' + escAttr(u.login) + '"' +
+      (selected ? ' selected' : '') + '>' + esc(label) + '</option>';
+  };
+  var internal = users.filter(function(u) { return !u.share; });
+  var portal = users.filter(function(u) { return u.portal; });
+  // Internal select: preselect admin (common case = one click). Always keep a
+  // "— None —" entry so it can be reset when a portal user is picked. Fall back
+  // to a bare admin option when the list is empty or failed to load.
+  if (internal.length) {
+    internalSel.innerHTML = '<option value="">— None —</option>' +
+      internal.map(function(u) { return opt(u, u.login === 'admin'); }).join('');
+    internalSel.disabled = false;
+  } else {
+    internalSel.innerHTML = '<option value="admin" selected>admin</option>';
+    internalSel.disabled = false;
+  }
+  // Portal select: always starts unselected; disabled when there are none.
+  if (portal.length) {
+    portalSel.innerHTML = '<option value="">— None —</option>' +
+      portal.map(function(u) { return opt(u, false); }).join('');
+    portalSel.disabled = false;
+  } else {
+    portalSel.innerHTML = '<option value="">— No portal users —</option>';
+    portalSel.disabled = true;
+  }
+  internalSel.onchange = function() { if (internalSel.value) portalSel.value = ''; };
+  portalSel.onchange = function() { if (portalSel.value) internalSel.value = ''; };
+}
+
 async function openConnect(branch) {
   _connectBranch = branch;
   document.getElementById('connect-title').textContent = 'Connect As — ' + branch;
-  var sel = document.getElementById('connect-user');
+  var internalSel = document.getElementById('connect-user-internal');
+  var portalSel = document.getElementById('connect-user-portal');
   var submit = document.getElementById('connect-submit');
-  sel.innerHTML = '<option>Loading users…</option>';
-  sel.disabled = true;
+  internalSel.innerHTML = '<option>Loading users…</option>';
+  portalSel.innerHTML = '<option>Loading users…</option>';
+  internalSel.disabled = true;
+  portalSel.disabled = true;
   submit.disabled = true;
   document.getElementById('connect-result').style.display = 'none';
   var ck = document.getElementById('connect-cookie');
@@ -2786,31 +2830,13 @@ async function openConnect(branch) {
     var r = await fetch(API + '/' + encodeURIComponent(branch) + '/users');
     var data = await r.json();
     if (!data.ok) {
-      sel.innerHTML = '<option value="admin">admin</option>';
-      showToast(data.error || 'Failed to load users', true);
+      fillConnectSelects([], data.error || 'Failed to load users');
     } else {
-      var users = (data.result && data.result.users) || [];
-      if (!users.length) {
-        sel.innerHTML = '<option value="admin">admin</option>';
-      } else {
-        var opt = function(u) {
-          var label = u.name ? (u.name + ' — ' + u.login) : u.login;
-          return '<option value="' + escAttr(u.login) + '"' +
-            (u.login === 'admin' ? ' selected' : '') + '>' + esc(label) + '</option>';
-        };
-        var internal = users.filter(function(u) { return !u.share; });
-        var portal = users.filter(function(u) { return u.share; });
-        var html = '';
-        if (internal.length) html += '<optgroup label="Internal">' + internal.map(opt).join('') + '</optgroup>';
-        if (portal.length) html += '<optgroup label="Portal">' + portal.map(opt).join('') + '</optgroup>';
-        sel.innerHTML = html;
-      }
+      fillConnectSelects((data.result && data.result.users) || []);
     }
   } catch (e) {
-    sel.innerHTML = '<option value="admin">admin</option>';
-    showToast('Connection error: ' + e.message, true);
+    fillConnectSelects([], 'Connection error: ' + e.message);
   }
-  sel.disabled = false;
   submit.disabled = false;
 }
 
@@ -2820,7 +2846,9 @@ function closeConnect(event) {
 }
 
 async function submitConnect() {
-  var user = document.getElementById('connect-user').value || 'admin';
+  var user = document.getElementById('connect-user-internal').value ||
+    document.getElementById('connect-user-portal').value;
+  if (!user) { showToast('Select an internal or portal user', true); return; }
   var btn = document.getElementById('connect-submit');
   var prev = btn.textContent;
   btn.disabled = true;

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -43,6 +43,7 @@ from oduflow.docker_ops import (
 )
 from oduflow import activity
 from oduflow import agent_config
+from oduflow import connect_tokens
 from oduflow import git_ops
 from oduflow import import_tokens
 from oduflow import production_registry
@@ -93,6 +94,9 @@ _PUBLIC_PATHS = frozenset(
         # GitHub can't carry a UI session; the handler verifies its own
         # X-Hub-Signature-256 HMAC against per-team webhook secrets.
         "/api/webhooks/github",
+        # Cross-subdomain Connect As landing: reached on an ENV host (no
+        # dashboard session there), authenticated by its own one-time token.
+        "/oduflow-connect",
     }
 )
 _PUBLIC_PREFIXES = ("/static/",)
@@ -2502,16 +2506,24 @@ def _build_routes(
             )
 
     async def api_connect_open(request: Request) -> Response:
-        """Same-host "Open": mint a session and land the browser in the env
-        already logged in.
+        """ "Open": mint a session and land the browser in the env already
+        logged in.
 
         The dashboard's Open button can't set the session_id cookie from
         JavaScript: Odoo issues session_id as HttpOnly and cookies are shared
         across localhost ports, so a ``document.cookie`` write is silently
-        dropped and the env keeps the browser's stale session. Setting it here
-        via an HTTP Set-Cookie overrides the HttpOnly cookie, and the redirect
-        lands authenticated. Only meaningful when the dashboard and env share a
-        host (local/port mode) — the frontend only calls this in that case.
+        dropped and the env keeps the browser's stale session.
+
+        Port / same-host mode: the dashboard and env share a host, so an HTTP
+        Set-Cookie here (which overrides the HttpOnly cookie) reaches the env and
+        the redirect lands authenticated.
+
+        Traefik mode: the env lives on its own host, so a cookie set here would
+        not reach it (and a parent-domain cookie would not override a stale
+        host-only session_id on the env host). Instead mint the session, stash it
+        behind a one-time token, and 303 the browser to the env's own
+        ``/oduflow-connect`` (routed to Oduflow by Traefik), which sets the cookie
+        host-only there.
         """
         branch = request.path_params["branch"]
         try:
@@ -2520,6 +2532,11 @@ def _build_routes(
             user = (request.query_params.get("user") or "admin").strip() or "admin"
             activity.touch(team, branch)
             result = odoo_ops.connect_as_user(settings, team, branch, user)
+            if settings.routing_mode == "traefik":
+                env_host = result["cookie_domain"]
+                token = connect_tokens.issue(env_host, result["sid"])
+                landing = f"https://{env_host}/oduflow-connect?token={token}"
+                return RedirectResponse(landing, status_code=303)
             response: Response = RedirectResponse(result["url"], status_code=303)
             # Host-only cookie (no domain): scoped to the dashboard's host and,
             # since cookies ignore ports, sent to the env on the same host.
@@ -2541,6 +2558,37 @@ def _build_routes(
             return Response(
                 f"Connect failed: {e}", status_code=500, media_type="text/plain"
             )
+
+    async def api_connect_land(request: Request) -> Response:
+        """Traefik cross-subdomain Connect As landing, served ON the env host.
+
+        Consumes the one-time token minted by :func:`api_connect_open`, sets the
+        env's ``session_id`` cookie HOST-ONLY (no ``Domain`` → scoped to this env
+        host, so it overrides any stale host-only cookie Odoo left here), and
+        303-redirects to ``/web`` already authenticated. No dashboard session is
+        required or present on this host; the token is the sole credential.
+        """
+        token = request.query_params.get("token") or ""
+        env_host = request.url.hostname or ""
+        sid = connect_tokens.consume(token, env_host)
+        if not sid:
+            return Response(
+                "Connect link is invalid or expired. Reopen it from the dashboard.",
+                status_code=400,
+                media_type="text/plain",
+            )
+        response: Response = RedirectResponse(
+            f"https://{env_host}/web", status_code=303
+        )
+        response.set_cookie(
+            "session_id",
+            sid,
+            path="/",
+            httponly=True,
+            samesite="lax",
+            secure=_is_secure_request(request),
+        )
+        return response
 
     async def ws_terminal(websocket: WebSocket) -> None:
         branch = websocket.path_params["branch"]
@@ -3782,6 +3830,9 @@ def _build_routes(
             api_connect_open,
             methods=["GET"],
         ),
+        # Served on an env host (routed here by Traefik's PathPrefix router);
+        # public + token-authenticated. See api_connect_land.
+        Route("/oduflow-connect", api_connect_land, methods=["GET"]),
         Route("/api/environments/{branch:path}/update", api_update, methods=["POST"]),
         Route(
             "/api/environments/{branch:path}/recreate", api_recreate, methods=["POST"]

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2501,6 +2501,47 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
 
+    async def api_connect_open(request: Request) -> Response:
+        """Same-host "Open": mint a session and land the browser in the env
+        already logged in.
+
+        The dashboard's Open button can't set the session_id cookie from
+        JavaScript: Odoo issues session_id as HttpOnly and cookies are shared
+        across localhost ports, so a ``document.cookie`` write is silently
+        dropped and the env keeps the browser's stale session. Setting it here
+        via an HTTP Set-Cookie overrides the HttpOnly cookie, and the redirect
+        lands authenticated. Only meaningful when the dashboard and env share a
+        host (local/port mode) — the frontend only calls this in that case.
+        """
+        branch = request.path_params["branch"]
+        try:
+            settings = get_settings()
+            team = _get_ui_team(request)
+            user = (request.query_params.get("user") or "admin").strip() or "admin"
+            activity.touch(team, branch)
+            result = odoo_ops.connect_as_user(settings, team, branch, user)
+            response: Response = RedirectResponse(result["url"], status_code=303)
+            # Host-only cookie (no domain): scoped to the dashboard's host and,
+            # since cookies ignore ports, sent to the env on the same host.
+            # HttpOnly mirrors Odoo's own session_id so it overrides it cleanly.
+            response.set_cookie(
+                "session_id",
+                result["sid"],
+                path="/",
+                httponly=True,
+                samesite="lax",
+            )
+            return response
+        except FlowError as e:
+            return Response(
+                f"Connect failed: {e}", status_code=400, media_type="text/plain"
+            )
+        except Exception as e:
+            logger.exception("Unexpected error in api_connect_open")
+            return Response(
+                f"Connect failed: {e}", status_code=500, media_type="text/plain"
+            )
+
     async def ws_terminal(websocket: WebSocket) -> None:
         branch = websocket.path_params["branch"]
         await websocket.accept()
@@ -3735,6 +3776,11 @@ def _build_routes(
             "/api/environments/{branch:path}/connect-as",
             api_connect_as,
             methods=["POST"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/connect-open",
+            api_connect_open,
+            methods=["GET"],
         ),
         Route("/api/environments/{branch:path}/update", api_update, methods=["POST"]),
         Route(

--- a/tests/test_connect_tokens.py
+++ b/tests/test_connect_tokens.py
@@ -1,0 +1,34 @@
+"""One-time token store for the cross-subdomain Connect As landing."""
+
+from oduflow import connect_tokens
+
+
+def test_issue_then_consume_returns_sid_once():
+    token = connect_tokens.issue("180.dev.example.com", "sid-abc")
+    assert connect_tokens.consume(token, "180.dev.example.com") == "sid-abc"
+    # One-time: a second consume of the same token fails.
+    assert connect_tokens.consume(token, "180.dev.example.com") is None
+
+
+def test_unknown_token_returns_none():
+    assert connect_tokens.consume("does-not-exist", "180.dev.example.com") is None
+
+
+def test_host_mismatch_rejected():
+    token = connect_tokens.issue("180.dev.example.com", "sid")
+    assert connect_tokens.consume(token, "181.dev.example.com") is None
+
+
+def test_host_match_is_case_insensitive():
+    token = connect_tokens.issue("180.DEV.Example.com", "sid")
+    assert connect_tokens.consume(token, "180.dev.example.COM") == "sid"
+
+
+def test_valid_within_ttl():
+    token = connect_tokens.issue("h", "sid", now=1000.0)
+    assert connect_tokens.consume(token, "h", now=1000.0 + 119) == "sid"
+
+
+def test_expired_token_rejected():
+    token = connect_tokens.issue("h", "sid", now=1000.0)
+    assert connect_tokens.consume(token, "h", now=1000.0 + 121) is None

--- a/tests/test_traefik_tls.py
+++ b/tests/test_traefik_tls.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import docker
 
 from oduflow.docker_ops import system_ops
+from oduflow.docker_ops.env_ops import build_env_traefik_labels
 from oduflow.settings import ExtraRoute, Settings, TeamSettings
 
 
@@ -37,6 +38,27 @@ class TestWriteDynamicConfig:
         router = json.loads(cfg.read_text())["http"]["routers"]["oduflow-team-1"]
         assert router["entryPoints"] == ["web"]
         assert "tls" not in router
+
+    def test_connect_landing_router_high_priority(self, tmp_path):
+        cfg = tmp_path / "traefik.yml"
+        system_ops._write_traefik_dynamic_config(
+            _traefik_settings(tmp_path, False), str(cfg)
+        )
+        router = json.loads(cfg.read_text())["http"]["routers"]["oduflow-connect"]
+        assert router["rule"] == "PathPrefix(`/oduflow-connect`)"
+        assert router["service"] == "oduflow"
+        # Must outrank the env's docker Host(...) router for this path.
+        assert router["priority"] == 100000
+        assert router["entryPoints"] == ["web"]
+
+    def test_connect_landing_router_tls_entrypoint(self, tmp_path):
+        cfg = tmp_path / "traefik.yml"
+        system_ops._write_traefik_dynamic_config(
+            _traefik_settings(tmp_path, True), str(cfg)
+        )
+        router = json.loads(cfg.read_text())["http"]["routers"]["oduflow-connect"]
+        assert router["entryPoints"] == ["websecure"]
+        assert router["tls"] == {"certResolver": "letsencrypt"}
 
     def test_extra_route_generates_router_and_service(self, tmp_path):
         cfg = tmp_path / "traefik.yml"
@@ -204,3 +226,51 @@ class TestEnsureTraefik:
         system_ops._ensure_traefik(client, _traefik_settings(tmp_path, False))
         existing.remove.assert_not_called()
         client.containers.run.assert_not_called()
+
+
+def _env_settings(routing_mode, tls):
+    team = TeamSettings(team_id="1", hostname="dev.example.com")
+    return Settings(
+        routing_mode=routing_mode,
+        routing_tls=tls,
+        teams={"1": team},
+    )
+
+
+class TestBuildEnvTraefikLabels:
+    """A3: single source of an environment's Traefik routing labels."""
+
+    ENV = "18.0"  # slug "180"
+    ROUTER = "oduflow-1-180"
+
+    def _labels(self, routing_mode, tls):
+        settings = _env_settings(routing_mode, tls)
+        return build_env_traefik_labels(settings, settings.teams["1"], self.ENV)
+
+    def test_port_mode_has_no_traefik_labels(self):
+        assert self._labels("port", False) == {}
+        assert self._labels("port", True) == {}
+
+    def test_no_tls_uses_web_entrypoint(self):
+        labels = self._labels("traefik", False)
+        assert labels["traefik.enable"] == "true"
+        assert (
+            labels[f"traefik.http.routers.{self.ROUTER}.rule"]
+            == "Host(`180.dev.example.com`)"
+        )
+        assert (
+            labels[f"traefik.http.services.{self.ROUTER}.loadbalancer.server.port"]
+            == "8069"
+        )
+        assert labels["traefik.docker.network"] == "oduflow-1-net"
+        assert labels[f"traefik.http.routers.{self.ROUTER}.entrypoints"] == "web"
+        assert f"traefik.http.routers.{self.ROUTER}.tls" not in labels
+
+    def test_tls_uses_websecure_and_certresolver(self):
+        labels = self._labels("traefik", True)
+        assert labels[f"traefik.http.routers.{self.ROUTER}.entrypoints"] == "websecure"
+        assert labels[f"traefik.http.routers.{self.ROUTER}.tls"] == "true"
+        assert (
+            labels[f"traefik.http.routers.{self.ROUTER}.tls.certresolver"]
+            == "letsencrypt"
+        )

--- a/tests/test_web_ui_connect_as.py
+++ b/tests/test_web_ui_connect_as.py
@@ -99,8 +99,8 @@ def test_connect_as_error_surfaced(tmp_path):
 def test_env_users_lists(tmp_path):
     client = _client(_open_settings(tmp_path))
     users = [
-        {"login": "admin", "name": "Mitchell Admin", "share": False},
-        {"login": "portal", "name": "Portal User", "share": True},
+        {"login": "admin", "name": "Mitchell Admin", "share": False, "portal": False},
+        {"login": "portal", "name": "Portal User", "share": True, "portal": True},
     ]
     with patch("oduflow.web_ui.odoo_ops.list_env_users", return_value=users):
         resp = client.get("/api/environments/18.0/users")

--- a/tests/test_web_ui_connect_as.py
+++ b/tests/test_web_ui_connect_as.py
@@ -136,6 +136,99 @@ def test_connect_open_defaults_to_admin(tmp_path):
     assert mock.call_args.args[3] == "admin"
 
 
+def _traefik_settings(tmp_path):
+    return Settings(
+        routing_mode="traefik",
+        routing_tls=False,
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1", hostname="dev.example.com")},
+    )
+
+
+_MINT_TRAEFIK = {
+    "sid": "t" * 80,
+    "login": "jane@acme.com",
+    "uid": "7",
+    "base_url": "https://180.dev.example.com",
+    "cookie_domain": "180.dev.example.com",
+    "url": "https://180.dev.example.com/web",
+    "expires_at": "2026-07-20T00:00:00Z",
+}
+
+
+def test_connect_open_traefik_redirects_to_token_landing(tmp_path):
+    # In traefik mode the env is on its own host, so connect-open does NOT set a
+    # cookie here; it hands the browser a token and lands it on the env host.
+    client = _client(_traefik_settings(tmp_path))
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user", return_value=dict(_MINT_TRAEFIK)
+        ),
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        resp = client.get(
+            "/api/environments/18.0/connect-open",
+            params={"user": "jane@acme.com"},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 303
+    loc = resp.headers["location"]
+    assert loc.startswith("https://180.dev.example.com/oduflow-connect?token=")
+    assert "session_id" not in resp.headers.get("set-cookie", "")
+
+
+def test_connect_land_sets_host_only_cookie_and_redirects(tmp_path):
+    from urllib.parse import parse_qs, urlparse
+
+    client = _client(_traefik_settings(tmp_path))
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user", return_value=dict(_MINT_TRAEFIK)
+        ),
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        r1 = client.get(
+            "/api/environments/18.0/connect-open",
+            params={"user": "jane@acme.com"},
+            follow_redirects=False,
+        )
+    token = parse_qs(urlparse(r1.headers["location"]).query)["token"][0]
+
+    # Land on the env host (Traefik would route /oduflow-connect here).
+    r2 = client.get(
+        "/oduflow-connect",
+        params={"token": token},
+        headers={"host": "180.dev.example.com"},
+        follow_redirects=False,
+    )
+    assert r2.status_code == 303
+    assert r2.headers["location"] == "https://180.dev.example.com/web"
+    set_cookie = r2.headers["set-cookie"]
+    assert "session_id=" + "t" * 80 in set_cookie
+    assert "httponly" in set_cookie.lower()
+    # Host-only: no Domain attribute, so it overrides Odoo's own host cookie.
+    assert "domain=" not in set_cookie.lower()
+    # One-time: reusing the token now fails.
+    r3 = client.get(
+        "/oduflow-connect",
+        params={"token": token},
+        headers={"host": "180.dev.example.com"},
+        follow_redirects=False,
+    )
+    assert r3.status_code == 400
+
+
+def test_connect_land_rejects_unknown_token(tmp_path):
+    client = _client(_traefik_settings(tmp_path))
+    r = client.get(
+        "/oduflow-connect",
+        params={"token": "nope"},
+        headers={"host": "180.dev.example.com"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 400
+
+
 def test_env_users_lists(tmp_path):
     client = _client(_open_settings(tmp_path))
     users = [

--- a/tests/test_web_ui_connect_as.py
+++ b/tests/test_web_ui_connect_as.py
@@ -1,8 +1,11 @@
 """REST endpoints behind the dashboard's Connect As button (issue #78).
 
 api_connect_as mints a session and returns the cookie payload; api_env_users
-feeds the user picker. Both delegate to odoo_ops and are exercised here with the
-docker layer mocked, mirroring test_web_ui_create_lock's TestClient harness.
+feeds the user picker; api_connect_open is the same-host "Open" bridge that mints
+a session and 303-redirects into the env with the session_id set via HTTP
+Set-Cookie (so it overrides Odoo's HttpOnly cookie, which JS can't touch). All
+delegate to odoo_ops and are exercised here with the docker layer mocked,
+mirroring test_web_ui_create_lock's TestClient harness.
 """
 
 from unittest.mock import patch
@@ -94,6 +97,43 @@ def test_connect_as_error_surfaced(tmp_path):
     data = resp.json()
     assert data["ok"] is False
     assert data.get("error")
+
+
+def test_connect_open_redirects_and_sets_cookie(tmp_path):
+    client = _client(_open_settings(tmp_path))
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user", return_value=dict(_MINT)
+        ) as mock,
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        resp = client.get(
+            "/api/environments/18.0/connect-open",
+            params={"user": "jane@acme.com"},
+            follow_redirects=False,
+        )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "http://localhost:50001/web"
+    # session_id set server-side + HttpOnly so it overrides Odoo's HttpOnly cookie
+    # that a JS document.cookie write cannot touch.
+    set_cookie = resp.headers["set-cookie"]
+    assert "session_id=" + "s" * 80 in set_cookie
+    assert "httponly" in set_cookie.lower()
+    # (settings, team, branch, user) — branch from the URL, user from the query.
+    assert mock.call_args.args[2] == "18.0"
+    assert mock.call_args.args[3] == "jane@acme.com"
+
+
+def test_connect_open_defaults_to_admin(tmp_path):
+    client = _client(_open_settings(tmp_path))
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user", return_value=dict(_MINT)
+        ) as mock,
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        client.get("/api/environments/18.0/connect-open", follow_redirects=False)
+    assert mock.call_args.args[3] == "admin"
 
 
 def test_env_users_lists(tmp_path):


### PR DESCRIPTION
## Summary

Makes the dashboard **Connect As** flow work end to end (including across env subdomains under Traefik), and lets a routing-mode switch be repaired without recreating environments.

### Connect As user picker
- Split the picker into **Internal** and **Portal** selects (mutually exclusive), preselecting `admin` for the common one-click case.

### Cross-subdomain "Open" login (Traefik)
- Under Traefik each env lives on its own subdomain, so the dashboard can't set the env's `session_id` cookie directly. A parent-domain cookie doesn't help — per RFC 6265 it doesn't override a stale host-only `session_id` Odoo may have left on the env host.
- New flow (odoo.sh-style, no Odoo addon): `connect_as_user` mints the session, a **one-time, host-bound token** (`connect_tokens`) is issued, and the browser lands on the env's own `/oduflow-connect` — a high-priority Traefik `PathPrefix` router that sends only that path to Oduflow, which sets `session_id` **host-only** there (overriding any stale cookie) and 303s to `/web`. Port/same-host mode is unchanged.
- The dialog is simplified to a user picker + one **Connect** button that opens the env already logged in; the URL/cookie/copy affordances are dropped (Playwright/API callers use the `connect_as_user` MCP tool).

### Routing-label regeneration on update
- `update_environment` now recomputes an environment's Traefik routing labels from the **current** settings (via a shared `build_env_traefik_labels` helper, also used by `create_environment`) instead of copying the old container's frozen labels. This repairs a `port`↔`traefik` / TLS / hostname switch with a plain `update_environment` (preserving the DB) instead of destroy+create; the published host port is allocated/released symmetrically.

## Tests
- New unit tests: `connect_tokens` (issue/consume/expiry/host-binding), the Traefik connect-open→token→landing flow, the `oduflow-connect` dynamic router, and `build_env_traefik_labels`.
- Full unit suite green (`pytest -m "not integration and not heavyweight"`), `ruff` clean.

## Decision record
- Adds `specs/0036-cross-subdomain-connect-as-landing.md` (realises the token-URL form deferred in 0031, without the per-env addon it assumed).