### PR TITLE
Quiet benign "Stateless session crashed" logs on MCP client disconnect

### DIFF
--- a/src/oduflow/mcp_log_filters.py
+++ b/src/oduflow/mcp_log_filters.py
@@ -1,0 +1,85 @@
+"""Log hygiene for the MCP StreamableHTTP stateless transport.
+
+The MCP SDK runs every stateless request's tool call in its own task
+(``mcp.server.streamable_http_manager.run_stateless_server``). When a client
+disconnects before a long-running tool (e.g. ``create_environment``) finishes,
+the tool still completes server-side, but its final response is written to an
+already-closed stream. anyio then raises ``ClosedResourceError`` — usually
+wrapped in a task-group ``ExceptionGroup`` — which the SDK logs at ERROR with a
+full traceback as ``"Stateless session crashed"``.
+
+That is benign: the operation itself succeeded; only response *delivery* failed
+because the client went away. This module installs a logging filter that drops
+those specific records (leaving a quiet DEBUG breadcrumb) while letting genuine
+stateless crashes through untouched.
+
+Note on why we drop rather than downgrade: ``logging.basicConfig`` installs a
+root handler at NOTSET, so a record that survives the originating logger's level
+check (ERROR passes INFO) is emitted regardless of its level. Rewriting the
+record to DEBUG would therefore still print it. Returning ``False`` is the only
+reliable way to suppress it by default.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+
+logger = logging.getLogger("oduflow")
+
+_SDK_LOGGER_NAME = "mcp.server.streamable_http_manager"
+_CRASH_MESSAGE = "Stateless session crashed"
+
+# Stream-closed errors that mean the peer vanished before we could reply.
+_DISCONNECT_ERRORS = (ClosedResourceError, BrokenResourceError, EndOfStream)
+
+
+def _is_client_disconnect(exc: BaseException | None) -> bool:
+    """True if ``exc`` is — or is an ``ExceptionGroup`` composed *solely* of —
+    a stream-closed error signalling the client disconnected before the
+    response could be sent.
+
+    Requiring *every* member of a group to be a disconnect (``all``) keeps a
+    real error mixed into the group from being silently swallowed.
+    """
+    if exc is None:
+        return False
+    if isinstance(exc, _DISCONNECT_ERRORS):
+        return True
+    # anyio surfaces task-group failures as an ExceptionGroup (``.exceptions``);
+    # unwrap without importing BaseExceptionGroup so this also works on 3.10.
+    nested = getattr(exc, "exceptions", None)
+    if isinstance(nested, tuple) and nested:
+        return all(_is_client_disconnect(sub) for sub in nested)
+    return False
+
+
+class StatelessDisconnectFilter(logging.Filter):
+    """Silence the SDK's ``"Stateless session crashed"`` ERROR when it is only
+    a client disconnect: drop the record (return ``False``) and leave a DEBUG
+    breadcrumb. Every other record — including genuine stateless crashes —
+    passes through unchanged.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.getMessage() != _CRASH_MESSAGE:
+            return True
+        exc = record.exc_info[1] if record.exc_info else None
+        if not _is_client_disconnect(exc):
+            return True
+        # Gated by the "oduflow" logger's level (INFO by default), so this is
+        # silent unless the operator turns on DEBUG.
+        logger.debug(
+            "MCP client disconnected before the tool finished; response not "
+            "delivered (the operation itself completed)."
+        )
+        return False
+
+
+def install_stateless_disconnect_filter() -> None:
+    """Attach :class:`StatelessDisconnectFilter` to the MCP SDK logger, once."""
+    sdk_logger = logging.getLogger(_SDK_LOGGER_NAME)
+    if any(isinstance(f, StatelessDisconnectFilter) for f in sdk_logger.filters):
+        return
+    sdk_logger.addFilter(StatelessDisconnectFilter())

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4669,6 +4669,14 @@ def _start_http() -> None:
 
     import uvicorn
 
+    from oduflow.mcp_log_filters import install_stateless_disconnect_filter
+
+    # A client that disconnects mid-tool (long ops like create_environment can
+    # outlast its HTTP timeout) makes the SDK log a benign ClosedResourceError
+    # as an ERROR "Stateless session crashed" traceback. Quiet those; the
+    # operation itself still completes server-side.
+    install_stateless_disconnect_filter()
+
     # Outermost shim so /mcp/<env> routes to the canonical /mcp route.
     served: Any = ScopedEnvASGI(app)
     # When the OAuth issuer is derived per-request (traefik, no fixed

--- a/tests/test_mcp_log_filters.py
+++ b/tests/test_mcp_log_filters.py
@@ -1,0 +1,122 @@
+"""Unit tests for the stateless-transport log filter."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
+
+if sys.version_info < (3, 11):  # ExceptionGroup is a builtin only on 3.11+
+    from exceptiongroup import ExceptionGroup  # type: ignore[import-not-found]
+
+from oduflow.mcp_log_filters import (
+    StatelessDisconnectFilter,
+    _is_client_disconnect,
+    install_stateless_disconnect_filter,
+)
+
+
+def _exc_info(exc: BaseException):
+    """Return a (type, value, tb) tuple with a real traceback for ``exc``."""
+    try:
+        raise exc
+    except BaseException:  # noqa: BLE001 - re-raise to capture exc_info
+        return sys.exc_info()
+
+
+def _crash_record(exc: BaseException | None) -> logging.LogRecord:
+    """Build the record the SDK emits via ``logger.exception(...)``."""
+    return logging.LogRecord(
+        name="mcp.server.streamable_http_manager",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="Stateless session crashed",
+        args=(),
+        exc_info=_exc_info(exc) if exc is not None else None,
+    )
+
+
+class TestIsClientDisconnect:
+    def test_none(self):
+        assert _is_client_disconnect(None) is False
+
+    def test_closed_resource(self):
+        assert _is_client_disconnect(ClosedResourceError()) is True
+
+    def test_broken_resource(self):
+        assert _is_client_disconnect(BrokenResourceError()) is True
+
+    def test_end_of_stream(self):
+        assert _is_client_disconnect(EndOfStream()) is True
+
+    def test_unrelated_error(self):
+        assert _is_client_disconnect(ValueError("boom")) is False
+
+    def test_exception_group_all_disconnect(self):
+        group = ExceptionGroup("tg", [ClosedResourceError()])
+        assert _is_client_disconnect(group) is True
+
+    def test_exception_group_nested(self):
+        inner = ExceptionGroup("inner", [ClosedResourceError()])
+        outer = ExceptionGroup("outer", [inner])
+        assert _is_client_disconnect(outer) is True
+
+    def test_exception_group_mixed_is_not_disconnect(self):
+        # A real error mixed in must NOT be swallowed.
+        group = ExceptionGroup("tg", [ClosedResourceError(), ValueError("real")])
+        assert _is_client_disconnect(group) is False
+
+
+class TestStatelessDisconnectFilter:
+    def test_drops_client_disconnect(self):
+        f = StatelessDisconnectFilter()
+        record = _crash_record(ExceptionGroup("tg", [ClosedResourceError()]))
+        assert f.filter(record) is False
+
+    def test_keeps_genuine_crash(self):
+        f = StatelessDisconnectFilter()
+        record = _crash_record(RuntimeError("something actually broke"))
+        assert f.filter(record) is True
+
+    def test_keeps_other_messages(self):
+        f = StatelessDisconnectFilter()
+        record = logging.LogRecord(
+            name="mcp.server.streamable_http_manager",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="Terminating session: %s",
+            args=("abc",),
+            exc_info=None,
+        )
+        assert f.filter(record) is True
+
+    def test_keeps_crash_message_without_exc_info(self):
+        f = StatelessDisconnectFilter()
+        assert f.filter(_crash_record(None)) is True
+
+
+class TestInstall:
+    def test_idempotent_and_attached_to_sdk_logger(self):
+        sdk_logger = logging.getLogger("mcp.server.streamable_http_manager")
+        before = [
+            fltr
+            for fltr in sdk_logger.filters
+            if isinstance(fltr, StatelessDisconnectFilter)
+        ]
+        try:
+            install_stateless_disconnect_filter()
+            install_stateless_disconnect_filter()
+            attached = [
+                fltr
+                for fltr in sdk_logger.filters
+                if isinstance(fltr, StatelessDisconnectFilter)
+            ]
+            assert len(attached) == 1
+        finally:
+            # Restore the pre-test filter set so this test stays isolated.
+            for fltr in list(sdk_logger.filters):
+                if isinstance(fltr, StatelessDisconnectFilter) and fltr not in before:
+                    sdk_logger.removeFilter(fltr)


### PR DESCRIPTION
When an MCP client disconnects before a long-running tool (e.g. `create_environment`) finishes, the SDK logs the resulting anyio `ClosedResourceError` as an ERROR `Stateless session crashed` traceback even though the operation itself completes server-side. This adds a `StatelessDisconnectFilter` on the `mcp.server.streamable_http_manager` logger that drops those specific records (leaving a quiet DEBUG breadcrumb) while letting genuine crashes — and `ExceptionGroup`s mixing a real error with a disconnect — through untouched. The filter is installed in `_start_http()` and is Python 3.10-safe (unwraps `ExceptionGroup` via `getattr(..., "exceptions")` rather than importing `BaseExceptionGroup`). Behavior is unchanged; this is log hygiene only, covered by 13 unit tests.