### PR TITLE
Make template dump cleanup concurrency-safe

### DIFF
--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -14,6 +14,7 @@ import stat
 import subprocess
 import tarfile
 import time
+import uuid
 from importlib.metadata import PackageNotFoundError, version
 
 import docker
@@ -988,7 +989,11 @@ def _is_text_dump(path: str) -> bool:
 
 
 def _copy_file_to_container(
-    container: docker.models.containers.Container, src_path: str, dest_dir: str
+    container: docker.models.containers.Container,
+    src_path: str,
+    dest_dir: str,
+    *,
+    archive_name: str | None = None,
 ) -> None:
     import tempfile
 
@@ -996,7 +1001,7 @@ def _copy_file_to_container(
         tmp_path = tmp.name
     try:
         with tarfile.open(tmp_path, mode="w") as tar:
-            tar.add(src_path, arcname=os.path.basename(src_path))
+            tar.add(src_path, arcname=archive_name or os.path.basename(src_path))
         with open(tmp_path, "rb") as f:
             container.put_archive(dest_dir, f)
     finally:
@@ -1554,17 +1559,27 @@ def reload_template(
     _exec_sql(client, settings, f'CREATE DATABASE "{tpl_db}" TABLESPACE "{ts_name}";')
 
     db_container = client.containers.get(settings.shared_db_container)
-    tmp_name = os.path.basename(resolved_dump)
-
     # Every dump copied into the db container's /tmp for pg_restore/psql is a
     # full-size file in the container's writable layer. Track each copy and
     # delete it in the finally below once the restore is done — otherwise every
     # import/reload/refresh leaves the dump behind and the oduflow-db container
     # grows without bound (mirrors the prod seed cleanup in production_ops).
-    container_tmp_files = {tmp_name}
-    _copy_file_to_container(db_container, resolved_dump, "/tmp")
+    container_tmp_files: set[str] = set()
 
     try:
+        # The DB container is shared across teams, whose locks do not contend.
+        # Use an opaque per-restore name so one restore cannot overwrite or
+        # clean up another restore's input file.
+        container_dump_name = f"oduflow-restore-{uuid.uuid4().hex}"
+        container_dump_path = f"/tmp/{container_dump_name}"
+        container_tmp_files.add(container_dump_path)
+        _copy_file_to_container(
+            db_container,
+            resolved_dump,
+            "/tmp",
+            archive_name=container_dump_name,
+        )
+
         # pg_restore runs with --no-owner so restored objects are owned by the
         # restoring superuser, not by whatever role the dump recorded. For
         # env-derived templates that role is the source env's per-env role
@@ -1577,10 +1592,10 @@ def reload_template(
         restore_tool = "psql" if use_psql else "pg_restore"
         if is_gzipped:
             if use_psql:
-                pipeline = f"gunzip -c /tmp/{tmp_name} | psql -U {settings.db_user} -d {tpl_db}"
+                pipeline = f"gunzip -c {container_dump_path} | psql -U {settings.db_user} -d {tpl_db}"
             else:
                 pipeline = (
-                    f"gunzip -c /tmp/{tmp_name} | "
+                    f"gunzip -c {container_dump_path} | "
                     f"pg_restore --no-owner -U {settings.db_user} -d {tpl_db}"
                 )
             restore_cmd = ["bash", "-c", f"set -o pipefail; {pipeline}"]
@@ -1593,7 +1608,7 @@ def reload_template(
                     "-d",
                     tpl_db,
                     "-f",
-                    f"/tmp/{tmp_name}",
+                    container_dump_path,
                 ]
             else:
                 restore_cmd = [
@@ -1603,7 +1618,7 @@ def reload_template(
                     settings.db_user,
                     "-d",
                     tpl_db,
-                    f"/tmp/{tmp_name}",
+                    container_dump_path,
                 ]
 
         logger.info(
@@ -1648,9 +1663,15 @@ def reload_template(
                     exit_code = helper_exit
                     output_str = helper_output
                 else:
-                    helper_tmp_name = os.path.basename(helper_sql_path)
-                    _copy_file_to_container(db_container, helper_sql_path, "/tmp")
-                    container_tmp_files.add(helper_tmp_name)
+                    helper_container_name = f"oduflow-restore-{uuid.uuid4().hex}"
+                    helper_container_path = f"/tmp/{helper_container_name}"
+                    container_tmp_files.add(helper_container_path)
+                    _copy_file_to_container(
+                        db_container,
+                        helper_sql_path,
+                        "/tmp",
+                        archive_name=helper_container_name,
+                    )
                     psql_cmd = [
                         "psql",
                         "-U",
@@ -1658,7 +1679,7 @@ def reload_template(
                         "-d",
                         tpl_db,
                         "-f",
-                        f"/tmp/{helper_tmp_name}",
+                        helper_container_path,
                     ]
                     psql_start = time.monotonic()
                     exit_code, output = db_container.exec_run(psql_cmd)
@@ -1764,7 +1785,7 @@ def reload_template(
         # exited (success, restore error, or an unexpected failure mid-flight).
         for _leftover in container_tmp_files:
             with contextlib.suppress(Exception):
-                db_container.exec_run(["rm", "-f", f"/tmp/{_leftover}"])
+                db_container.exec_run(["rm", "-f", _leftover])
 
 
 def init_template(

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -512,6 +512,10 @@ class TestCreateEnvironment:
 class TestReloadTemplate:
     @patch("oduflow.docker_ops.system_ops._update_template_sizes")
     @patch("oduflow.docker_ops.system_ops._copy_file_to_container")
+    @patch(
+        "oduflow.docker_ops.system_ops.ensure_team_tablespace",
+        return_value="oduflow_team_1",
+    )
     @patch("oduflow.docker_ops.system_ops._is_text_dump", return_value=False)
     @patch("oduflow.docker_ops.system_ops._db_exists", return_value=False)
     @patch("oduflow.docker_ops.system_ops._exec_sql", return_value="5")
@@ -524,6 +528,7 @@ class TestReloadTemplate:
         mock_sql,
         mock_db_exists,
         mock_text,
+        mock_tablespace,
         mock_copy,
         mock_sizes,
         mock_docker_client,
@@ -537,6 +542,12 @@ class TestReloadTemplate:
         mock_docker_client.containers.get.return_value = db_container
 
         system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
+        system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
+
+        archive_names = [
+            call.kwargs["archive_name"] for call in mock_copy.call_args_list
+        ]
+        assert len(set(archive_names)) == 2
 
         # exec_run is also used for the post-restore /tmp cleanup, so locate the
         # pg_restore invocation explicitly rather than assuming it is the last.
@@ -546,8 +557,10 @@ class TestReloadTemplate:
             if "pg_restore" in " ".join(call.args[0])
         ]
         assert restore_cmds, "expected a pg_restore invocation"
-        joined = " ".join(restore_cmds[0])
-        assert "--no-owner" in joined
+        assert all("--no-owner" in " ".join(cmd) for cmd in restore_cmds)
+        assert {cmd[-1] for cmd in restore_cmds} == {
+            f"/tmp/{name}" for name in archive_names
+        }
 
         # The dump copied into the container's /tmp must be removed afterwards so
         # the oduflow-db writable layer does not accumulate full-size dumps.
@@ -556,8 +569,44 @@ class TestReloadTemplate:
             for call in db_container.exec_run.call_args_list
             if call.args[0][:2] == ["rm", "-f"]
         ]
-        assert cleanup_cmds, "expected the /tmp dump copy to be cleaned up"
-        assert all(c[2].startswith("/tmp/") for c in cleanup_cmds)
+        assert {cmd[2] for cmd in cleanup_cmds} == {
+            f"/tmp/{name}" for name in archive_names
+        }
+
+    @patch("oduflow.docker_ops.system_ops._update_template_sizes")
+    @patch("oduflow.docker_ops.system_ops._copy_file_to_container")
+    @patch(
+        "oduflow.docker_ops.system_ops.ensure_team_tablespace",
+        return_value="oduflow_team_1",
+    )
+    @patch("oduflow.docker_ops.system_ops._is_text_dump", return_value=False)
+    @patch("oduflow.docker_ops.system_ops._db_exists", return_value=False)
+    @patch("oduflow.docker_ops.system_ops._exec_sql", return_value="5")
+    @patch("oduflow.docker_ops.system_ops._wait_pg_ready")
+    @patch("oduflow.docker_ops.system_ops.os.path.isfile", return_value=True)
+    def test_cleanup_when_initial_copy_fails(
+        self,
+        mock_isfile,
+        mock_wait,
+        mock_sql,
+        mock_db_exists,
+        mock_text,
+        mock_tablespace,
+        mock_copy,
+        mock_sizes,
+        mock_docker_client,
+    ):
+        db_container = MagicMock()
+        mock_docker_client.containers.get.return_value = db_container
+        mock_copy.side_effect = RuntimeError("upload failed")
+
+        with pytest.raises(RuntimeError, match="upload failed"):
+            system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
+
+        archive_name = mock_copy.call_args.kwargs["archive_name"]
+        db_container.exec_run.assert_called_once_with(
+            ["rm", "-f", f"/tmp/{archive_name}"]
+        )
 
     def test_restore_retries_unsupported_archive_with_helper(self, mock_docker_client):
         db_container = MagicMock()
@@ -616,6 +665,57 @@ class TestReloadTemplate:
             'CREATE DATABASE "oduflow_template_1_mytpl"' in call.args[2]
             for call in sql.call_args_list
         )
+
+    def test_cleanup_when_helper_copy_fails(self, mock_docker_client):
+        db_container = MagicMock()
+
+        def _exec_run(cmd, *args, **kwargs):
+            if cmd and cmd[0] == "pg_restore":
+                return (
+                    1,
+                    b"pg_restore: error: unsupported version (1.16) in file header",
+                )
+            return (0, b"")
+
+        db_container.exec_run.side_effect = _exec_run
+        mock_docker_client.containers.get.return_value = db_container
+
+        with (
+            patch("oduflow.docker_ops.system_ops.os.path.isfile", return_value=True),
+            patch("oduflow.docker_ops.system_ops._wait_pg_ready"),
+            patch("oduflow.docker_ops.system_ops._exec_sql", return_value="5"),
+            patch("oduflow.docker_ops.system_ops._db_exists", return_value=False),
+            patch(
+                "oduflow.docker_ops.system_ops.ensure_team_tablespace",
+                return_value="oduflow_team_1",
+            ),
+            patch("oduflow.docker_ops.system_ops._is_text_dump", return_value=False),
+            patch(
+                "oduflow.docker_ops.system_ops._copy_file_to_container",
+                side_effect=[None, RuntimeError("helper upload failed")],
+            ) as copy_file,
+            patch("oduflow.docker_ops.system_ops._update_template_sizes"),
+            patch(
+                "oduflow.docker_ops.system_ops._convert_custom_dump_to_sql_with_helper",
+                return_value=(
+                    0,
+                    "converted",
+                    "/tmp/flow-test/templates/mytpl/dump.sql",
+                ),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="helper upload failed"):
+                system_ops.reload_template(TEST_SETTINGS, TEST_TEAM, "mytpl")
+
+        archive_names = [
+            call.kwargs["archive_name"] for call in copy_file.call_args_list
+        ]
+        cleanup_paths = {
+            call.args[0][2]
+            for call in db_container.exec_run.call_args_list
+            if call.args[0][:2] == ["rm", "-f"]
+        }
+        assert cleanup_paths == {f"/tmp/{name}" for name in archive_names}
 
 
 class TestPullEnvironmentLocal:


### PR DESCRIPTION
## Summary
- stage template dumps under unique per-restore names in the shared DB container
- register cleanup paths before uploads so partial upload failures are reclaimed
- cover concurrent naming and initial/helper upload failure paths

## Validation
- `pytest -m "not integration and not heavyweight" -q` (1105 passed, 15 deselected)
- `ruff check src/oduflow tests`
- `mypy src/oduflow`