### PR TITLE
Reject empty branches for extra addon worktrees

### DIFF
--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -13,6 +13,7 @@ from oduflow.errors import (
     ConflictError,
     ExternalCommandError,
     NotFoundError,
+    PrerequisiteNotMetError,
     ProtectedError,
 )
 from oduflow.git_ops import RepoAuthError, git_env_for_team
@@ -514,6 +515,16 @@ def fetch_extra_repo(
 def create_worktree(
     team: TeamSettings, repo_name: str, branch: str, target_path: str
 ) -> str:
+    # A blank branch would produce `git worktree add ... ""` → the cryptic
+    # `fatal: invalid reference:`. Reject it up front with a clear message,
+    # naming the repo (the empty branch itself is useless in the error). This
+    # is the shared choke point for every caller — env create, production
+    # deploy, webhook auto-deploy — so guarding here covers them all.
+    if not branch or not branch.strip():
+        raise PrerequisiteNotMetError(
+            f"Extra addon repo '{repo_name}' requires a branch (e.g. '18.0'); "
+            "none was given."
+        )
     bare_path = os.path.join(team.shared_repos_dir, repo_name)
     if not os.path.isdir(bare_path):
         raise NotFoundError(f"Extra repo '{repo_name}' not found. Add it first.")

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3553,12 +3553,21 @@ async function submitCreate() {
 
   try {
     var extraAddonsObj = {};
+    var missingBranch = [];
     document.querySelectorAll('.cr-extra-cb:checked').forEach(function(cb) {
       var repoName = cb.value;
       var branchInput = document.querySelector('.cr-extra-branch-input[data-repo="' + repoName + '"]');
       var br = branchInput ? branchInput.value.trim() : '';
-      extraAddonsObj[repoName] = br;
+      if (!br) { missingBranch.push(repoName); }
+      else { extraAddonsObj[repoName] = br; }
     });
+    if (missingBranch.length) {
+      errEl.textContent = 'Branch is required for extra addon(s): ' + missingBranch.join(', ') + '.';
+      errEl.style.display = 'block';
+      btn.disabled = false;
+      btn.textContent = 'Create';
+      return;
+    }
     var payload = {
       env_name: branch,
       repo_url: repo,


### PR DESCRIPTION
## Summary
- reject blank extra-addon branches before invoking git worktree
- surface missing branches directly in the dashboard create flow
- return an actionable prerequisite error naming the affected repository

## Validation
- pytest -q tests/test_extra_addons.py tests/test_extra_addons_clone.py tests/test_extra_addons_local.py tests/test_web_ui_create_lock.py
- ruff check src/oduflow/extra_addons.py
- mypy src/oduflow/extra_addons.py
- JavaScript syntax checks for both dashboard script blocks
- git diff --check