### PR TITLE
Improve hosted agent runtime and MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ By default, the server starts in **stdio** mode (for local MCP clients). For rem
 
 ```bash
 oduflow --transport http
+oduflow -t http
 ```
 
 ### 3. Connect an MCP client

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -28,7 +28,7 @@
 
 FROM node:24-bookworm-slim
 
-ARG CODER_VERSION=0.1.0
+ARG CODER_VERSION=0.2.0
 LABEL org.opencontainers.image.title="oduflow-coder" \
       org.opencontainers.image.version="${CODER_VERSION}" \
       org.opencontainers.image.source="https://github.com/oduist/oduflow"

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -11,8 +11,10 @@
 # the structured browser chat over the same bridge. The container just stays
 # alive.
 #
-# LICENSING: this image bakes in only Apache-2.0 components (OpenAI Codex CLI
-# and the ACP adapters' Codex side), which we may redistribute. Claude Code
+# LICENSING: the published image contains redistributable open-source software.
+# Codex CLI, codex-acp and agent-browser are Apache-2.0; Debian's Chromium
+# package carries its upstream BSD-style/component licenses and preserves the
+# corresponding notices under /usr/share/doc. Claude Code
 # (@anthropic-ai/claude-code) and its ACP adapter are PROPRIETARY-adjacent
 # (Anthropic Commercial Terms; the adapter pulls Anthropic's closed SDK), so
 # they are NOT part of the published image: entrypoint.sh npm-installs them at
@@ -24,7 +26,7 @@
 # (see AGENTS.md "Publishing the Coder Image").
 # See specs/0029-agent-console-and-chat.md.
 
-FROM node:22-bookworm-slim
+FROM node:24-bookworm-slim
 
 ARG CODER_VERSION=0.1.0
 LABEL org.opencontainers.image.title="oduflow-coder" \
@@ -36,16 +38,28 @@ RUN apt-get update \
         git \
         ca-certificates \
         jq \
+        chromium \
     && rm -rf /var/lib/apt/lists/*
 
-# Apache-2.0 components only (redistribution OK):
-#   - OpenAI Codex CLI + its ACP (Agent Client Protocol) adapter.
+# The upstream Node image already reserves uid/gid 1000 for its `node` user.
+# Rename that account instead of inventing another numeric identity: files in
+# the persistent HOME/workspace volumes have one stable owner on every host.
+RUN usermod --login agent --home /home/agent --move-home --shell /bin/bash node \
+    && groupmod --new-name agent node \
+    && mkdir -p /workspace \
+    && chown agent:agent /workspace
+
+# Apache-2.0 npm components (redistribution OK):
+#   - OpenAI Codex CLI + its ACP (Agent Client Protocol) adapter;
+#   - agent-browser, including its stdio MCP server. Pin the browser package so
+#     its MCP surface is deterministic; current releases require Node >= 24.
 # NOTE: the Codex ACP bridge package is still settling (published
 # `@agentclientprotocol/codex-acp`, `@zed-industries/codex-acp` on GitHub, and an
 # emerging native `codex --acp`). Confirm the working one at build time.
 RUN npm install -g \
         @openai/codex \
         @agentclientprotocol/codex-acp \
+        agent-browser@0.32.3 \
     && npm cache clean --force
 
 # Agent auth + sessions live under HOME (mounted from the persistent home
@@ -56,11 +70,12 @@ RUN npm install -g \
 # for the runtime-installed Claude packages also sits on the HOME volume
 # (one-time download, survives recreation); its bin dir is on PATH for both
 # the entrypoint and `docker exec` sessions.
-ENV HOME=/root \
-    CLAUDE_CONFIG_DIR=/root/.claude \
-    CODEX_HOME=/root/.codex \
-    NPM_CONFIG_PREFIX=/root/.npm-global \
-    PATH=/root/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV HOME=/home/agent \
+    CLAUDE_CONFIG_DIR=/home/agent/.claude \
+    CODEX_HOME=/home/agent/.codex \
+    AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium \
+    NPM_CONFIG_PREFIX=/home/agent/.npm-global \
+    PATH=/home/agent/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 WORKDIR /workspace
 
@@ -68,4 +83,5 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY clone-env.sh /usr/local/bin/clone-env.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/clone-env.sh
 
+USER agent
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/agent/clone-env.sh
+++ b/docker/agent/clone-env.sh
@@ -7,7 +7,7 @@
 #   BRANCH      branch to check out
 #   SLUG        filesystem-safe env slug; checkout goes to /workspace/<SLUG>
 #   MCP_URL     this environment's SCOPED Oduflow MCP endpoint (/mcp/<env>;
-#               optional; enables Claude's .mcp.json)
+#               optional; enables the Oduflow entry in Claude's .mcp.json)
 #   GIT_USER    commit author for this checkout (optional; global default otherwise)
 #
 # No token argument on purpose: nothing secret is ever written to the checkout.
@@ -67,20 +67,23 @@ if [ -n "$GIT_USER" ]; then
     git -C "$DEST" config user.email "${GIT_USER}@oduflow.local"
 fi
 
-# Claude Code: project-scoped .mcp.json at the checkout root. The Authorization
-# value is a ${VAR} placeholder — Claude Code expands environment variables in
-# .mcp.json, and the scoped per-env token arrives via the session's exec env.
+# Claude Code: project-scoped .mcp.json at the checkout root. Agent Browser is
+# always available as a local stdio MCP. When present, the Oduflow Authorization
+# value is a ${VAR} placeholder — Claude expands it from the scoped token in the
+# session's exec env, so no secret is written to the checkout.
+jq -n \
+    --arg url "$MCP_URL" \
+    '{mcpServers: ({agent_browser: {type: "stdio", command: "agent-browser", args: ["mcp", "--tools", "all"]}} + (if $url == "" then {} else {oduflow: {type: "http", url: $url, headers: {Authorization: "Bearer ${ODUFLOW_MCP_TOKEN}"}}} end))}' \
+    > "$DEST/.mcp.json"
+# Not secret (the Oduflow value is a placeholder, not a token), but still a
+# generated artifact a `git add -A` by the agent should never push. Local
+# exclude, so the repo's own .gitignore stays untouched.
+mkdir -p "$DEST/.git/info"
+if ! grep -qxF '/.mcp.json' "$DEST/.git/info/exclude" 2>/dev/null; then
+    echo '/.mcp.json' >> "$DEST/.git/info/exclude"
+fi
 if [ -n "$MCP_URL" ]; then
-    jq -n \
-        --arg url "$MCP_URL" \
-        '{mcpServers: {oduflow: {type: "http", url: $url, headers: {Authorization: "Bearer ${ODUFLOW_MCP_TOKEN}"}}}}' \
-        > "$DEST/.mcp.json"
-    # Not secret (a placeholder, not a token), but still a generated artifact a
-    # `git add -A` by the agent should never push. Local exclude, so the repo's
-    # own .gitignore stays untouched.
-    mkdir -p "$DEST/.git/info"
-    if ! grep -qxF '/.mcp.json' "$DEST/.git/info/exclude" 2>/dev/null; then
-        echo '/.mcp.json' >> "$DEST/.git/info/exclude"
-    fi
-    log "wrote $DEST/.mcp.json -> $MCP_URL (git-excluded)"
+    log "wrote $DEST/.mcp.json -> Agent Browser + $MCP_URL (git-excluded)"
+else
+    log "wrote $DEST/.mcp.json -> Agent Browser (git-excluded)"
 fi

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -98,6 +98,7 @@ mkdir -p "$CODEX_HOME"
     echo "[mcp_servers.agent_browser]"
     echo 'command = "agent-browser"'
     echo 'args = ["mcp", "--tools", "all"]'
+    echo 'env_vars = ["AGENT_BROWSER_SESSION", "AGENT_BROWSER_EXECUTABLE_PATH"]'
 } > "$CODEX_HOME/config.toml"
 log "base Codex config written (Agent Browser built in; Oduflow is per session)"
 

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -13,8 +13,9 @@
 #      the npm prefix on the persistent home volume. They are proprietary
 #      (Anthropic Commercial Terms), so the published image must not
 #      redistribute them; the container downloads them directly, once.
-#   3. Write the base Codex config (feature flags only — NO Oduflow endpoint
-#      or token here; see the MCP note below).
+#   3. Write the base Codex config (feature flags + built-in Agent Browser MCP;
+#      NO Oduflow endpoint or token here) and add Agent Browser to existing
+#      Claude checkout configs; see the MCP note below.
 #   4. Resolve provider auth: subscription if a subscription credential is
 #      present, otherwise an API key (per provider).
 #   5. Stay alive. Per-env checkouts are created on demand by the env_ops hooks
@@ -26,7 +27,9 @@
 # console/chat exec injects ODUFLOW_MCP_TOKEN — the SCOPED per-environment
 # token (see ADR 0028) — plus the /mcp/<env> URL into its own environment;
 # Claude reads them through the ${VAR} placeholders in the checkout's
-# .mcp.json, Codex through `-c mcp_servers.*` CLI overrides.
+# .mcp.json. Codex CLI uses `-c mcp_servers.*` overrides; the web relay adds
+# the same scoped server to Codex ACP session-open requests. Agent Browser is a
+# local stdio MCP available to both agents and contains no Oduflow credential.
 #
 # Expected environment (injected by _ensure_agent_container; team-wide):
 #   ODUFLOW_GIT_USER    credential username to match in the store (optional)
@@ -34,9 +37,10 @@
 #   CLAUDE_CODE_OAUTH_TOKEN | ANTHROPIC_API_KEY   (+ optional ANTHROPIC_MODEL)
 #   OPENAI_API_KEY                                 (+ optional CODEX_MODEL)
 # Mounts:
-#   /run/oduflow/git-credentials   git credential store (read-only)
+#   HOME already contains the copied team git credential store; a readable
+#   /run/oduflow/git-credentials is also accepted for standalone use.
 #   /run/oduflow/codex-auth.json   optional Codex subscription seed (auth.json)
-#   HOME (/root)                   persistent home volume (auth + sessions)
+#   HOME (/home/agent)             persistent home volume (auth + sessions)
 #   /workspace                     persistent workspace volume (per-env checkouts)
 
 set -euo pipefail
@@ -49,14 +53,16 @@ CRED_FILE="$HOME/.git-credentials"
 # --- 1. git credentials ------------------------------------------------------
 git config --global user.name  "${ODUFLOW_GIT_USER:-oduflow-coder}"
 git config --global user.email "${ODUFLOW_GIT_USER:-agent}@oduflow.local"
-if [ -f "$CRED_SRC" ]; then
+if [ -r "$CRED_SRC" ]; then
     # Copy so refresh/rotation never writes back to the shared store.
     cp "$CRED_SRC" "$CRED_FILE"
     chmod 600 "$CRED_FILE"
+fi
+if [ -f "$CRED_FILE" ]; then
     git config --global credential.helper "store --file=$CRED_FILE"
     log "git credential store wired"
 else
-    log "WARNING: no git credential store at $CRED_SRC (private repos will fail)"
+    log "WARNING: no git credential store in HOME (private repos will fail)"
 fi
 
 # --- 2. Claude Code: runtime install onto the home volume --------------------
@@ -75,19 +81,54 @@ else
     fi
 fi
 
-# --- 3. base Codex config (feature flags only) -------------------------------
+# --- 3. base Codex config ----------------------------------------------------
 # Streamable-HTTP MCP needs the rmcp client. The Oduflow MCP server itself is
 # deliberately NOT configured here: its URL and token are per environment and
 # per session (scoped tokens, ADR 0028) and are supplied by the web console as
 # `codex -c mcp_servers.oduflow.*` overrides + the session's exec env. Keeping
 # them out of the global config means no session can see another environment's
-# credentials — and the container itself holds no MCP secret at all.
+# credentials — and the container itself holds no MCP secret at all. Agent
+# Browser is safe to configure globally because it is local and credentialless;
+# AGENT_BROWSER_SESSION on each exec isolates its browser state per environment.
 mkdir -p "$CODEX_HOME"
 {
     echo "[features]"
     echo "experimental_use_rmcp_client = true"
+    echo
+    echo "[mcp_servers.agent_browser]"
+    echo 'command = "agent-browser"'
+    echo 'args = ["mcp", "--tools", "all"]'
 } > "$CODEX_HOME/config.toml"
-log "base Codex config written (MCP wiring is per session)"
+log "base Codex config written (Agent Browser built in; Oduflow is per session)"
+
+# Existing checkouts predate the built-in browser and survive image/container
+# recreation on the workspace volume. Merge the local server into their
+# generated Claude configs in place so they gain the capability immediately;
+# preserve each checkout's scoped Oduflow entry and any custom MCP servers.
+shopt -s nullglob
+for git_dir in /workspace/*/.git; do
+    checkout="${git_dir%/.git}"
+    mcp_file="$checkout/.mcp.json"
+    mcp_tmp="$mcp_file.tmp.$$"
+    if [ -f "$mcp_file" ]; then
+        if ! jq '.mcpServers = ((if (.mcpServers | type) == "object" then .mcpServers else {} end) + {agent_browser: {type: "stdio", command: "agent-browser", args: ["mcp", "--tools", "all"]}})' \
+            "$mcp_file" > "$mcp_tmp"; then
+            rm -f "$mcp_tmp"
+            log "WARNING: could not add Agent Browser to malformed $mcp_file"
+            continue
+        fi
+    else
+        jq -n '{mcpServers: {agent_browser: {type: "stdio", command: "agent-browser", args: ["mcp", "--tools", "all"]}}}' \
+            > "$mcp_tmp"
+    fi
+    mv "$mcp_tmp" "$mcp_file"
+    mkdir -p "$checkout/.git/info"
+    if ! grep -qxF '/.mcp.json' "$checkout/.git/info/exclude" 2>/dev/null; then
+        echo '/.mcp.json' >> "$checkout/.git/info/exclude"
+    fi
+done
+shopt -u nullglob
+log "existing Claude checkout MCP configs refreshed"
 
 # --- 4a. Claude auth ---------------------------------------------------------
 # Subscription (CLAUDE_CODE_OAUTH_TOKEN) outranks a key. If the OAuth token is
@@ -114,7 +155,15 @@ fi
 # prefer an API key.
 mkdir -p "$CODEX_HOME"
 if [ -n "${OPENAI_API_KEY:-}" ]; then
-    log "Codex auth: API key (OPENAI_API_KEY)"
+    # Current Codex releases require an explicit login to materialize auth.json;
+    # merely inheriting OPENAI_API_KEY is not enough. This is idempotent and
+    # intentionally runs on every start so key rotation updates the persistent
+    # HOME volume. The key is passed on stdin and never appears in argv/logs.
+    if printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1; then
+        log "Codex auth: API key (OPENAI_API_KEY) -> auth.json written"
+    else
+        log "WARNING: codex login --with-api-key failed (Codex will prompt for auth)"
+    fi
 elif [ -f "/run/oduflow/codex-auth.json" ] && [ ! -f "$CODEX_HOME/auth.json" ]; then
     cp "/run/oduflow/codex-auth.json" "$CODEX_HOME/auth.json"
     chmod 600 "$CODEX_HOME/auth.json"

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -36,6 +36,11 @@ environment (at `/workspace/<slug>` in the container), edits its own clone,
 server** (`pull_and_apply`, `run_odoo_tests`, etc.) — the same closed loop a
 remote MCP client uses.
 
+The image also includes **Agent Browser MCP** backed by Debian Chromium. It is
+wired automatically into both Claude and Codex with the complete Agent Browser
+tool set. Each environment gets a separate browser profile, while browser data
+persists with the team's agent HOME volume across container recreation.
+
 Lifecycle is automatic: the container is created on startup for each enabled
 team and removed for disabled ones; `create_environment` adds the environment's
 checkout, `delete_environment` removes it. The container carries a hash of its
@@ -93,6 +98,11 @@ reference.
   only in single-team deployments; with several teams, each team sets its own
   keys in `[team.X.agent_env]` so an operator credential never leaks to
   tenants.
+- **Codex sandbox and approvals.** Codex CLI uses
+  `--dangerously-bypass-approvals-and-sandbox`, and Codex ACP starts in
+  `agent-full-access`, so installed MCP tools run without interactive
+  permission prompts or a nested Bubblewrap sandbox. The security boundary is
+  the unprivileged `agent` user inside the per-team Docker container.
 
 ## Limitations
 
@@ -100,11 +110,8 @@ reference.
 - Environments created before per-environment tokens existed have no scoped
   token; their consoles warn and the agent works without MCP until the
   environment is updated/recreated.
-- The Codex ACP adapter has no config-override channel yet, so **Codex *chat*
-  runs without Oduflow MCP** for now (the Codex CLI console is fully wired);
-  Claude is the fully supported path.
-
-The published image redistributes only Apache-2.0 software (Codex CLI + its ACP
-adapter). Claude Code and its adapter are installed at first container start
-onto the persistent home volume — downloaded directly from npm by the end
-user's container.
+The published image contains redistributable open-source software: Codex CLI,
+Codex ACP and Agent Browser are Apache-2.0, and Debian Chromium includes its
+upstream component license notices. Claude Code and its adapter are installed
+at first container start onto the persistent home volume — downloaded directly
+from npm by the end user's container.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -110,6 +110,7 @@ reference.
 - Environments created before per-environment tokens existed have no scoped
   token; their consoles warn and the agent works without MCP until the
   environment is updated/recreated.
+
 The published image contains redistributable open-source software: Codex CLI,
 Codex ACP and Agent Browser are Apache-2.0, and Debian Chromium includes its
 upstream component license notices. Claude Code and its adapter are installed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@
 - **OAuth `client_id` is no longer the secret** — a team's OAuth `client_id` is now the non-secret identifier `team_<id>` (e.g. `team_1`); the team's `auth_token` is the `client_secret` and remains the issued access token. Previously `client_id == client_secret == auth_token`, so the secret appeared in the `/authorize` query string (and thus in server logs, browser history, and the `Referer`). The secret now travels only in the POST `/token` body. **Breaking:** re-enter any existing claude.ai connector as `Client ID = team_<id>`, `Client Secret = auth_token`.
 - **OAuth issues independent, expiring, revocable tokens** — completing the previous item, the OAuth Authorization Code / refresh exchange now mints an *independent, opaque* `access_token` (with a rotating refresh token) instead of handing back the team's `auth_token`. A minted access token expires (~1h) and can be revoked via the now-enabled `/revoke` endpoint; using a refresh token rotates the pair so a leaked refresh token is single-use. The OAuth client (claude.ai/IDE) therefore never stores the team's long-lived master secret. Minted tokens are persisted (`oauth_token_store.py`) so live connections survive an Oduflow restart. The `auth_token` still works as a non-expiring direct Bearer credential for curl/CLI, and per-environment tokens remain Bearer-only. (#83)
 
+### Documentation
+
+- **Document the short transport flag** — HTTP server startup examples now show `oduflow -t http` / `uvx oduflow -t http` as the short form of `--transport http`.
+
 ## v1.67.0
 
 ### Features

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,7 +16,9 @@ uvx oduflow
 
 # Server / HTTP mode (for remote and multi-user deployments)
 oduflow --transport http
+oduflow -t http
 uvx oduflow --transport http
+uvx oduflow -t http
 ```
 
 Shared infrastructure (Docker network, PostgreSQL, team directories) is initialized automatically on startup.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,6 +45,7 @@ With [uv](https://docs.astral.sh/uv/) you can run Oduflow directly — no instal
 ```bash
 uvx oduflow                      # stdio mode (default)
 uvx oduflow --transport http     # HTTP server mode
+uvx oduflow -t http              # HTTP server mode (short form)
 ```
 
 This is the quickest way to try Oduflow or use it in CI pipelines.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -160,7 +160,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 ## Coding Agent (hosting)
 
-An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with durable per-environment sessions). The agent edits its own git checkout, `git push`es, and drives the environment only through the Oduflow MCP server with a scoped per-environment token. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments. See the **Coding Agent** section below for details.
+An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with durable per-environment sessions). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to both agents, with one persistent profile per environment. Codex runs installed MCP methods without interactive approval prompts. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments. See the **Coding Agent** section below for details.
 
 ## Typical Agent Workflow
 
@@ -1409,6 +1409,8 @@ Both drive the same agent container over the dashboard's existing WebSocket ↔ 
 
 The agent never touches host files. It holds one full git checkout per environment (at `/workspace/<slug>` in the container), edits its own clone, `git push`es, and then drives the environment **only through the Oduflow MCP server** (`pull_and_apply`, `run_odoo_tests`, etc.) — the same closed loop a remote MCP client uses.
 
+The image also includes **Agent Browser MCP** backed by Debian Chromium. It is wired automatically into both Claude and Codex with the complete Agent Browser tool set. Each environment gets a separate browser profile, while browser data persists with the team's agent HOME volume across container recreation.
+
 Lifecycle is automatic: the container is created on startup for each enabled team and removed for disabled ones; `create_environment` adds the environment's checkout, `delete_environment` removes it. The container carries a hash of its injected config as a label and is **recreated automatically** when the config changes.
 
 The dashboard exposes one status endpoint and two WebSocket surfaces (available only when `agent_enabled` is set):
@@ -1450,14 +1452,13 @@ Opening an Agent CLI or Agent Chat is arbitrary code execution **inside the team
 - **Per-team isolation.** Each team gets its own agent container, volumes, and network; the dashboard auth middleware resolves the team, so a team can only ever reach its own agent.
 - **Scoped MCP access.** The team `auth_token` never enters the agent container. Each session injects that **environment's** scoped per-environment token, which grants only the dev-loop allowlist on the one environment the session already controls. The agent **cannot** create, delete, or stop environments, or touch templates, services, or volumes — those remain operator actions.
 - **Credentials.** Server-level provider keys are inherited by the container only in single-team deployments; with several teams, each team sets its own keys in `[team.X.agent_env]`.
+- **Codex sandbox and approvals.** Codex CLI uses `--dangerously-bypass-approvals-and-sandbox`, and Codex ACP starts in `agent-full-access`, so installed MCP tools run without interactive permission prompts or a nested Bubblewrap sandbox. The security boundary is the unprivileged `agent` user inside the per-team Docker container.
 
 ## Limitations
 
 - Hidden for live-mount (`local_path`) environments.
 - Environments created before per-environment tokens existed have no scoped token; their consoles warn and the agent works without MCP until the environment is updated/recreated.
-- The Codex ACP adapter has no config-override channel yet, so **Codex *chat*** runs without Oduflow MCP for now (the Codex CLI console is fully wired); Claude is the fully supported path.
-
-The published image redistributes only Apache-2.0 software (Codex CLI + its ACP adapter). Claude Code and its adapter are installed at first container start onto the persistent home volume — downloaded directly from npm by the end user's container.
+The published image contains redistributable open-source software: Codex CLI, Codex ACP and Agent Browser are Apache-2.0, and Debian Chromium includes its upstream component license notices. Claude Code and its adapter are installed at first container start onto the persistent home volume — downloaded directly from npm by the end user's container.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1458,6 +1458,7 @@ Opening an Agent CLI or Agent Chat is arbitrary code execution **inside the team
 
 - Hidden for live-mount (`local_path`) environments.
 - Environments created before per-environment tokens existed have no scoped token; their consoles warn and the agent works without MCP until the environment is updated/recreated.
+
 The published image contains redistributable open-source software: Codex CLI, Codex ACP and Agent Browser are Apache-2.0, and Debian Chromium includes its upstream component license notices. Claude Code and its adapter are installed at first container start onto the persistent home volume — downloaded directly from npm by the end user's container.
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -183,7 +183,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 
 ## Coding Agent (hosting)
 
-An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with durable per-environment sessions). The agent edits its own git checkout, `git push`es, and drives the environment only through the Oduflow MCP server with a scoped per-environment token. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
+An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with durable per-environment sessions). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to both agents, with one persistent profile per environment. Codex runs installed MCP methods without interactive approval prompts. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
 
 ## Typical Agent Workflow
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -62,8 +62,10 @@ HTTP transport starts a persistent server with Streamable HTTP, a Web Dashboard,
 ```bash
 # Start the HTTP server:
 uvx oduflow --transport http
+uvx oduflow -t http
 # or, if installed:
 oduflow --transport http
+oduflow -t http
 ```
 
 The server starts on `http://0.0.0.0:8000` by default (configurable via `[server]` section in `oduflow.toml`). The MCP endpoint is at `/mcp`.

--- a/specs/0029-agent-console-and-chat.md
+++ b/specs/0029-agent-console-and-chat.md
@@ -41,17 +41,26 @@ WebSocket↔`docker exec` bridge:
   ACP adapter (`claude-code-acp` / `codex-acp`), rendered by a vendored,
   framework-free browser client (`acp-client.js` + `chat.js`). One durable
   session per (environment, agent) is persisted and resumed via ACP
-  `session/load`; chats minimize to a dock so several run in parallel.
+`session/load`; chats minimize to a dock so several run in parallel.
+
+The coder also ships a local Agent Browser MCP backed by Debian Chromium. Both
+agents receive it automatically; browser profiles are separated by environment
+slug. Codex sessions run without approval prompts or a nested process sandbox:
+the CLI bypasses approvals and sandboxing, while ACP uses its
+`agent-full-access` mode. This deliberate trust choice is bounded by the
+dedicated unprivileged user and per-team Docker container described in
+[[0037-built-in-agent-browser-and-noninteractive-codex]].
 
 The agent never touches host files: it edits its own clone → `git push` → drives
 the environment through the Oduflow MCP server (`pull_and_apply`, tests). MCP
 access is **scoped and per session**: the team `auth_token` never enters the
-agent container (a console is a root shell there — anything the container
-holds, its user can read). Instead each console/chat exec injects that
+agent container (a console can read anything held by its unprivileged container
+user). Instead each console/chat exec injects that
 environment's per-env token ([[0028-scoped-environment-mcp-access]]) plus its
 `/mcp/<env>` URL into its own exec environment; Claude resolves them through
 `${VAR}` placeholders in the checkout's `.mcp.json` (which therefore contains
-no secret), Codex through per-session `-c mcp_servers.*` CLI overrides. A
+no secret), Codex CLI through per-session `-c mcp_servers.*` overrides, and
+Codex ACP through the adapter's client-provided HTTP MCP session contract. A
 leaked session credential grants only the ADR-0028 dev-loop allowlist on the
 one environment the session already controls.
 
@@ -98,10 +107,12 @@ runtime state is `agent_sessions.json` (durable ACP session ids) in
   [[0028-scoped-environment-mcp-access]]); those stay operator actions.
 - Environments created before per-env tokens existed have no
   `oduflow.mcp_token` label; their consoles warn and the agent works without
-  MCP until the environment is updated/recreated. The Codex ACP adapter has no
-  config-override channel yet, so Codex *chat* runs without Oduflow MCP for
-  now (the Codex CLI console is fully wired) — consistent with the adapter's
-  best-effort status below.
+  MCP until the environment is updated/recreated. Both Claude and Codex chat
+  receive the same environment-scoped MCP authority once a token exists.
+- The long-lived container, interactive CLIs, checkout hooks and ACP adapters
+  run as the dedicated unprivileged `agent` user. A short-lived networkless
+  root init container only migrates ownership of legacy persistent volumes and
+  copies the team git credential store; it exits before any agent starts.
 - Server-level provider keys (`ANTHROPIC_API_KEY` etc.) are inherited by the
   container **only in single-team deployments**; with several teams each team
   must set its own keys in the dashboard, so an operator credential never
@@ -110,14 +121,15 @@ runtime state is `agent_sessions.json` (durable ACP session ids) in
   Chat / Agent CLI): there is nothing for the containerized agent to clone,
   the host path is deliberately not mounted into it, and the local developer
   uses their own agents anyway.
-- **The published image redistributes only Apache-2.0 software** (Codex CLI +
-  Codex ACP adapter). Claude Code and its adapter are under Anthropic's
-  Commercial Terms, so `entrypoint.sh` npm-installs them at first container
-  start onto the persistent HOME volume — downloaded by the end user's
-  container directly from npm, never shipped by us.
-- Claude is the clean path (`loadSession: true` verified upstream); the Codex
-  ACP adapter is best-effort, and the client self-heals a failed resume by
-  starting fresh.
+- **The published image contains redistributable open-source software.** Codex
+  CLI, Codex ACP and Agent Browser are Apache-2.0; Debian Chromium preserves
+  its upstream BSD-style/component license notices in the image. Claude Code
+  and its adapter are under Anthropic's Commercial Terms, so `entrypoint.sh`
+  npm-installs them at first container start onto the persistent HOME volume —
+  downloaded by the end user's container directly from npm, never shipped by
+  us.
+- The browser client self-heals an adapter's failed session resume by starting
+  a fresh chat.
 
 ## History
 
@@ -138,3 +150,20 @@ runtime state is `agent_sessions.json` (durable ACP session ids) in
   scoped per-environment tokens from [[0028-scoped-environment-mcp-access]] in
   their own exec env; `.mcp.json` holds a `${ODUFLOW_MCP_TOKEN}` placeholder
   instead of a secret, and the global Codex config holds no Oduflow endpoint.
+- 2026-07-21 — moved the long-lived coder container and every interactive/ACP
+  exec from root to the dedicated `agent` user. Existing per-team HOME and
+  workspace volumes are migrated in place by a short-lived, networkless root
+  init container, preserving logins, runtime-installed Claude packages and
+  checkouts; the host git credential store is copied into the migrated HOME
+  with `0600` permissions before the unprivileged container starts.
+- 2026-07-21 — completed scoped MCP wiring for Codex ACP chat after
+  `codex-acp` gained per-session config support. The relay injects a
+  client-provided HTTP MCP entry into ACP session-open frames for the
+  environment's `/mcp/<env>` endpoint; the bearer travels only over that
+  exec's local stdin and is never exposed to the browser or written to disk.
+  API-key auth was also adapted to current Codex releases by materializing
+  persistent `auth.json` through `codex login --with-api-key` at startup.
+- 2026-07-21 — added the built-in Agent Browser MCP and Chromium runtime for
+  both Claude and Codex, with per-environment browser profiles. Codex CLI and
+  ACP sessions now run non-interactively without approval prompts or a nested
+  process sandbox; see [[0037-built-in-agent-browser-and-noninteractive-codex]].

--- a/specs/0037-built-in-agent-browser-and-noninteractive-codex.md
+++ b/specs/0037-built-in-agent-browser-and-noninteractive-codex.md
@@ -1,0 +1,73 @@
+# 0037 — Built-in Agent Browser MCP and non-interactive Codex
+
+**Status:** Adopted
+**Type:** Architecture — agent runtime capability and trust model
+**First introduced:** this change (2026-07-21), branch `litnimax/codex-agent-env-key`
+**Key code today:** `docker/agent/Dockerfile`; `docker/agent/entrypoint.sh`; `docker/agent/clone-env.sh`; `_wire_codex_acp_mcp`, `ws_agent_console`, and `ws_agent_acp` in `web_ui.py`; `_ensure_agent_container` in `docker_ops/env_ops.py`
+
+## Context
+
+The hosted coding agent already receives environment-scoped Oduflow MCP access
+([[0028-scoped-environment-mcp-access]]) through its CLI and ACP chat surfaces
+([[0029-agent-console-and-chat]]). Odoo development also needs a real browser
+for UI flows, screenshots, interaction testing, and frontend debugging. Installing
+browser automation ad hoc in a persistent HOME is slow and makes capabilities
+depend on which team happened to initialize its container first.
+
+Codex's default approval policy also interrupts hosted, unattended MCP loops.
+The user opening Agent CLI or Agent Chat has already authorized arbitrary code
+execution in the team's dedicated coder container, so a second interactive
+Codex approval boundary adds friction without separating a different principal.
+
+## Decision
+
+The published coder image includes a pinned Agent Browser CLI/MCP package and
+Debian Chromium. Agent Browser is configured as a local stdio MCP with all of
+its tools for both Claude and Codex. Every console/chat exec sets a profile name
+derived from the environment slug, preventing two environments in the same
+team container from sharing a browser daemon or session accidentally.
+
+Codex runs without interactive approval requests or a nested process sandbox:
+Agent CLI passes `--dangerously-bypass-approvals-and-sandbox`; Codex ACP starts
+in the adapter's `agent-full-access` mode, which maps to approval `never` and
+danger-full-access. This is an explicit relocation of the security boundary to
+Docker and the dedicated unprivileged `agent` account, not an assertion that
+browser or MCP actions are intrinsically safe. It also avoids Bubblewrap's
+unprivileged-user-namespace requirement, which Docker's default seccomp profile
+blocks; Oduflow does not weaken that outer profile to make a nested sandbox run.
+
+## How it works
+
+- The multi-architecture image moves to Node 24, installs a pinned
+  `agent-browser` package, and installs Debian's Chromium package for both
+  amd64 and arm64. `AGENT_BROWSER_EXECUTABLE_PATH` selects that system browser.
+- The Codex HOME config declares `agent_browser`; per-checkout Claude `.mcp.json`
+  declares the same stdio server. Codex ACP session-open frames receive it
+  alongside the scoped Oduflow HTTP server.
+- `AGENT_BROWSER_SESSION` equals the checkout basename on every CLI/ACP exec.
+  Agent Browser state remains on the persistent HOME volume, but profiles do
+  not collide across environments.
+- The long-lived container receives a larger shared-memory allocation for
+  Chromium stability. It and every agent process still run as uid/gid 1000
+  (`agent`); no host browser socket or host filesystem is mounted. Codex CLI
+  bypasses its own Bubblewrap sandbox while Docker's seccomp remains enabled.
+
+## Consequences
+
+- Browser automation is deterministic and immediately available from either
+  hosted agent, including fresh HOME volumes and both supported CPU families.
+- Codex can invoke all installed MCP methods without pausing for approvals.
+  A compromised prompt can therefore exercise the full authority already
+  granted to that session: its checkout, browser profile, outbound network, and
+  environment-scoped Oduflow MCP allowlist. It still cannot obtain the team
+  token or cross Docker's per-team container/network boundary by design.
+- The coder image is larger because Chromium is preinstalled, and its base must
+  remain on a Node version supported by Agent Browser.
+- Redistribution remains permitted: Agent Browser/Codex components are
+  Apache-2.0, while Debian Chromium carries and preserves its upstream
+  BSD-style/component notices. Proprietary Claude packages remain runtime-only.
+
+## History
+
+- 2026-07-21 — adopted built-in Agent Browser MCP, per-environment browser
+  profiles, and non-interactive Codex approval policy.

--- a/specs/README.md
+++ b/specs/README.md
@@ -55,6 +55,7 @@ precursors).
 | [0034](0034-external-traefik-routes.md) | 2026-07-16 | External `[route.*]` domains → upstream URLs, plus operator drop-in Traefik dynamic files |
 | [0035](0035-production-hosting.md) | 2026-07-11 | Production hosting: dedicated PG cluster, WAL-G/S3 backups, snapshots, auto-rollback deploys |
 | [0036](0036-cross-subdomain-connect-as-landing.md) | 2026-07-19 | Cross-subdomain "Connect as user" landing: one-time token → env-host `/oduflow-connect` sets the session cookie host-only |
+| [0037](0037-built-in-agent-browser-and-noninteractive-codex.md) | 2026-07-21 | Built-in Agent Browser MCP and non-interactive Codex trust model |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -65,6 +65,10 @@ from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
 
+AGENT_USER = "agent"
+AGENT_HOME = "/home/agent"
+_AGENT_RUNTIME_VERSION = "3"  # browser MCP + non-root runtime
+
 
 def _trace(msg: str, *args: object) -> None:
     if settings.TRACE:
@@ -1342,16 +1346,79 @@ def _agent_config_hash(
 
     Stored as a container label; a mismatch on ensure means oduflow.toml
     changed (credentials, image, port), so the container is recreated. HOME
-    and /workspace are volumes — nothing is lost. The git-credentials mount is
-    fixed at container creation, so its presence is part of the fingerprint:
-    a container created before setup_repo_auth would otherwise keep matching
-    forever and never pick up the credentials file."""
+    and /workspace are volumes — nothing is lost. Git credentials are copied
+    into HOME by the volume init step at container creation, so their presence
+    is part of the fingerprint: a container created before setup_repo_auth
+    would otherwise keep matching forever and never pick up the file."""
     import hashlib
 
     payload = json.dumps(
-        [image, sorted(env.items()), has_git_credentials], separators=(",", ":")
+        [
+            _AGENT_RUNTIME_VERSION,
+            image,
+            sorted(env.items()),
+            has_git_credentials,
+        ],
+        separators=(",", ":"),
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _prepare_agent_volumes(
+    client: DockerClient,
+    image: str,
+    home_volume: str,
+    workspace_volume: str,
+    cred_file: str | None,
+) -> None:
+    """Make persistent agent data usable by the unprivileged image user.
+
+    Older coder images mounted HOME at ``/root`` and consequently left both
+    named volumes root-owned. A short-lived, networkless init container runs
+    as root only to migrate that existing data and copy the host credential
+    store; the long-lived container and every agent exec run as ``agent``.
+    Marker files avoid recursively walking large checkouts after migration.
+    """
+    volumes: dict[str, dict[str, str]] = {
+        home_volume: {"bind": AGENT_HOME, "mode": "rw"},
+        workspace_volume: {"bind": "/workspace", "mode": "rw"},
+    }
+    if cred_file:
+        volumes[cred_file] = {
+            "bind": "/run/oduflow/git-credentials",
+            "mode": "ro",
+        }
+
+    script = """
+if ! id agent >/dev/null 2>&1; then
+    echo "incompatible coder image: missing required user 'agent'" >&2
+    echo "build the current docker/agent image and configure [agent].image to that tag" >&2
+    exit 64
+fi
+if [ ! -f /home/agent/.oduflow-owner-v2 ]; then
+    chown -R agent:agent /home/agent
+    touch /home/agent/.oduflow-owner-v2
+    chown agent:agent /home/agent/.oduflow-owner-v2
+fi
+if [ ! -f /workspace/.oduflow-owner-v2 ]; then
+    chown -R agent:agent /workspace
+    touch /workspace/.oduflow-owner-v2
+    chown agent:agent /workspace/.oduflow-owner-v2
+fi
+if [ -f /run/oduflow/git-credentials ]; then
+    install -m 600 -o agent -g agent \
+        /run/oduflow/git-credentials /home/agent/.git-credentials
+fi
+"""
+    client.containers.run(
+        image=image,
+        command=["-eu", "-c", script],
+        entrypoint=["/bin/sh"],
+        user="root",
+        remove=True,
+        network_disabled=True,
+        volumes=volumes,
+    )
 
 
 def _ensure_agent_container(
@@ -1423,14 +1490,9 @@ def _ensure_agent_container(
         ensure_team_network(client, settings, team)
 
         volumes: dict[str, dict[str, str]] = {
-            home_volume: {"bind": "/root", "mode": "rw"},
+            home_volume: {"bind": AGENT_HOME, "mode": "rw"},
             workspace_volume: {"bind": "/workspace", "mode": "rw"},
         }
-        if has_git_credentials:
-            volumes[cred_file] = {
-                "bind": "/run/oduflow/git-credentials",
-                "mode": "ro",
-            }
 
         labels = dict(agent_labels)
         labels.update(
@@ -1445,15 +1507,24 @@ def _ensure_agent_container(
 
         with contextlib.suppress(Exception):
             client.images.pull(settings.agent_image)
+        _prepare_agent_volumes(
+            client,
+            settings.agent_image,
+            home_volume,
+            workspace_volume,
+            cred_file if has_git_credentials else None,
+        )
         client.containers.run(
             image=settings.agent_image,
             name=container_name,
             detach=True,
+            user=AGENT_USER,
             network=get_team_network_name(team.team_id, settings.prefix),
             environment=agent_env,
             labels=labels,
             volumes=volumes,
             extra_hosts={"host.docker.internal": "host-gateway"},
+            shm_size="1g",
             restart_policy={"Name": "unless-stopped"},
         )
         logger.info("Agent container ensured", extra={"container": container_name})
@@ -1494,7 +1565,7 @@ def _agent_add_env(
             get_agent_mcp_url(settings, env_name),
             git_user,
         ]
-        exit_code, output = container.exec_run(cmd)
+        exit_code, output = container.exec_run(cmd, user=AGENT_USER)
         if exit_code not in (0, None):
             detail = (
                 output.decode("utf-8", "replace")
@@ -1570,7 +1641,9 @@ def _agent_remove_env(
         )
         return
     with contextlib.suppress(Exception):
-        container.exec_run(["rm", "-rf", get_agent_checkout_dir(env_name)])
+        container.exec_run(
+            ["rm", "-rf", get_agent_checkout_dir(env_name)], user=AGENT_USER
+        )
 
 
 def _remove_agent_container(

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4126,6 +4126,7 @@ def _run_cli() -> None:
         "--version", action="version", version=f"oduflow {_get_version()}"
     )
     parser.add_argument(
+        "-t",
         "--transport",
         choices=["stdio", "http"],
         default="stdio",

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -399,6 +399,79 @@ def _acp_adapter_cmd(agent_type: str) -> list[str]:
     return ["claude-code-acp"]
 
 
+def _codex_cli_cmd(mcp_url: str, model: str = "") -> list[str]:
+    """Build the hosted Codex CLI command.
+
+    Docker is the security boundary for hosted agents: the container is
+    per-team and runs as the unprivileged ``agent`` user. Disabling Codex's
+    nested Linux sandbox avoids requiring user namespaces (bubblewrap), which
+    Docker's default seccomp profile intentionally blocks.
+    """
+    cmd = [
+        "codex",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-c",
+        f'mcp_servers.oduflow.url="{mcp_url}"',
+        "-c",
+        'mcp_servers.oduflow.bearer_token_env_var="ODUFLOW_MCP_TOKEN"',
+    ]
+    if model:
+        cmd += ["--model", model]
+    return cmd
+
+
+def _wire_codex_acp_mcp(frame: str, mcp_url: str, mcp_token: str) -> str:
+    """Inject built-in MCP servers into Codex ACP session-open requests.
+
+    The browser intentionally knows neither URL nor token. The WebSocket relay
+    augments only ``session/new``/``session/load``/``session/resume`` frames on
+    their way to the adapter, using codex-acp's native client-provided MCP
+    contract. Agent Browser is a local credentialless stdio server. Oduflow is
+    added only when a scoped token exists; that credential lives only in this
+    exec's environment and stdio and is never returned to the browser or disk.
+    """
+    try:
+        message = json.loads(frame)
+    except json.JSONDecodeError:
+        return frame
+    if not isinstance(message, dict) or message.get("method") not in {
+        "session/new",
+        "session/load",
+        "session/resume",
+    }:
+        return frame
+    params = message.get("params")
+    if not isinstance(params, dict):
+        return frame
+    existing = params.get("mcpServers")
+    servers = existing if isinstance(existing, list) else []
+    servers = [
+        server
+        for server in servers
+        if not isinstance(server, dict)
+        or server.get("name") not in {"agent_browser", "oduflow"}
+    ]
+    servers.append(
+        {
+            "name": "agent_browser",
+            "command": "agent-browser",
+            "args": ["mcp", "--tools", "all"],
+            "env": [],
+        }
+    )
+    if mcp_token:
+        servers.append(
+            {
+                "type": "http",
+                "name": "oduflow",
+                "url": mcp_url,
+                "headers": [{"name": "Authorization", "value": f"Bearer {mcp_token}"}],
+            }
+        )
+    params["mcpServers"] = servers
+    return json.dumps(message, separators=(",", ":"))
+
+
 class _LoginRateLimiter:
     """Best-effort in-memory throttle for failed logins (issue #56).
 
@@ -2940,7 +3013,9 @@ def _build_routes(
             checkout = get_agent_checkout_dir(branch)
 
             def _checkout_missing() -> bool:
-                code, _ = container.exec_run(["test", "-d", checkout])
+                code, _ = container.exec_run(
+                    ["test", "-d", checkout], user=env_ops.AGENT_USER
+                )
                 return bool(code != 0)
 
             missing = await asyncio.get_event_loop().run_in_executor(
@@ -2985,20 +3060,14 @@ def _build_routes(
             exec_env = {
                 "ODUFLOW_MCP_URL": mcp_url,
                 "ODUFLOW_MCP_TOKEN": mcp_token or "",
+                "AGENT_BROWSER_SESSION": os.path.basename(checkout),
             }
 
             if agent_type == "codex":
                 # Codex has no project-scoped config; wire the Oduflow MCP
-                # server via CLI overrides (values are parsed as TOML).
-                cmd = [
-                    "codex",
-                    "-c",
-                    f'mcp_servers.oduflow.url="{mcp_url}"',
-                    "-c",
-                    'mcp_servers.oduflow.bearer_token_env_var="ODUFLOW_MCP_TOKEN"',
-                ]
-                if settings.agent_codex_model:
-                    cmd += ["--model", settings.agent_codex_model]
+                # server via CLI overrides. Docker is the outer sandbox, so
+                # Codex does not attempt a nested bubblewrap sandbox.
+                cmd = _codex_cli_cmd(mcp_url, settings.agent_codex_model)
             else:
                 cmd = ["claude"]
                 if settings.agent_claude_model:
@@ -3013,6 +3082,7 @@ def _build_routes(
                 stderr=True,
                 workdir=checkout,
                 environment=exec_env,
+                user=env_ops.AGENT_USER,
             )["Id"]
             sock = client.api.exec_start(exec_id, detach=False, tty=True, socket=True)
             raw_sock = sock._sock
@@ -3189,7 +3259,9 @@ def _build_routes(
             checkout = get_agent_checkout_dir(branch)
 
             def _checkout_missing() -> bool:
-                code, _ = container.exec_run(["test", "-d", checkout])
+                code, _ = container.exec_run(
+                    ["test", "-d", checkout], user=env_ops.AGENT_USER
+                )
                 return bool(code != 0)
 
             missing = await asyncio.get_event_loop().run_in_executor(
@@ -3213,9 +3285,9 @@ def _build_routes(
 
             # SCOPED per-env MCP credentials for THIS session only (see the
             # matching block in ws_agent_console). Claude's adapter picks them
-            # up via the ${VAR} placeholders in the checkout's .mcp.json; the
-            # Codex adapter has no override channel yet (best-effort, per the
-            # ADR) so its chat runs without Oduflow MCP for now.
+            # up via the ${VAR} placeholders in the checkout's .mcp.json;
+            # Codex ACP receives the same server through its native session
+            # request contract in browser_to_docker below.
             try:
                 mcp_token = await asyncio.get_event_loop().run_in_executor(
                     None, lambda: env_ops.get_env_token(settings, team, branch)
@@ -3228,17 +3300,17 @@ def _build_routes(
                     "MCP Access existed) — the agent cannot drive it over MCP. "
                     "Update or recreate the environment."
                 )
-            if agent_type == "codex":
-                await _notice(
-                    "Codex chat cannot reach the Oduflow MCP server yet (its "
-                    "ACP adapter has no configuration channel) — the agent can "
-                    "edit and push code, but use Claude chat or the Agent CLI "
-                    "to drive the environment."
-                )
+            mcp_url = env_ops.get_agent_mcp_url(settings, branch)
             exec_env = {
-                "ODUFLOW_MCP_URL": env_ops.get_agent_mcp_url(settings, branch),
+                "ODUFLOW_MCP_URL": mcp_url,
                 "ODUFLOW_MCP_TOKEN": mcp_token or "",
+                "AGENT_BROWSER_SESSION": os.path.basename(checkout),
             }
+            if agent_type == "codex":
+                # codex-acp maps this official mode to approval_policy=never
+                # and dangerFullAccess. Docker + the unprivileged agent user
+                # remain the outer security boundary for browser chat.
+                exec_env["INITIAL_AGENT_MODE"] = "agent-full-access"
 
             exec_id = client.api.exec_create(
                 container.id,
@@ -3249,6 +3321,7 @@ def _build_routes(
                 stderr=True,
                 workdir=checkout,
                 environment=exec_env,
+                user=env_ops.AGENT_USER,
             )["Id"]
             sock = client.api.exec_start(exec_id, detach=False, tty=False, socket=True)
             raw_sock = sock._sock
@@ -3300,6 +3373,8 @@ def _build_routes(
                         text = await websocket.receive_text()
                         if not text:
                             continue
+                        if agent_type == "codex":
+                            text = _wire_codex_acp_mcp(text, mcp_url, mcp_token or "")
                         frame = text if text.endswith("\n") else text + "\n"
                         await loop.run_in_executor(
                             None, raw_sock.sendall, frame.encode("utf-8")

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -420,7 +420,9 @@ def _codex_cli_cmd(mcp_url: str, model: str = "") -> list[str]:
     return cmd
 
 
-def _wire_codex_acp_mcp(frame: str, mcp_url: str, mcp_token: str) -> str:
+def _wire_codex_acp_mcp(
+    frame: str, mcp_url: str, mcp_token: str, browser_session: str
+) -> str:
     """Inject built-in MCP servers into Codex ACP session-open requests.
 
     The browser intentionally knows neither URL nor token. The WebSocket relay
@@ -456,7 +458,13 @@ def _wire_codex_acp_mcp(frame: str, mcp_url: str, mcp_token: str) -> str:
             "name": "agent_browser",
             "command": "agent-browser",
             "args": ["mcp", "--tools", "all"],
-            "env": [],
+            "env": [
+                {"name": "AGENT_BROWSER_SESSION", "value": browser_session},
+                {
+                    "name": "AGENT_BROWSER_EXECUTABLE_PATH",
+                    "value": "/usr/bin/chromium",
+                },
+            ],
         }
     )
     if mcp_token:
@@ -3374,7 +3382,12 @@ def _build_routes(
                         if not text:
                             continue
                         if agent_type == "codex":
-                            text = _wire_codex_acp_mcp(text, mcp_url, mcp_token or "")
+                            text = _wire_codex_acp_mcp(
+                                text,
+                                mcp_url,
+                                mcp_token or "",
+                                os.path.basename(checkout),
+                            )
                         frame = text if text.endswith("\n") else text + "\n"
                         await loop.run_in_executor(
                             None, raw_sock.sendall, frame.encode("utf-8")

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -112,7 +112,9 @@ def test_wire_codex_acp_mcp_adds_scoped_server_and_preserves_others():
         }
     )
     wired = json.loads(
-        _wire_codex_acp_mcp(frame, "http://scoped/mcp/env", "scoped-token")
+        _wire_codex_acp_mcp(
+            frame, "http://scoped/mcp/env", "scoped-token", "environment-x"
+        )
     )
     assert wired["params"]["mcpServers"] == [
         {"name": "custom", "command": "custom-mcp", "args": [], "env": []},
@@ -120,7 +122,13 @@ def test_wire_codex_acp_mcp_adds_scoped_server_and_preserves_others():
             "name": "agent_browser",
             "command": "agent-browser",
             "args": ["mcp", "--tools", "all"],
-            "env": [],
+            "env": [
+                {"name": "AGENT_BROWSER_SESSION", "value": "environment-x"},
+                {
+                    "name": "AGENT_BROWSER_EXECUTABLE_PATH",
+                    "value": "/usr/bin/chromium",
+                },
+            ],
         },
         {
             "type": "http",
@@ -141,26 +149,28 @@ def test_wire_codex_acp_mcp_handles_load_but_not_other_frames():
         }
     )
     assert (
-        json.loads(_wire_codex_acp_mcp(load, "http://scoped", "token"))["params"][
-            "mcpServers"
-        ][0]["name"]
+        json.loads(_wire_codex_acp_mcp(load, "http://scoped", "token", "env"))[
+            "params"
+        ]["mcpServers"][0]["name"]
         == "agent_browser"
     )
-    load_servers = json.loads(_wire_codex_acp_mcp(load, "http://scoped", "token"))[
-        "params"
-    ]["mcpServers"]
+    load_servers = json.loads(
+        _wire_codex_acp_mcp(load, "http://scoped", "token", "env")
+    )["params"]["mcpServers"]
     assert [server["name"] for server in load_servers] == [
         "agent_browser",
         "oduflow",
     ]
 
     prompt = '{"jsonrpc":"2.0","method":"session/prompt","params":{}}'
-    assert _wire_codex_acp_mcp(prompt, "http://scoped", "token") == prompt
-    no_token = json.loads(_wire_codex_acp_mcp(load, "http://scoped", ""))
+    assert _wire_codex_acp_mcp(prompt, "http://scoped", "token", "env") == prompt
+    no_token = json.loads(_wire_codex_acp_mcp(load, "http://scoped", "", "env"))
     assert [server["name"] for server in no_token["params"]["mcpServers"]] == [
         "agent_browser"
     ]
-    assert _wire_codex_acp_mcp("not-json", "http://scoped", "token") == "not-json"
+    assert (
+        _wire_codex_acp_mcp("not-json", "http://scoped", "token", "env") == "not-json"
+    )
 
 
 def test_delete_environment_clears_chat_sessions(tmp_path, monkeypatch):

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -1,9 +1,10 @@
+import json
 import os
 import stat
 
 from oduflow import agent_sessions
 from oduflow.settings import Settings, TeamSettings
-from oduflow.web_ui import _acp_adapter_cmd
+from oduflow.web_ui import _acp_adapter_cmd, _codex_cli_cmd, _wire_codex_acp_mcp
 
 
 def _team(tmp_path) -> TeamSettings:
@@ -74,6 +75,92 @@ def test_acp_adapter_cmd():
     assert _acp_adapter_cmd("codex") == ["codex-acp"]
     # Unknown agent falls back to Claude (the configured default agent).
     assert _acp_adapter_cmd("something-else") == ["claude-code-acp"]
+
+
+def test_codex_cli_cmd_uses_docker_as_the_sandbox():
+    assert _codex_cli_cmd("http://scoped/mcp/env", "gpt-test") == [
+        "codex",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-c",
+        'mcp_servers.oduflow.url="http://scoped/mcp/env"',
+        "-c",
+        'mcp_servers.oduflow.bearer_token_env_var="ODUFLOW_MCP_TOKEN"',
+        "--model",
+        "gpt-test",
+    ]
+
+
+def test_wire_codex_acp_mcp_adds_scoped_server_and_preserves_others():
+    frame = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "session/new",
+            "params": {
+                "cwd": "/workspace/x",
+                "mcpServers": [
+                    {"name": "custom", "command": "custom-mcp", "args": [], "env": []},
+                    {"name": "agent_browser", "command": "wrong-browser"},
+                    {
+                        "type": "http",
+                        "name": "oduflow",
+                        "url": "http://wrong",
+                        "headers": [],
+                    },
+                ],
+            },
+        }
+    )
+    wired = json.loads(
+        _wire_codex_acp_mcp(frame, "http://scoped/mcp/env", "scoped-token")
+    )
+    assert wired["params"]["mcpServers"] == [
+        {"name": "custom", "command": "custom-mcp", "args": [], "env": []},
+        {
+            "name": "agent_browser",
+            "command": "agent-browser",
+            "args": ["mcp", "--tools", "all"],
+            "env": [],
+        },
+        {
+            "type": "http",
+            "name": "oduflow",
+            "url": "http://scoped/mcp/env",
+            "headers": [{"name": "Authorization", "value": "Bearer scoped-token"}],
+        },
+    ]
+
+
+def test_wire_codex_acp_mcp_handles_load_but_not_other_frames():
+    load = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/load",
+            "params": {"sessionId": "sid", "cwd": "/workspace", "mcpServers": []},
+        }
+    )
+    assert (
+        json.loads(_wire_codex_acp_mcp(load, "http://scoped", "token"))["params"][
+            "mcpServers"
+        ][0]["name"]
+        == "agent_browser"
+    )
+    load_servers = json.loads(_wire_codex_acp_mcp(load, "http://scoped", "token"))[
+        "params"
+    ]["mcpServers"]
+    assert [server["name"] for server in load_servers] == [
+        "agent_browser",
+        "oduflow",
+    ]
+
+    prompt = '{"jsonrpc":"2.0","method":"session/prompt","params":{}}'
+    assert _wire_codex_acp_mcp(prompt, "http://scoped", "token") == prompt
+    no_token = json.loads(_wire_codex_acp_mcp(load, "http://scoped", ""))
+    assert [server["name"] for server in no_token["params"]["mcpServers"]] == [
+        "agent_browser"
+    ]
+    assert _wire_codex_acp_mcp("not-json", "http://scoped", "token") == "not-json"
 
 
 def test_delete_environment_clears_chat_sessions(tmp_path, monkeypatch):

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1853,9 +1853,23 @@ class TestAgentContainer:
         assert "oduflow-1-agent-home" in created
         assert "oduflow-1-agent-workspace" in created
 
-        mock_docker_client.containers.run.assert_called_once()
-        kwargs = mock_docker_client.containers.run.call_args.kwargs
+        # A short-lived root init migrates/copies persistent data; only the
+        # second call is the long-lived, unprivileged agent container.
+        assert mock_docker_client.containers.run.call_count == 2
+        init_kwargs = mock_docker_client.containers.run.call_args_list[0].kwargs
+        assert init_kwargs["user"] == "root"
+        assert init_kwargs["network_disabled"] is True
+        assert init_kwargs["remove"] is True
+        assert "missing required user 'agent'" in init_kwargs["command"][2]
+        assert init_kwargs["volumes"]["oduflow-1-agent-home"]["bind"] == ("/home/agent")
+        assert any(
+            v["bind"] == "/run/oduflow/git-credentials"
+            for v in init_kwargs["volumes"].values()
+        )
+
+        kwargs = mock_docker_client.containers.run.call_args_list[1].kwargs
         assert kwargs["name"] == "oduflow-1-agent"
+        assert kwargs["user"] == "agent"
         # Tenant isolation: the agent joins the team network, not a shared one.
         assert kwargs["network"] == "oduflow-1-net"
         assert kwargs["labels"]["oduflow.agent"] == "true"
@@ -1866,10 +1880,13 @@ class TestAgentContainer:
         # Team-wide: no per-env branch label.
         assert s.branch_label not in kwargs["labels"]
         assert kwargs["extra_hosts"] == {"host.docker.internal": "host-gateway"}
+        assert kwargs["shm_size"] == "1g"
         vols = kwargs["volumes"]
-        assert vols["oduflow-1-agent-home"]["bind"] == "/root"
+        assert vols["oduflow-1-agent-home"]["bind"] == "/home/agent"
         assert vols["oduflow-1-agent-workspace"]["bind"] == "/workspace"
-        assert any(v["bind"] == "/run/oduflow/git-credentials" for v in vols.values())
+        assert not any(
+            v["bind"] == "/run/oduflow/git-credentials" for v in vols.values()
+        )
         env = kwargs["environment"]
         # The team auth_token must never enter the container: any console
         # session could read it. Sessions get SCOPED per-env tokens via their
@@ -1933,17 +1950,16 @@ class TestAgentContainer:
         env_ops._ensure_agent_container(mock_docker_client, s, team)
 
         existing.remove.assert_called_once_with(force=True)
-        mock_docker_client.containers.run.assert_called_once()
+        assert mock_docker_client.containers.run.call_count == 2
         env = mock_docker_client.containers.run.call_args.kwargs["environment"]
         assert env["OPENAI_API_KEY"] == "new-key"
 
     def test_ensure_recreates_when_git_credentials_appear(
         self, monkeypatch, mock_docker_client
     ):
-        # Mounts are fixed at creation: a container created BEFORE
-        # setup_repo_auth has no credentials mount, so the file appearing later
-        # must change the fingerprint and trigger a recreate — otherwise
-        # private-repo clones fail forever.
+        # Credentials are copied into HOME at creation: a container created
+        # BEFORE setup_repo_auth has no copy, so the file appearing later must
+        # change the fingerprint and trigger a recreate.
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -1970,7 +1986,7 @@ class TestAgentContainer:
             env_ops._ensure_agent_container(mock_docker_client, s, team)
 
         existing.remove.assert_called_once_with(force=True)
-        vols = mock_docker_client.containers.run.call_args.kwargs["volumes"]
+        vols = mock_docker_client.containers.run.call_args_list[0].kwargs["volumes"]
         assert any(v["bind"] == "/run/oduflow/git-credentials" for v in vols.values())
 
     def test_api_key_when_no_subscription(self, monkeypatch, mock_docker_client):
@@ -2066,6 +2082,7 @@ class TestAgentContainer:
         assert cmd[4] == "http://host.docker.internal:8000/mcp/feature/x"
         assert cmd[5] == "alice"
         assert "tok" not in cmd
+        assert container.exec_run.call_args.kwargs["user"] == "agent"
 
     def test_add_env_skipped_when_disabled(self, mock_docker_client):
         team = self._team(agent_enabled=False)
@@ -2115,6 +2132,7 @@ class TestAgentContainer:
         assert cmd[3] == "prod"  # slug from env name -> checkout dir
         assert cmd[4] == "http://host.docker.internal:8000/mcp/prod"
         assert cmd[5] == "alice"
+        assert agent.exec_run.call_args.kwargs["user"] == "agent"
 
     def test_ensure_env_checkout_skips_repo_for_live_mount(
         self, monkeypatch, mock_docker_client

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,7 @@
-import pytest
+import sys
 from unittest.mock import patch
+
+import pytest
 
 from fastmcp.exceptions import ToolError
 from oduflow.settings import Settings, TeamSettings
@@ -51,6 +53,23 @@ class TestMCPBootstrapInstructions:
 
 
 class TestCLIInitDestroy:
+    def test_cli_transport_short_flag_starts_http(self):
+        from oduflow import server
+
+        with (
+            patch.object(sys, "argv", ["oduflow", "-t", "http"]),
+            patch.object(server.migrations, "run_pending"),
+            patch.object(server, "_ensure_initialized"),
+            patch.object(server.quotas, "apply_all"),
+            patch.object(server, "_start_stdio") as mock_stdio,
+            patch.object(server, "_start_http") as mock_http,
+        ):
+            server._run_cli()
+
+        mock_stdio.assert_not_called()
+        mock_http.assert_called_once_with()
+        assert server.settings_module.TRANSPORT == "http"
+
     @patch("oduflow.docker_ops.system_ops.destroy_system")
     def test_cli_destroy(self, mock_destroy):
         from oduflow.server import _run_destroy


### PR DESCRIPTION
## Summary

- run hosted coding agents as an unprivileged `agent` user and migrate persistent runtime files safely
- bundle Agent Browser MCP with Chromium and wire it into Claude, Codex CLI, and Codex ACP chat with per-environment profiles
- pass scoped Oduflow MCP access through Codex ACP, enable noninteractive Codex operation inside the container boundary, and add API-key login support
- add the short `-t` transport flag and update the related documentation, specifications, and tests

## Root cause fixed during review

Codex sanitizes the environment inherited by stdio MCP servers. The browser server therefore lost both the Chromium path and the environment-specific session name. The Codex config now explicitly allows those variables, while ACP session-open frames provide their concrete values. This makes Chromium startup reliable and preserves profile isolation between environments.

The documentation also restores the missing paragraph break in the Limitations section.

## Impact

Both Codex surfaces can now use the built-in browser and the scoped Oduflow MCP server without interactive nested-sandbox approvals. Browser profiles remain isolated per environment and persist on the team's home volume.

The coder image version is bumped to `0.2.0` so the merge-gated image workflow publishes a new tag.

## Validation

- `pytest -m 'not integration and not heavyweight' -q` — 1,109 passed, 15 deselected
- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow/web_ui.py tests/test_agent_sessions.py`
- `bash -n docker/agent/entrypoint.sh`
- `git diff --check`
