### PR TITLE
Fix Claude Agent CLI credential onboarding

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -28,7 +28,7 @@
 
 FROM node:24-bookworm-slim
 
-ARG CODER_VERSION=0.2.0
+ARG CODER_VERSION=0.2.1
 LABEL org.opencontainers.image.title="oduflow-coder" \
       org.opencontainers.image.version="${CODER_VERSION}" \
       org.opencontainers.image.source="https://github.com/oduist/oduflow"

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -131,10 +131,69 @@ done
 shopt -u nullglob
 log "existing Claude checkout MCP configs refreshed"
 
-# --- 4a. Claude auth ---------------------------------------------------------
+# --- 4a. Claude auth + onboarding --------------------------------------------
+# An environment credential authenticates Claude Code but does not complete its
+# first-run wizard. Pre-seed that persistent state when either credential is
+# configured; without one, leave the normal interactive login path untouched.
+seed_claude_onboarding() {
+    local auth_mode="$1"
+    local api_key_suffix="${2:-}"
+    local claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    local claude_json="$claude_dir/.claude.json"
+    local tmp_json
+    local use_existing=false
+    local jq_failed=false
+    local jq_filter='
+        .hasCompletedOnboarding = true
+        | if $api_key_suffix != "" then
+            .customApiKeyResponses = (
+                if (.customApiKeyResponses | type) == "object"
+                then .customApiKeyResponses
+                else {}
+                end
+            )
+            | .customApiKeyResponses.approved = (
+                ((.customApiKeyResponses.approved // [])
+                    | if type == "array" then . else [] end)
+                + [$api_key_suffix]
+                | unique
+            )
+          else .
+          end
+    '
+
+    mkdir -p "$claude_dir"
+    tmp_json="$(mktemp "${claude_json}.tmp.XXXXXX")"
+
+    if [ -f "$claude_json" ] && jq -e 'type == "object"' "$claude_json" >/dev/null 2>&1; then
+        use_existing=true
+    else
+        if [ -e "$claude_json" ]; then
+            log "WARNING: replacing invalid Claude config at $claude_json"
+        fi
+    fi
+
+    if [ "$use_existing" = true ]; then
+        jq --arg api_key_suffix "$api_key_suffix" "$jq_filter" \
+            "$claude_json" > "$tmp_json" || jq_failed=true
+    else
+        jq --null-input --arg api_key_suffix "$api_key_suffix" "$jq_filter" \
+            > "$tmp_json" || jq_failed=true
+    fi
+
+    if [ "$jq_failed" = true ]; then
+        rm -f "$tmp_json"
+        log "WARNING: could not pre-seed Claude onboarding for $auth_mode auth"
+        return
+    fi
+
+    chmod 600 "$tmp_json"
+    mv -f "$tmp_json" "$claude_json"
+    log "Claude onboarding pre-seeded for $auth_mode auth"
+}
+
 # Subscription (CLAUDE_CODE_OAUTH_TOKEN) outranks a key. If the OAuth token is
-# present, ANTHROPIC_API_KEY MUST be unset or it wins by precedence. With no
-# credential at all, an interactive `claude` login persists to the home volume.
+# present, ANTHROPIC_API_KEY MUST be unset or it wins by precedence.
 if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
     # ANTHROPIC_API_KEY is already excluded from the container env by
     # _agent_env_vars() in env_ops.py; this unset is belt-and-suspenders for
@@ -142,8 +201,15 @@ if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
     # container-level env, which already lacks the key).
     unset ANTHROPIC_API_KEY || true
     log "Claude auth: subscription (CLAUDE_CODE_OAUTH_TOKEN)"
+    seed_claude_onboarding "subscription"
 elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
     log "Claude auth: API key (ANTHROPIC_API_KEY)"
+    claude_api_key_suffix="$ANTHROPIC_API_KEY"
+    if [ "${#claude_api_key_suffix}" -gt 20 ]; then
+        claude_api_key_suffix="${claude_api_key_suffix: -20}"
+    fi
+    seed_claude_onboarding "API key" "$claude_api_key_suffix"
+    unset claude_api_key_suffix
 else
     log "Claude auth: NONE configured (use an interactive login; it persists on the home volume)"
 fi

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -75,6 +75,10 @@ ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
 OPENAI_API_KEY = ""            # Codex API key
 ```
 
+When `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured, the
+container automatically marks Claude Code's first-run onboarding as complete,
+so Agent CLI opens directly in the REPL without asking to select a login method.
+
 See the [`[agent]`](installation.md#agent-settings) and
 [per-team](installation.md#per-team-settings) settings tables for the full
 reference.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1445,6 +1445,10 @@ ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
 OPENAI_API_KEY = ""            # Codex API key
 ```
 
+When `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured, the
+container automatically marks Claude Code's first-run onboarding as complete,
+so Agent CLI opens directly in the REPL without asking to select a login method.
+
 ## Security model
 
 Opening an Agent CLI or Agent Chat is arbitrary code execution **inside the team's agent container** — confined to that container, its clones, and the session's scoped MCP token.


### PR DESCRIPTION
## What changed

- Pre-seed Claude Code's persistent `hasCompletedOnboarding` state when `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured.
- Preserve valid Claude settings, atomically replace malformed/non-object config, and store API-key approval suffixes without duplicates.
- Bump the coder image from `0.2.0` to `0.2.1`.
- Document the automatic onboarding behavior in the canonical agent guide and `llms-full.txt` mirror.

## Why

Claude Code 2.1.216 still showed its first-run "Select login method" wizard in interactive Agent CLI sessions even though the environment credential was correctly injected. The credential authenticates API requests but does not set Claude Code's persisted onboarding-complete flag.

## Validation

- `bash -n docker/agent/entrypoint.sh`
- JSON fixture coverage for OAuth, API key merge/idempotency, malformed/non-object config, nested-value normalization, permissions, and no-credential no-op
- `mkdocs build --strict`
- Built `oduist/oduflow-coder:dev-local` with version `0.2.1`
- Recreated `oduflow-1-agent` with persistent volumes; verified `0600` config owned by `agent:agent`
- Interactive Claude skipped the login-method wizard
- Claude Code 2.1.216 returned the expected authenticated smoke-test response