### PR TITLE
Explain Claude ACP authentication failures

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -79,6 +79,16 @@ When `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured, the
 container automatically marks Claude Code's first-run onboarding as complete,
 so Agent CLI opens directly in the REPL without asking to select a login method.
 
+Claude supports three alternative authentication modes. Oduflow selects exactly
+one for each team: a non-empty `CLAUDE_CODE_OAUTH_TOKEN` wins, otherwise a
+non-empty `ANTHROPIC_API_KEY` uses Console API billing, otherwise Claude uses the
+interactive `/login` stored on the team's persistent agent home volume. Known
+credential values are trimmed when loaded, so whitespace accidentally copied
+around a token is not sent to Anthropic. A configured environment credential
+always overrides the persisted interactive login; if Anthropic rejects it,
+Agent Chat fails closed with mode-specific recovery guidance instead of silently
+trying another account or billing method.
+
 See the [`[agent]`](installation.md#agent-settings) and
 [per-team](installation.md#per-team-settings) settings tables for the full
 reference.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - **Hosted agents use the reachable scoped MCP endpoint** — Agent CLI and Agent Chat now use the team's public HTTPS `/mcp/<environment>` URL in Traefik mode (and an explicit `oauth_base_url` in port mode), matching the dashboard's **MCP Access** dialog. Local port-mode deployments retain the `host.docker.internal` fallback.
+- **Claude Agent Chat explains rejected credentials** — provider credentials copied into `[team.*.agent_env]` now have surrounding whitespace removed before they reach the coder container. When Claude ACP returns a recognizable authentication failure, Agent Chat preserves the provider error and adds recovery specific to the active setup-token, API-key, or interactive-login mode. Oduflow still fails closed instead of silently switching accounts or billing methods.
 - **claude.ai OAuth connector reaches the authorization endpoint** — a claude.ai custom connector derives its OAuth endpoints path-relative to the MCP URL (requesting `https://<host>/mcp/authorize` and `/mcp/token`) instead of following the root endpoints advertised by discovery. The outer scoped-access shim treated `authorize`/`token` as an environment name and rewrote the request onto the auth-protected `/mcp` endpoint, so the flow failed with `401 invalid_token` before it could start. Oduflow now routes the reserved OAuth/discovery sub-paths requested under `/mcp/` (`/mcp/authorize`, `/mcp/token`, `/mcp/register`, `/mcp/.well-known/*`) to the real root routes. Scoped `/mcp/<env>` connectors remain Bearer-only.
 
 ### Security

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1449,6 +1449,16 @@ When `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured, the
 container automatically marks Claude Code's first-run onboarding as complete,
 so Agent CLI opens directly in the REPL without asking to select a login method.
 
+Claude supports three alternative authentication modes. Oduflow selects exactly
+one for each team: a non-empty `CLAUDE_CODE_OAUTH_TOKEN` wins, otherwise a
+non-empty `ANTHROPIC_API_KEY` uses Console API billing, otherwise Claude uses the
+interactive `/login` stored on the team's persistent agent home volume. Known
+credential values are trimmed when loaded, so whitespace accidentally copied
+around a token is not sent to Anthropic. A configured environment credential
+always overrides the persisted interactive login; if Anthropic rejects it,
+Agent Chat fails closed with mode-specific recovery guidance instead of silently
+trying another account or billing method.
+
 ## Security model
 
 Opening an Agent CLI or Agent Chat is arbitrary code execution **inside the team's agent container** — confined to that container, its clones, and the session's scoped MCP token.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -100,6 +100,62 @@ read the container logs.
 
 ---
 
+## Agent Chat: Claude returns `401 Invalid bearer token`
+
+The ACP session may open successfully and fail only on the first prompt:
+
+```text
+Failed to authenticate. API Error: 401 ... Invalid bearer token
+```
+
+This is a Claude provider credential failure, not an Oduflow MCP-token failure.
+Claude authentication is selected in this order:
+
+1. `CLAUDE_CODE_OAUTH_TOKEN` (subscription setup token)
+2. `ANTHROPIC_API_KEY` (Console API billing)
+3. the interactive `/login` saved on the team's persistent agent home volume
+
+A configured setup token or API key overrides the interactive login. Oduflow
+does not automatically fall back after an authentication error because doing so
+could silently switch the account or billing method.
+
+To keep subscription authentication, generate a fresh token on a trusted
+machine while signed in to the intended Claude account:
+
+```bash
+claude setup-token
+```
+
+Replace `CLAUDE_CODE_OAUTH_TOKEN` under `[team.<id>.agent_env]` in
+`oduflow.toml`. In a single-team deployment, the Oduflow systemd service may
+instead supply this variable through its server environment; update the source
+that is actually in use. Do not print the token with `docker inspect`, `env`, or
+diagnostic shell commands.
+
+Restart Oduflow so the changed config hash recreates the agent container. Its
+home and workspace volumes are persistent, so conversations, login state, and
+checkouts survive:
+
+```bash
+systemctl restart oduflow
+journalctl -u oduflow --since "5 minutes ago" \
+  | grep -E 'Agent config changed|Claude auth:'
+```
+
+The log should report subscription auth. Send a real Agent Chat prompt to
+verify the new token; local auth-status output alone does not prove that
+Anthropic accepts it.
+
+To use interactive authentication instead, remove both
+`CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` from the team config and, for
+single-team deployments, from the server environment. Restart Oduflow, open
+Agent CLI, run `/login`, complete sign-in, and reopen Agent Chat.
+
+The separate `$/ping` "Method not found" line is harmless adapter noise and is
+not the cause of the `401`.
+
+---
+
 ## Overlay filestore
 
 Large template filestores are shared with `fuse-overlayfs` instead of copied.

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1296,6 +1296,13 @@ def create_environment(
     return result
 
 
+_AGENT_PROVIDER_CREDENTIALS = (
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+)
+
+
 def _agent_env_vars(settings: Settings, team: TeamSettings) -> dict[str, str]:
     """Variables injected into the team's agent container.
 
@@ -1314,15 +1321,43 @@ def _agent_env_vars(settings: Settings, team: TeamSettings) -> dict[str, str]:
     """
     env: dict[str, str] = {}
     if len(settings.teams) == 1:
-        for key in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+        for key in _AGENT_PROVIDER_CREDENTIALS:
             value = os.environ.get(key, "").strip()
             if value:
                 env[key] = value
     env.update(team.agent_env)
 
-    if env.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip():
+    # Credentials are routinely pasted from another terminal. Normalize only
+    # the known secret values (arbitrary user variables may intentionally carry
+    # surrounding whitespace), and make an explicitly blank team override mask
+    # a same-named server credential instead of injecting an empty value.
+    for key in _AGENT_PROVIDER_CREDENTIALS:
+        if key not in env:
+            continue
+        value = env[key].strip()
+        if value:
+            env[key] = value
+        else:
+            env.pop(key)
+
+    if env.get("CLAUDE_CODE_OAUTH_TOKEN"):
         env.pop("ANTHROPIC_API_KEY", None)
     return env
+
+
+def _claude_auth_mode(settings: Settings, team: TeamSettings) -> str:
+    """Return the one effective Claude credential mode, without secrets.
+
+    Environment credentials are alternatives, not an automatic fallback
+    chain: a setup token wins over an API key, and a persisted interactive
+    login is used only when neither environment credential is present.
+    """
+    env = _agent_env_vars(settings, team)
+    if env.get("CLAUDE_CODE_OAUTH_TOKEN"):
+        return "setup_token"
+    if env.get("ANTHROPIC_API_KEY"):
+        return "api_key"
+    return "interactive"
 
 
 def get_agent_mcp_url(settings: Settings, team: TeamSettings, env_name: str) -> str:

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1621,6 +1621,17 @@ def _ensure_agent_container(
             restart_policy={"Name": "unless-stopped"},
         )
         logger.info("Agent container ensured", extra={"container": container_name})
+        # Report which Claude credential the (re)created container will use, so
+        # authentication failures can be diagnosed from the logs. The secret
+        # value is never logged, only the selected mode.
+        auth_label = {
+            "setup_token": "subscription (CLAUDE_CODE_OAUTH_TOKEN)",
+            "api_key": "Console API (ANTHROPIC_API_KEY)",
+            "interactive": "interactive /login",
+        }.get(_claude_auth_mode(settings, team), "unknown")
+        logger.info(
+            "Claude auth: %s", auth_label, extra={"container": container_name}
+        )
     except Exception:
         logger.warning("Agent container ensure failed", exc_info=True)
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -399,6 +399,75 @@ def _acp_adapter_cmd(agent_type: str) -> list[str]:
     return ["claude-code-acp"]
 
 
+_CLAUDE_AUTH_GUIDANCE_MARKER = "Oduflow authentication guidance:"
+
+
+def _annotate_acp_auth_error(
+    frame: str, agent_type: str, auth_mode: str, team_id: str
+) -> str:
+    """Add mode-specific recovery to Claude ACP authentication errors.
+
+    The adapter returns provider failures as JSON-RPC response frames. Keep the
+    provider's original code/data/message intact and append guidance only for
+    recognizable authentication failures. In particular, quota/spend-limit
+    failures must remain untouched: silently trying a different credential
+    could switch accounts or billing modes.
+    """
+    if agent_type != "claude":
+        return frame
+    try:
+        message = json.loads(frame)
+    except (TypeError, ValueError):
+        return frame
+    if not isinstance(message, dict) or not isinstance(message.get("error"), dict):
+        return frame
+    error = message["error"]
+    error_message = error.get("message")
+    if not isinstance(error_message, str):
+        return frame
+
+    lowered = error_message.lower()
+    specific_markers = (
+        "invalid bearer token",
+        "invalid api key",
+        "oauth token has expired",
+        "oauth token expired",
+        "oauth token revoked",
+    )
+    generic_401 = "401" in lowered and (
+        "failed to authenticate" in lowered or "authentication_error" in lowered
+    )
+    if not generic_401 and not any(marker in lowered for marker in specific_markers):
+        return frame
+    if _CLAUDE_AUTH_GUIDANCE_MARKER in error_message:
+        return frame
+
+    if auth_mode == "setup_token":
+        guidance = (
+            "Claude is using CLAUDE_CODE_OAUTH_TOKEN, which overrides interactive "
+            "/login. Run `claude setup-token` while signed in to the intended "
+            "account, replace the token in "
+            f"[team.{team_id}.agent_env] (or the single-team server environment), "
+            "then restart Oduflow."
+        )
+    elif auth_mode == "api_key":
+        guidance = (
+            "Claude is using ANTHROPIC_API_KEY (Console API billing). Update or "
+            "remove that key in "
+            f"[team.{team_id}.agent_env] (or the single-team server environment), "
+            "then restart Oduflow."
+        )
+    else:
+        guidance = (
+            "No Claude environment credential is configured. Open Agent CLI for "
+            "this team, run `/login`, complete the interactive sign-in, then "
+            "reopen Agent Chat."
+        )
+
+    error["message"] = f"{error_message}\n\n{_CLAUDE_AUTH_GUIDANCE_MARKER} {guidance}"
+    return json.dumps(message, separators=(",", ":"), ensure_ascii=False)
+
+
 def _codex_cli_cmd(mcp_url: str, model: str = "") -> list[str]:
     """Build the hosted Codex CLI command.
 
@@ -3273,6 +3342,7 @@ def _build_routes(
             agent_type = agent_config.resolve_agent_type(
                 websocket.query_params.get("type"), team
             )
+            claude_auth_mode = env_ops._claude_auth_mode(settings, team)
 
             container_name = get_agent_container_name(team.team_id, settings.prefix)
             try:
@@ -3399,9 +3469,14 @@ def _build_routes(
                             line, buf = buf.split(b"\n", 1)
                             text = line.strip()
                             if text:
-                                await websocket.send_text(
-                                    text.decode("utf-8", "replace")
+                                frame = text.decode("utf-8", "replace")
+                                frame = _annotate_acp_auth_error(
+                                    frame,
+                                    agent_type,
+                                    claude_auth_mode,
+                                    team.team_id,
                                 )
+                                await websocket.send_text(frame)
                 except Exception:
                     pass
                 finally:

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1878,6 +1878,69 @@ class TestAgentContainer:
         mock_docker_client.containers.run.assert_not_called()
         mock_docker_client.volumes.create.assert_not_called()
 
+    def test_claude_auth_mode_and_credential_normalization(self, monkeypatch):
+        for key in env_ops._AGENT_PROVIDER_CREDENTIALS:
+            monkeypatch.delenv(key, raising=False)
+
+        interactive_team = self._team()
+        interactive_settings = self._settings(team=interactive_team)
+        assert (
+            env_ops._claude_auth_mode(interactive_settings, interactive_team)
+            == "interactive"
+        )
+
+        api_team = self._team(
+            agent_env={"ANTHROPIC_API_KEY": "  sk-ant-api  ", "MY_FLAG": "  keep  "}
+        )
+        api_settings = self._settings(team=api_team)
+        api_env = env_ops._agent_env_vars(api_settings, api_team)
+        assert api_env["ANTHROPIC_API_KEY"] == "sk-ant-api"
+        assert api_env["MY_FLAG"] == "  keep  "
+        assert env_ops._claude_auth_mode(api_settings, api_team) == "api_key"
+
+        token_team = self._team(
+            agent_env={
+                "CLAUDE_CODE_OAUTH_TOKEN": "  sk-ant-oat  ",
+                "ANTHROPIC_API_KEY": "  ignored-key  ",
+            }
+        )
+        token_settings = self._settings(team=token_team)
+        token_env = env_ops._agent_env_vars(token_settings, token_team)
+        assert token_env["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat"
+        assert "ANTHROPIC_API_KEY" not in token_env
+        assert env_ops._claude_auth_mode(token_settings, token_team) == "setup_token"
+
+    def test_blank_team_credential_masks_server_value(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "server-token")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "server-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        team = self._team(
+            agent_env={
+                "CLAUDE_CODE_OAUTH_TOKEN": "  ",
+                "ANTHROPIC_API_KEY": " team-key ",
+            }
+        )
+        settings = self._settings(team=team)
+
+        env = env_ops._agent_env_vars(settings, team)
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env["ANTHROPIC_API_KEY"] == "team-key"
+        assert env_ops._claude_auth_mode(settings, team) == "api_key"
+
+    def test_multi_team_ignores_server_claude_credentials(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "operator-token")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "operator-key")
+        team1 = self._team()
+        team2 = TeamSettings(team_id="2", data_dir="/tmp/flow-test-2")
+        settings = Settings(
+            base_data_dir="/tmp/flow-test",
+            teams={"1": team1, "2": team2},
+        )
+
+        assert env_ops._agent_env_vars(settings, team1) == {}
+        assert env_ops._claude_auth_mode(settings, team1) == "interactive"
+
     @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=True)
     def test_ensure_creates_single_container_with_volumes(
         self, mock_isfile, monkeypatch, mock_docker_client

--- a/tests/test_web_ui_agent_acp.py
+++ b/tests/test_web_ui_agent_acp.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import base64
+import json
 
+import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
-from oduflow.web_ui import mount_web_ui
+from oduflow.web_ui import _annotate_acp_auth_error, mount_web_ui
 
 _PW = "s3cret"
 _BRANCH = "feature-x"
@@ -84,3 +86,118 @@ def test_posting_historical_session_selects_and_moves_it_to_front(tmp_path):
         "sid-1",
         "sid-2",
     ]
+
+
+@pytest.mark.parametrize(
+    ("auth_mode", "expected"),
+    [
+        ("setup_token", "CLAUDE_CODE_OAUTH_TOKEN"),
+        ("api_key", "ANTHROPIC_API_KEY"),
+        ("interactive", "run `/login`"),
+    ],
+)
+def test_claude_auth_errors_get_mode_specific_guidance(auth_mode, expected):
+    original = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "error": {
+            "code": -32603,
+            "message": (
+                "Internal error: Failed to authenticate. API Error: 401 "
+                '{"type":"error","error":{"type":"authentication_error",'
+                '"message":"Invalid bearer token"}}'
+            ),
+            "data": {"provider": "anthropic"},
+        },
+    }
+
+    annotated = json.loads(
+        _annotate_acp_auth_error(json.dumps(original), "claude", auth_mode, "7")
+    )
+
+    assert annotated["id"] == original["id"]
+    assert annotated["error"]["code"] == original["error"]["code"]
+    assert annotated["error"]["data"] == original["error"]["data"]
+    assert annotated["error"]["message"].startswith(original["error"]["message"])
+    assert "Oduflow authentication guidance:" in annotated["error"]["message"]
+    assert expected in annotated["error"]["message"]
+
+
+@pytest.mark.parametrize(
+    "provider_message",
+    [
+        "Invalid API key · Fix external API key",
+        "OAuth token has expired. Please obtain a new token.",
+        "OAuth token revoked",
+    ],
+)
+def test_specific_claude_auth_errors_are_recognized(provider_message):
+    frame = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32603, "message": provider_message},
+        }
+    )
+
+    annotated = _annotate_acp_auth_error(frame, "claude", "setup_token", "1")
+
+    assert (
+        "Oduflow authentication guidance:" in json.loads(annotated)["error"]["message"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("frame", "agent_type"),
+    [
+        ("not-json", "claude"),
+        (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {
+                        "code": -32603,
+                        "message": "You've hit your monthly spend limit",
+                    },
+                }
+            ),
+            "claude",
+        ),
+        (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": 401, "message": "Repository access denied"},
+                }
+            ),
+            "claude",
+        ),
+        (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32603, "message": "Invalid bearer token"},
+                }
+            ),
+            "codex",
+        ),
+    ],
+)
+def test_non_claude_auth_failures_are_unchanged(frame, agent_type):
+    assert _annotate_acp_auth_error(frame, agent_type, "setup_token", "1") == frame
+
+
+def test_auth_guidance_is_not_appended_twice():
+    frame = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32603, "message": "Invalid bearer token"},
+        }
+    )
+    once = _annotate_acp_auth_error(frame, "claude", "setup_token", "1")
+
+    assert _annotate_acp_auth_error(once, "claude", "setup_token", "1") == once


### PR DESCRIPTION
## Summary

- Normalize copied provider credentials and retain the setup-token → API-key → interactive-login precedence.
- Enrich recognizable Claude ACP authentication failures with mode-specific recovery while leaving quota errors, Codex, and fail-closed billing behavior unchanged.
- Document token rotation and interactive-login recovery, with focused coverage for credential resolution and JSON-RPC preservation.

## Validation

- `pytest -m "not integration and not heavyweight"` (1132 passed, 15 deselected), `ruff check src/oduflow tests`, `mypy src/oduflow`, and `mkdocs build --strict`.
