### PR TITLE
Make production hosting opt-in

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -28,15 +28,16 @@ they never mix with dev environment tooling.
 
 ## Configuration
 
-Everything is optional; productions themselves are created at runtime, not in
-TOML:
+Production hosting is disabled by default. Enable it globally in TOML and
+restart Oduflow; productions themselves are then created at runtime:
 
 ```toml
-[production]            # all keys optional
+[production]
+enabled = true          # required; restart Oduflow after changing
 postgres_image = ""     # default: [database].image
 workers_cap = 8         # upper bound for auto-tuned Odoo workers
 
-[backup]                # presence enables the backup subsystem
+[backup]                # configures backups; production must also be enabled
 bucket = "acme-backups"
 access_key = "AKIA..."
 secret_key = "..."
@@ -50,8 +51,15 @@ region = "eu-central-1"
 # walg_keep_full = 7           (base backups retained)
 ```
 
-The production PostgreSQL cluster is provisioned lazily and idempotently: a
-dev-only install never grows a second database container.
+While disabled, the dashboard tab and production HTTP/webhook routes are not
+registered, production MCP tools return an enablement error, and scheduled
+backup work does not run.
+
+The production PostgreSQL cluster is provisioned lazily and idempotently. If
+production hosting is disabled, Oduflow stops every managed production Odoo
+container and then its dedicated PostgreSQL container without deleting any
+container, volume, database, filestore, or registry data. Re-enabling starts
+PostgreSQL first and then starts all managed production Odoo containers.
 
 ## Creating a production
 

--- a/specs/0035-production-hosting.md
+++ b/specs/0035-production-hosting.md
@@ -50,6 +50,13 @@ dev quotas/reaper. Multi-production hosting on one instance works but is
 deliberately not optimized for ("90% of production installs host one
 production").
 
+Production hosting is a **strict global opt-in**: `[production].enabled =
+true` is required. When disabled, Oduflow removes the dashboard and HTTP
+entry points, rejects production MCP tools, suspends webhooks and backups,
+and stops managed production Odoo containers before the dedicated PostgreSQL
+container without deleting data. Re-enabling starts PostgreSQL first and then
+all managed production Odoo containers.
+
 **Deploys reuse the pull→classify→apply engine with code-only auto-rollback.**
 `update_production` records the pre-pull commits (full clone — history is the
 point), runs the shared engine (a "refresh" outcome is promoted to restart:
@@ -109,8 +116,8 @@ plain filestore dir (no overlay) → container with a custom-domain Traefik
 `Host()` rule, production odoo.conf chain (`.oduflow/odoo.prod.conf` > team >
 bundled) with auto-tuned workers, no `--dev=xml`, no sanitize. Failure rolls
 everything back including the registry record. `[backup]` in `oduflow.toml`
-(bucket + keys; everything else defaulted) enables the whole backup
-subsystem; `[production]` is optional entirely.
+(bucket + keys; everything else defaulted) configures the backup subsystem;
+scheduled backup work runs only while `[production].enabled = true`.
 
 ## Consequences
 
@@ -131,6 +138,9 @@ subsystem; `[production]` is optional entirely.
 
 ## History
 
+- 2026-07-21 — production hosting became an explicit global opt-in; disabling
+  it gates every entry point and stops the managed production workload stack
+  without deleting state.
 - 2026-07-11 — v1 landed as a staged series on `litnimax/production-hosting`:
   foundation (settings/naming/registry/tuning) → prod PG infra + WAL-G →
   lifecycle + MCP stack → update engine with rollback → chunkstore →

--- a/src/oduflow/backup_scheduler.py
+++ b/src/oduflow/backup_scheduler.py
@@ -339,6 +339,8 @@ def _run_prune_job(
 
 def tick(settings: Settings, locks: LockManager) -> None:
     """One scheduler pass. Cheap when nothing is due."""
+    if not settings.prod_enabled:
+        return
     backup = settings.backup
     if backup is None:
         return
@@ -418,8 +420,11 @@ def start_backup_scheduler(
     locks: LockManager,
     interval: float = TICK_SECONDS,
 ) -> threading.Thread | None:
-    """Start the scheduler thread. Returns None when [backup] is absent."""
+    """Start the scheduler thread when production and backups are enabled."""
     settings = get_settings()
+    if not settings.prod_enabled:
+        logger.info("Backup scheduler disabled (production hosting disabled)")
+        return None
     if settings.backup is None:
         logger.info("Backup scheduler disabled ([backup] not configured)")
         return None

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1356,6 +1356,55 @@ def ensure_prod_infra(
     return True
 
 
+def reconcile_prod_workloads(client: DockerClient, settings: Settings) -> None:
+    """Apply the global production-hosting switch to managed containers.
+
+    Disabling production is an active shutdown: stop production Odoo
+    containers before the dedicated PostgreSQL container, preserving every
+    container and volume.  Enabling does the inverse: ensure PostgreSQL first,
+    then start every managed production Odoo container.  Individual container
+    failures are logged so production drift never prevents the development
+    tier from starting.
+    """
+
+    label_filters = [
+        f"{settings.managed_label}=true",
+        "oduflow.prod=true",
+    ]
+
+    if settings.prod_enabled:
+        ensure_prod_infra(client, settings)
+        containers = client.containers.list(all=True, filters={"label": label_filters})
+        for container in sorted(containers, key=lambda item: item.name):
+            if container.name == settings.prod_db_container:
+                continue
+            if container.status == "running":
+                continue
+            try:
+                container.start()
+                logger.info("Started production container %s", container.name)
+            except Exception:
+                logger.exception(
+                    "Could not start production container %s", container.name
+                )
+        return
+
+    containers = client.containers.list(all=True, filters={"label": label_filters})
+    # PostgreSQL is deliberately last so applications cannot keep writing while
+    # the shared production database is being stopped.
+    containers.sort(key=lambda item: item.name == settings.prod_db_container)
+    for container in containers:
+        if container.status != "running":
+            continue
+        try:
+            container.stop()
+            logger.info("Stopped disabled production container %s", container.name)
+        except Exception:
+            logger.exception(
+                "Could not stop disabled production container %s", container.name
+            )
+
+
 def ensure_team_tablespace(
     client: DockerClient, settings: Settings, team: TeamSettings
 ) -> str:
@@ -1501,13 +1550,14 @@ def init_system(
     for team in settings.teams.values():
         ensure_team_network(client, settings, team)
 
-    # Production tier (second PG cluster + WAL-G): lazily provisioned — a
-    # no-op until the first production exists. Best-effort so a production
-    # infra hiccup never blocks dev environments from starting.
+    # Production hosting is a strict opt-in. Disabled installations stop all
+    # managed production workloads without deleting them; enabled installations
+    # ensure PostgreSQL first and then start every production Odoo container.
+    # Best-effort so production drift never blocks dev environments from starting.
     try:
-        ensure_prod_infra(client, settings)
+        reconcile_prod_workloads(client, settings)
     except Exception:
-        logger.exception("Production infra initialization failed")
+        logger.exception("Production workload reconciliation failed")
 
     # Per-team coding-agent containers. init_system runs on every server
     # start, so oduflow.toml is applied here: enabled teams get their container

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1356,15 +1356,33 @@ def ensure_prod_infra(
     return True
 
 
+def _prod_pg_running(client: DockerClient, settings: Settings) -> bool:
+    """True when the dedicated production PostgreSQL container is up."""
+    try:
+        container = client.containers.get(settings.prod_db_container)
+    except docker.errors.NotFound:
+        return False
+    return bool(container.status == "running")
+
+
 def reconcile_prod_workloads(client: DockerClient, settings: Settings) -> None:
     """Apply the global production-hosting switch to managed containers.
 
     Disabling production is an active shutdown: stop production Odoo
     containers before the dedicated PostgreSQL container, preserving every
-    container and volume.  Enabling does the inverse: ensure PostgreSQL first,
-    then start every managed production Odoo container.  Individual container
-    failures are logged so production drift never prevents the development
-    tier from starting.
+    container and volume.  Re-enabling does the inverse: ensure PostgreSQL
+    first, then start every managed production Odoo container.  Individual
+    container failures are logged so production drift never prevents the
+    development tier from starting.
+
+    Because init_system runs on every server start, "start every production"
+    must fire only on a genuine disabled->enabled transition, not on an
+    ordinary restart -- otherwise a production deliberately stopped via
+    stop_production (containers use restart_policy=unless-stopped) would be
+    resurrected on the next boot.  The disabled path stops the shared PG last,
+    so a stopped production PG is the fingerprint of a prior disable: when it
+    is already running this is a steady-state restart and per-container
+    running state is left to Docker.
     """
 
     label_filters = [
@@ -1373,7 +1391,11 @@ def reconcile_prod_workloads(client: DockerClient, settings: Settings) -> None:
     ]
 
     if settings.prod_enabled:
+        # Capture the transition signal before ensure_prod_infra starts PG.
+        was_disabled = not _prod_pg_running(client, settings)
         ensure_prod_infra(client, settings)
+        if not was_disabled:
+            return
         containers = client.containers.list(all=True, filters={"label": label_filters})
         for container in sorted(containers, key=lambda item: item.name):
             if container.name == settings.prod_db_container:

--- a/src/oduflow/health.py
+++ b/src/oduflow/health.py
@@ -64,6 +64,8 @@ def _check_traefik(client: Any, settings: Settings) -> dict[str, Any]:
 
 
 def _check_s3(settings: Settings) -> dict[str, Any]:
+    if not settings.prod_enabled:
+        return {"status": "off", "detail": "production hosting disabled"}
     if settings.backup is None:
         return {"status": "off", "detail": "backups not configured"}
     from oduflow.s3_client import check_s3
@@ -103,6 +105,35 @@ def _unhealthy_productions(settings: Settings) -> list[str]:
     return names
 
 
+def _disabled_production_status(client: Any, settings: Settings) -> dict[str, Any]:
+    """Confirm disabled production workloads are actually stopped."""
+    try:
+        containers = client.containers.list(
+            all=True,
+            filters={
+                "label": [
+                    f"{settings.managed_label}=true",
+                    "oduflow.prod=true",
+                ]
+            },
+        )
+    except Exception as exc:
+        return {"status": "error", "detail": str(exc)[:200], "running": []}
+    running = sorted(c.name for c in containers if c.status == "running")
+    if running:
+        return {
+            "status": "error",
+            "detail": "production disabled but containers still running: "
+            + ", ".join(running),
+            "running": running,
+        }
+    return {
+        "status": "off",
+        "detail": "production hosting disabled",
+        "running": [],
+    }
+
+
 def collect_health(settings: Settings, *, force: bool = False) -> dict[str, Any]:
     """All checks with a short cache. ``ok`` is the /healthz verdict."""
     now = time.monotonic()
@@ -122,17 +153,24 @@ def collect_health(settings: Settings, *, force: bool = False) -> dict[str, Any]
 
     if client is not None:
         checks["dev_pg"] = _check_pg(client, settings, settings.shared_db_container)
-        checks["prod_pg"] = _check_pg(client, settings, settings.prod_db_container)
+        checks["prod_pg"] = (
+            _check_pg(client, settings, settings.prod_db_container)
+            if settings.prod_enabled
+            else {"status": "off", "detail": "production hosting disabled"}
+        )
         checks["traefik"] = _check_traefik(client, settings)
     checks["s3"] = _check_s3(settings)
     checks["disk"] = _check_disk(settings)
 
-    unhealthy = _unhealthy_productions(settings)
-    checks["productions"] = {
-        "status": "error" if unhealthy else "ok",
-        "detail": ", ".join(unhealthy),
-        "unhealthy": unhealthy,
-    }
+    if not settings.prod_enabled and client is not None:
+        checks["productions"] = _disabled_production_status(client, settings)
+    else:
+        unhealthy = _unhealthy_productions(settings) if settings.prod_enabled else []
+        checks["productions"] = {
+            "status": "error" if unhealthy else "ok",
+            "detail": ", ".join(unhealthy),
+            "unhealthy": unhealthy,
+        }
 
     # Critical checks: dev PG always; prod PG only when provisioned; traefik
     # when in traefik mode; S3 when configured; unhealthy productions.

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -293,6 +293,24 @@ def prod_lock_key(team_id: str, name: str) -> str:
     return f"prod:{team_id}:{name}"
 
 
+_PRODUCTION_DISABLED_MESSAGE = (
+    "Production hosting is disabled. Set enabled = true in the [production] "
+    "section of oduflow.toml and restart Oduflow."
+)
+
+
+def production_enabled(fn: Callable[P, R]) -> Callable[P, R]:
+    """Reject production MCP calls before they acquire locks or touch state."""
+
+    @functools.wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        if not _get_settings().prod_enabled:
+            raise PrerequisiteNotMetError(_PRODUCTION_DISABLED_MESSAGE)
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
 def with_prod_lock(fn: Callable[P, R]) -> Callable[P, R]:
     """Acquire the production's lock before executing the tool function."""
 
@@ -2773,6 +2791,7 @@ def delete_file_in_volume(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def create_production(
     name: str,
@@ -2842,6 +2861,7 @@ def create_production(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def list_productions(ctx: Context | None = None) -> str:
     """
     List the team's production environments with status, domain, deployed
@@ -2859,6 +2879,7 @@ def list_productions(ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def get_production_info(name: str, ctx: Context | None = None) -> str:
     """
     Detailed information about a production: status, health, deployed commit,
@@ -2877,6 +2898,7 @@ def get_production_info(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def production_logs(
     name: str,
     n_lines: int = 100,
@@ -2908,6 +2930,7 @@ def production_logs(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def start_production(name: str, ctx: Context | None = None) -> str:
     """
@@ -2924,6 +2947,7 @@ def start_production(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def stop_production(name: str, ctx: Context | None = None) -> str:
     """
@@ -2940,6 +2964,7 @@ def stop_production(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def restart_production(name: str, ctx: Context | None = None) -> str:
     """
@@ -2956,6 +2981,7 @@ def restart_production(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def set_production_auto_update(
     name: str, enabled: bool, ctx: Context | None = None
@@ -2979,6 +3005,7 @@ def set_production_auto_update(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def update_production(
     name: str,
@@ -3035,6 +3062,7 @@ def update_production(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def rollback_production(
     name: str, to_commit: str = "", ctx: Context | None = None
@@ -3058,6 +3086,7 @@ def rollback_production(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def production_deploys(name: str, limit: int = 20, ctx: Context | None = None) -> str:
     """
     Deploy history of a production (newest last): commits, actions, modules,
@@ -3079,6 +3108,7 @@ def production_deploys(name: str, limit: int = 20, ctx: Context | None = None) -
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def snapshot_production(name: str, note: str = "", ctx: Context | None = None) -> str:
     """
@@ -3112,6 +3142,7 @@ def snapshot_production(name: str, note: str = "", ctx: Context | None = None) -
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def list_production_snapshots(
     name: str, refresh: bool = False, ctx: Context | None = None
 ) -> str:
@@ -3140,6 +3171,7 @@ def list_production_snapshots(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def restore_production(
     name: str, snapshot_id: str, confirm: str = "", ctx: Context | None = None
@@ -3175,6 +3207,7 @@ def restore_production(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def production_backup_status(ctx: Context | None = None) -> str:
     """
     Backup posture for the team: per-production snapshot state (schedule,
@@ -3193,6 +3226,7 @@ def production_backup_status(ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def set_production_backup_schedule(
     name: str, schedule: str, ctx: Context | None = None
@@ -3217,6 +3251,7 @@ def set_production_backup_schedule(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def prune_production_backups(ctx: Context | None = None) -> str:
     """
     Apply the retention policy ([backup] keep) to the team's snapshots and
@@ -3240,6 +3275,7 @@ def prune_production_backups(ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 def restore_cluster_pitr(
     target_time: str = "", confirm: str = "", ctx: Context | None = None
 ) -> str:
@@ -3304,6 +3340,7 @@ def restore_cluster_pitr(
 
 @mcp.tool()
 @handle_errors
+@production_enabled
 @with_prod_lock
 def delete_production(
     name: str,

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -223,11 +223,12 @@ class Settings:
     traefik_container: str = "oduflow-traefik"
     traefik_acme_volume: str = "oduflow-traefik-acme"
 
-    # Production hosting ([production] TOML section — every key optional).
+    # Production hosting ([production] TOML section — strict opt-in).
     # Productions themselves are created at runtime via MCP/UI and live in
     # per-team registries (productions.json), not in TOML. The production
     # PostgreSQL cluster is physically separate from the dev one and is
     # provisioned lazily (first production or existing container).
+    prod_enabled: bool = False
     prod_db_container: str = "oduflow-prod-db"
     prod_db_volume: str = "oduflow-prod-db-data"
     prod_postgres_image: str = ""  # empty = [database].image
@@ -446,6 +447,9 @@ class Settings:
         lifecycle = raw.get("lifecycle", {})
         agent = raw.get("agent", {})
         production = raw.get("production", {})
+        prod_enabled = production.get("enabled", False)
+        if not isinstance(prod_enabled, bool):
+            raise ValueError("[production] enabled must be true or false")
         oauth = raw.get("oauth", server)  # [oauth] section or fall back to [server]
         routing_mode = str(routing.get("mode", "port")).strip().lower()
         backup = _parse_backup_section(raw.get("backup", {}))
@@ -571,6 +575,7 @@ class Settings:
             auto_stop_hours=int(lifecycle.get("auto_stop_hours", 48)),
             auto_delete_hours=int(lifecycle.get("auto_delete_hours", 0)),
             oauth_base_url=str(oauth.get("oauth_base_url", "")).strip(),
+            prod_enabled=prod_enabled,
             prod_postgres_image=str(production.get("postgres_image", "")).strip(),
             prod_walg_version=str(production.get("walg_version", "")).strip(),
             prod_workers_cap=int(production.get("workers_cap", 8)),

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1214,7 +1214,7 @@
 
 <div class="tabs">
   <button class="tab-btn active" data-tab="environments" onclick="switchTab('environments')">Environments</button>
-  <button class="tab-btn" data-tab="production" onclick="switchTab('production')">Production</button>
+  <button class="tab-btn" data-tab="production" onclick="switchTab('production')" __PRODUCTION_TAB_HIDDEN__>Production</button>
   <button class="tab-btn" data-tab="services" onclick="switchTab('services')">Services</button>
   <button class="tab-btn" data-tab="volumes" onclick="switchTab('volumes')">Volumes</button>
   <button class="tab-btn" data-tab="extra-addons" onclick="switchTab('extra-addons')">Extra Addons</button>
@@ -2109,7 +2109,7 @@ function acceptConfirm() { _settleConfirm(true); }
   });
   tablist.addEventListener('keydown', function(e) {
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
-    var tabs = Array.from(document.querySelectorAll('.tab-btn'));
+    var tabs = Array.from(document.querySelectorAll('.tab-btn:not([hidden])'));
     var i = tabs.indexOf(document.activeElement);
     if (i === -1) return;
     e.preventDefault();
@@ -3111,6 +3111,10 @@ function closeLogsModal(event) {
 
 
 function switchTab(name) {
+  var targetTab = Array.from(document.querySelectorAll('.tab-btn')).find(function(b) {
+    return b.getAttribute('data-tab') === name;
+  });
+  if (!targetTab || targetTab.hidden) return;
   document.querySelectorAll('.tab-btn').forEach(function(b) {
     var active = b.getAttribute('data-tab') === name;
     b.classList.toggle('active', active);

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -84,14 +84,16 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 # Productions (long-lived customer environments with their own domain and a
 # dedicated production PostgreSQL cluster) are created at runtime via the
 # create_production MCP tool or the dashboard's Production tab — not here.
-# Both sections are optional. See https://docs.oduflow.dev/production/
+# Production hosting is disabled by default. Uncomment the section header and
+# enabled flag, then restart Oduflow. See https://docs.oduflow.dev/production/
 # [production]
+# enabled = true
 # postgres_image = ""             # default: [database].image
 # workers_cap = 8                 # upper bound for auto-tuned Odoo workers
 
 # S3 backups for productions: continuous WAL archiving (WAL-G), scheduled
 # snapshots (pg_dump + deduplicated filestore) and retention. Presence of
-# the section (bucket + keys) enables the whole backup subsystem.
+# the section (bucket + keys) configures backups; jobs run while production is enabled.
 # [backup]
 # bucket = ""
 # access_key = ""

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -611,7 +611,11 @@ def _build_routes(
 
     def dashboard(request: Request) -> HTMLResponse:
         html_path = _TEMPLATE_DIR / "dashboard.html"
-        response = HTMLResponse(html_path.read_text(encoding="utf-8"))
+        html = html_path.read_text(encoding="utf-8").replace(
+            "__PRODUCTION_TAB_HIDDEN__",
+            "" if get_settings().prod_enabled else "hidden",
+        )
+        response = HTMLResponse(html)
         team = getattr(request.state, "team", None)
         if team is not None and team.ui_password:
             _set_session_cookie(response, team, request)
@@ -3945,6 +3949,85 @@ def _build_routes(
         )
         return JSONResponse(payload, status_code=status)
 
+    production_routes: list[BaseRoute] = []
+    if get_settings().prod_enabled:
+        production_routes = [
+            Route("/api/productions", api_productions, methods=["GET"]),
+            Route("/api/productions/create", api_production_create, methods=["POST"]),
+            Route(
+                "/api/productions/backup-status",
+                api_production_backup_status,
+                methods=["GET"],
+            ),
+            Route("/api/productions/{name}", api_production_info, methods=["GET"]),
+            Route(
+                "/api/productions/{name}/start",
+                api_production_start,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/stop",
+                api_production_stop,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/restart",
+                api_production_restart,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/update",
+                api_production_update,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/rollback",
+                api_production_rollback,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/auto-update",
+                api_production_auto_update,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/logs",
+                api_production_logs,
+                methods=["GET"],
+            ),
+            Route(
+                "/api/productions/{name}/deploys",
+                api_production_deploys,
+                methods=["GET"],
+            ),
+            Route(
+                "/api/productions/{name}/delete",
+                api_production_delete,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/snapshots",
+                api_production_snapshots,
+                methods=["GET"],
+            ),
+            Route(
+                "/api/productions/{name}/snapshot",
+                api_production_snapshot_now,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/restore",
+                api_production_restore,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/productions/{name}/backup-schedule",
+                api_production_backup_schedule,
+                methods=["POST"],
+            ),
+            Route("/api/webhooks/github", webhook_github, methods=["POST"]),
+        ]
+
     return [
         Route("/", dashboard, methods=["GET"]),
         Route("/login", login, methods=["GET", "POST"]),
@@ -3974,65 +4057,8 @@ def _build_routes(
         Route("/api/templates/{name}/rename", api_template_rename, methods=["POST"]),
         Route("/api/environments", api_list, methods=["GET"]),
         Route("/api/environments/create", api_create, methods=["POST"]),
-        Route("/api/productions", api_productions, methods=["GET"]),
-        Route("/api/productions/create", api_production_create, methods=["POST"]),
-        Route(
-            "/api/productions/backup-status",
-            api_production_backup_status,
-            methods=["GET"],
-        ),
-        Route("/api/productions/{name}", api_production_info, methods=["GET"]),
-        Route("/api/productions/{name}/start", api_production_start, methods=["POST"]),
-        Route("/api/productions/{name}/stop", api_production_stop, methods=["POST"]),
-        Route(
-            "/api/productions/{name}/restart",
-            api_production_restart,
-            methods=["POST"],
-        ),
-        Route(
-            "/api/productions/{name}/update", api_production_update, methods=["POST"]
-        ),
-        Route(
-            "/api/productions/{name}/rollback",
-            api_production_rollback,
-            methods=["POST"],
-        ),
-        Route(
-            "/api/productions/{name}/auto-update",
-            api_production_auto_update,
-            methods=["POST"],
-        ),
-        Route("/api/productions/{name}/logs", api_production_logs, methods=["GET"]),
-        Route(
-            "/api/productions/{name}/deploys",
-            api_production_deploys,
-            methods=["GET"],
-        ),
-        Route(
-            "/api/productions/{name}/delete", api_production_delete, methods=["POST"]
-        ),
-        Route(
-            "/api/productions/{name}/snapshots",
-            api_production_snapshots,
-            methods=["GET"],
-        ),
-        Route(
-            "/api/productions/{name}/snapshot",
-            api_production_snapshot_now,
-            methods=["POST"],
-        ),
-        Route(
-            "/api/productions/{name}/restore",
-            api_production_restore,
-            methods=["POST"],
-        ),
-        Route(
-            "/api/productions/{name}/backup-schedule",
-            api_production_backup_schedule,
-            methods=["POST"],
-        ),
+        *production_routes,
         Route("/healthz", healthz, methods=["GET"]),
-        Route("/api/webhooks/github", webhook_github, methods=["POST"]),
         Route("/api/stats", api_stats, methods=["GET"]),
         Route("/api/usage", api_usage, methods=["GET"]),
         Route("/api/usage/refresh", api_usage_refresh, methods=["POST"]),

--- a/src/oduflow/webhooks.py
+++ b/src/oduflow/webhooks.py
@@ -199,6 +199,8 @@ def handle_github_event(
     signature_header: str,
 ) -> tuple[int, dict[str, Any]]:
     """Process a GitHub webhook request; returns (http_status, json_body)."""
+    if not settings.prod_enabled:
+        return 404, {"ok": False, "error": "production hosting disabled"}
     team = resolve_team(settings, body, signature_header)
     if team is None:
         return 401, {"ok": False, "error": "invalid signature"}

--- a/tests/test_backup_scheduler.py
+++ b/tests/test_backup_scheduler.py
@@ -71,6 +71,7 @@ def team(tmp_path):
 def settings(team, tmp_path):
     return Settings(
         base_data_dir=str(tmp_path),
+        prod_enabled=True,
         backup=BackupSettings(
             bucket="b", access_key="a", secret_key="s", snapshot_time="02:00"
         ),
@@ -84,6 +85,28 @@ class TestTick:
         with patch.object(sched, "_run_snapshot_job") as job:
             sched.tick(settings, LockManager())
         job.assert_not_called()
+
+    def test_disabled_production_is_noop(self, settings):
+        settings = Settings(
+            base_data_dir=settings.base_data_dir,
+            prod_enabled=False,
+            backup=settings.backup,
+            teams=settings.teams,
+        )
+        with patch.object(sched, "_run_snapshot_job") as job:
+            sched.tick(settings, LockManager())
+        job.assert_not_called()
+
+    def test_disabled_production_does_not_start_scheduler(self, settings):
+        settings = Settings(
+            base_data_dir=settings.base_data_dir,
+            prod_enabled=False,
+            backup=settings.backup,
+            teams=settings.teams,
+        )
+        with patch("threading.Thread") as thread:
+            assert sched.start_backup_scheduler(lambda: settings, LockManager()) is None
+        thread.assert_not_called()
 
     def test_due_snapshot_fires(self, settings, team):
         production_registry.create_production(team, "erp", {})

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -21,6 +21,7 @@ def settings(tmp_path):
     team_dir.mkdir()
     return Settings(
         base_data_dir=str(tmp_path),
+        prod_enabled=True,
         routing_mode="traefik",
         acme_email="a@b.co",
         teams={"1": TeamSettings(team_id="1", data_dir=str(team_dir))},
@@ -40,6 +41,7 @@ def _client(running: dict[str, bool]):
         return container
 
     client.containers.get.side_effect = _get
+    client.containers.list.return_value = []
     return client
 
 
@@ -88,6 +90,7 @@ class TestCollectHealth:
     def test_s3_error_degrades(self, settings, tmp_path):
         settings = Settings(
             base_data_dir=settings.base_data_dir,
+            prod_enabled=True,
             routing_mode="traefik",
             acme_email="a@b.co",
             backup=BackupSettings(bucket="b", access_key="a", secret_key="s"),
@@ -106,6 +109,37 @@ class TestCollectHealth:
             result = health.collect_health(settings, force=True)
         assert result["checks"]["s3"]["status"] == "error"
         assert result["ok"] is False
+
+    def test_disabled_production_checks_are_off(self, settings):
+        settings = Settings(
+            base_data_dir=settings.base_data_dir,
+            routing_mode=settings.routing_mode,
+            teams=settings.teams,
+        )
+        client = _client({"oduflow-db": True, "oduflow-traefik": True})
+        with patch("oduflow.docker_ops.client.get_client", return_value=client):
+            result = health.collect_health(settings, force=True)
+        assert result["ok"] is True
+        assert result["checks"]["prod_pg"]["status"] == "off"
+        assert result["checks"]["s3"]["status"] == "off"
+        assert result["checks"]["productions"]["status"] == "off"
+
+    def test_disabled_but_running_production_degrades(self, settings):
+        settings = Settings(
+            base_data_dir=settings.base_data_dir,
+            routing_mode=settings.routing_mode,
+            teams=settings.teams,
+        )
+        client = _client({"oduflow-db": True, "oduflow-traefik": True})
+        running = MagicMock(name="production")
+        running.name = "oduflow-1-prod-erp-odoo"
+        running.status = "running"
+        client.containers.list.return_value = [running]
+        with patch("oduflow.docker_ops.client.get_client", return_value=client):
+            result = health.collect_health(settings, force=True)
+        assert result["ok"] is False
+        assert result["checks"]["productions"]["status"] == "error"
+        assert result["checks"]["productions"]["running"] == [running.name]
 
     def test_disk_warn_does_not_degrade(self, settings):
         client = _client(

--- a/tests/test_prod_infra.py
+++ b/tests/test_prod_infra.py
@@ -67,7 +67,7 @@ class TestProductionWorkloadReconciliation:
 
         app.stop.assert_not_called()
 
-    def test_enabled_ensures_postgres_before_starting_all_odoo(self, settings):
+    def test_reenable_ensures_postgres_before_starting_all_odoo(self, settings):
         settings = Settings(
             base_data_dir=settings.base_data_dir,
             etc_dir=settings.etc_dir,
@@ -81,6 +81,11 @@ class TestProductionWorkloadReconciliation:
         app_a.start.side_effect = lambda: events.append(app_a.name)
         app_b.start.side_effect = lambda: events.append(app_b.name)
         client = MagicMock()
+        # PG stopped before ensure_prod_infra is the disable fingerprint that
+        # marks this as a genuine re-enable transition.
+        client.containers.get.return_value = _container(
+            settings.prod_db_container, status="exited"
+        )
         client.containers.list.return_value = [app_b, postgres, app_a]
 
         with patch.object(
@@ -92,6 +97,26 @@ class TestProductionWorkloadReconciliation:
 
         assert events == ["postgres", app_a.name, app_b.name]
         postgres.start.assert_not_called()
+
+    def test_steady_restart_preserves_manual_stops(self, settings):
+        settings = Settings(
+            base_data_dir=settings.base_data_dir,
+            etc_dir=settings.etc_dir,
+            prod_enabled=True,
+            teams=settings.teams,
+        )
+        client = MagicMock()
+        # PG already running => ordinary restart, not a re-enable: a production
+        # stopped via stop_production must stay stopped.
+        client.containers.get.return_value = _container(
+            settings.prod_db_container, status="running"
+        )
+
+        with patch.object(system_ops, "ensure_prod_infra") as ensure:
+            system_ops.reconcile_prod_workloads(client, settings)
+
+        ensure.assert_called_once()
+        client.containers.list.assert_not_called()
 
 
 class TestLazyProvisioning:

--- a/tests/test_prod_infra.py
+++ b/tests/test_prod_infra.py
@@ -26,6 +26,74 @@ def _client_without_prod():
     return client
 
 
+def _container(name, status="running"):
+    container = MagicMock()
+    container.name = name
+    container.status = status
+    return container
+
+
+class TestProductionWorkloadReconciliation:
+    def test_disabled_stops_odoo_before_postgres_without_removing(self, settings):
+        app = _container("oduflow-1-prod-erp-odoo")
+        postgres = _container(settings.prod_db_container)
+        stopped = []
+        app.stop.side_effect = lambda: stopped.append(app.name)
+        postgres.stop.side_effect = lambda: stopped.append(postgres.name)
+        client = MagicMock()
+        client.containers.list.return_value = [postgres, app]
+
+        system_ops.reconcile_prod_workloads(client, settings)
+
+        assert stopped == [app.name, postgres.name]
+        client.containers.list.assert_called_once_with(
+            all=True,
+            filters={
+                "label": [
+                    f"{settings.managed_label}=true",
+                    "oduflow.prod=true",
+                ]
+            },
+        )
+        app.remove.assert_not_called()
+        postgres.remove.assert_not_called()
+
+    def test_disabled_ignores_already_stopped_containers(self, settings):
+        app = _container("oduflow-1-prod-erp-odoo", status="exited")
+        client = MagicMock()
+        client.containers.list.return_value = [app]
+
+        system_ops.reconcile_prod_workloads(client, settings)
+
+        app.stop.assert_not_called()
+
+    def test_enabled_ensures_postgres_before_starting_all_odoo(self, settings):
+        settings = Settings(
+            base_data_dir=settings.base_data_dir,
+            etc_dir=settings.etc_dir,
+            prod_enabled=True,
+            teams=settings.teams,
+        )
+        app_a = _container("oduflow-1-prod-a-odoo", status="exited")
+        app_b = _container("oduflow-1-prod-b-odoo", status="exited")
+        postgres = _container(settings.prod_db_container, status="running")
+        events = []
+        app_a.start.side_effect = lambda: events.append(app_a.name)
+        app_b.start.side_effect = lambda: events.append(app_b.name)
+        client = MagicMock()
+        client.containers.list.return_value = [app_b, postgres, app_a]
+
+        with patch.object(
+            system_ops,
+            "ensure_prod_infra",
+            side_effect=lambda *_args, **_kwargs: events.append("postgres"),
+        ):
+            system_ops.reconcile_prod_workloads(client, settings)
+
+        assert events == ["postgres", app_a.name, app_b.name]
+        postgres.start.assert_not_called()
+
+
 class TestLazyProvisioning:
     def test_noop_without_productions(self, settings):
         client = _client_without_prod()

--- a/tests/test_production_enabled_web.py
+++ b/tests/test_production_enabled_web.py
@@ -1,0 +1,54 @@
+import re
+from unittest.mock import patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path, *, enabled: bool) -> TestClient:
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        prod_enabled=enabled,
+        teams={"1": team},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def _production_tab(html: str) -> str:
+    match = re.search(r'<button[^>]+data-tab="production"[^>]*>', html)
+    assert match is not None
+    return match.group(0)
+
+
+def test_disabled_hides_production_tab_and_omits_routes(tmp_path):
+    client = _client(tmp_path, enabled=False)
+
+    dashboard = client.get("/")
+
+    assert dashboard.status_code == 200
+    assert " hidden" in _production_tab(dashboard.text)
+    assert "__PRODUCTION_TAB_HIDDEN__" not in dashboard.text
+    assert ".tab-btn:not([hidden])" in dashboard.text
+    assert "if (!targetTab || targetTab.hidden) return;" in dashboard.text
+    assert client.get("/api/productions").status_code == 404
+    assert client.post("/api/webhooks/github").status_code == 404
+
+
+def test_enabled_shows_production_tab_and_registers_routes(tmp_path):
+    client = _client(tmp_path, enabled=True)
+
+    dashboard = client.get("/")
+
+    assert dashboard.status_code == 200
+    assert " hidden" not in _production_tab(dashboard.text)
+    with patch("oduflow.web_ui.production_ops.list_productions", return_value=[]):
+        response = client.get("/api/productions")
+    assert response.status_code == 200
+    assert response.json()["productions"] == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -374,6 +374,49 @@ class TestErrorHandling:
             _call_tool("restart_environment", env_name="main")
 
 
+class TestProductionFeatureGate:
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "create_production",
+            "list_productions",
+            "get_production_info",
+            "production_logs",
+            "start_production",
+            "stop_production",
+            "restart_production",
+            "set_production_auto_update",
+            "update_production",
+            "rollback_production",
+            "production_deploys",
+            "snapshot_production",
+            "list_production_snapshots",
+            "restore_production",
+            "production_backup_status",
+            "set_production_backup_schedule",
+            "prune_production_backups",
+            "restore_cluster_pitr",
+            "delete_production",
+        ],
+    )
+    def test_every_production_tool_is_rejected_when_disabled(self, tool_name):
+        with pytest.raises(ToolError, match="Production hosting is disabled"):
+            _call_tool(tool_name)
+
+    @patch("oduflow.docker_ops.production_ops.list_productions", return_value=[])
+    def test_enabled_production_tool_runs(self, mock_list):
+        import oduflow.server
+
+        oduflow.server._settings = Settings(
+            prod_enabled=True,
+            teams={"1": TEST_TEAM},
+        )
+        assert _call_tool("list_productions") == (
+            "No productions found. Use create_production to provision one."
+        )
+        mock_list.assert_called_once()
+
+
 def _get_tool_fn(tool_name: str):
     """Get a sync-callable wrapper for a registered MCP tool."""
     import asyncio

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 from oduflow.settings import Settings, TeamSettings
 
 
@@ -402,6 +403,7 @@ class TestExtraRoutes:
 class TestProductionSettings:
     def test_defaults(self):
         s = Settings()
+        assert s.prod_enabled is False
         assert s.prod_db_container == "oduflow-prod-db"
         assert s.prod_db_volume == "oduflow-prod-db-data"
         assert s.prod_postgres_image == ""
@@ -412,13 +414,32 @@ class TestProductionSettings:
         toml = tmp_path / "oduflow.toml"
         toml.write_text(
             "[production]\n"
+            "enabled = true\n"
             'postgres_image = "postgres:17"\n'
             "workers_cap = 12\n"
             '[team.1]\nhostname = "localhost"\n'
         )
         s = Settings.from_toml(str(toml))
+        assert s.prod_enabled is True
         assert s.prod_postgres_image == "postgres:17"
         assert s.prod_workers_cap == 12
+
+    def test_production_section_without_enabled_stays_disabled(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text("[production]\nworkers_cap = 12\n[team.1]\n")
+        assert Settings.from_toml(str(toml)).prod_enabled is False
+
+    def test_production_enabled_must_be_boolean(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text('[production]\nenabled = "true"\n[team.1]\n')
+        with pytest.raises(ValueError, match="enabled must be true or false"):
+            Settings.from_toml(str(toml))
+
+    def test_bundled_template_has_commented_opt_in(self):
+        template = (
+            Path(__file__).parents[1] / "src" / "oduflow" / "templates" / "oduflow.toml"
+        ).read_text()
+        assert "# [production]\n# enabled = true\n" in template
 
 
 class TestBackupSettings:

--- a/tests/test_web_ui_auth.py
+++ b/tests/test_web_ui_auth.py
@@ -42,9 +42,12 @@ _PW = "s3cret"
 _DATA_DIR = tempfile.mkdtemp(prefix="oduflow-uiauth-test-")
 
 
-def _settings(routing_mode: str = "port", etc_dir: str = "") -> Settings:
+def _settings(
+    routing_mode: str = "port", etc_dir: str = "", *, prod_enabled: bool = False
+) -> Settings:
     return Settings(
         routing_mode=routing_mode,
+        prod_enabled=prod_enabled,
         base_data_dir=_DATA_DIR,
         etc_dir=etc_dir,
         teams={
@@ -418,7 +421,7 @@ def test_healthz_degraded_is_503():
 
 def test_github_webhook_is_public_but_verifies_hmac():
     # No UI session: the route is reachable, but a bad signature is 401.
-    client = TestClient(_full_app(_settings()))
+    client = TestClient(_full_app(_settings(prod_enabled=True)))
     resp = client.post(
         "/api/webhooks/github",
         content=b"{}",

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -19,7 +19,7 @@ def team(tmp_path):
 
 @pytest.fixture
 def settings(team, tmp_path):
-    return Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    return Settings(base_data_dir=str(tmp_path), prod_enabled=True, teams={"1": team})
 
 
 def _sign(secret: str, body: bytes) -> str:
@@ -119,6 +119,20 @@ class TestMatchProductions:
 
 
 class TestHandleGithubEvent:
+    def test_disabled_production_returns_404(self, team, tmp_path):
+        settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+        with patch.object(webhooks, "resolve_team") as resolve:
+            status, body = webhooks.handle_github_event(
+                settings,
+                LockManager(),
+                event="push",
+                body=b"{}",
+                signature_header="sha256=deadbeef",
+            )
+        assert status == 404
+        assert body == {"ok": False, "error": "production hosting disabled"}
+        resolve.assert_not_called()
+
     def test_bad_signature_401(self, settings, team):
         production_registry.create_production(team, "erp", {})
         status, body = webhooks.handle_github_event(


### PR DESCRIPTION
## Summary

Makes production hosting a strict global opt-in through `[production].enabled`, with disabled dashboard, REST, MCP, webhook, and scheduler surfaces.
On startup, disabled mode stops production Odoo containers before PostgreSQL while preserving state; re-enabling starts PostgreSQL before all production workloads, and health checks expose reconciliation drift.
Updates the bundled configuration, production documentation and ADR, with regression coverage across settings, web routing, MCP tools, automation, lifecycle, and health.

## Validation

`pytest -m "not integration and not heavyweight" -q` (1,151 passed); isolated Docker integration scenario passed; `ruff check src/oduflow tests`; `mypy src/oduflow`.
