### PR TITLE
Bust stale Agent Chat assets after dashboard updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ Any change to the web dashboard (`src/oduflow/templates/dashboard.html`, served 
 
 Read both before touching dashboard UI. Key hard rules: no external CDNs (all assets ship with the package), every `var(--*)` must be declared in `:root`, status is never conveyed by color alone, no emoji as UI affordances.
 
+The dashboard loads `/static/chat.js` with its own positive integer cache
+version in the query string. Whenever
+`src/oduflow/templates/static/chat.js` changes, increment that `v` value in
+`src/oduflow/templates/dashboard.html`. This cache version is independent of
+the Oduflow product version.
+
 ## Commands
 
 ```bash

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -4903,10 +4903,11 @@ function ensureChatAssets() {
       document.head.appendChild(s);
     });
   }
+  // Increment the cache version whenever chat.js changes (see AGENTS.md).
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
     loadScript('/static/acp-client.js')
-  ]).then(function() { return loadScript('/static/chat.js'); });
+  ]).then(function() { return loadScript('/static/chat.js?v=1'); });
   return _chatAssets;
 }
 

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -1,0 +1,39 @@
+"""Regression tests for dashboard static asset cache versioning."""
+
+from __future__ import annotations
+
+import re
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path) -> TestClient:
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1")},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def test_chat_script_uses_positive_integer_cache_version(tmp_path):
+    client = _client(tmp_path)
+    dashboard = client.get("/")
+
+    assert dashboard.status_code == 200
+    match = re.search(r"/static/chat\.js\?v=([1-9][0-9]*)", dashboard.text)
+    assert match is not None
+
+    versioned = client.get(match.group(0))
+    unversioned = client.get("/static/chat.js")
+
+    assert versioned.status_code == 200
+    assert versioned.headers["content-type"].startswith("application/javascript")
+    assert versioned.headers["cache-control"] == "public, max-age=86400"
+    assert versioned.content == unversioned.content


### PR DESCRIPTION
## Summary

Adds a manual `v=1` cache key to the lazy-loaded `chat.js` URL so browsers fetch updated Agent Chat code instead of reusing a day-old cached copy. Documents the required version increment in `AGENTS.md` while keeping it independent from the Oduflow product version. Adds regression coverage that validates the positive integer cache key and confirms the versioned URL serves the same JavaScript with the existing cache headers.

## Validation

`pytest tests/test_web_ui_static.py -q` and `ruff check src/oduflow tests`.