### PR TITLE
Share one cache version across chat.js and acp-client.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,16 @@ Any change to the web dashboard (`src/oduflow/templates/dashboard.html`, served 
 
 Read both before touching dashboard UI. Key hard rules: no external CDNs (all assets ship with the package), every `var(--*)` must be declared in `:root`, status is never conveyed by color alone, no emoji as UI affordances.
 
-The dashboard loads `/static/chat.js` with its own positive integer cache
-version in the query string. Whenever
-`src/oduflow/templates/static/chat.js` changes, increment that `v` value in
-`src/oduflow/templates/dashboard.html`. This cache version is independent of
-the Oduflow product version.
+The dashboard loads `/static/chat.js` and `/static/acp-client.js` with a
+shared positive integer cache version in the query string, held in the
+`CHAT_V` variable in `src/oduflow/templates/dashboard.html`. Whenever either
+`src/oduflow/templates/static/chat.js` or
+`src/oduflow/templates/static/acp-client.js` changes, increment `CHAT_V`. The
+two files are an interdependent pair of our own code, so one shared version
+busts both at once and prevents a stale mismatch between them. This cache
+version is independent of the Oduflow product version. (The vendored
+third-party assets — `marked.min.js`, `xterm.js`, etc. — are not versioned this
+way; bump the filename if you ever upgrade them.)
 
 ## Commands
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -4903,11 +4903,14 @@ function ensureChatAssets() {
       document.head.appendChild(s);
     });
   }
-  // Increment the cache version whenever chat.js changes (see AGENTS.md).
+  // chat.js and acp-client.js are an interdependent pair of our own code; bump
+  // this shared CHAT_V whenever either one changes (see AGENTS.md). One version
+  // busts both at once, preventing a stale chat.js/acp-client.js mismatch.
+  var CHAT_V = '1';
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
-    loadScript('/static/acp-client.js')
-  ]).then(function() { return loadScript('/static/chat.js?v=1'); });
+    loadScript('/static/acp-client.js?v=' + CHAT_V)
+  ]).then(function() { return loadScript('/static/chat.js?v=' + CHAT_V); });
   return _chatAssets;
 }
 

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -22,18 +22,28 @@ def _client(tmp_path) -> TestClient:
     return TestClient(app)
 
 
-def test_chat_script_uses_positive_integer_cache_version(tmp_path):
+def test_chat_assets_share_one_positive_integer_cache_version(tmp_path):
     client = _client(tmp_path)
     dashboard = client.get("/")
-
     assert dashboard.status_code == 200
-    match = re.search(r"/static/chat\.js\?v=([1-9][0-9]*)", dashboard.text)
-    assert match is not None
 
-    versioned = client.get(match.group(0))
-    unversioned = client.get("/static/chat.js")
+    # chat.js and acp-client.js are an interdependent pair; the dashboard holds
+    # ONE shared cache version (CHAT_V) so a single bump busts both at once.
+    match = re.search(r"var CHAT_V = '([1-9][0-9]*)'", dashboard.text)
+    assert match is not None, "CHAT_V positive integer cache version not found"
+    version = match.group(1)
 
-    assert versioned.status_code == 200
-    assert versioned.headers["content-type"].startswith("application/javascript")
-    assert versioned.headers["cache-control"] == "public, max-age=86400"
-    assert versioned.content == unversioned.content
+    for filename in ("chat.js", "acp-client.js"):
+        # Both assets must reference the shared CHAT_V, not a hardcoded number,
+        # so they can never drift out of sync.
+        assert re.search(
+            rf"/static/{re.escape(filename)}\?v='\s*\+\s*CHAT_V", dashboard.text
+        ), f"{filename} does not use the shared CHAT_V cache version"
+
+        versioned = client.get(f"/static/{filename}?v={version}")
+        unversioned = client.get(f"/static/{filename}")
+
+        assert versioned.status_code == 200
+        assert versioned.headers["content-type"].startswith("application/javascript")
+        assert versioned.headers["cache-control"] == "public, max-age=86400"
+        assert versioned.content == unversioned.content


### PR DESCRIPTION
## What

`acp-client.js` is our own code and changes together with `chat.js`, but the dashboard loaded it without a cache version. Bumping only `chat.js?v=` could leave a user on a fresh `chat.js` paired with a stale, browser-cached `acp-client.js` — a hard-to-reproduce runtime mismatch (new `chat.js` calling an API absent from the old `acp-client.js`).

## Change

- `dashboard.html`: hold a single `CHAT_V` and apply it to both `chat.js` and `acp-client.js`, so one bump busts the interdependent pair at once and they can never drift out of sync. Vendored third-party assets (`marked.min.js`, `xterm.js`) stay unversioned.
- `AGENTS.md`: update the cache-version note to describe the shared `CHAT_V` and both files.
- `tests/test_web_ui_static.py`: extend the regression test to assert both assets reference the shared `CHAT_V` and are served identically under a versioned URL.

## Test

`pytest tests/test_web_ui_static.py` passes; `ruff check`/`ruff format --check` clean.