### PR TITLE
Improve Agent Chat details, scrolling, and file uploads

### DIFF
--- a/specs/0038-agent-chat-file-attachments.md
+++ b/specs/0038-agent-chat-file-attachments.md
@@ -1,0 +1,81 @@
+# 0038 — Agent Chat file attachments through persistent workspace resources
+
+**Status:** Adopted
+**Type:** Architecture — new Agent Chat capability
+**First introduced:** this change (2026-07-22), branch `litnimax/collapse-agent-details`
+**Key code today:** `agent_uploads.py`; Agent Chat attachment routes in `web_ui.py`; `get_agent_upload_dir` and `_agent_remove_env`; `templates/static/acp-client.js` + `chat.js`; Agent Chat composer styles in `templates/dashboard.html`
+
+## Context
+
+The browser Agent Chat could send only text even though users routinely need an
+agent to inspect screenshots, exported data, PDFs and other files that are not
+part of the environment's git checkout. Sending every file as base64 over the
+ACP WebSocket would increase prompt and session-history size, duplicate large
+payloads on every replay, and depend on optional multimodal support in each ACP
+adapter. Saving uploads inside the checkout would instead pollute `git status`
+and risk committing user attachments into the repository.
+
+The existing [[0029-agent-console-and-chat]] architecture already provides a
+stronger boundary: each team has a persistent `/workspace` volume shared with
+its unprivileged coding-agent container, and every ACP session runs with the
+environment checkout as its working directory.
+
+## Decision
+
+Agent Chat uses an **upload-then-reference** model. The authenticated dashboard
+uploads each file over a dedicated HTTP endpoint, Oduflow copies it into the
+team's persistent agent workspace, and the subsequent ACP prompt refers to the
+stored file with a standard `resource_link` content block. The user's textual
+instruction is always required; a file is context for an explicit request, not
+a prompt by itself.
+
+Attachments live outside every git checkout at
+`/workspace/.oduflow-uploads/<environment>/<random-id>/<safe-name>`. They remain
+available to resumed conversations and agent tools until the environment is
+deleted. Environment deletion removes both its checkout and attachment tree.
+
+Small images take a capability-aware fast path: when the ACP agent advertises
+`promptCapabilities.image`, the prompt carries an ACP `image` block with the
+stored file URI and inline image data so the model receives visual context
+directly. Other files, large images, and agents without that capability use the
+baseline `resource_link` representation.
+
+## How it works
+
+- The browser uploads raw file bytes separately from JSON-RPC. This keeps the
+  ACP WebSocket line-framed and avoids adding multipart parsing dependencies.
+- The server authenticates the team and environment, normalizes the filename,
+  streams into a temporary file, and copies a private (`0600`) tar member into
+  the team's running agent container. Paths and upload ids are server-derived.
+- Limits are enforced at both boundaries: five files per prompt, 25 MiB per
+  file, and 100 MiB of attachment storage per environment. The server is
+  authoritative for byte and quota limits.
+- The composer exposes upload progress, failure and removal as text states.
+  `Send` remains disabled until the instruction is non-empty and every selected
+  attachment is ready. Removing an unsent completed upload deletes its stored
+  directory.
+- Live messages and `session/load` replay render attachment content blocks as
+  compact filename/type/size rows. Payloads are never rendered as active HTML.
+
+## Consequences
+
+- Agents can inspect attachments with their native multimodal input or ordinary
+  filesystem tools, while follow-up turns keep access to the same path.
+- The per-team container and volume remain the tenancy boundary; no host path is
+  mounted into an agent and no attachment URL crosses teams.
+- Storage is intentionally tied to environment lifetime rather than browser or
+  conversation lifetime. The fixed environment quota bounds persistent growth
+  while preserving history semantics.
+- Oduflow does not extract archives or promise built-in parsing for every
+  binary format. Predictable PDF/Office extraction can evolve independently by
+  adding readers to the coder image; the attachment transport stays unchanged.
+- Content inside an attachment remains untrusted input to a full-access coding
+  agent. The feature does not weaken the Docker/team boundary established by
+  [[0029-agent-console-and-chat]], but it cannot eliminate prompt injection in
+  user-supplied documents.
+
+## History
+
+- 2026-07-22 — introduced authenticated uploads, persistent workspace storage,
+  ACP resource/image blocks, composer attachment states and environment-scoped
+  cleanup.

--- a/specs/README.md
+++ b/specs/README.md
@@ -56,6 +56,7 @@ precursors).
 | [0035](0035-production-hosting.md) | 2026-07-11 | Production hosting: dedicated PG cluster, WAL-G/S3 backups, snapshots, auto-rollback deploys |
 | [0036](0036-cross-subdomain-connect-as-landing.md) | 2026-07-19 | Cross-subdomain "Connect as user" landing: one-time token → env-host `/oduflow-connect` sets the session cookie host-only |
 | [0037](0037-built-in-agent-browser-and-noninteractive-codex.md) | 2026-07-21 | Built-in Agent Browser MCP and non-interactive Codex trust model |
+| [0038](0038-agent-chat-file-attachments.md) | 2026-07-22 | Agent Chat file attachments through persistent workspace resources |
 
 ## Design docs
 

--- a/src/oduflow/agent_uploads.py
+++ b/src/oduflow/agent_uploads.py
@@ -1,0 +1,192 @@
+"""Persistent file attachments for browser Agent Chat prompts."""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import secrets
+import tarfile
+from typing import BinaryIO, Any
+from urllib.parse import quote
+
+import docker
+
+from oduflow.docker_ops.client import get_client
+from oduflow.errors import FlowError, NotFoundError
+from oduflow.naming import (
+    get_agent_container_name,
+    get_agent_upload_dir,
+    get_resource_name,
+    slugify_branch,
+)
+from oduflow.settings import Settings, TeamSettings
+
+MAX_FILE_BYTES = 25 * 1024 * 1024
+MAX_ENV_BYTES = 100 * 1024 * 1024
+MAX_FILES_PER_PROMPT = 5
+AGENT_USER = "agent"
+
+_UPLOAD_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_MIME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9.+-]*/[a-zA-Z0-9][a-zA-Z0-9.+-]*$")
+
+
+class AttachmentError(FlowError):
+    """A user-visible attachment failure with an HTTP status code."""
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def normalize_filename(filename: str) -> tuple[str, str]:
+    """Return safe display and storage names for an untrusted browser name."""
+    display_name = os.path.basename(filename.replace("\\", "/")).strip()
+    display_name = "".join(
+        char for char in display_name if char >= " " and char != "\x7f"
+    )
+    if not display_name or display_name in {".", ".."}:
+        raise AttachmentError("A valid file name is required.")
+    display_name = display_name[:180]
+
+    storage_name = re.sub(r"[^\w. -]", "_", display_name, flags=re.UNICODE)
+    storage_name = re.sub(r"\s+", "_", storage_name).strip(" ._")
+    if not storage_name:
+        storage_name = "attachment"
+    stem, suffix = os.path.splitext(storage_name)
+    storage_name = (stem[:140] or "attachment") + suffix[:20]
+    return display_name, storage_name
+
+
+def normalize_mime_type(mime_type: str | None) -> str:
+    candidate = (mime_type or "").split(";", 1)[0].strip()
+    if len(candidate) <= 127 and _MIME_RE.fullmatch(candidate):
+        return candidate.lower()
+    return "application/octet-stream"
+
+
+def _decode_output(output: Any) -> str:
+    if isinstance(output, (bytes, bytearray)):
+        return output.decode("utf-8", "replace")
+    return str(output or "")
+
+
+def _agent_container(settings: Settings, team: TeamSettings, env_name: str) -> Any:
+    if not team.agent_enabled:
+        raise AttachmentError("The coding agent is disabled for this team.", 403)
+    if not slugify_branch(env_name):
+        raise AttachmentError("Invalid environment name.")
+
+    client = get_client()
+    env_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
+    try:
+        client.containers.get(env_container_name)
+    except docker.errors.NotFound as exc:
+        raise NotFoundError(f"Environment '{env_name}' does not exist.") from exc
+
+    try:
+        container = client.containers.get(
+            get_agent_container_name(team.team_id, settings.prefix)
+        )
+    except docker.errors.NotFound as exc:
+        raise AttachmentError("The coding-agent container was not found.", 503) from exc
+    if container.status != "running":
+        raise AttachmentError("The coding-agent container is not running.", 503)
+    return container
+
+
+def _directory_size(container: Any, path: str) -> int:
+    code, output = container.exec_run(["du", "-sb", path], user=AGENT_USER)
+    if code not in (0, None):
+        return 0
+    try:
+        return int(_decode_output(output).split(None, 1)[0])
+    except (ValueError, IndexError):
+        return 0
+
+
+def _attachment_archive(
+    upload_id: str, storage_name: str, source: BinaryIO, size: int
+) -> bytes:
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w") as tar:
+        directory = tarfile.TarInfo(upload_id)
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o700
+        directory.uid = 1000
+        directory.gid = 1000
+        directory.uname = AGENT_USER
+        directory.gname = AGENT_USER
+        tar.addfile(directory)
+
+        item = tarfile.TarInfo(f"{upload_id}/{storage_name}")
+        item.size = size
+        item.mode = 0o600
+        item.uid = 1000
+        item.gid = 1000
+        item.uname = AGENT_USER
+        item.gname = AGENT_USER
+        source.seek(0)
+        tar.addfile(item, source)
+    return archive.getvalue()
+
+
+def store_attachment(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    filename: str,
+    mime_type: str | None,
+    source: BinaryIO,
+    size: int,
+) -> dict[str, object]:
+    """Copy one validated attachment into the team's agent workspace volume."""
+    if size < 0 or size > MAX_FILE_BYTES:
+        raise AttachmentError(
+            f"Files must be no larger than {MAX_FILE_BYTES // (1024 * 1024)} MiB.",
+            413,
+        )
+    display_name, storage_name = normalize_filename(filename)
+    mime_type = normalize_mime_type(mime_type)
+    container = _agent_container(settings, team, env_name)
+    upload_root = get_agent_upload_dir(env_name)
+
+    code, _output = container.exec_run(["mkdir", "-p", upload_root], user=AGENT_USER)
+    if code not in (0, None):
+        raise AttachmentError("Could not prepare attachment storage.", 500)
+    if _directory_size(container, upload_root) + size > MAX_ENV_BYTES:
+        raise AttachmentError(
+            "Attachment storage for this environment is full "
+            f"({MAX_ENV_BYTES // (1024 * 1024)} MiB limit).",
+            413,
+        )
+
+    upload_id = secrets.token_hex(16)
+    archive = _attachment_archive(upload_id, storage_name, source, size)
+    if not container.put_archive(upload_root, archive):
+        raise AttachmentError("Could not copy the attachment to the agent.", 500)
+
+    path = f"{upload_root}/{upload_id}/{storage_name}"
+    return {
+        "id": upload_id,
+        "name": display_name,
+        "path": path,
+        "uri": "file://" + quote(path, safe="/"),
+        "mimeType": mime_type,
+        "size": size,
+    }
+
+
+def delete_attachment(
+    settings: Settings, team: TeamSettings, env_name: str, upload_id: str
+) -> None:
+    """Delete one unsent attachment directory from the agent workspace."""
+    if not _UPLOAD_ID_RE.fullmatch(upload_id):
+        raise AttachmentError("Invalid attachment id.")
+    container = _agent_container(settings, team, env_name)
+    path = f"{get_agent_upload_dir(env_name)}/{upload_id}"
+    code, _output = container.exec_run(["rm", "-rf", "--", path], user=AGENT_USER)
+    if code not in (0, None):
+        raise AttachmentError("Could not remove the attachment.", 500)

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -45,6 +45,7 @@ from oduflow.naming import (
     get_agent_checkout_dir,
     get_agent_container_name,
     get_agent_home_volume_name,
+    get_agent_upload_dir,
     get_agent_workspace_volume_name,
     get_db_name,
     get_env_hostname,
@@ -1629,9 +1630,7 @@ def _ensure_agent_container(
             "api_key": "Console API (ANTHROPIC_API_KEY)",
             "interactive": "interactive /login",
         }.get(_claude_auth_mode(settings, team), "unknown")
-        logger.info(
-            "Claude auth: %s", auth_label, extra={"container": container_name}
-        )
+        logger.info("Claude auth: %s", auth_label, extra={"container": container_name})
     except Exception:
         logger.warning("Agent container ensure failed", exc_info=True)
 
@@ -1723,7 +1722,7 @@ def ensure_agent_env_checkout(
 def _agent_remove_env(
     client: DockerClient, settings: Settings, team: TeamSettings, env_name: str
 ) -> None:
-    """Remove one environment's checkout from the team's agent container.
+    """Remove one environment's checkout and Agent Chat attachments.
 
     Best-effort; the container itself keeps running (it serves other envs).
     """
@@ -1746,7 +1745,14 @@ def _agent_remove_env(
         return
     with contextlib.suppress(Exception):
         container.exec_run(
-            ["rm", "-rf", get_agent_checkout_dir(env_name)], user=AGENT_USER
+            [
+                "rm",
+                "-rf",
+                "--",
+                get_agent_checkout_dir(env_name),
+                get_agent_upload_dir(env_name),
+            ],
+            user=AGENT_USER,
         )
 
 

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -195,6 +195,15 @@ def get_agent_checkout_dir(env_name: str) -> str:
     return f"/workspace/{slugify_branch(env_name)}"
 
 
+def get_agent_upload_dir(env_name: str) -> str:
+    """Directory for Agent Chat attachments inside the team's workspace volume.
+
+    Attachments deliberately live outside the environment's git checkout so
+    they never appear in ``git status`` or get committed by the coding agent.
+    """
+    return f"/workspace/.oduflow-uploads/{slugify_branch(env_name)}"
+
+
 def get_workspace_path(env_name: str, workspaces_dir: str) -> str:
     return os.path.join(workspaces_dir, env_name.replace("/", "-"))
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -602,6 +602,12 @@
   .chat-msg-user { justify-content: flex-end; }
   .chat-bubble { padding: 8px 12px; border-radius: var(--radius); font-size: var(--text-sm); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
   .chat-msg-user .chat-bubble { max-width: 80%; background: color-mix(in oklab, var(--accent) 18%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent); }
+  .chat-user-text { white-space: pre-wrap; }
+  .chat-attachments { display: grid; gap: 4px; margin-top: 7px; min-width: 0; }
+  .chat-user-text:empty + .chat-attachments { margin-top: 0; }
+  .chat-attachment { display: flex; align-items: baseline; gap: 8px; min-width: 0; padding-top: 5px; border-top: 1px solid var(--border); }
+  .chat-attachment-name { min-width: 0; overflow: hidden; color: var(--text); font-family: var(--font-mono); font-size: var(--text-xs); font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+  .chat-attachment-meta { flex: 0 0 auto; color: var(--text-dim); font-size: var(--text-2xs); }
   .chat-msg-agent { display: block; min-width: 0; }
   .chat-msg-agent .chat-bubble { width: 100%; max-width: none; padding: 0; border-radius: 0; background: transparent; border: 0; }
   .chat-md { white-space: normal; }
@@ -647,12 +653,28 @@
   .chat-perm-btn { background: transparent; color: var(--text); border: 1px solid var(--border-raised); border-radius: var(--radius-sm); font-size: var(--text-xs); font-weight: 600; padding: 5px 12px; cursor: pointer; }
   .chat-perm-btn:hover, .chat-perm-btn:focus-visible { border-color: var(--text-dim); }
   .chat-perm-btn.primary { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
-  .chat-composer { flex: 0 0 auto; display: flex; gap: 8px; align-items: flex-end; padding: 10px 12px; border-top: 1px solid var(--border); }
+  .chat-composer { flex: 0 0 auto; display: flex; flex-direction: column; gap: 7px; padding: 10px 12px; border-top: 1px solid var(--border); }
+  .chat-composer.is-dragover { background: var(--subtle); box-shadow: inset 0 0 0 1px var(--accent); }
+  .chat-composer-main { display: flex; gap: 8px; align-items: flex-end; min-width: 0; }
+  .chat-composer-attachments { display: grid; gap: 4px; }
+  .chat-pending-attachment { display: flex; align-items: center; gap: 10px; min-width: 0; padding: 4px 2px; border-bottom: 1px solid var(--border); }
+  .chat-pending-attachment[data-status="failed"] .chat-pending-meta { color: var(--red); }
+  .chat-pending-attachment[data-status="uploading"] .chat-pending-meta { color: var(--accent); }
+  .chat-pending-attachment[data-status="ready"] .chat-pending-meta { color: var(--green); }
+  .chat-pending-body { display: flex; align-items: baseline; gap: 8px; min-width: 0; flex: 1; }
+  .chat-pending-meta { flex: 0 0 auto; color: var(--text-dim); font-size: var(--text-2xs); }
+  .chat-attachment-remove { flex: 0 0 auto; border: 0; border-radius: var(--radius-sm); background: transparent; color: var(--text-dim); cursor: pointer; font-family: var(--font-sans); font-size: var(--text-2xs); font-weight: 600; padding: 3px 5px; }
+  .chat-attachment-remove:hover { color: var(--red); }
+  .chat-attachment-remove:focus-visible { outline: none; color: var(--red); box-shadow: var(--focus-ring); }
   .chat-input { flex: 1; resize: none; background: var(--bg); color: var(--text); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px; font-family: var(--font-sans); font-size: var(--text-sm); line-height: 1.4; max-height: 40vh; }
   .chat-input:focus { outline: none; border-color: var(--accent); box-shadow: var(--focus-ring); }
   .chat-composer-actions { display: flex; gap: 8px; flex: 0 0 auto; }
+  .chat-attach { background: transparent; color: var(--text); border: 1px solid var(--border-raised); }
+  .chat-attach:hover, .chat-attach:focus-visible { border-color: var(--accent); color: var(--accent); }
+  .chat-attach:disabled { opacity: 0.4; cursor: not-allowed; }
   .chat-send { background: var(--accent); color: var(--accent-fg); border: 1px solid var(--accent); }
   .chat-send:disabled { opacity: 0.4; cursor: not-allowed; }
+  .chat-composer-error { color: var(--red); font-size: var(--text-2xs); }
   .chat-stop:hover, .chat-stop:focus-visible { border-color: var(--red); color: var(--red); }
   #chat-dock { position: fixed; left: 16px; bottom: 16px; display: flex; flex-wrap: wrap; gap: 8px; z-index: var(--z-toast); max-width: calc(100vw - 32px); }
   .chat-pill { display: inline-flex; align-items: center; gap: 8px; background: var(--surface-raised); border: 1px solid var(--border-raised); border-radius: var(--radius); box-shadow: var(--shadow-bar); padding: 6px 8px 6px 10px; cursor: pointer; color: var(--text); text-align: left; }
@@ -4926,7 +4948,7 @@ function ensureChatAssets() {
   // chat.js and acp-client.js are an interdependent pair of our own code; bump
   // this shared CHAT_V whenever either one changes (see AGENTS.md). One version
   // busts both at once, preventing a stale chat.js/acp-client.js mismatch.
-  var CHAT_V = '3';
+  var CHAT_V = '4';
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
     loadScript('/static/acp-client.js?v=' + CHAT_V)

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -59,6 +59,7 @@
     --violet: #a78bfa;
     --rose: #fb7185;
     --terminal-bg: #060a12;
+    --terminal-text: oklch(0.93 0.005 260);
     /* Theme-derived tokens — overridden in the light theme below */
     --accent-fg: #fff;
     --backdrop: rgba(0,0,0,0.72);
@@ -599,9 +600,10 @@
   .chat-messages { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
   .chat-msg { display: flex; }
   .chat-msg-user { justify-content: flex-end; }
-  .chat-bubble { max-width: 80%; padding: 8px 12px; border-radius: var(--radius); font-size: var(--text-sm); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
-  .chat-msg-user .chat-bubble { background: color-mix(in oklab, var(--accent) 18%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent); }
-  .chat-msg-agent .chat-bubble { background: var(--surface); border: 1px solid var(--border); }
+  .chat-bubble { padding: 8px 12px; border-radius: var(--radius); font-size: var(--text-sm); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+  .chat-msg-user .chat-bubble { max-width: 80%; background: color-mix(in oklab, var(--accent) 18%, var(--surface)); border: 1px solid color-mix(in oklab, var(--accent) 35%, transparent); }
+  .chat-msg-agent { display: block; min-width: 0; }
+  .chat-msg-agent .chat-bubble { width: 100%; max-width: none; padding: 0; border-radius: 0; background: transparent; border: 0; }
   .chat-md { white-space: normal; }
   .chat-md p { margin: 0 0 8px; } .chat-md p:last-child { margin-bottom: 0; }
   .chat-md pre { background: var(--terminal-bg); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; overflow-x: auto; font-family: var(--font-mono); font-size: var(--text-xs); }
@@ -609,17 +611,31 @@
   .chat-md :not(pre) > code { background: var(--subtle); padding: 1px 5px; border-radius: 4px; }
   .chat-md ul, .chat-md ol { margin: 0 0 8px; padding-left: 1.3em; }
   .chat-md a { color: var(--accent); }
-  .chat-thinking { font-size: var(--text-xs); color: var(--text-dim); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 10px; }
-  .chat-thinking summary { cursor: pointer; font-weight: 600; }
+  .chat-activity { color: var(--text-dim); font-size: var(--text-sm); }
+  .chat-activity-summary { width: fit-content; max-width: 100%; padding: 3px 5px; border-radius: var(--radius-sm); cursor: pointer; color: var(--text-dim); }
+  .chat-activity-summary:hover { color: var(--text); }
+  .chat-activity-summary:focus-visible, .chat-tool-head:focus-visible, .chat-thinking summary:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+  .chat-activity-state { font-weight: 600; }
+  .chat-activity-state[data-status="running"] { color: var(--accent); }
+  .chat-activity-state[data-status="failed"] { color: var(--red); }
+  .chat-activity-body { display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 8px 0 2px 20px; }
+  .chat-activity .chat-msg-agent .chat-bubble { color: var(--text-dim); }
+  .chat-thinking { font-size: var(--text-xs); color: var(--text-dim); }
+  .chat-thinking summary { width: fit-content; padding: 2px 4px; border-radius: var(--radius-sm); cursor: pointer; font-weight: 600; }
   .chat-thinking-body { margin-top: 6px; white-space: pre-wrap; font-family: var(--font-mono); }
-  .chat-tool { border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); padding: 6px 10px; font-size: var(--text-xs); }
-  .chat-tool-head { display: flex; align-items: center; gap: 8px; justify-content: space-between; }
-  .chat-tool-title { font-family: var(--font-mono); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .chat-tool-status { font-weight: 600; color: var(--text-dim); flex: 0 0 auto; }
+  .chat-tool { min-width: 0; font-size: var(--text-xs); border-bottom: 1px solid var(--border); }
+  .chat-tool-head { min-width: 0; padding: 5px 4px; border-radius: var(--radius-sm); cursor: pointer; }
+  .chat-tool-head:hover { background: var(--subtle); }
+  .chat-tool-title { display: inline-block; max-width: calc(100% - 86px); overflow: hidden; color: var(--text); font-family: var(--font-mono); text-overflow: ellipsis; vertical-align: bottom; white-space: nowrap; }
+  .chat-tool-status { float: right; margin-left: 8px; color: var(--text-dim); font-weight: 600; }
   .chat-tool-status[data-status="completed"] { color: var(--green); }
   .chat-tool-status[data-status="failed"] { color: var(--red); }
   .chat-tool-status[data-status="in_progress"] { color: var(--accent); }
-  .chat-plan { border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface); padding: 8px 10px; font-size: var(--text-xs); }
+  .chat-tool-payload { display: grid; gap: 8px; padding: 4px 4px 10px 18px; }
+  .chat-tool-payload-section { min-width: 0; }
+  .chat-tool-payload-label { margin-bottom: 3px; color: var(--text-dim); font-size: var(--text-2xs); font-weight: 600; }
+  .chat-tool-payload-value { max-height: 40vh; margin: 0; overflow: auto; padding: 8px 10px; border-radius: var(--radius-sm); background: var(--terminal-bg); color: var(--terminal-text); font-family: var(--font-mono); font-size: var(--text-xs); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+  .chat-plan { padding: 2px 4px; font-size: var(--text-xs); }
   .chat-plan-title { font-weight: 600; margin-bottom: 4px; }
   .chat-plan-list { margin: 0; padding-left: 1.2em; }
   .chat-plan-list li[data-status="completed"] { color: var(--text-dim); text-decoration: line-through; }
@@ -4910,7 +4926,7 @@ function ensureChatAssets() {
   // chat.js and acp-client.js are an interdependent pair of our own code; bump
   // this shared CHAT_V whenever either one changes (see AGENTS.md). One version
   // busts both at once, preventing a stale chat.js/acp-client.js mismatch.
-  var CHAT_V = '1';
+  var CHAT_V = '2';
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
     loadScript('/static/acp-client.js?v=' + CHAT_V)

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -4926,7 +4926,7 @@ function ensureChatAssets() {
   // chat.js and acp-client.js are an interdependent pair of our own code; bump
   // this shared CHAT_V whenever either one changes (see AGENTS.md). One version
   // busts both at once, preventing a stale chat.js/acp-client.js mismatch.
-  var CHAT_V = '2';
+  var CHAT_V = '3';
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
     loadScript('/static/acp-client.js?v=' + CHAT_V)

--- a/src/oduflow/templates/static/acp-client.js
+++ b/src/oduflow/templates/static/acp-client.js
@@ -209,11 +209,14 @@
     // No timeout: replaying a long transcript legitimately takes a while.
     return this._request('session/load', { sessionId: sessionId, cwd: cwd, mcpServers: [] }, 0);
   };
-  AcpClient.prototype.prompt = function (sessionId, text) {
+  AcpClient.prototype.prompt = function (sessionId, content) {
+    var prompt = Array.isArray(content)
+      ? content
+      : [{ type: 'text', text: String(content || '') }];
     // No timeout: resolves only when the agent's whole turn ends (stopReason).
     return this._request('session/prompt', {
       sessionId: sessionId,
-      prompt: [{ type: 'text', text: text }]
+      prompt: prompt
     }, 0);
   };
   AcpClient.prototype.cancel = function (sessionId) {

--- a/src/oduflow/templates/static/chat.js
+++ b/src/oduflow/templates/static/chat.js
@@ -23,7 +23,11 @@
 
   var instances = {};      // key -> instance
   var activeKey = null;
+  var nextDomId = 0;
   var FOLLOW_BOTTOM_THRESHOLD = 48;
+  var DEFAULT_MAX_FILE_BYTES = 25 * 1024 * 1024;
+  var DEFAULT_MAX_FILES = 5;
+  var INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 
   function keyOf(branch, type) { return branch + ' ' + type; }
   function labelOf(type) { return AGENT_LABELS[type] || type; }
@@ -85,6 +89,51 @@
     return '';
   }
 
+  function fileNameFromUri(uri) {
+    var tail = String(uri || '').split('/').pop() || 'Attachment';
+    try { return decodeURIComponent(tail); } catch (e) { return tail; }
+  }
+
+  function attachmentFromContent(content) {
+    if (!content || typeof content !== 'object') return null;
+    var meta = content._meta && content._meta.oduflow;
+    if (content.type === 'resource_link') {
+      return {
+        name: content.name || fileNameFromUri(content.uri),
+        uri: content.uri || '',
+        path: (meta && meta.path) || '',
+        mimeType: content.mimeType || '',
+        size: content.size
+      };
+    }
+    if (content.type === 'image' || content.type === 'audio') {
+      return {
+        name: (meta && meta.name) || fileNameFromUri(content.uri),
+        uri: content.uri || '',
+        path: (meta && meta.path) || '',
+        mimeType: content.mimeType || '',
+        size: meta && meta.size
+      };
+    }
+    if (content.type === 'resource' && content.resource) {
+      return {
+        name: (meta && meta.name) || fileNameFromUri(content.resource.uri),
+        uri: content.resource.uri || '',
+        path: (meta && meta.path) || '',
+        mimeType: content.resource.mimeType || '',
+        size: meta && meta.size
+      };
+    }
+    return null;
+  }
+
+  function formatBytes(size) {
+    if (typeof size !== 'number' || !isFinite(size) || size < 0) return '';
+    if (size < 1024) return size + ' B';
+    if (size < 1024 * 1024) return Math.round(size / 1024) + ' KiB';
+    return (size / (1024 * 1024)).toFixed(size < 10 * 1024 * 1024 ? 1 : 0) + ' MiB';
+  }
+
   // -- DOM helpers scoped to an instance -------------------------------------
   function q(inst, sel) { return inst.el.querySelector(sel); }
 
@@ -123,6 +172,9 @@
   function finishUserChunks(inst) {
     inst.userChunkBubble = null;
     inst.userChunkBuffer = '';
+    inst.userChunkText = null;
+    inst.userChunkAttachments = null;
+    inst.userChunkAttachmentKeys = Object.create(null);
   }
 
   function pluralCount(count, singular, plural) {
@@ -209,28 +261,82 @@
     scrollToBottom(inst);
   }
 
-  function addUser(inst, text) {
+  function renderAttachmentRow(attachment) {
+    var row = el('div', 'chat-attachment');
+    row.appendChild(el('span', 'chat-attachment-name', attachment.name || 'Attachment'));
+    var meta = [];
+    var size = formatBytes(attachment.size);
+    if (size) meta.push(size);
+    if (attachment.mimeType) meta.push(attachment.mimeType);
+    if (meta.length) row.appendChild(el('span', 'chat-attachment-meta', meta.join(' · ')));
+    return row;
+  }
+
+  function appendAttachments(container, attachments) {
+    if (!attachments || !attachments.length) return;
+    var list = el('div', 'chat-attachments');
+    for (var i = 0; i < attachments.length; i++) {
+      list.appendChild(renderAttachmentRow(attachments[i]));
+    }
+    container.appendChild(list);
+  }
+
+  function addUser(inst, text, attachments) {
     finalizeTurn(inst);
     var wrap = el('div', 'chat-msg chat-msg-user');
-    wrap.appendChild(el('div', 'chat-bubble', text));
+    var bubble = el('div', 'chat-bubble');
+    bubble.appendChild(el('div', 'chat-user-text', text));
+    appendAttachments(bubble, attachments);
+    wrap.appendChild(bubble);
     q(inst, '.chat-messages').appendChild(wrap);
     finishUserChunks(inst);
     scrollToBottom(inst, true);
   }
 
-  function appendUserChunk(inst, text) {
-    if (!text) return;
+  function ensureUserChunk(inst) {
     if (!inst.userChunkBubble) {
       finalizeTurn(inst);
       var wrap = el('div', 'chat-msg chat-msg-user');
       inst.userChunkBubble = el('div', 'chat-bubble');
       inst.userChunkBuffer = '';
+      inst.userChunkText = null;
+      inst.userChunkAttachments = null;
+      inst.userChunkAttachmentKeys = Object.create(null);
       wrap.appendChild(inst.userChunkBubble);
       q(inst, '.chat-messages').appendChild(wrap);
     }
+  }
+
+  function appendUserText(inst, text) {
+    if (!text) return;
+    ensureUserChunk(inst);
+    if (!inst.userChunkText) {
+      inst.userChunkText = el('div', 'chat-user-text');
+      inst.userChunkBubble.insertBefore(inst.userChunkText, inst.userChunkBubble.firstChild);
+    }
     inst.userChunkBuffer += text;
-    inst.userChunkBubble.textContent = inst.userChunkBuffer;
+    inst.userChunkText.textContent = inst.userChunkBuffer;
     scrollToBottom(inst);
+  }
+
+  function appendUserAttachment(inst, attachment) {
+    if (!attachment) return;
+    ensureUserChunk(inst);
+    var key = attachment.uri || (attachment.name + ' ' + attachment.mimeType);
+    if (inst.userChunkAttachmentKeys[key]) return;
+    inst.userChunkAttachmentKeys[key] = true;
+    if (!inst.userChunkAttachments) {
+      inst.userChunkAttachments = el('div', 'chat-attachments');
+      inst.userChunkBubble.appendChild(inst.userChunkAttachments);
+    }
+    inst.userChunkAttachments.appendChild(renderAttachmentRow(attachment));
+    scrollToBottom(inst);
+  }
+
+  function appendUserContent(inst, content) {
+    var text = contentText(content);
+    if (text) appendUserText(inst, text);
+    else appendUserAttachment(inst, attachmentFromContent(content));
   }
 
   function appendAgent(inst, text) {
@@ -465,14 +571,14 @@
       badge.className = 'chat-status ' + meta.cls;
     }
     updatePill(inst);
+    updateComposerState(inst);
   }
 
   function setBusy(inst, busy) {
     inst.busy = busy;
-    var send = q(inst, '.chat-send');
     var stop = q(inst, '.chat-stop');
-    if (send) send.disabled = busy;
     if (stop) stop.hidden = !busy;
+    updateComposerState(inst);
   }
 
   function updatePill(inst) {
@@ -547,7 +653,7 @@
     var u = params && params.update;
     if (!u) return;
     switch (u.sessionUpdate) {
-      case 'user_message_chunk': appendUserChunk(inst, contentText(u.content)); break;
+      case 'user_message_chunk': appendUserContent(inst, u.content); break;
       case 'agent_message_chunk': appendAgent(inst, contentText(u.content)); break;
       case 'agent_thought_chunk': appendThought(inst, contentText(u.content)); break;
       case 'tool_call': renderToolCall(inst, u); break;
@@ -575,6 +681,11 @@
     };
   }
 
+  function applyPromptCapabilities(inst, initializeResult) {
+    var capabilities = initializeResult && initializeResult.agentCapabilities;
+    inst.promptCapabilities = (capabilities && capabilities.promptCapabilities) || {};
+  }
+
   // -- REST helpers -----------------------------------------------------------
   function apiBase(branch) {
     return '/api/environments/' + encodeURIComponent(branch) + '/agent-acp';
@@ -597,6 +708,244 @@
       body: JSON.stringify(body)
     }).then(function (r) { return r.json(); })
       .catch(function () { return null; });
+  }
+
+  function setComposerError(inst, message) {
+    var error = q(inst, '.chat-composer-error');
+    var ta = q(inst, '.chat-input');
+    if (error) {
+      error.textContent = message || '';
+      error.hidden = !message;
+    }
+    if (ta) ta.setAttribute('aria-invalid', message ? 'true' : 'false');
+  }
+
+  function attachmentStateText(attachment) {
+    if (attachment.state === 'queued') return 'queued';
+    if (attachment.state === 'uploading') return 'uploading ' + (attachment.progress || 0) + '%';
+    if (attachment.state === 'ready') return 'ready';
+    return 'failed' + (attachment.error ? ': ' + attachment.error : '');
+  }
+
+  function renderPendingAttachments(inst) {
+    var list = q(inst, '.chat-composer-attachments');
+    if (!list) return;
+    list.innerHTML = '';
+    list.hidden = !inst.attachments.length;
+    for (var i = 0; i < inst.attachments.length; i++) {
+      (function (attachment) {
+        var row = el('div', 'chat-pending-attachment');
+        row.setAttribute('data-status', attachment.state);
+        var body = el('div', 'chat-pending-body');
+        body.appendChild(el('span', 'chat-attachment-name', attachment.name));
+        var details = [];
+        var size = formatBytes(attachment.size);
+        if (size) details.push(size);
+        details.push(attachmentStateText(attachment));
+        body.appendChild(el('span', 'chat-pending-meta', details.join(' · ')));
+        row.appendChild(body);
+        var remove = el('button', 'chat-attachment-remove', 'Remove');
+        remove.type = 'button';
+        remove.onclick = function () { removePendingAttachment(inst, attachment); };
+        row.appendChild(remove);
+        list.appendChild(row);
+      })(inst.attachments[i]);
+    }
+    updateComposerState(inst);
+  }
+
+  function updateComposerState(inst) {
+    if (!inst.el) return;
+    var ta = q(inst, '.chat-input');
+    var send = q(inst, '.chat-send');
+    var attach = q(inst, '.chat-attach');
+    var hasText = !!(ta && (ta.value || '').trim());
+    var blocked = false;
+    for (var i = 0; i < inst.attachments.length; i++) {
+      if (inst.attachments[i].state !== 'ready') blocked = true;
+    }
+    if (send) send.disabled = inst.busy || !inst.sessionId || !hasText || blocked;
+    if (attach) attach.disabled = !inst.cwd || !inst.sessionId ||
+      inst.status === 'connecting' || inst.status === 'closed' ||
+      inst.attachments.length >= inst.maxFiles;
+  }
+
+  function deletePendingUpload(inst, attachment) {
+    if (!attachment.id) return;
+    fetch(apiBase(inst.branch) + '/attachments/' + encodeURIComponent(attachment.id), {
+      method: 'DELETE',
+      credentials: 'same-origin'
+    }).catch(function () {});
+  }
+
+  function removePendingAttachment(inst, attachment) {
+    attachment.removed = true;
+    var idx = inst.attachments.indexOf(attachment);
+    if (idx !== -1) inst.attachments.splice(idx, 1);
+    if (attachment.xhr) {
+      try { attachment.xhr.abort(); } catch (e) { /* already complete */ }
+    }
+    if (attachment.state === 'ready') deletePendingUpload(inst, attachment);
+    setComposerError(inst, '');
+    renderPendingAttachments(inst);
+    processUploadQueue(inst);
+  }
+
+  function clearPendingAttachments(inst, removeRemote) {
+    var pending = inst.attachments.slice();
+    inst.attachments = [];
+    for (var i = 0; i < pending.length; i++) {
+      pending[i].removed = true;
+      if (pending[i].xhr) {
+        try { pending[i].xhr.abort(); } catch (e) { /* already complete */ }
+      }
+      if (removeRemote && pending[i].state === 'ready') deletePendingUpload(inst, pending[i]);
+    }
+    inst.uploadActive = null;
+    setComposerError(inst, '');
+    renderPendingAttachments(inst);
+  }
+
+  function finishUpload(inst, attachment) {
+    attachment.xhr = null;
+    if (inst.uploadActive === attachment) inst.uploadActive = null;
+    renderPendingAttachments(inst);
+    processUploadQueue(inst);
+  }
+
+  function processUploadQueue(inst) {
+    if (inst.uploadActive) return;
+    var attachment = null;
+    for (var i = 0; i < inst.attachments.length; i++) {
+      if (inst.attachments[i].state === 'queued') {
+        attachment = inst.attachments[i];
+        break;
+      }
+    }
+    if (!attachment) { updateComposerState(inst); return; }
+
+    inst.uploadActive = attachment;
+    attachment.state = 'uploading';
+    attachment.progress = 0;
+    var xhr = new XMLHttpRequest();
+    attachment.xhr = xhr;
+    xhr.open('POST', apiBase(inst.branch) + '/attachments?name=' + encodeURIComponent(attachment.name));
+    xhr.setRequestHeader('Content-Type', attachment.mimeType || 'application/octet-stream');
+    xhr.upload.onprogress = function (event) {
+      if (!event.lengthComputable || attachment.removed) return;
+      attachment.progress = Math.min(99, Math.round(event.loaded * 100 / event.total));
+      renderPendingAttachments(inst);
+    };
+    xhr.onload = function () {
+      var payload = null;
+      try { payload = JSON.parse(xhr.responseText || '{}'); } catch (e) { /* invalid response */ }
+      if (xhr.status >= 200 && xhr.status < 300 && payload && payload.attachment) {
+        var uploaded = payload.attachment;
+        attachment.id = uploaded.id;
+        attachment.path = uploaded.path;
+        attachment.uri = uploaded.uri;
+        attachment.mimeType = uploaded.mimeType || attachment.mimeType;
+        attachment.size = uploaded.size;
+        attachment.state = 'ready';
+        attachment.progress = 100;
+        if (attachment.removed) deletePendingUpload(inst, attachment);
+      } else {
+        attachment.state = 'failed';
+        attachment.error = (payload && payload.error) || 'Upload failed';
+      }
+      finishUpload(inst, attachment);
+    };
+    xhr.onerror = function () {
+      attachment.state = 'failed';
+      attachment.error = 'Network error';
+      finishUpload(inst, attachment);
+    };
+    xhr.onabort = function () { finishUpload(inst, attachment); };
+    renderPendingAttachments(inst);
+    xhr.send(attachment.file);
+  }
+
+  function addFiles(inst, files) {
+    var available = inst.maxFiles - inst.attachments.length;
+    if (available <= 0) {
+      setComposerError(inst, 'You can attach up to ' + inst.maxFiles + ' files.');
+      return;
+    }
+    var count = Math.min(files.length, available);
+    for (var i = 0; i < count; i++) {
+      var file = files[i];
+      var attachment = {
+        name: file.name || 'attachment',
+        mimeType: file.type || 'application/octet-stream',
+        size: file.size,
+        file: file,
+        state: file.size > inst.maxFileBytes ? 'failed' : 'queued',
+        error: file.size > inst.maxFileBytes
+          ? 'Larger than ' + formatBytes(inst.maxFileBytes) + ' limit'
+          : ''
+      };
+      inst.attachments.push(attachment);
+    }
+    if (files.length > count) {
+      setComposerError(inst, 'You can attach up to ' + inst.maxFiles + ' files.');
+    } else {
+      setComposerError(inst, '');
+    }
+    renderPendingAttachments(inst);
+    processUploadQueue(inst);
+  }
+
+  function resourceLinkBlock(attachment) {
+    return {
+      type: 'resource_link',
+      name: attachment.name,
+      uri: attachment.uri,
+      mimeType: attachment.mimeType,
+      size: attachment.size,
+      _meta: { oduflow: { id: attachment.id, path: attachment.path } }
+    };
+  }
+
+  function attachmentPromptBlock(attachment, canInlineImage) {
+    if (!canInlineImage) return Promise.resolve(resourceLinkBlock(attachment));
+    return new Promise(function (resolve) {
+      var reader = new FileReader();
+      reader.onload = function () {
+        var dataUrl = String(reader.result || '');
+        var comma = dataUrl.indexOf(',');
+        if (comma === -1) { resolve(resourceLinkBlock(attachment)); return; }
+        resolve({
+          type: 'image',
+          data: dataUrl.slice(comma + 1),
+          mimeType: attachment.mimeType,
+          uri: attachment.uri,
+          _meta: {
+            oduflow: {
+              id: attachment.id,
+              name: attachment.name,
+              path: attachment.path,
+              size: attachment.size
+            }
+          }
+        });
+      };
+      reader.onerror = function () { resolve(resourceLinkBlock(attachment)); };
+      reader.readAsDataURL(attachment.file);
+    });
+  }
+
+  function buildPromptBlocks(inst, text, attachments) {
+    var blocks = [Promise.resolve({ type: 'text', text: text })];
+    var inlineImageBytes = 0;
+    for (var i = 0; i < attachments.length; i++) {
+      var attachment = attachments[i];
+      var canInlineImage = inst.promptCapabilities.image &&
+        attachment.mimeType.indexOf('image/') === 0 && attachment.file &&
+        inlineImageBytes + attachment.size <= INLINE_IMAGE_MAX_BYTES;
+      if (canInlineImage) inlineImageBytes += attachment.size;
+      blocks.push(attachmentPromptBlock(attachment, canInlineImage));
+    }
+    return Promise.all(blocks);
   }
 
   function refreshHistory(inst, res) {
@@ -660,11 +1009,27 @@
     root.appendChild(perm);
 
     var form = el('form', 'chat-composer');
+    var pending = el('div', 'chat-composer-attachments');
+    pending.hidden = true;
+    pending.setAttribute('aria-live', 'polite');
+    form.appendChild(pending);
+    var composerMain = el('div', 'chat-composer-main');
     var ta = el('textarea', 'chat-input');
     ta.rows = 2;
     ta.placeholder = 'Message the agent…  (Enter to send, Shift+Enter for a new line)';
-    form.appendChild(ta);
+    ta.setAttribute('aria-describedby', 'chat-composer-help-' + inst.domId);
+    composerMain.appendChild(ta);
     var actions = el('div', 'chat-composer-actions');
+    var fileInput = el('input', 'chat-file-input');
+    fileInput.type = 'file';
+    fileInput.multiple = true;
+    fileInput.hidden = true;
+    fileInput.setAttribute('aria-label', 'Choose files to attach');
+    actions.appendChild(fileInput);
+    var attach = el('button', 'btn chat-attach', 'Attach');
+    attach.type = 'button';
+    attach.onclick = function () { fileInput.click(); };
+    actions.appendChild(attach);
     var send = el('button', 'btn chat-send', 'Send');
     send.type = 'submit';
     var stop = el('button', 'btn chat-stop', 'Stop');
@@ -673,15 +1038,47 @@
     stop.onclick = function () { if (inst.sessionId) inst.client.cancel(inst.sessionId); setBusy(inst, false); setStatus(inst, 'ready'); };
     actions.appendChild(stop);
     actions.appendChild(send);
-    form.appendChild(actions);
+    composerMain.appendChild(actions);
+    form.appendChild(composerMain);
+    var error = el('div', 'chat-composer-error');
+    error.id = 'chat-composer-help-' + inst.domId;
+    error.hidden = true;
+    error.setAttribute('aria-live', 'polite');
+    form.appendChild(error);
     form.onsubmit = function (e) { e.preventDefault(); sendPrompt(inst); };
+    fileInput.onchange = function () {
+      addFiles(inst, fileInput.files || []);
+      fileInput.value = '';
+    };
+    ta.addEventListener('input', function () {
+      if ((ta.value || '').trim()) setComposerError(inst, '');
+      updateComposerState(inst);
+    });
+    ta.addEventListener('paste', function (event) {
+      var files = event.clipboardData && event.clipboardData.files;
+      if (files && files.length) addFiles(inst, files);
+    });
     ta.addEventListener('keydown', function (e) {
       if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendPrompt(inst); }
+    });
+    form.addEventListener('dragover', function (event) {
+      event.preventDefault();
+      form.classList.add('is-dragover');
+    });
+    form.addEventListener('dragleave', function (event) {
+      if (!form.contains(event.relatedTarget)) form.classList.remove('is-dragover');
+    });
+    form.addEventListener('drop', function (event) {
+      event.preventDefault();
+      form.classList.remove('is-dragover');
+      var files = event.dataTransfer && event.dataTransfer.files;
+      if (files && files.length) addFiles(inst, files);
     });
     root.appendChild(form);
 
     inst.el = root;
     renderHistoryMenu(inst);
+    updateComposerState(inst);
   }
 
   function renderHistoryMenu(inst) {
@@ -720,9 +1117,9 @@
   }
 
   function resetTranscript(inst) {
+    clearPendingAttachments(inst, true);
     inst.turn = null;
-    inst.userChunkBubble = null;
-    inst.userChunkBuffer = '';
+    finishUserChunks(inst);
     inst.tools = Object.create(null);
     inst.followOutput = true;
     q(inst, '.chat-messages').innerHTML = '';
@@ -731,12 +1128,36 @@
   function sendPrompt(inst) {
     var ta = q(inst, '.chat-input');
     var text = (ta.value || '').trim();
-    if (!text || inst.busy || !inst.sessionId) return;
-    addUser(inst, text);
+    if (inst.busy || !inst.sessionId) return;
+    if (!text) {
+      setComposerError(inst, inst.attachments.length
+        ? 'Describe what the agent should do with the attached files.'
+        : 'Enter a message for the agent.');
+      ta.focus();
+      return;
+    }
+    for (var i = 0; i < inst.attachments.length; i++) {
+      if (inst.attachments[i].state === 'failed') {
+        setComposerError(inst, 'Remove failed attachments before sending.');
+        return;
+      }
+      if (inst.attachments[i].state !== 'ready') {
+        setComposerError(inst, 'Wait for attachments to finish uploading.');
+        return;
+      }
+    }
+
+    var attachments = inst.attachments.slice();
+    addUser(inst, text, attachments);
     ta.value = '';
+    inst.attachments = [];
+    renderPendingAttachments(inst);
+    setComposerError(inst, '');
     setBusy(inst, true);
     setStatus(inst, 'thinking');
-    var prompt = inst.client.prompt(inst.sessionId, text);
+    var prompt = buildPromptBlocks(inst, text, attachments).then(function (blocks) {
+      return inst.client.prompt(inst.sessionId, blocks);
+    });
     if (!inst.titled && inst.sessionId) {
       inst.titled = true;
       postSession(inst.branch, inst.type, inst.sessionId, titleFrom(text))
@@ -834,6 +1255,9 @@
     fetchInfo(inst.branch, inst.type).then(function (info) {
       if (!info || !info.ok) throw new Error((info && info.error) || 'Failed to load chat info');
       inst.cwd = info.cwd;
+      var limits = info.attachment_limits || {};
+      inst.maxFileBytes = limits.max_file_bytes || DEFAULT_MAX_FILE_BYTES;
+      inst.maxFiles = limits.max_files || DEFAULT_MAX_FILES;
       inst.history = Array.isArray(info.history) ? info.history : [];
       inst.titled = false;
       for (var i = 0; i < inst.history.length; i++) {
@@ -850,7 +1274,8 @@
       inst.client.on('close', function () { setStatus(inst, 'closed'); setBusy(inst, false); });
       return inst.client.connect().then(function () {
         return inst.client.initialize();
-      }).then(function () {
+      }).then(function (initializeResult) {
+        applyPromptCapabilities(inst, initializeResult);
         if (info.session_id) {
           return inst.client.loadSession(info.session_id, inst.cwd).then(function (res) {
             finalizeTurn(inst);
@@ -894,11 +1319,15 @@
     var key = keyOf(branch, type);
     if (instances[key]) { activate(instances[key]); return; }
     var inst = {
-      key: key, branch: branch, type: type, status: 'connecting', busy: false,
+      key: key, domId: ++nextDomId, branch: branch, type: type, status: 'connecting', busy: false,
       client: new window.AcpClient(wsUrlFor(branch, type)),
       sessionId: null, cwd: null, turn: null, tools: Object.create(null), pill: null, unread: false,
       userChunkBubble: null, userChunkBuffer: '', followOutput: true,
-      history: [], titled: false
+      userChunkText: null, userChunkAttachments: null,
+      userChunkAttachmentKeys: Object.create(null),
+      history: [], titled: false, attachments: [], uploadActive: null,
+      maxFileBytes: DEFAULT_MAX_FILE_BYTES, maxFiles: DEFAULT_MAX_FILES,
+      promptCapabilities: {}
     };
     buildInstanceDom(inst);
     instances[key] = inst;
@@ -936,6 +1365,7 @@
   function closeChat(key) {
     var inst = instances[key];
     if (!inst) return;
+    clearPendingAttachments(inst, true);
     try { inst.client.close(); } catch (e) { /* ignore */ }
     removePill(inst);
     if (inst.el && inst.el.parentNode) inst.el.parentNode.removeChild(inst.el);

--- a/src/oduflow/templates/static/chat.js
+++ b/src/oduflow/templates/static/chat.js
@@ -92,43 +92,173 @@
     if (m) m.scrollTop = m.scrollHeight;
   }
 
+  function newTurn() {
+    return {
+      activity: null,
+      candidateWrap: null,
+      candidateBubble: null,
+      candidateBuffer: '',
+      streamType: null,
+      thoughtBox: null,
+      thoughtBuffer: '',
+      planBox: null
+    };
+  }
+
+  function currentTurn(inst) {
+    if (!inst.turn) inst.turn = newTurn();
+    return inst.turn;
+  }
+
+  function finishUserChunks(inst) {
+    inst.userChunkBubble = null;
+    inst.userChunkBuffer = '';
+  }
+
+  function pluralCount(count, singular, plural) {
+    return count + ' ' + (count === 1 ? singular : plural);
+  }
+
+  function updateActivitySummary(activity) {
+    var parts = [];
+    if (activity.toolCount) parts.push(pluralCount(activity.toolCount, 'tool call', 'tool calls'));
+    if (activity.messageCount) parts.push(pluralCount(activity.messageCount, 'message', 'messages'));
+    activity.label.textContent = parts.length ? parts.join(', ') : 'Details';
+
+    var failed = false;
+    var running = false;
+    for (var i = 0; i < activity.tools.length; i++) {
+      var status = activity.tools[i].status;
+      if (status === 'failed') failed = true;
+      if (status === 'pending' || status === 'in_progress' || !status) running = true;
+    }
+    var statusText = failed ? 'failed' : (running ? 'running' : '');
+    activity.status.textContent = statusText ? ' · ' + statusText : '';
+    activity.status.setAttribute('data-status', statusText || 'completed');
+  }
+
+  function ensureActivity(inst) {
+    var turn = currentTurn(inst);
+    if (turn.activity) return turn.activity;
+
+    var details = el('details', 'chat-activity');
+    var summary = el('summary', 'chat-activity-summary');
+    var label = el('span', 'chat-activity-label', 'Details');
+    var status = el('span', 'chat-activity-state');
+    summary.appendChild(label);
+    summary.appendChild(status);
+    details.appendChild(summary);
+    var body = el('div', 'chat-activity-body');
+    details.appendChild(body);
+
+    var messages = q(inst, '.chat-messages');
+    if (turn.candidateWrap && turn.candidateWrap.parentNode === messages) {
+      messages.insertBefore(details, turn.candidateWrap);
+    } else {
+      messages.appendChild(details);
+    }
+    turn.activity = {
+      el: details,
+      label: label,
+      status: status,
+      body: body,
+      toolCount: 0,
+      messageCount: 0,
+      messages: [],
+      tools: []
+    };
+    return turn.activity;
+  }
+
+  function archiveCandidate(inst) {
+    var turn = currentTurn(inst);
+    if (!turn.candidateWrap) return;
+    var activity = ensureActivity(inst);
+    activity.body.appendChild(turn.candidateWrap);
+    activity.messages.push(turn.candidateWrap);
+    activity.messageCount += 1;
+    updateActivitySummary(activity);
+    turn.candidateWrap = null;
+    turn.candidateBubble = null;
+    turn.candidateBuffer = '';
+  }
+
+  function finalizeTurn(inst) {
+    if (!inst.turn) return;
+    var turn = inst.turn;
+    var activity = turn.activity;
+    if (activity && !turn.candidateWrap && activity.messages.length) {
+      var finalWrap = activity.messages.pop();
+      var messages = q(inst, '.chat-messages');
+      messages.insertBefore(finalWrap, activity.el.nextSibling);
+      activity.messageCount -= 1;
+    }
+    if (activity) updateActivitySummary(activity);
+    inst.turn = null;
+    finishUserChunks(inst);
+  }
+
   function addUser(inst, text) {
+    finalizeTurn(inst);
     var wrap = el('div', 'chat-msg chat-msg-user');
     wrap.appendChild(el('div', 'chat-bubble', text));
     q(inst, '.chat-messages').appendChild(wrap);
-    inst.agentBubble = null;
+    finishUserChunks(inst);
+    scrollToBottom(inst);
+  }
+
+  function appendUserChunk(inst, text) {
+    if (!text) return;
+    if (!inst.userChunkBubble) {
+      finalizeTurn(inst);
+      var wrap = el('div', 'chat-msg chat-msg-user');
+      inst.userChunkBubble = el('div', 'chat-bubble');
+      inst.userChunkBuffer = '';
+      wrap.appendChild(inst.userChunkBubble);
+      q(inst, '.chat-messages').appendChild(wrap);
+    }
+    inst.userChunkBuffer += text;
+    inst.userChunkBubble.textContent = inst.userChunkBuffer;
     scrollToBottom(inst);
   }
 
   function appendAgent(inst, text) {
     if (!text) return;
-    if (!inst.agentBubble) {
+    finishUserChunks(inst);
+    var turn = currentTurn(inst);
+    if (turn.streamType !== 'agent' || !turn.candidateBubble) {
       var wrap = el('div', 'chat-msg chat-msg-agent');
       var bubble = el('div', 'chat-bubble chat-md');
       wrap.appendChild(bubble);
       q(inst, '.chat-messages').appendChild(wrap);
-      inst.agentBubble = bubble;
-      inst.agentBuffer = '';
+      turn.candidateWrap = wrap;
+      turn.candidateBubble = bubble;
+      turn.candidateBuffer = '';
     }
-    inst.agentBuffer += text;
-    inst.agentBubble.innerHTML = renderMarkdown(inst.agentBuffer);
+    turn.streamType = 'agent';
+    turn.candidateBuffer += text;
+    turn.candidateBubble.innerHTML = renderMarkdown(turn.candidateBuffer);
     scrollToBottom(inst);
   }
 
   function appendThought(inst, text) {
     if (!text) return;
-    if (!inst.thoughtBox) {
+    finishUserChunks(inst);
+    var turn = currentTurn(inst);
+    archiveCandidate(inst);
+    if (turn.streamType !== 'thought' || !turn.thoughtBox) {
+      var activity = ensureActivity(inst);
       var det = el('details', 'chat-thinking');
       det.appendChild(el('summary', null, 'Reasoning'));
       var body = el('div', 'chat-thinking-body');
       det.appendChild(body);
-      q(inst, '.chat-messages').appendChild(det);
-      inst.thoughtBox = body;
-      inst.thoughtBuffer = '';
+      activity.body.appendChild(det);
+      turn.thoughtBox = body;
+      turn.thoughtBuffer = '';
     }
-    inst.thoughtBuffer += text;
-    inst.thoughtBox.textContent = inst.thoughtBuffer;
-    inst.agentBubble = null;
+    turn.streamType = 'thought';
+    turn.thoughtBuffer += text;
+    turn.thoughtBox.textContent = turn.thoughtBuffer;
     scrollToBottom(inst);
   }
 
@@ -139,39 +269,155 @@
     return 'pending';
   }
 
-  function renderToolCall(inst, u) {
-    var card = el('div', 'chat-tool');
-    var head = el('div', 'chat-tool-head');
-    head.appendChild(el('span', 'chat-tool-title', u.title || u.kind || 'Tool'));
-    var st = el('span', 'chat-tool-status', toolStatusText(u.status));
-    st.setAttribute('data-status', u.status || 'pending');
-    head.appendChild(st);
-    card.appendChild(head);
-    q(inst, '.chat-messages').appendChild(card);
-    inst.tools[u.toolCallId] = card;
-    inst.agentBubble = null;
+  function hasOwn(obj, name) {
+    return Object.prototype.hasOwnProperty.call(obj, name);
+  }
+
+  function formatToolValue(value) {
+    if (typeof value === 'string') return value;
+    try {
+      var json = JSON.stringify(value, null, 2);
+      return json === undefined ? String(value) : json;
+    } catch (e) {
+      return String(value);
+    }
+  }
+
+  function toolOutputValue(tool) {
+    if (tool.hasRawOutput) return tool.rawOutput;
+    if (!tool.hasContent) return undefined;
+    if (Array.isArray(tool.content) && tool.content.length === 1) {
+      var item = tool.content[0];
+      if (item && item.type === 'content' && item.content && item.content.type === 'text') {
+        return item.content.text || '';
+      }
+    }
+    return tool.content;
+  }
+
+  function renderToolPayload(tool) {
+    tool.input.textContent = tool.hasRawInput
+      ? formatToolValue(tool.rawInput)
+      : 'Not provided by agent';
+    var output = toolOutputValue(tool);
+    tool.output.textContent = output === undefined
+      ? 'Not provided by agent'
+      : formatToolValue(output);
+  }
+
+  function patchTool(tool, u) {
+    var wasFailed = tool.status === 'failed';
+    if (hasOwn(u, 'title') && u.title != null) tool.title = u.title;
+    if (hasOwn(u, 'kind') && u.kind != null) tool.kind = u.kind;
+    if (hasOwn(u, 'status') && u.status != null) tool.status = u.status;
+    if (hasOwn(u, 'rawInput')) {
+      tool.hasRawInput = true;
+      tool.rawInput = u.rawInput;
+    }
+    if (hasOwn(u, 'rawOutput')) {
+      tool.hasRawOutput = true;
+      tool.rawOutput = u.rawOutput;
+    }
+    if (hasOwn(u, 'content')) {
+      tool.hasContent = true;
+      tool.content = u.content;
+    }
+
+    tool.titleEl.textContent = tool.title || tool.kind || 'Tool';
+    tool.statusEl.textContent = toolStatusText(tool.status);
+    tool.statusEl.setAttribute('data-status', tool.status || 'pending');
+    renderToolPayload(tool);
+    updateActivitySummary(tool.activity);
+    if (tool.status === 'failed' && !wasFailed) {
+      tool.activity.el.open = true;
+      tool.el.open = true;
+    }
+  }
+
+  function createTool(inst, u) {
+    finishUserChunks(inst);
+    var turn = currentTurn(inst);
+    archiveCandidate(inst);
+    turn.streamType = 'tool';
+    turn.thoughtBox = null;
+    turn.thoughtBuffer = '';
+    var activity = ensureActivity(inst);
+
+    var details = el('details', 'chat-tool');
+    var head = el('summary', 'chat-tool-head');
+    var title = el('span', 'chat-tool-title');
+    var status = el('span', 'chat-tool-status');
+    head.appendChild(title);
+    head.appendChild(status);
+    details.appendChild(head);
+
+    var payload = el('div', 'chat-tool-payload');
+    var inputSection = el('div', 'chat-tool-payload-section');
+    inputSection.appendChild(el('div', 'chat-tool-payload-label', 'Input'));
+    var input = el('pre', 'chat-tool-payload-value');
+    inputSection.appendChild(input);
+    payload.appendChild(inputSection);
+    var outputSection = el('div', 'chat-tool-payload-section');
+    outputSection.appendChild(el('div', 'chat-tool-payload-label', 'Output'));
+    var output = el('pre', 'chat-tool-payload-value');
+    outputSection.appendChild(output);
+    payload.appendChild(outputSection);
+    details.appendChild(payload);
+    activity.body.appendChild(details);
+
+    var tool = {
+      el: details,
+      titleEl: title,
+      statusEl: status,
+      input: input,
+      output: output,
+      activity: activity,
+      title: null,
+      kind: null,
+      status: null,
+      hasRawInput: false,
+      rawInput: undefined,
+      hasRawOutput: false,
+      rawOutput: undefined,
+      hasContent: false,
+      content: undefined
+    };
+    activity.tools.push(tool);
+    activity.toolCount += 1;
+    inst.tools[u.toolCallId] = tool;
+    patchTool(tool, u);
     scrollToBottom(inst);
+    return tool;
+  }
+
+  function renderToolCall(inst, u) {
+    var tool = inst.tools[u.toolCallId];
+    if (tool) {
+      patchTool(tool, u);
+    } else {
+      createTool(inst, u);
+    }
   }
 
   function updateToolCall(inst, u) {
-    var card = inst.tools[u.toolCallId];
-    if (!card) { renderToolCall(inst, u); return; }
-    if (u.status) {
-      var st = card.querySelector('.chat-tool-status');
-      st.textContent = toolStatusText(u.status);
-      st.setAttribute('data-status', u.status);
-    }
-    if (u.title) {
-      card.querySelector('.chat-tool-title').textContent = u.title;
-    }
+    var tool = inst.tools[u.toolCallId];
+    if (!tool) { createTool(inst, u); return; }
+    patchTool(tool, u);
+    scrollToBottom(inst);
   }
 
   function renderPlan(inst, u) {
+    finishUserChunks(inst);
+    var turn = currentTurn(inst);
+    archiveCandidate(inst);
     var entries = u.entries || u.plan || [];
-    if (inst.planBox && inst.planBox.parentNode) {
-      inst.planBox.parentNode.removeChild(inst.planBox);
+    var box = turn.planBox;
+    if (!box) {
+      box = el('div', 'chat-plan');
+      ensureActivity(inst).body.appendChild(box);
+      turn.planBox = box;
     }
-    var box = el('div', 'chat-plan');
+    box.innerHTML = '';
     box.appendChild(el('div', 'chat-plan-title', 'Plan'));
     var list = el('ul', 'chat-plan-list');
     for (var i = 0; i < entries.length; i++) {
@@ -181,9 +427,9 @@
       list.appendChild(li);
     }
     box.appendChild(list);
-    q(inst, '.chat-messages').appendChild(box);
-    inst.planBox = box;
-    inst.agentBubble = null;
+    turn.streamType = 'plan';
+    turn.thoughtBox = null;
+    turn.thoughtBuffer = '';
     scrollToBottom(inst);
   }
 
@@ -289,7 +535,7 @@
     var u = params && params.update;
     if (!u) return;
     switch (u.sessionUpdate) {
-      case 'user_message_chunk': addUser(inst, contentText(u.content)); break;
+      case 'user_message_chunk': appendUserChunk(inst, contentText(u.content)); break;
       case 'agent_message_chunk': appendAgent(inst, contentText(u.content)); break;
       case 'agent_thought_chunk': appendThought(inst, contentText(u.content)); break;
       case 'tool_call': renderToolCall(inst, u); break;
@@ -461,12 +707,10 @@
   }
 
   function resetTranscript(inst) {
-    inst.agentBubble = null;
-    inst.agentBuffer = '';
-    inst.thoughtBox = null;
-    inst.thoughtBuffer = '';
-    inst.planBox = null;
-    inst.tools = {};
+    inst.turn = null;
+    inst.userChunkBubble = null;
+    inst.userChunkBuffer = '';
+    inst.tools = Object.create(null);
     q(inst, '.chat-messages').innerHTML = '';
   }
 
@@ -487,9 +731,8 @@
     prompt
       .catch(function (e) { addErrorLine(inst, e.message || String(e)); })
       .then(function () {
+        finalizeTurn(inst);
         setBusy(inst, false);
-        inst.agentBubble = null;
-        inst.thoughtBox = null;
         if (inst.status !== 'closed') setStatus(inst, 'ready');
       });
     q(inst, '.chat-input').focus();
@@ -532,6 +775,7 @@
     setStatus(inst, 'connecting');
     resetTranscript(inst);
     inst.client.loadSession(sid, inst.cwd).then(function (res) {
+      finalizeTurn(inst);
       inst.sessionId = sid;
       if (res && res.models) applyModels(inst, res.models);
       addSystemLine(inst, 'Switched to a previous conversation.');
@@ -542,6 +786,7 @@
       if (!previousId) return startFallbackSession(inst);
       resetTranscript(inst);
       return inst.client.loadSession(previousId, inst.cwd).then(function (res) {
+        finalizeTurn(inst);
         inst.sessionId = previousId;
         if (res && res.models) applyModels(inst, res.models);
         addSystemLine(inst, 'Could not open that conversation. Restored the current conversation.');
@@ -594,6 +839,7 @@
       }).then(function () {
         if (info.session_id) {
           return inst.client.loadSession(info.session_id, inst.cwd).then(function (res) {
+            finalizeTurn(inst);
             inst.sessionId = info.session_id;
             if (res && res.models) applyModels(inst, res.models);
             renderHistoryMenu(inst);
@@ -636,8 +882,8 @@
     var inst = {
       key: key, branch: branch, type: type, status: 'connecting', busy: false,
       client: new window.AcpClient(wsUrlFor(branch, type)),
-      sessionId: null, cwd: null, agentBubble: null, agentBuffer: '',
-      thoughtBox: null, tools: {}, planBox: null, pill: null, unread: false,
+      sessionId: null, cwd: null, turn: null, tools: Object.create(null), pill: null, unread: false,
+      userChunkBubble: null, userChunkBuffer: '',
       history: [], titled: false
     };
     buildInstanceDom(inst);

--- a/src/oduflow/templates/static/chat.js
+++ b/src/oduflow/templates/static/chat.js
@@ -23,6 +23,7 @@
 
   var instances = {};      // key -> instance
   var activeKey = null;
+  var FOLLOW_BOTTOM_THRESHOLD = 48;
 
   function keyOf(branch, type) { return branch + ' ' + type; }
   function labelOf(type) { return AGENT_LABELS[type] || type; }
@@ -87,9 +88,18 @@
   // -- DOM helpers scoped to an instance -------------------------------------
   function q(inst, sel) { return inst.el.querySelector(sel); }
 
-  function scrollToBottom(inst) {
+  function updateFollowOutput(inst) {
     var m = q(inst, '.chat-messages');
-    if (m) m.scrollTop = m.scrollHeight;
+    if (!m) return;
+    var distance = m.scrollHeight - m.scrollTop - m.clientHeight;
+    inst.followOutput = distance <= FOLLOW_BOTTOM_THRESHOLD;
+  }
+
+  function scrollToBottom(inst, force) {
+    var m = q(inst, '.chat-messages');
+    if (!m) return;
+    if (force) inst.followOutput = true;
+    if (inst.followOutput) m.scrollTop = m.scrollHeight;
   }
 
   function newTurn() {
@@ -196,6 +206,7 @@
     if (activity) updateActivitySummary(activity);
     inst.turn = null;
     finishUserChunks(inst);
+    scrollToBottom(inst);
   }
 
   function addUser(inst, text) {
@@ -204,7 +215,7 @@
     wrap.appendChild(el('div', 'chat-bubble', text));
     q(inst, '.chat-messages').appendChild(wrap);
     finishUserChunks(inst);
-    scrollToBottom(inst);
+    scrollToBottom(inst, true);
   }
 
   function appendUserChunk(inst, text) {
@@ -394,6 +405,7 @@
     var tool = inst.tools[u.toolCallId];
     if (tool) {
       patchTool(tool, u);
+      scrollToBottom(inst);
     } else {
       createTool(inst, u);
     }
@@ -640,6 +652,7 @@
     var messages = el('div', 'chat-messages');
     messages.setAttribute('role', 'log');
     messages.setAttribute('aria-live', 'polite');
+    messages.addEventListener('scroll', function () { updateFollowOutput(inst); }, { passive: true });
     root.appendChild(messages);
 
     var perm = el('div', 'chat-permission');
@@ -711,6 +724,7 @@
     inst.userChunkBubble = null;
     inst.userChunkBuffer = '';
     inst.tools = Object.create(null);
+    inst.followOutput = true;
     q(inst, '.chat-messages').innerHTML = '';
   }
 
@@ -883,7 +897,7 @@
       key: key, branch: branch, type: type, status: 'connecting', busy: false,
       client: new window.AcpClient(wsUrlFor(branch, type)),
       sessionId: null, cwd: null, turn: null, tools: Object.create(null), pill: null, unread: false,
-      userChunkBubble: null, userChunkBuffer: '',
+      userChunkBubble: null, userChunkBuffer: '', followOutput: true,
       history: [], titled: false
     };
     buildInstanceDom(inst);

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -21,7 +21,7 @@ from urllib.parse import quote, urlsplit
 from itsdangerous import BadData, URLSafeTimedSerializer
 from starlette.datastructures import Headers
 from starlette.exceptions import HTTPException
-from starlette.requests import HTTPConnection, Request
+from starlette.requests import ClientDisconnect, HTTPConnection, Request
 from starlette.responses import (
     HTMLResponse,
     JSONResponse,
@@ -2414,12 +2414,19 @@ def _build_routes(
         size = 0
         too_large = False
         with tempfile.TemporaryFile() as source:
-            async for chunk in request.stream():
-                size += len(chunk)
-                if size > agent_uploads.MAX_FILE_BYTES:
-                    too_large = True
-                    continue
-                source.write(chunk)
+            try:
+                async for chunk in request.stream():
+                    size += len(chunk)
+                    if size > agent_uploads.MAX_FILE_BYTES:
+                        too_large = True
+                        continue
+                    source.write(chunk)
+            except ClientDisconnect:
+                # Normal outcome, not an error: the browser aborts the XHR when
+                # the user removes an in-flight attachment or closes the tab.
+                return JSONResponse(
+                    {"ok": False, "error": "Upload cancelled."}, status_code=400
+                )
             if too_large:
                 return JSONResponse(
                     {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -13,6 +13,7 @@ import pathlib
 import re
 import secrets
 import socket
+import tempfile
 import threading
 import time
 from urllib.parse import quote, urlsplit
@@ -45,6 +46,7 @@ from oduflow.docker_ops import (
 )
 from oduflow import activity
 from oduflow import agent_config
+from oduflow import agent_uploads
 from oduflow import connect_tokens
 from oduflow import git_ops
 from oduflow import import_tokens
@@ -2330,6 +2332,10 @@ def _build_routes(
                     "type": agent_type,
                     "session_id": agent_sessions.get_session(team, branch, agent_type),
                     "history": agent_sessions.get_history(team, branch, agent_type),
+                    "attachment_limits": {
+                        "max_file_bytes": agent_uploads.MAX_FILE_BYTES,
+                        "max_files": agent_uploads.MAX_FILES_PER_PROMPT,
+                    },
                 }
             )
         except Exception:
@@ -2372,6 +2378,124 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
+
+    async def api_agent_acp_attachment_upload(request: Request) -> JSONResponse:
+        """Stream one chat attachment, then copy it into the agent workspace."""
+        branch = request.path_params["branch"]
+        team = _get_ui_team(request)
+        filename = request.query_params.get("name", "")
+        try:
+            agent_uploads.normalize_filename(filename)
+        except agent_uploads.AttachmentError as e:
+            return JSONResponse(
+                {"ok": False, "error": str(e)}, status_code=e.status_code
+            )
+
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > agent_uploads.MAX_FILE_BYTES:
+                    return JSONResponse(
+                        {
+                            "ok": False,
+                            "error": (
+                                "Files must be no larger than "
+                                f"{agent_uploads.MAX_FILE_BYTES // (1024 * 1024)} MiB."
+                            ),
+                        },
+                        status_code=413,
+                    )
+            except ValueError:
+                return JSONResponse(
+                    {"ok": False, "error": "Invalid Content-Length header."},
+                    status_code=400,
+                )
+
+        size = 0
+        too_large = False
+        with tempfile.TemporaryFile() as source:
+            async for chunk in request.stream():
+                size += len(chunk)
+                if size > agent_uploads.MAX_FILE_BYTES:
+                    too_large = True
+                    continue
+                source.write(chunk)
+            if too_large:
+                return JSONResponse(
+                    {
+                        "ok": False,
+                        "error": (
+                            "Files must be no larger than "
+                            f"{agent_uploads.MAX_FILE_BYTES // (1024 * 1024)} MiB."
+                        ),
+                    },
+                    status_code=413,
+                )
+
+            try:
+                locks.acquire_env(branch, team.team_id)
+            except BusyError as e:
+                return _error_response(e)
+            try:
+                source.seek(0)
+                attachment = await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    lambda: agent_uploads.store_attachment(
+                        get_settings(),
+                        team,
+                        branch,
+                        filename,
+                        request.headers.get("content-type"),
+                        source,
+                        size,
+                    ),
+                )
+                return JSONResponse({"ok": True, "attachment": attachment})
+            except agent_uploads.AttachmentError as e:
+                return JSONResponse(
+                    {"ok": False, "error": str(e)}, status_code=e.status_code
+                )
+            except FlowError as e:
+                return _error_response(e)
+            except Exception:
+                logger.exception("Unexpected Agent Chat attachment upload error")
+                return JSONResponse(
+                    {"ok": False, "error": "Internal server error."},
+                    status_code=500,
+                )
+            finally:
+                locks.release_env(branch)
+
+    async def api_agent_acp_attachment_delete(request: Request) -> JSONResponse:
+        """Remove one attachment that has not been sent in a prompt."""
+        branch = request.path_params["branch"]
+        upload_id = request.path_params["upload_id"]
+        team = _get_ui_team(request)
+        try:
+            locks.acquire_env(branch, team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            await asyncio.get_running_loop().run_in_executor(
+                None,
+                lambda: agent_uploads.delete_attachment(
+                    get_settings(), team, branch, upload_id
+                ),
+            )
+            return JSONResponse({"ok": True})
+        except agent_uploads.AttachmentError as e:
+            return JSONResponse(
+                {"ok": False, "error": str(e)}, status_code=e.status_code
+            )
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected Agent Chat attachment delete error")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+        finally:
+            locks.release_env(branch)
 
     def api_license(request: Request) -> JSONResponse:
         settings = get_settings()
@@ -4079,6 +4203,16 @@ def _build_routes(
             "/api/environments/{branch:path}/agent-acp/session",
             api_agent_acp_session,
             methods=["POST"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/agent-acp/attachments",
+            api_agent_acp_attachment_upload,
+            methods=["POST"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/agent-acp/attachments/{upload_id}",
+            api_agent_acp_attachment_delete,
+            methods=["DELETE"],
         ),
         Route("/api/environments/{branch:path}/start", api_start, methods=["POST"]),
         Route("/api/environments/{branch:path}/stop", api_stop, methods=["POST"]),

--- a/tests/test_agent_uploads.py
+++ b/tests/test_agent_uploads.py
@@ -1,0 +1,136 @@
+"""Unit coverage for persistent Agent Chat attachments."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from oduflow import agent_uploads
+from oduflow.settings import Settings, TeamSettings
+
+
+def _settings() -> tuple[Settings, TeamSettings]:
+    team = TeamSettings(team_id="7", agent_enabled=True)
+    settings = Settings(prefix="test-", teams={"7": team})
+    return settings, team
+
+
+def _containers(monkeypatch, *, used_bytes: int = 0):
+    environment = MagicMock()
+    agent = MagicMock(status="running")
+
+    def exec_run(command, **_kwargs):
+        if command[:2] == ["du", "-sb"]:
+            return 0, f"{used_bytes}\t{command[2]}\n".encode()
+        return 0, b""
+
+    agent.exec_run.side_effect = exec_run
+    agent.put_archive.return_value = True
+    client = MagicMock()
+    client.containers.get.side_effect = lambda name: (
+        environment if name.endswith("-odoo") else agent
+    )
+    monkeypatch.setattr(agent_uploads, "get_client", lambda: client)
+    return agent
+
+
+def test_store_attachment_copies_safe_private_tar(monkeypatch):
+    settings, team = _settings()
+    agent = _containers(monkeypatch)
+
+    result = agent_uploads.store_attachment(
+        settings,
+        team,
+        "feature/x",
+        "../Q2 invoice.pdf",
+        "application/pdf; charset=binary",
+        io.BytesIO(b"pdf-data"),
+        8,
+    )
+
+    assert result["name"] == "Q2 invoice.pdf"
+    assert result["path"].startswith("/workspace/.oduflow-uploads/feature-x/")
+    assert result["path"].endswith("/Q2_invoice.pdf")
+    assert result["uri"].startswith("file:///workspace/.oduflow-uploads/")
+    assert result["mimeType"] == "application/pdf"
+    assert result["size"] == 8
+
+    root, archive = agent.put_archive.call_args.args
+    assert root == "/workspace/.oduflow-uploads/feature-x"
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r") as tar:
+        members = tar.getmembers()
+        file_member = next(member for member in members if member.isfile())
+        assert file_member.name.endswith("/Q2_invoice.pdf")
+        assert file_member.mode == 0o600
+        assert file_member.uid == 1000
+        extracted = tar.extractfile(file_member)
+        assert extracted is not None
+        assert extracted.read() == b"pdf-data"
+
+
+def test_store_attachment_enforces_environment_quota(monkeypatch):
+    settings, team = _settings()
+    agent = _containers(monkeypatch, used_bytes=agent_uploads.MAX_ENV_BYTES)
+
+    with pytest.raises(agent_uploads.AttachmentError, match="storage.*full") as exc:
+        agent_uploads.store_attachment(
+            settings,
+            team,
+            "main",
+            "notes.txt",
+            "text/plain",
+            io.BytesIO(b"x"),
+            1,
+        )
+
+    assert exc.value.status_code == 413
+    agent.put_archive.assert_not_called()
+
+
+def test_store_attachment_rejects_oversized_file_before_docker(monkeypatch):
+    settings, team = _settings()
+    get_client = MagicMock()
+    monkeypatch.setattr(agent_uploads, "get_client", get_client)
+
+    with pytest.raises(agent_uploads.AttachmentError) as exc:
+        agent_uploads.store_attachment(
+            settings,
+            team,
+            "main",
+            "large.bin",
+            "application/octet-stream",
+            io.BytesIO(),
+            agent_uploads.MAX_FILE_BYTES + 1,
+        )
+
+    assert exc.value.status_code == 413
+    get_client.assert_not_called()
+
+
+def test_delete_attachment_is_scoped_to_environment(monkeypatch):
+    settings, team = _settings()
+    agent = _containers(monkeypatch)
+
+    agent_uploads.delete_attachment(settings, team, "feature/x", "a" * 32)
+
+    assert agent.exec_run.call_args.args[0] == [
+        "rm",
+        "-rf",
+        "--",
+        "/workspace/.oduflow-uploads/feature-x/" + "a" * 32,
+    ]
+
+
+@pytest.mark.parametrize("upload_id", ["../escape", "ABC", "", "a" * 31])
+def test_delete_attachment_rejects_invalid_id_before_docker(monkeypatch, upload_id):
+    settings, team = _settings()
+    get_client = MagicMock()
+    monkeypatch.setattr(agent_uploads, "get_client", get_client)
+
+    with pytest.raises(agent_uploads.AttachmentError, match="Invalid attachment id"):
+        agent_uploads.delete_attachment(settings, team, "main", upload_id)
+
+    get_client.assert_not_called()

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -2283,6 +2283,23 @@ class TestAgentContainer:
 
         agent.exec_run.assert_not_called()
 
+    def test_remove_env_removes_checkout_and_chat_attachments(self, mock_docker_client):
+        team = self._team()
+        agent = MagicMock()
+        mock_docker_client.containers.get.return_value = agent
+
+        env_ops._agent_remove_env(
+            mock_docker_client, self._settings(team=team), team, "feature/x"
+        )
+
+        assert agent.exec_run.call_args.args[0] == [
+            "rm",
+            "-rf",
+            "--",
+            "/workspace/feature-x",
+            "/workspace/.oduflow-uploads/feature-x",
+        ]
+
 
 class TestFinalizeShellScript:
     """`odoo shell` rolls back at the end, so auto_commit must append a commit."""

--- a/tests/test_web_ui_agent_acp.py
+++ b/tests/test_web_ui_agent_acp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+from unittest.mock import patch
 
 import pytest
 from starlette.applications import Starlette
@@ -17,6 +18,7 @@ _PW = "s3cret"
 _BRANCH = "feature-x"
 _INFO_URL = f"/api/environments/{_BRANCH}/agent-acp/info?type=claude"
 _SESSION_URL = f"/api/environments/{_BRANCH}/agent-acp/session"
+_ATTACHMENTS_URL = f"/api/environments/{_BRANCH}/agent-acp/attachments"
 
 
 def _basic() -> dict[str, str]:
@@ -24,8 +26,13 @@ def _basic() -> dict[str, str]:
     return {"Authorization": f"Basic {blob}"}
 
 
-def _client(tmp_path) -> TestClient:
-    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team-1"), ui_password=_PW)
+def _client(tmp_path, *, agent_enabled: bool = False) -> TestClient:
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path / "team-1"),
+        ui_password=_PW,
+        agent_enabled=agent_enabled,
+    )
     settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
     app = Starlette()
     mount_web_ui(app, lambda: settings, LockManager())
@@ -45,6 +52,66 @@ def test_info_starts_with_empty_history(tmp_path):
     assert response.status_code == 200
     assert response.json()["session_id"] is None
     assert response.json()["history"] == []
+    assert response.json()["attachment_limits"] == {
+        "max_file_bytes": 25 * 1024 * 1024,
+        "max_files": 5,
+    }
+
+
+def test_attachment_upload_streams_raw_body_and_returns_descriptor(tmp_path):
+    client = _client(tmp_path, agent_enabled=True)
+    captured = {}
+    descriptor = {
+        "id": "a" * 32,
+        "name": "notes.txt",
+        "path": "/workspace/.oduflow-uploads/feature-x/a/notes.txt",
+        "uri": "file:///workspace/.oduflow-uploads/feature-x/a/notes.txt",
+        "mimeType": "text/plain",
+        "size": 5,
+    }
+
+    def _store(*args):
+        captured["body"] = args[5].read()
+        return descriptor
+
+    with patch(
+        "oduflow.web_ui.agent_uploads.store_attachment", side_effect=_store
+    ) as store:
+        response = client.post(
+            _ATTACHMENTS_URL + "?name=notes.txt",
+            content=b"hello",
+            headers={"Content-Type": "text/plain"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "attachment": descriptor}
+    args = store.call_args.args
+    assert args[2:5] == (_BRANCH, "notes.txt", "text/plain")
+    assert captured["body"] == b"hello"
+    assert args[6] == 5
+
+
+def test_attachment_upload_rejects_oversized_body_before_storage(tmp_path, monkeypatch):
+    client = _client(tmp_path, agent_enabled=True)
+    monkeypatch.setattr("oduflow.web_ui.agent_uploads.MAX_FILE_BYTES", 3)
+
+    with patch("oduflow.web_ui.agent_uploads.store_attachment") as store:
+        response = client.post(_ATTACHMENTS_URL + "?name=large.bin", content=b"four")
+
+    assert response.status_code == 413
+    assert "no larger" in response.json()["error"]
+    store.assert_not_called()
+
+
+def test_attachment_delete_calls_scoped_storage(tmp_path):
+    client = _client(tmp_path, agent_enabled=True)
+
+    with patch("oduflow.web_ui.agent_uploads.delete_attachment") as delete:
+        response = client.delete(_ATTACHMENTS_URL + "/" + "a" * 32)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert delete.call_args.args[2:] == (_BRANCH, "a" * 32)
 
 
 def test_post_adds_session_and_title_is_first_write_wins(tmp_path):

--- a/tests/test_web_ui_agent_acp.py
+++ b/tests/test_web_ui_agent_acp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 from unittest.mock import patch
@@ -26,7 +27,7 @@ def _basic() -> dict[str, str]:
     return {"Authorization": f"Basic {blob}"}
 
 
-def _client(tmp_path, *, agent_enabled: bool = False) -> TestClient:
+def _app(tmp_path, *, agent_enabled: bool = False) -> Starlette:
     team = TeamSettings(
         team_id="1",
         data_dir=str(tmp_path / "team-1"),
@@ -36,7 +37,11 @@ def _client(tmp_path, *, agent_enabled: bool = False) -> TestClient:
     settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
     app = Starlette()
     mount_web_ui(app, lambda: settings, LockManager())
-    return TestClient(app, headers=_basic())
+    return app
+
+
+def _client(tmp_path, *, agent_enabled: bool = False) -> TestClient:
+    return TestClient(_app(tmp_path, agent_enabled=agent_enabled), headers=_basic())
 
 
 def _post(client: TestClient, session_id: str, title: str | None = None):
@@ -100,6 +105,41 @@ def test_attachment_upload_rejects_oversized_body_before_storage(tmp_path, monke
 
     assert response.status_code == 413
     assert "no larger" in response.json()["error"]
+    store.assert_not_called()
+
+
+def test_attachment_upload_handles_client_disconnect_quietly(tmp_path):
+    """An aborted XHR (Remove during upload) must not raise through ASGI."""
+    app = _app(tmp_path, agent_enabled=True)
+    messages = [
+        {"type": "http.request", "body": b"partial", "more_body": True},
+        {"type": "http.disconnect"},
+    ]
+    sent = []
+
+    async def receive():
+        return messages.pop(0)
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 123),
+        "root_path": "",
+        "path": f"/api/environments/{_BRANCH}/agent-acp/attachments",
+        "query_string": b"name=notes.txt",
+        "headers": [(b"authorization", _basic()["Authorization"].encode())],
+    }
+
+    with patch("oduflow.web_ui.agent_uploads.store_attachment") as store:
+        asyncio.run(app(scope, receive, send))
+
+    assert sent[0]["status"] == 400
     store.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Groups intermediate messages, reasoning, plans, and tool calls into compact expandable details while keeping final answers visible.
- Preserves the reader’s scroll position as streamed messages arrive, so reviewing earlier content no longer jumps to the bottom.
- Adds secure Agent Chat file attachments with progress, removal, drag-and-drop and paste support, requiring an instruction before files can be sent to the agent.

## Validation
- Passed JavaScript syntax checks, Ruff, mypy, targeted Agent Chat tests, browser QA, and the full non-integration/non-heavyweight unit suite (1,149 tests).