### PR TITLE
Fix server shutdown hang from leaked web terminal threads

### DIFF
--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2902,9 +2902,24 @@ def _build_routes(
                 finally:
                     closed.set()
 
+            tasks = [
+                asyncio.ensure_future(docker_to_browser()),
+                asyncio.ensure_future(browser_to_docker()),
+            ]
             try:
-                await asyncio.gather(docker_to_browser(), browser_to_docker())
+                # Return as soon as EITHER side ends so a browser-closed/idle
+                # terminal never parks docker_to_browser in recv() forever,
+                # leaking the executor thread that blocks interpreter shutdown.
+                await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
             finally:
+                closed.set()
+                # shutdown() reliably wakes a thread blocked in recv (a bare
+                # close() need not) and gives the exec'd process EOF on stdin so
+                # it exits.
+                try:
+                    raw_sock.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
                 try:
                     raw_sock.close()
                 except Exception:
@@ -2913,6 +2928,13 @@ def _build_routes(
                     sock.close()
                 except Exception:
                     pass
+                try:
+                    await websocket.close()
+                except Exception:
+                    pass
+                for t in tasks:
+                    t.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
 
         except Exception as e:
             logger.exception("WebSocket terminal error for branch %s", branch)
@@ -3032,9 +3054,24 @@ def _build_routes(
                 finally:
                     closed.set()
 
+            tasks = [
+                asyncio.ensure_future(docker_to_browser()),
+                asyncio.ensure_future(browser_to_docker()),
+            ]
             try:
-                await asyncio.gather(docker_to_browser(), browser_to_docker())
+                # Return as soon as EITHER side ends so a browser-closed/idle
+                # terminal never parks docker_to_browser in recv() forever,
+                # leaking the executor thread that blocks interpreter shutdown.
+                await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
             finally:
+                closed.set()
+                # shutdown() reliably wakes a thread blocked in recv (a bare
+                # close() need not) and gives the exec'd process EOF on stdin so
+                # it exits.
+                try:
+                    raw_sock.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
                 try:
                     raw_sock.close()
                 except Exception:
@@ -3043,6 +3080,13 @@ def _build_routes(
                     sock.close()
                 except Exception:
                     pass
+                try:
+                    await websocket.close()
+                except Exception:
+                    pass
+                for t in tasks:
+                    t.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
 
         except Exception as e:
             logger.exception("WebSocket SQL terminal error for branch %s", branch)


### PR DESCRIPTION
## Problem

`ws_terminal` and `ws_sql_terminal` awaited both relay tasks with `asyncio.gather`. When the browser closed an idle terminal, `browser_to_docker` finished but `docker_to_browser` stayed parked in `raw_sock.recv()` forever, leaking a non-daemon executor thread that blocked interpreter shutdown and leaving the exec'd odoo shell / psql process running in the container.

## Fix

Ports the teardown pattern already used by `ws_agent_console` and `ws_agent_acp` to both handlers: return as soon as either side ends (`asyncio.wait` with `FIRST_COMPLETED`), then `shutdown(SHUT_RDWR)` the docker socket — which reliably wakes a thread blocked in `recv` and gives the exec'd process EOF on stdin so it exits — close the websocket cleanly (code 1000, so the browser shows only "[Session ended]" without a spurious "[Connection error]"), and finally cancel and reap both tasks.