### PR TITLE
Document first-run credentials and config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ oduflow
 
 That's it. On first launch, Oduflow automatically creates a default config and initializes shared infrastructure (Docker network, PostgreSQL, team directories).
 
+The generated config is written to `/etc/oduflow/oduflow.toml` when writable,
+otherwise to `~/.oduflow/conf/oduflow.toml`. Fresh configs include generated
+secrets for HTTP access: `[team.1].auth_token` for MCP clients and
+`[team.1].ui_password` for the Web Dashboard. Both values are also printed in
+the startup log.
+
 By default, the server starts in **stdio** mode (for local MCP clients). For remote/multi-user deployments:
 
 ```bash
@@ -90,7 +96,12 @@ oduflow -t http
 }
 ```
 
-**HTTP (remote)** — point your MCP client to `http://<host>:8000/mcp`.
+**HTTP (remote)** — point your MCP client to `http://<host>:8000/mcp` and send
+`Authorization: Bearer <auth_token>` using the token from `oduflow.toml`.
+
+The Web Dashboard is available at `http://<host>:8000/`. Sign in as `admin`
+with the `ui_password` from `oduflow.toml`; this is separate from the MCP Bearer
+token.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,9 +98,13 @@ All settings are configured via a TOML file. Oduflow searches for `oduflow.toml`
 1. `ODUFLOW_TOML` environment variable (explicit path)
 2. `/etc/oduflow/oduflow.toml`
 3. `~/.oduflow/conf/oduflow.toml`
-4. `~/.oduflow/oduflow.toml`
 
-If no config file exists when Oduflow starts, the bundled default is automatically copied to the appropriate location.
+If no config file exists when Oduflow starts, the bundled default is copied to
+`/etc/oduflow/oduflow.toml` when that directory is writable, otherwise to
+`~/.oduflow/conf/oduflow.toml`. The copied file is populated with generated
+values for `[database].password`, `[team.1].auth_token`, and
+`[team.1].ui_password`; the generated MCP token and Web Dashboard password are
+also printed in the startup log.
 
 ### Minimal configuration
 
@@ -133,14 +137,15 @@ mode = "port"               # "port" (direct host port) | "traefik" (reverse pro
 # automatically and runs on each team's own hostname (issuer derived per-request),
 # so oauth_base_url is NOT needed. Set it only to pin a fixed issuer, or in port
 # mode: the public URL of this instance (for Claude.ai and other OAuth MCP
-# clients). OAuth client_id = team_<id> (non-secret); auth_token = client_secret = token.
+# clients). OAuth client_id = team_<id> (non-secret); auth_token = client_secret.
+# OAuth mints independent expiring access tokens; auth_token also works as Bearer.
 [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"               # PostgreSQL user for the shared database container
-password = "odoo"           # PostgreSQL password (auto-generated on first init; set to override)
+# password = "..."          # auto-generated on first init; set explicitly to override
 image = "postgres:15"       # PostgreSQL Docker image
 
 # ── Storage ───────────────────────────────────────────
@@ -167,8 +172,8 @@ auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 di
 
 [team.1]
 hostname = "localhost"               # port mode: http://{hostname}:{port}, traefik mode: https://{slug}.{hostname}
-auth_token = ""                      # MCP bearer token (empty = MCP auth disabled)
-ui_password = ""                     # Web UI password (empty = UI auth disabled)
+auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Bearer token
+ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
 # agent_enabled = false              # enable the per-team coding agent (Agent Chat / Agent CLI)
 # agent_default = "claude"           # "claude" | "codex" — default agent for consoles/chats
@@ -202,14 +207,14 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 
 | Key | Default | Description |
 |---|---|---|
-| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; the OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`) and each team's `auth_token` is the `client_secret` and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only. See [Authentication & Security](security.md) |
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; the OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`) and each team's `auth_token` is the `client_secret`. OAuth mints independent expiring access tokens; `auth_token` also works directly as a Bearer token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only. See [Authentication & Security](security.md) |
 
 ### Database settings
 
 | Key | Default | Description |
 |---|---|---|
 | `[database].user` | `odoo` | PostgreSQL user for the shared database container |
-| `[database].password` | `odoo` | PostgreSQL password. The bundled config omits it and one is auto-generated on first init; set explicitly to override |
+| `[database].password` | *(generated)* | PostgreSQL password. The bundled config omits it and one is auto-generated on first init; set explicitly to override |
 | `[database].image` | `postgres:15` | PostgreSQL Docker image |
 
 ### Storage settings
@@ -238,8 +243,8 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | Key | Default | Description |
 |---|---|---|
 | `hostname` | `localhost` | Team hostname. In port mode: `http://{hostname}:{port}`. In traefik mode: `https://{slug}.{hostname}` |
-| `auth_token` | *(empty)* | Bearer token for MCP HTTP auth. Empty = MCP auth disabled for this team |
-| `ui_password` | *(empty)* | Password for Web UI Basic auth (user: `admin`). Separate from MCP auth token. Empty = UI auth disabled |
+| `auth_token` | *(generated in fresh config)* | Bearer token for MCP HTTP auth and OAuth client secret. Empty disables MCP auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
+| `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
 | `agent_enabled` | `false` | Enable the per-team coding agent (dashboard Agent Chat / Agent CLI). Off by default |
 | `agent_default` | `claude` | Which agent consoles/chats open by default: `claude` or `codex` |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -27,7 +27,7 @@ pip install oduflow
 
 ### Configure
 
-All settings are configured via `oduflow.toml` (searched in `/etc/oduflow/` then `~/.oduflow/`, or set `ODUFLOW_TOML`).
+All settings are configured via `oduflow.toml`. Oduflow searches `ODUFLOW_TOML`, then `/etc/oduflow/oduflow.toml`, then `~/.oduflow/conf/oduflow.toml`.
 
 Minimal configuration:
 
@@ -49,7 +49,7 @@ mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 
 [database]
 user = "odoo"
-password = "odoo"                     # auto-generated on first init; set to override
+# password = "..."                    # auto-generated on first init; set to override
 image = "postgres:15"
 
 [storage]
@@ -66,8 +66,8 @@ auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disabl
 
 [team.1]
 hostname = "localhost"
-auth_token = ""                       # MCP bearer token (empty = auth disabled)
-ui_password = ""                      # Web UI password (empty = UI open)
+auth_token = ""                       # auto-filled in fresh configs; HTTP MCP Bearer token / OAuth client_secret
+ui_password = ""                      # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]           # port range for Odoo containers
 # agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
 # agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
@@ -78,7 +78,7 @@ port_range = [50000, 50100]           # port range for Odoo containers
 
 ### Initialize
 
-No separate init step is needed. On first launch Oduflow automatically creates a default `oduflow.toml` (if none exists) and initializes shared infrastructure (Docker network, PostgreSQL, team directories). Just start the server (below).
+No separate init step is needed. On first launch Oduflow automatically creates a default `oduflow.toml` at `/etc/oduflow/oduflow.toml` when writable, otherwise at `~/.oduflow/conf/oduflow.toml`, and initializes shared infrastructure (Docker network, PostgreSQL, team directories). Fresh configs include generated `[database].password`, `[team.1].auth_token`, and `[team.1].ui_password`; the MCP token and Web Dashboard password are also printed in the startup log.
 
 ### Set up a template
 
@@ -94,10 +94,11 @@ oduflow reload-template default
 ### Start the MCP server
 
 ```bash
-oduflow
+oduflow --transport http
+# or: oduflow -t http
 ```
 
-The server starts on `http://0.0.0.0:8000`. MCP endpoint: `http://<host>:8000/mcp`.
+For HTTP mode, the server starts on `http://0.0.0.0:8000`. MCP endpoint: `http://<host>:8000/mcp`; send `Authorization: Bearer <auth_token>` using the value from `oduflow.toml`. The Web Dashboard is at `http://<host>:8000/`; sign in as `admin` with `ui_password`.
 
 ## MCP Client Configuration
 
@@ -266,7 +267,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 
 ## 1. Configure
 
-Create `oduflow.toml` (searched in `/etc/oduflow/` then `~/.oduflow/`, or set `ODUFLOW_TOML`):
+Create `oduflow.toml` if you want to customize before first launch. Oduflow searches `ODUFLOW_TOML`, then `/etc/oduflow/oduflow.toml`, then `~/.oduflow/conf/oduflow.toml`:
 
 ```toml
 [team.1]
@@ -275,21 +276,22 @@ hostname = "localhost"
 
 ## 2. Initialize the system
 
-No separate step is needed — on first launch Oduflow automatically creates a default `oduflow.toml` (if none exists) and initializes shared infrastructure (Docker network, PostgreSQL container, team directories).
+No separate step is needed — on first launch Oduflow automatically creates a default `oduflow.toml` at `/etc/oduflow/oduflow.toml` when writable, otherwise at `~/.oduflow/conf/oduflow.toml`, and initializes shared infrastructure (Docker network, PostgreSQL container, team directories). Fresh configs include generated `[database].password`, `[team.1].auth_token`, and `[team.1].ui_password`.
 
 To set up a template database, use `oduflow init-template` (see [Template Management](templates.md)).
 
 ## 3. Start the MCP server
 
 ```bash
-oduflow
+oduflow --transport http
+# or: oduflow -t http
 ```
 
-The server starts on `http://0.0.0.0:8000` by default (configurable via `[server]` section in `oduflow.toml`).
+In HTTP mode, the server starts on `http://0.0.0.0:8000` by default (configurable via `[server]` section in `oduflow.toml`).
 
 ## 4. Connect an MCP client
 
-Point your MCP client (Cursor, Cline, Amp, etc.) to `http://<host>:8000/mcp`.
+Point your MCP client (Cursor, Cline, Amp, etc.) to `http://<host>:8000/mcp` and send `Authorization: Bearer <auth_token>` using the value from `oduflow.toml`. The Web Dashboard is at `http://<host>:8000/`; sign in as `admin` with `ui_password`.
 
 ---
 
@@ -363,9 +365,9 @@ All settings are configured via a TOML file. Oduflow searches for `oduflow.toml`
 
 1. `ODUFLOW_TOML` environment variable (explicit path)
 2. `/etc/oduflow/oduflow.toml`
-3. `~/.oduflow/oduflow.toml`
+3. `~/.oduflow/conf/oduflow.toml`
 
-If no config file exists, the bundled default is automatically copied to the appropriate location on first startup.
+If no config file exists, the bundled default is copied to `/etc/oduflow/oduflow.toml` when writable, otherwise to `~/.oduflow/conf/oduflow.toml`. The copied file is populated with generated values for `[database].password`, `[team.1].auth_token`, and `[team.1].ui_password`; the generated MCP token and Web Dashboard password are also printed in the startup log.
 
 ### Minimal configuration
 
@@ -397,14 +399,15 @@ mode = "port"               # "port" (direct host port) | "traefik" (reverse pro
 # automatically and runs on each team's own hostname (issuer derived per-request),
 # so oauth_base_url is NOT needed. Set it only to pin a fixed issuer, or in port
 # mode: the public URL of this instance (for Claude.ai and other OAuth MCP
-# clients). OAuth client_id = team_<id> (non-secret); auth_token = client_secret = token.
+# clients). OAuth client_id = team_<id> (non-secret); auth_token = client_secret.
+# OAuth mints independent expiring access tokens; auth_token also works as Bearer.
 [oauth]
 # oauth_base_url = "https://oduflow.example.com"
 
 # ── Database ──────────────────────────────────────────
 [database]
 user = "odoo"               # PostgreSQL user for the shared database container
-password = "odoo"           # PostgreSQL password (auto-generated on first init; set to override)
+# password = "..."          # auto-generated on first init; set explicitly to override
 image = "postgres:15"       # PostgreSQL Docker image
 
 # ── Storage ───────────────────────────────────────────
@@ -431,8 +434,8 @@ auto_delete_hours = 0                # auto-delete stopped environments after N 
 
 [team.1]
 hostname = "localhost"               # port mode: http://{hostname}:{port}, traefik mode: https://{slug}.{hostname}
-auth_token = ""                      # MCP bearer token (empty = MCP auth disabled)
-ui_password = ""                     # Web UI password (empty = UI auth disabled)
+auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Bearer token
+ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
 # agent_enabled = false              # enable the per-team coding agent (Agent Chat / Agent CLI)
 # agent_default = "claude"           # "claude" | "codex" — default agent for consoles/chats
@@ -464,7 +467,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 
 | Key | Default | Description |
 |---|---|---|
-| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; the OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`) and each team's `auth_token` is the `client_secret` and the issued access token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only |
+| `[oauth].oauth_base_url` | *(empty)* | Public URL of this Oduflow instance used as the OAuth issuer. Oduflow runs a self-hosted OAuth 2.1 Authorization Server (exposes `/.well-known/oauth-authorization-server`, `/authorize`, `/token`) so OAuth-based MCP clients like Claude.ai can connect; the OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`) and each team's `auth_token` is the `client_secret`. OAuth mints independent expiring access tokens; `auth_token` also works directly as a Bearer token. **In traefik mode this is enabled automatically and the issuer is derived per-request from each team's own hostname — leave empty.** Set it to pin a fixed issuer, or in port mode. Empty + port mode = plain Bearer-token auth only |
 
 ### Database settings
 
@@ -500,8 +503,8 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | Key | Default | Description |
 |---|---|---|
 | `hostname` | `localhost` | Team hostname. In port mode: `http://{hostname}:{port}`. In traefik mode: `https://{slug}.{hostname}` |
-| `auth_token` | *(empty)* | Bearer token for MCP HTTP auth. Empty = MCP auth disabled for this team |
-| `ui_password` | *(empty)* | Password for Web UI Basic auth (user: `admin`). Separate from MCP auth token. Empty = UI auth disabled |
+| `auth_token` | *(generated in fresh config)* | Bearer token for MCP HTTP auth and OAuth client secret. Empty disables MCP auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
+| `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
 | `agent_enabled` | `false` | Enable the per-team coding agent (dashboard Agent Chat / Agent CLI). Off by default |
 | `agent_default` | `claude` | Which agent consoles/chats open by default: `claude` or `codex` |
@@ -2272,17 +2275,26 @@ The web dashboard and REST API use HTTP Basic authentication with a **separate**
 
 This is independent from the MCP Bearer token (`auth_token`). Credentials are compared using `hmac.compare_digest` to prevent timing attacks.
 
+Fresh configs get a generated `ui_password` for `[team.1]` on first startup. Older HTTP configs with an empty `ui_password` are also auto-filled on startup and written back to `oduflow.toml`, so an upgrade does not expose the dashboard.
+
 ## When auth is disabled
 
 MCP auth and Web UI auth are configured independently per team:
 
-- If `auth_token` is empty, the MCP endpoint runs without authentication
-- If `ui_password` is empty, the web dashboard runs without authentication
+- If `auth_token` is empty, the MCP endpoint has no team Bearer token
+- If `ui_password` is empty, the web dashboard has no login password
 
-Warnings are logged on startup for each team:
+In HTTP mode, Oduflow refuses to start with an unauthenticated MCP endpoint or dashboard unless the operator explicitly sets:
+
+```toml
+[server]
+allow_insecure_http = true
+```
+
+Use that only behind your own authenticating proxy. In normal fresh HTTP deployments, `auth_token` and `ui_password` are generated automatically and startup logs show auth as enabled:
 
 ```
-INFO  [team.1] http://localhost:8000/ (MCP token OFF, OAuth OFF, UI auth OFF)
+INFO  [team.1] http://localhost:8000/ (MCP token ON, OAuth OFF, UI auth ON)
 ```
 
 When OAuth is enabled the status reads `OAuth ON (self-hosted)`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,7 +27,7 @@ pip install oduflow
 
 ### Configure
 
-All settings are configured via `oduflow.toml` (searched in `/etc/oduflow/` then `~/.oduflow/`, or set `ODUFLOW_TOML`).
+All settings are configured via `oduflow.toml`. Oduflow searches `ODUFLOW_TOML`, then `/etc/oduflow/oduflow.toml`, then `~/.oduflow/conf/oduflow.toml`.
 
 Minimal configuration:
 
@@ -48,11 +48,11 @@ mode = "port"                         # "port" | "traefik" (auto-HTTPS)
 # acme_email = "admin@example.com"    # required for traefik mode
 
 [oauth]
-# oauth_base_url = "https://oduflow.example.com"  # OAuth issuer; NOT needed in traefik (auto, per-team host). Set to pin an issuer or in port mode. OAuth client_id = team_<id> (non-secret); auth_token = client_secret = access token
+# oauth_base_url = "https://oduflow.example.com"  # OAuth issuer; NOT needed in traefik (auto, per-team host). Set to pin an issuer or in port mode. OAuth client_id = team_<id> (non-secret); auth_token = client_secret and also works as a Bearer token
 
 [database]
 user = "odoo"
-password = "odoo"                     # auto-generated on first init; set to override
+# password = "..."                    # auto-generated on first init; set to override
 image = "postgres:15"
 
 [storage]
@@ -69,8 +69,8 @@ auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disabl
 
 [team.1]
 hostname = "localhost"
-auth_token = ""                       # MCP bearer token (empty = auth disabled)
-ui_password = ""                      # Web UI password (empty = UI open)
+auth_token = ""                       # auto-filled in fresh configs; HTTP MCP Bearer token / OAuth client_secret
+ui_password = ""                      # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]           # port range for Odoo containers
 # agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
 # agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
@@ -82,7 +82,7 @@ port_range = [50000, 50100]           # port range for Odoo containers
 
 ### Initialize
 
-No separate init step is needed. On first launch Oduflow automatically creates a default `oduflow.toml` (if none exists) and initializes shared infrastructure (Docker network, PostgreSQL, team directories). Just start the server (below).
+No separate init step is needed. On first launch Oduflow automatically creates a default `oduflow.toml` at `/etc/oduflow/oduflow.toml` when writable, otherwise at `~/.oduflow/conf/oduflow.toml`, and initializes shared infrastructure (Docker network, PostgreSQL, team directories). Fresh configs include generated `[database].password`, `[team.1].auth_token`, and `[team.1].ui_password`; the MCP token and Web Dashboard password are also printed in the startup log.
 
 ### Upgrade
 
@@ -110,10 +110,11 @@ oduflow reload-template default --source /backups/prod-latest/
 ### Start the MCP server
 
 ```bash
-oduflow
+oduflow --transport http
+# or: oduflow -t http
 ```
 
-The server starts on `http://0.0.0.0:8000`. MCP endpoint: `http://<host>:8000/mcp`.
+For HTTP mode, the server starts on `http://0.0.0.0:8000`. MCP endpoint: `http://<host>:8000/mcp`; send `Authorization: Bearer <auth_token>` using the value from `oduflow.toml`. The Web Dashboard is at `http://<host>:8000/`; sign in as `admin` with `ui_password`.
 
 ## MCP Client Configuration
 
@@ -141,7 +142,7 @@ Same JSON format in `claude_desktop_config.json` or `.amp/settings.json`.
 
 ### Claude.ai (self-hosted OAuth)
 
-For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAuth 2.1 Authorization Server (no external IdP). In **traefik mode** it is enabled automatically and runs on each team's own hostname (issuer derived per-request) — no `oauth_base_url` needed. In **port mode**, set `[oauth].oauth_base_url` to this instance's public URL. In Claude.ai add a custom MCP at `https://<team-hostname>/mcp` and enter `Client ID = team_<id>` (e.g. `team_1`, non-secret) and `Client Secret = the team's auth_token`. The issued access token equals the `auth_token`, so the same value also works as a plain Bearer token.
+For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAuth 2.1 Authorization Server (no external IdP). In **traefik mode** it is enabled automatically and runs on each team's own hostname (issuer derived per-request) — no `oauth_base_url` needed. In **port mode**, set `[oauth].oauth_base_url` to this instance's public URL. In Claude.ai add a custom MCP at `https://<team-hostname>/mcp` and enter `Client ID = team_<id>` (e.g. `team_1`, non-secret) and `Client Secret = the team's auth_token`. The OAuth flow issues an independent expiring access token; the configured `auth_token` also works directly as a plain Bearer token.
 
 ## Core MCP Tools
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -16,8 +16,24 @@ uv tool install oduflow
 
 On first launch, Oduflow automatically:
 
-- Creates a default `oduflow.toml` config (in `/etc/oduflow/` or `~/.oduflow/conf/`)
+- Creates a default `oduflow.toml` config with generated secrets
 - Initializes shared infrastructure (Docker network, PostgreSQL, team directories)
+
+The config is created at `/etc/oduflow/oduflow.toml` when that directory is
+writable, otherwise at `~/.oduflow/conf/oduflow.toml`. Oduflow searches for the
+config in this order:
+
+1. `ODUFLOW_TOML` environment variable (explicit file path)
+2. `/etc/oduflow/oduflow.toml`
+3. `~/.oduflow/conf/oduflow.toml`
+
+Fresh configs include generated values for:
+
+- `[database].password` — PostgreSQL superuser password
+- `[team.1].auth_token` — HTTP MCP Bearer token and OAuth client secret
+- `[team.1].ui_password` — Web Dashboard password
+
+The generated `auth_token` and `ui_password` are also printed in the startup log.
 
 ## Single-user mode (stdio)
 
@@ -72,16 +88,26 @@ The server starts on `http://0.0.0.0:8000` by default (configurable via `[server
 
 ### Authentication
 
-In HTTP mode it is recommended to set a Bearer token for MCP and a password for the Web Dashboard. Add to your `oduflow.toml`:
+Fresh HTTP installs already have a generated Bearer token for MCP and a separate
+generated password for the Web Dashboard. Read them from `oduflow.toml`:
 
 ```toml
 [team.1]
 hostname = "localhost"
-auth_token = "my-secret-mcp-token"      # Bearer token for MCP clients
-ui_password = "my-dashboard-password"    # Basic auth for Web Dashboard (user: admin)
+auth_token = "..."     # Bearer token for MCP clients
+ui_password = "..."    # Web Dashboard password for user admin
 ```
 
-MCP auth and Web Dashboard auth are independent — they use different tokens and different mechanisms (Bearer vs Basic).
+To sign in to the Web Dashboard, open `http://<host>:8000/`, use username
+`admin`, and enter the `ui_password` value. To connect an HTTP MCP client, use
+`http://<host>:8000/mcp` with:
+
+```
+Authorization: Bearer <auth_token>
+```
+
+MCP auth and Web Dashboard auth are independent — they use different credentials
+and different mechanisms (Bearer vs form/Basic auth).
 
 ### Self-hosted OAuth (Claude.ai)
 
@@ -92,7 +118,7 @@ Some MCP clients (e.g. Claude.ai Remote MCP) require an OAuth flow instead of a 
 oauth_base_url = "https://oduflow.example.com"
 ```
 
-The OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`); each team's `auth_token` is the `client_secret` and the issued access token. See [Authentication & Security](security.md#self-hosted-oauth-for-claudeai-and-other-mcp-clients) for the full setup and how to connect from Claude.ai.
+The OAuth `client_id` is the non-secret `team_<id>` (e.g. `team_1`); each team's `auth_token` is the `client_secret`, and OAuth mints an independent expiring access token. See [Authentication & Security](security.md#self-hosted-oauth-for-claudeai-and-other-mcp-clients) for the full setup and how to connect from Claude.ai.
 
 ### MCP client configuration
 
@@ -130,7 +156,7 @@ If the server is behind a reverse proxy with HTTPS (see [Traefik Routing](traefi
 
 ### Web Dashboard
 
-When running in HTTP mode, a web dashboard is available at the root URL (`http://your-server:8000/`). It provides environment management, service controls, a WebSocket terminal, and more. See [Web Dashboard & REST API](web-api.md) for details.
+When running in HTTP mode, a web dashboard is available at the root URL (`http://your-server:8000/`). Sign in as `admin` with the `ui_password` from `oduflow.toml`. It provides environment management, service controls, a WebSocket terminal, and more. See [Web Dashboard & REST API](web-api.md) for details.
 
 ## Next steps
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,6 +20,10 @@ auth_token = "secret-token-team-2"
 
 The token is used to both authenticate and identify the team. This is implemented via FastMCP's `StaticTokenVerifier`.
 
+Fresh configs get a generated `auth_token` for `[team.1]` on first startup. The
+value is printed in the startup log and stored in `oduflow.toml`; use it as
+`Authorization: Bearer <auth_token>` when connecting HTTP MCP clients.
+
 ## Self-hosted OAuth (for Claude.ai and other MCP clients)
 
 Oduflow can act as its own OAuth 2.1 Authorization Server, so MCP clients that require an OAuth flow (e.g. Claude.ai Remote MCP, MCP Inspector) can connect without any external identity provider.
@@ -135,17 +139,31 @@ The web dashboard and REST API use HTTP Basic authentication with a **separate**
 
 This is independent from the MCP Bearer token (`auth_token`). Credentials are compared using `hmac.compare_digest` to prevent timing attacks.
 
+Fresh configs get a generated `ui_password` for `[team.1]` on first startup.
+Older HTTP configs with an empty `ui_password` are also auto-filled on startup
+and written back to `oduflow.toml`, so an upgrade does not expose the dashboard.
+
 ## When auth is disabled
 
 MCP auth and Web UI auth are configured independently per team:
 
-- If `auth_token` is empty, the MCP endpoint runs without authentication
-- If `ui_password` is empty, the web dashboard runs without authentication
+- If `auth_token` is empty, the MCP endpoint has no team Bearer token
+- If `ui_password` is empty, the web dashboard has no login password
 
-Warnings are logged on startup for each team:
+In HTTP mode, Oduflow refuses to start with an unauthenticated MCP endpoint or
+dashboard unless the operator explicitly sets:
+
+```toml
+[server]
+allow_insecure_http = true
+```
+
+Use that only behind your own authenticating proxy. In normal fresh HTTP
+deployments, `auth_token` and `ui_password` are generated automatically and
+startup logs show auth as enabled:
 
 ```
-INFO  [team.1] http://localhost:8000/ (MCP token OFF, OAuth OFF, UI auth OFF)
+INFO  [team.1] http://localhost:8000/ (MCP token ON, OAuth OFF, UI auth ON)
 ```
 
 When OAuth is enabled the status reads `OAuth ON (self-hosted)`.

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4763,8 +4763,8 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
       derived per-request from the team's own (TLS-terminated) hostname, so no
       central oauth_base_url is needed; each team's OAuth flow runs on its own
       host. Each team's client_id is public (team_<id>), while auth_token is the
-      client_secret and issued access token, so Bearer-token callers keep working
-      unchanged.
+      client_secret and also works directly as a Bearer token, so Bearer-token
+      callers keep working unchanged.
       Suitable for claude.ai and other MCP clients that require an OAuth flow.
     - Static Bearer tokens — port mode with no oauth_base_url: auth_token is
       consumed directly from the Authorization header. Suitable for curl, CLI
@@ -4774,7 +4774,7 @@ def _build_auth(settings: Settings):  # type: ignore[no-untyped-def]
 
     if settings.oauth_enabled:
         # oauth_enabled already implies a team auth_token (see Settings), used as
-        # the OAuth client_secret and issued access token.
+        # the OAuth client_secret and as a direct Bearer token.
         from oduflow.oauth_provider import OduflowOAuthProvider
 
         return OduflowOAuthProvider(settings)

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -251,7 +251,7 @@ class Settings:
     # used as the OAuth issuer and to advertise authorize/token endpoints.
     # When set, Oduflow exposes /.well-known/oauth-authorization-server,
     # /authorize, and /token. Each team's client_id is public (team_<id>), while
-    # auth_token is the client_secret and issued access token.
+    # auth_token is the client_secret and also works directly as a Bearer token.
     # In traefik mode this is optional: the issuer is derived per-request from
     # the team's own hostname (already TLS-terminated), so OAuth works without a
     # central host. Set it only to pin a fixed issuer or in port mode.
@@ -621,7 +621,7 @@ def _parse_backup_section(backup_raw: dict[str, object]) -> BackupSettings | Non
 
 
 def find_toml() -> str:
-    """Locate oduflow.toml: ODUFLOW_TOML env > /etc/oduflow > ~/.oduflow."""
+    """Locate oduflow.toml: ODUFLOW_TOML > /etc/oduflow > ~/.oduflow/conf."""
     explicit = os.getenv("ODUFLOW_TOML", "").strip()
     if explicit:
         if os.path.isfile(explicit):
@@ -631,7 +631,6 @@ def find_toml() -> str:
     candidates = [
         "/etc/oduflow/oduflow.toml",
         os.path.join(os.path.expanduser("~"), ".oduflow", "conf", "oduflow.toml"),
-        os.path.join(os.path.expanduser("~"), ".oduflow", "oduflow.toml"),
     ]
     for path in candidates:
         if os.path.isfile(path):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,9 +1,56 @@
 import pytest
 from pathlib import Path
-from oduflow.settings import Settings, TeamSettings
+from oduflow.settings import Settings, TeamSettings, find_toml
 
 
 class TestSettings:
+    def test_find_toml_explicit_env_has_priority(self, monkeypatch, tmp_path):
+        explicit = tmp_path / "custom.toml"
+        monkeypatch.setenv("ODUFLOW_TOML", str(explicit))
+
+        def exists(path):
+            return path in {str(explicit), "/etc/oduflow/oduflow.toml"}
+
+        monkeypatch.setattr("oduflow.settings.os.path.isfile", exists)
+
+        assert find_toml() == str(explicit)
+
+    def test_find_toml_implicit_candidates(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        user_conf = home / ".oduflow" / "conf" / "oduflow.toml"
+        monkeypatch.delenv("ODUFLOW_TOML", raising=False)
+        monkeypatch.setenv("HOME", str(home))
+
+        seen = []
+
+        def exists(path):
+            seen.append(path)
+            return path == str(user_conf)
+
+        monkeypatch.setattr("oduflow.settings.os.path.isfile", exists)
+
+        assert find_toml() == str(user_conf)
+        assert seen == [
+            "/etc/oduflow/oduflow.toml",
+            str(user_conf),
+        ]
+
+    def test_find_toml_ignores_legacy_home_file(self, monkeypatch, tmp_path):
+        home = tmp_path / "home"
+        legacy = home / ".oduflow" / "oduflow.toml"
+        monkeypatch.delenv("ODUFLOW_TOML", raising=False)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(
+            "oduflow.settings.os.path.isfile", lambda path: path == str(legacy)
+        )
+
+        with pytest.raises(FileNotFoundError) as exc:
+            find_toml()
+
+        message = str(exc.value)
+        assert str(legacy) not in message
+        assert str(home / ".oduflow" / "conf" / "oduflow.toml") in message
+
     def test_lifecycle_defaults(self):
         s = Settings(teams={"1": TeamSettings(team_id="1")})
         assert s.auto_stop_hours == 48


### PR DESCRIPTION
This simplifies Oduflow config discovery by removing the legacy `~/.oduflow/oduflow.toml` fallback and documenting the remaining `ODUFLOW_TOML`, `/etc/oduflow/oduflow.toml`, and `~/.oduflow/conf/oduflow.toml` lookup order. It updates the README, quick start, installation, security, and LLM docs so first-run users know where generated `auth_token` and `ui_password` values live and how to use them for HTTP MCP and Web Dashboard login. It also adds focused tests for config lookup behavior and refreshes stale OAuth comments to match independent expiring access tokens. Validated with `pytest tests/test_settings.py -q` and `ruff check src/oduflow/settings.py src/oduflow/server.py tests/test_settings.py`; `mkdocs build` is blocked locally because the `glightbox` plugin is not installed.
