### PR TITLE
Fix concurrent Connect As temp-script collision

### DIFF
--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+import secrets
 from typing import Any
 
 import docker
@@ -745,69 +746,81 @@ def connect_as_user(
     # sentinel-framed so they survive the merged banner/log stream.
     mint_script = _build_connect_as_user_script(user)
 
-    script_path = "/tmp/_oduflow_connect_script.py"
+    script_basename = f"_oduflow_connect_script_{secrets.token_hex(16)}.py"
+    script_path = f"/tmp/{script_basename}"
     data = mint_script.encode("utf-8")
     tar_stream = io.BytesIO()
     with tarfile.open(fileobj=tar_stream, mode="w") as tar:
-        info = tarfile.TarInfo(name="_oduflow_connect_script.py")
+        info = tarfile.TarInfo(name=script_basename)
         info.size = len(data)
         tar.addfile(info, io.BytesIO(data))
     tar_stream.seek(0)
-    container.put_archive("/tmp", tar_stream)
+    try:
+        container.put_archive("/tmp", tar_stream)
 
-    cmd = (
-        f"odoo shell --no-http --stop-after-init "
-        f"--db_host={settings.shared_db_container} "
-        f"-r {creds['pg_user']} -w {creds['pg_password']} "
-        f"--database={env_db} "
-        f"< {script_path}"
-    )
-    logger.info("Minting session", extra={"env_name": env_name})
-    exit_code, output = container.exec_run(["sh", "-c", cmd], user="odoo")
-    output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
-    container.exec_run(["rm", "-f", script_path])
-
-    err = _extract_sentinel(output_str, "ERR")
-    if err is not None:
-        if err.startswith("NOTFOUND:"):
-            raise NotFoundError(
-                f"User '{err[len('NOTFOUND:') :]}' not found in environment "
-                f"'{env_name}'. Pass an existing login or numeric user id."
-            )
-        raise ExternalCommandError("odoo shell (connect_as_user)", exit_code, err)
-
-    sid = _extract_sentinel(output_str, "SID")
-    if not sid:
-        # No sid and no framed error → surface the raw shell output for debugging.
-        raise ExternalCommandError(
-            "odoo shell (connect_as_user)", exit_code, output_str
+        cmd = (
+            f"odoo shell --no-http --stop-after-init "
+            f"--db_host={settings.shared_db_container} "
+            f"-r {creds['pg_user']} -w {creds['pg_password']} "
+            f"--database={env_db} "
+            f"< {script_path}"
+        )
+        logger.info("Minting session", extra={"env_name": env_name})
+        exit_code, output = container.exec_run(["sh", "-c", cmd], user="odoo")
+        output_str = (
+            output.decode("utf-8") if isinstance(output, bytes) else str(output)
         )
 
-    login = _extract_sentinel(output_str, "LOGIN") or user
-    uid = _extract_sentinel(output_str, "UID") or ""
-    ttl_raw = _extract_sentinel(output_str, "TTL")
-    try:
-        ttl = int(ttl_raw) if ttl_raw else _DEFAULT_SESSION_LIFETIME
-    except ValueError:
-        ttl = _DEFAULT_SESSION_LIFETIME
+        err = _extract_sentinel(output_str, "ERR")
+        if err is not None:
+            if err.startswith("NOTFOUND:"):
+                raise NotFoundError(
+                    f"User '{err[len('NOTFOUND:') :]}' not found in environment "
+                    f"'{env_name}'. Pass an existing login or numeric user id."
+                )
+            raise ExternalCommandError(
+                "odoo shell (connect_as_user)", exit_code, err
+            )
 
-    from oduflow.docker_ops.env_ops import get_env_base_url
+        sid = _extract_sentinel(output_str, "SID")
+        if not sid:
+            # No sid and no framed error → surface the raw shell output for debugging.
+            raise ExternalCommandError(
+                "odoo shell (connect_as_user)", exit_code, output_str
+            )
 
-    base_url, cookie_domain = get_env_base_url(settings, team, env_name, container)
-    expires_at = (
-        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=ttl)
-    ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        login = _extract_sentinel(output_str, "LOGIN") or user
+        uid = _extract_sentinel(output_str, "UID") or ""
+        ttl_raw = _extract_sentinel(output_str, "TTL")
+        try:
+            ttl = int(ttl_raw) if ttl_raw else _DEFAULT_SESSION_LIFETIME
+        except ValueError:
+            ttl = _DEFAULT_SESSION_LIFETIME
 
-    logger.info("Connected as user", extra={"env_name": env_name, "login": login})
-    return {
-        "sid": sid,
-        "login": login,
-        "uid": uid,
-        "base_url": base_url,
-        "cookie_domain": cookie_domain,
-        "url": f"{base_url}/web",
-        "expires_at": expires_at,
-    }
+        from oduflow.docker_ops.env_ops import get_env_base_url
+
+        base_url, cookie_domain = get_env_base_url(
+            settings, team, env_name, container
+        )
+        expires_at = (
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(seconds=ttl)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        logger.info(
+            "Connected as user", extra={"env_name": env_name, "login": login}
+        )
+        return {
+            "sid": sid,
+            "login": login,
+            "uid": uid,
+            "base_url": base_url,
+            "cookie_domain": cookie_domain,
+            "url": f"{base_url}/web",
+            "expires_at": expires_at,
+        }
+    finally:
+        container.exec_run(["rm", "-f", script_path])
 
 
 def list_env_users(

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tarfile
 
 import pytest
 import docker
@@ -1510,6 +1511,89 @@ class TestConnectAsUserScript:
         assert "user_context['uid'] = user.id" in script
         assert "'context': user_context" in script
         assert "'context': dict(u.context_get())" not in script
+
+
+class TestConnectAsUser:
+    _SHELL_OUTPUT = (
+        b"__ODUFLOW_SID__session-id__END__\n"
+        b"__ODUFLOW_LOGIN__jane@acme.com__END__\n"
+        b"__ODUFLOW_UID__7__END__\n"
+    )
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops.get_env_base_url",
+        return_value=("https://main.example.com", "main.example.com"),
+    )
+    def test_each_invocation_uses_one_distinct_path_everywhere(
+        self, mock_base_url, mock_load_creds, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.return_value = (0, self._SHELL_OUTPUT)
+        mock_docker_client.containers.get.return_value = container
+
+        archive_members = []
+
+        def capture_archive(_path, stream):
+            with tarfile.open(fileobj=stream, mode="r") as archive:
+                archive_members.append(archive.getnames())
+
+        container.put_archive.side_effect = capture_archive
+
+        odoo_ops.connect_as_user(
+            TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com"
+        )
+        odoo_ops.connect_as_user(
+            TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com"
+        )
+
+        shell_calls = [
+            call
+            for call in container.exec_run.call_args_list
+            if call.args[0][:2] == ["sh", "-c"]
+        ]
+        shell_paths = [call.args[0][2].rsplit("< ", 1)[1] for call in shell_calls]
+        cleanup_paths = [
+            call.args[0][2]
+            for call in container.exec_run.call_args_list
+            if call.args[0][:2] == ["rm", "-f"]
+        ]
+
+        assert len(set(shell_paths)) == 2
+        assert archive_members == [
+            [shell_paths[0].removeprefix("/tmp/")],
+            [shell_paths[1].removeprefix("/tmp/")],
+        ]
+        assert cleanup_paths == shell_paths
+        assert all(call.kwargs["user"] == "odoo" for call in shell_calls)
+
+    @patch("oduflow.docker_ops.odoo_ops.secrets.token_hex", return_value="a1b2c3")
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_cleanup_targets_invocation_file_after_exec_raises(
+        self, mock_load_creds, mock_token_hex, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.side_effect = [RuntimeError("exec failed"), (0, b"")]
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(RuntimeError, match="exec failed"):
+            odoo_ops.connect_as_user(
+                TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com"
+            )
+
+        assert container.exec_run.call_args_list[0].args[0][0:2] == ["sh", "-c"]
+        assert container.exec_run.call_args_list[1].args[0] == [
+            "rm",
+            "-f",
+            "/tmp/_oduflow_connect_script_a1b2c3.py",
+        ]
+        assert container.exec_run.call_count == 2
 
 
 class TestGetLogs:


### PR DESCRIPTION
## Summary

Concurrent Connect As requests targeting one Odoo container reused the same temporary script path, allowing one request to overwrite or delete another request's script.
This change gives every invocation a filesystem-safe random basename and reuses it for the tar member, shell redirection, and cleanup without introducing serialization.
The upload, execution, sentinel parsing, and result construction now run inside `try/finally`, ensuring invocation-specific cleanup after Docker or parsing failures while preserving the existing API and error behavior.
Regression tests cover distinct paths, archive/command consistency, cleanup after execution errors, and cleanup isolation; validation passed with 1,197 pytest tests, Ruff, and mypy.
