### PR TITLE
Preserve OAuth refresh tokens after access expiry

### DIFF
--- a/src/oduflow/oauth_token_store.py
+++ b/src/oduflow/oauth_token_store.py
@@ -10,9 +10,10 @@ same lock + atomic-write pattern as :mod:`oduflow.port_registry`.
 ``load_access_token`` runs on every authenticated request, so reads are served
 from an in-memory cache; the JSON file is the durable source of truth, read on
 startup and re-read on a cache miss (so a token minted or revoked by another
-worker process is eventually picked up). Writes (mint / rotate / revoke / expiry
-cleanup) run under a cross-thread + cross-process lock and rewrite the file
-atomically with ``0o600`` perms (the file holds bearer secrets).
+worker process is eventually picked up). Access-token expiry removes only the
+expired access record; explicit revocation and refresh rotation invalidate both
+records in a pair. Writes run under a cross-thread + cross-process lock and
+rewrite the file atomically with ``0o600`` perms (the file holds bearer secrets).
 """
 
 from __future__ import annotations
@@ -112,16 +113,18 @@ def _save_file(path: str, data: StoreData) -> None:
 
 
 def _prune_expired(data: StoreData, now: float) -> bool:
-    """Drop expired access tokens and their refresh partners. Returns whether
-    anything was removed."""
+    """Drop expired access records, preserving their refresh-token partners.
+
+    Refresh tokens do not expire with their access partners: they remain valid
+    so they can rotate an expired (or otherwise missing) access token into a new
+    pair. Pair deletion is reserved for explicit revocation and rotation.
+    Returns whether anything was removed.
+    """
     removed = False
     for token, rec in list(data["access"].items()):
         expires_at = rec.get("expires_at")
         if expires_at is not None and expires_at < now:
             del data["access"][token]
-            partner = rec.get("refresh")
-            if partner:
-                data["refresh"].pop(partner, None)
             removed = True
     return removed
 
@@ -185,7 +188,9 @@ class OAuthTokenStore:
             return None
         expires_at = rec.get("expires_at")
         if expires_at is not None and expires_at < time.time():
-            self.revoke(token)
+            # Expiry invalidates only the access token. Reloading prunes the
+            # durable access record while preserving its refresh partner.
+            self._reload()
             return None
         return dict(rec)
 
@@ -262,7 +267,11 @@ class OAuthTokenStore:
         return access, refresh, expires_at, client_id, scopes
 
     def revoke(self, token: str) -> None:
-        """Delete ``token`` (whether access or refresh) and its partner."""
+        """Explicitly revoke ``token`` and its access/refresh partner.
+
+        Unlike access-token expiry, explicit revocation invalidates the entire
+        pair regardless of which side is presented.
+        """
         with _file_lock(self._path):
             data = _load_file(self._path)
             changed = False

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -205,17 +205,36 @@ class TestOduflowOAuthProvider:
         # A non-issued value is not a valid refresh token.
         assert _run(provider.load_refresh_token(client, "team_1")) is None
 
-    def test_minted_access_token_expires(self, monkeypatch):
+    def test_expired_access_token_keeps_refresh_token_across_restart(
+        self, monkeypatch
+    ):
         from oduflow import oauth_token_store as store_mod
+        from mcp.server.auth.provider import TokenError
 
-        provider = OduflowOAuthProvider(_settings())
+        data_dir = tempfile.mkdtemp()
+        provider = OduflowOAuthProvider(_settings(base_data_dir=data_dir))
         clock = {"t": 1000.0}
         monkeypatch.setattr(store_mod.time, "time", lambda: clock["t"])
         token = _mint(provider)
         assert _run(provider.load_access_token(token.access_token)) is not None
-        # Advance past the TTL: the token is rejected and purged.
+
+        # A restart after the TTL prunes only the expired access record. The
+        # refresh record remains available to rotate into a new pair.
         clock["t"] = 1000.0 + 3600 + 1
-        assert _run(provider.load_access_token(token.access_token)) is None
+        restarted = OduflowOAuthProvider(_settings(base_data_dir=data_dir))
+        assert _run(restarted.load_access_token(token.access_token)) is None
+
+        client = _run(restarted.get_client("team_1"))
+        refresh = _run(restarted.load_refresh_token(client, token.refresh_token))
+        assert refresh is not None
+        rotated = _run(restarted.exchange_refresh_token(client, refresh, []))
+        assert _run(restarted.load_access_token(rotated.access_token)) is not None
+
+        # Rotation consumes the old refresh token; it cannot be replayed.
+        assert _run(restarted.load_refresh_token(client, token.refresh_token)) is None
+        with pytest.raises(TokenError, match="Unknown or already-used") as exc_info:
+            _run(restarted.exchange_refresh_token(client, refresh, []))
+        assert exc_info.value.error == "invalid_grant"
 
     def test_revoke_deletes_minted_token(self):
         provider = OduflowOAuthProvider(_settings())
@@ -228,6 +247,14 @@ class TestOduflowOAuthProvider:
         assert _run(provider.load_access_token(token.access_token)) is None
         client = _run(provider.get_client("team_1"))
         assert _run(provider.load_refresh_token(client, token.refresh_token)) is None
+
+        # Explicitly revoking the refresh side also removes its access partner.
+        token = _mint(provider)
+        refresh = _run(provider.load_refresh_token(client, token.refresh_token))
+        assert refresh is not None
+        _run(provider.revoke_token(refresh))
+        assert _run(provider.load_refresh_token(client, token.refresh_token)) is None
+        assert _run(provider.load_access_token(token.access_token)) is None
 
         # The preseeded auth_token is NOT revocable at runtime (config-bound).
         preseeded = _run(provider.load_access_token("tok-a"))


### PR DESCRIPTION
Expired OAuth access tokens were pruned together with their non-expiring refresh partners, preventing refresh after the access-token TTL or a server restart.

This changes expiry cleanup to remove only access records while preserving explicit pair revocation and refresh rotation semantics.

Regression tests cover restart persistence, successful rotation, replay rejection, and explicit revocation from either token side.

Validated with the focused OAuth tests, the full 1,192-test suite, Ruff, and mypy.