### PR TITLE
Document agent UI live-mount limitation

### DIFF
--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -118,6 +118,7 @@ port_range = [50000, 50100]       # port range for Odoo containers
 # db_quota_gb = 50                # combined size cap for the team's PostgreSQL DBs (environments + templates); 0 = off
 # disk_quota_gb = 0               # cap on team files + databases via XFS project quotas (needs data dir on XFS with prjquota)
 # agent_enabled = false           # per-team coding agent (dashboard Agent Chat / Agent CLI); off by default
+#                                  # Agent UI is hidden for local_path live-mount environments.
 # agent_default = "claude"        # "claude" | "codex" — which agent consoles/chats open by default
 
 # Variables injected into the team's agent container — provider credentials


### PR DESCRIPTION
## What changed

Added a short note to the bundled `oduflow.toml` template next to `agent_enabled` explaining that Agent Chat / Agent CLI are hidden for `local_path` live-mount environments.

## Why

When `agent_enabled = true` is configured but an environment uses `local_path`, the dashboard intentionally hides the hosted agent UI. The template now surfaces that limitation at the point where operators enable the feature.

## Validation

No tests run. This is a comment-only documentation/template change.