### PR TITLE
Share immutable extra-addons checkouts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- **Shared immutable extra-addons checkouts** — development environments using the same extra-addons commit now mount one persistent team-level checkout instead of materialising identical per-environment worktrees. Branch updates create a new SHA-keyed checkout and `pull_and_apply` switches only the requested environment, preserving independent database state; production keeps private worktrees for rollback. Existing environments migrate lazily on their next sync, and cached revisions remain until the extra repository is deleted.
+
 ### Dashboard
 
 - **Agent Chat conversation history** — each environment and agent now keeps up to 20 recent conversations in MRU order, titled from the first user prompt. The new **History** menu resumes a selected conversation through ACP `session/load`, preserves legacy sessions without a migration, and recovers safely when an adapter cannot load an older session.
@@ -20,6 +24,7 @@
 ### Documentation
 
 - **Document the short transport flag** — HTTP server startup examples now show `oduflow -t http` / `uvx oduflow -t http` as the short form of `--transport http`.
+- **Record the shared extra-addons cache decision** — specs/0039 documents SHA-keyed checkout sharing, isolation from moving branches, persistent cache lifecycle, and why production remains on private worktrees.
 
 ## v1.67.0
 

--- a/docs/extra-addons.md
+++ b/docs/extra-addons.md
@@ -2,7 +2,9 @@
 
 ![Extra Addons Dashboard](img/extra_addons.png)
 
-Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise, third-party themes) into environments. Extra repos are cloned once at the instance level and shared across environments via git worktrees.
+Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise,
+third-party themes) into environments. Git objects and immutable checkouts are
+shared by all development environments in a team.
 
 ## Architecture
 
@@ -11,13 +13,24 @@ Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise, th
   shared_repos/
     enterprise/          ← bare git clone (shared)
     custom-themes/       ← bare git clone (shared)
+  shared_extra_checkouts/
+    enterprise/
+      a1b2c3.../          ← immutable checkout of one commit (shared)
+    custom-themes/
+      d4e5f6.../          ← immutable checkout of one commit (shared)
   workspaces/
     feature-x/
       repo/              ← main project repo (existing)
-      extra/
-        enterprise/      ← git worktree (branch 19.0)
-        custom-themes/   ← git worktree (branch main)
 ```
+
+The requested branch selects a commit when an environment is created. Several
+environments on the same commit mount the same checkout read-only, without
+duplicating its files. Checkouts are keyed by commit rather than branch because
+branches move; an environment stays isolated on its current revision until it
+is explicitly synced.
+
+Production deployments retain private worktrees because their deploy engine
+records and resets each worktree HEAD during rollback.
 
 ## Setting Up Extra Repos
 
@@ -44,11 +57,12 @@ oduflow call create_environment feature-x "" default https://github.com/company/
 oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0,custom-themes:main"
 ```
 
-Oduflow automatically:
+For each development environment Oduflow automatically:
 
-1. Creates a git worktree for each extra repo at the specified branch
-2. Mounts the worktree **read-only** into the container as `/mnt/extra-addons-{name}`
-3. Generates a merged `odoo.conf` with all extra paths added to `addons_path`
+1. Fetches the specified branch and resolves its current commit SHA
+2. Creates or reuses the team's immutable checkout for that SHA
+3. Mounts the checkout **read-only** as `/mnt/extra-addons-{name}`
+4. Generates a merged `odoo.conf` with all extra paths added to `addons_path`
 
 ## Managing Extra Repos
 
@@ -93,24 +107,23 @@ Use `update_extra_repo` to fetch the latest changes from the remote:
 oduflow call update_extra_repo enterprise
 ```
 
-This runs `git fetch --all --prune` on the **shared bare repository** only. It does **not** affect any running environments.
+This runs `git fetch --all --prune` on the **shared bare repository** only. It
+does **not** change the checkout mounted by any running environment.
 
-### Why environments are not updated automatically
+### Updating an environment
 
-Each environment gets a **detached git worktree** pinned to a specific commit at creation time. This is by design:
-
-- **Stability** — the environment keeps working with the exact version of extra addons it was deployed with, regardless of upstream changes.
-- **Isolation** — updating one environment's dependencies cannot break another.
-- **Predictability** — `pull_and_apply` handles only the main project repository; extra addons remain unchanged.
-
-### How to update extra addons in an environment
-
-Delete and recreate the environment. The new environment will get a fresh worktree pointing to the latest commit on the specified branch:
+Run the normal sync operation:
 
 ```bash
-oduflow call delete_environment feature-x
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0"
+oduflow call pull_and_apply feature-x
 ```
 
-!!! tip
-    Run `update_extra_repo` **before** recreating the environment to ensure the bare repo has the latest commits.
+`pull_and_apply` fetches every configured extra-addons branch, creates or reuses
+the new SHA checkout, classifies its changed files, switches only that
+environment's read-only mount, and performs the required install, upgrade, or
+restart. Other environments continue using their previous checkout.
+
+Cached checkouts are deliberately not reference-counted or removed with an
+environment. Deleting the extra repository removes its bare clone and every
+cached revision after Oduflow verifies that no environment or production still
+depends on it.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1607,7 +1607,9 @@ oduflow call delete_service_preset redis
 
 [![Extra Addons Dashboard](img/extra_addons.png)](img/extra_addons.png)
 
-Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise, third-party themes) into environments. Extra repos are cloned once at the instance level and shared across environments via git worktrees.
+Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise,
+third-party themes) into environments. Git objects and immutable checkouts are
+shared by all development environments in a team.
 
 ## Architecture
 
@@ -1616,13 +1618,24 @@ Oduflow supports mounting **extra addon repositories** (e.g. Odoo Enterprise, th
   shared_repos/
     enterprise/          ← bare git clone (shared)
     custom-themes/       ← bare git clone (shared)
+  shared_extra_checkouts/
+    enterprise/
+      a1b2c3.../          ← immutable checkout of one commit (shared)
+    custom-themes/
+      d4e5f6.../          ← immutable checkout of one commit (shared)
   workspaces/
     feature-x/
       repo/              ← main project repo (existing)
-      extra/
-        enterprise/      ← git worktree (branch 19.0)
-        custom-themes/   ← git worktree (branch main)
 ```
+
+The requested branch selects a commit when an environment is created. Several
+environments on the same commit mount the same checkout read-only, without
+duplicating its files. Checkouts are keyed by commit rather than branch because
+branches move; an environment stays isolated on its current revision until it
+is explicitly synced.
+
+Production deployments retain private worktrees because their deploy engine
+records and resets each worktree HEAD during rollback.
 
 ## Setting Up Extra Repos
 
@@ -1649,11 +1662,12 @@ oduflow call create_environment feature-x "" default https://github.com/company/
 oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0,custom-themes:main"
 ```
 
-Oduflow automatically:
+For each development environment Oduflow automatically:
 
-1. Creates a git worktree for each extra repo at the specified branch
-2. Mounts the worktree **read-only** into the container as `/mnt/extra-addons-{name}`
-3. Generates a merged `odoo.conf` with all extra paths added to `addons_path`
+1. Fetches the specified branch and resolves its current commit SHA
+2. Creates or reuses the team's immutable checkout for that SHA
+3. Mounts the checkout **read-only** as `/mnt/extra-addons-{name}`
+4. Generates a merged `odoo.conf` with all extra paths added to `addons_path`
 
 ## Managing Extra Repos
 
@@ -1698,27 +1712,26 @@ Use `update_extra_repo` to fetch the latest changes from the remote:
 oduflow call update_extra_repo enterprise
 ```
 
-This runs `git fetch --all --prune` on the **shared bare repository** only. It does **not** affect any running environments.
+This runs `git fetch --all --prune` on the **shared bare repository** only. It
+does **not** change the checkout mounted by any running environment.
 
-### Why environments are not updated automatically
+### Updating an environment
 
-Each environment gets a **detached git worktree** pinned to a specific commit at creation time. This is by design:
-
-- **Stability** — the environment keeps working with the exact version of extra addons it was deployed with, regardless of upstream changes.
-- **Isolation** — updating one environment's dependencies cannot break another.
-- **Predictability** — `pull_and_apply` handles only the main project repository; extra addons remain unchanged.
-
-### How to update extra addons in an environment
-
-Delete and recreate the environment. The new environment will get a fresh worktree pointing to the latest commit on the specified branch:
+Run the normal sync operation:
 
 ```bash
-oduflow call delete_environment feature-x
-oduflow call create_environment feature-x "" default https://github.com/company/addons.git odoo:19.0 "enterprise:19.0"
+oduflow call pull_and_apply feature-x
 ```
 
-!!! tip
-    Run `update_extra_repo` **before** recreating the environment to ensure the bare repo has the latest commits.
+`pull_and_apply` fetches every configured extra-addons branch, creates or reuses
+the new SHA checkout, classifies its changed files, switches only that
+environment's read-only mount, and performs the required install, upgrade, or
+restart. Other environments continue using their previous checkout.
+
+Cached checkouts are deliberately not reference-counted or removed with an
+environment. Deleting the extra repository removes its bare clone and every
+cached revision after Oduflow verifies that no environment or production still
+depends on it.
 
 ---
 

--- a/specs/0010-extra-addons-repositories.md
+++ b/specs/0010-extra-addons-repositories.md
@@ -1,6 +1,6 @@
 # 0010 — Extra addons repositories (bare clones + per-environment worktrees)
 
-**Status:** Adopted (still in force)
+**Status:** Adopted (development checkout lifecycle partially superseded by [[0039-shared-immutable-extra-addons-checkouts]])
 **Type:** Architecture
 **First introduced:** `d495dd8` "extra addons repos support" (2026-02-13)
 **Key code today:** `extra_addons.py` (bare clone / worktree lifecycle, fetch summaries), `docker_ops/env_ops.py` (worktree creation + read-only mount, addons_path generation), `server.py` (`add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo`)
@@ -93,6 +93,10 @@ bind-mounted **read-only** into the container.
   fallback branch when none was given (`ea297fd`), since `default_branch`
   (`prod`) rarely exists in addon repos. That fallback was later removed in
   favour of **requiring an explicit branch** (`9254169`) — the current behaviour.
+- Development environments originally received one worktree each. On 2026-07-22,
+  [[0039-shared-immutable-extra-addons-checkouts]] replaced those duplicate
+  worktrees with persistent team-shared SHA checkouts. Production retains the
+  original per-deployment worktree model for independent rollback.
 
 ## History
 

--- a/specs/0039-shared-immutable-extra-addons-checkouts.md
+++ b/specs/0039-shared-immutable-extra-addons-checkouts.md
@@ -1,0 +1,77 @@
+# 0039 — Shared immutable extra-addons checkouts
+
+**Status:** Adopted
+**Type:** Architecture
+**First introduced:** this change (2026-07-22)
+**Key code:** `extra_addons.py` (SHA checkout cache + repo locks), `docker_ops/env_ops.py` (dev mount lifecycle and lazy migration)
+
+## Context
+
+The original extra-addons design ([[0010-extra-addons-repositories]]) already
+shared one bare Git object store per team, but materialised a complete worktree
+inside every environment. Teams commonly run many environments against the same
+Enterprise or OCA branch, so identical unpacked files and inodes still consumed
+disk once per environment.
+
+A single mutable checkout per branch would save that space but break environment
+isolation. Branches move, and `pull_and_apply` for one environment would expose
+new files immediately to every other container sharing the checkout, without
+upgrading their databases or restarting their Odoo registries. Production also
+needs private worktree HEADs for independent deploy rollback
+([[0035-production-hosting]]).
+
+## Decision
+
+Development environments share **persistent immutable checkouts keyed by the
+resolved commit SHA**, not by branch. A checkout lives under the team's
+`shared_extra_checkouts/<repo>/<sha>` cache and is mounted read-only into every
+development environment pinned to that revision.
+
+- The requested branch remains the user-facing selector; Oduflow fetches it and
+  records the resolved SHA in the environment's Docker labels.
+- Moving a branch creates or reuses a different SHA checkout. Existing
+  environments keep their old mount until their own `pull_and_apply`.
+- Cached checkouts are not reference-counted and are not deleted with an
+  environment. Deleting the owning extra repo removes all of its revisions.
+- Production keeps per-production mutable worktrees so its existing deploy log
+  and rollback semantics remain independent.
+
+## How it works
+
+Creating an environment resolves every configured extra-addons branch, ensures
+the SHA checkout exists, and mounts it at the existing
+`/mnt/extra-addons-<name>` path. Operations that fetch, create, remove, or reset
+worktrees are serialized by a team/repo lock while unrelated extra repos remain
+parallel.
+
+During `pull_and_apply`, Oduflow compares the mounted SHA with the current branch
+tip and classifies the Git diff against the new immutable checkout. After strict
+guardrails accept the action, it recreates only that environment's container
+with the new read-only bind while preserving its database and filestore, then
+runs the normal install/upgrade/restart action. Existing per-environment
+worktrees are migrated lazily on their next sync and removed after a successful
+mount switch.
+
+## Consequences
+
+- Environments on the same dependency revision pay for one checkout while
+  retaining independent update timing and database state.
+- Old revisions accumulate by design until the extra repo is deleted. This
+  avoids reference accounting and makes rollback/reproducibility predictable;
+  explicit cache pruning can be added later if operational data warrants it.
+- An extra-addons revision change requires a transparent container recreation
+  to change the host bind source. Database, filestore, ports, labels, and the
+  public container path remain stable.
+- Production does not receive the disk optimization yet; extending it requires
+  a separate immutable-mount rollback design.
+
+## Evolution
+
+This decision supersedes only the **per-development-environment worktree** part
+of [[0010-extra-addons-repositories]]. Its shared bare clones, explicit branches,
+read-only mounts, protection, and deletion dependency guards remain in force.
+
+## History
+
+- 2026-07-22 — adopt team-shared immutable SHA checkouts for development
+  environments, with lazy migration and persistent cache lifecycle.

--- a/specs/README.md
+++ b/specs/README.md
@@ -57,6 +57,7 @@ precursors).
 | [0036](0036-cross-subdomain-connect-as-landing.md) | 2026-07-19 | Cross-subdomain "Connect as user" landing: one-time token → env-host `/oduflow-connect` sets the session cookie host-only |
 | [0037](0037-built-in-agent-browser-and-noninteractive-codex.md) | 2026-07-21 | Built-in Agent Browser MCP and non-interactive Codex trust model |
 | [0038](0038-agent-chat-file-attachments.md) | 2026-07-22 | Agent Chat file attachments through persistent workspace resources |
+| [0039](0039-shared-immutable-extra-addons-checkouts.md) | 2026-07-22 | Shared immutable extra-addons checkouts for development environments |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -92,6 +92,59 @@ def _normalize_extra_addons(raw_addons: object) -> dict[str, str]:
     return {}
 
 
+def _extra_checkout_sources(
+    container: Any, repo_names: Iterator[str]
+) -> dict[str, str]:
+    """Map extra-repo names to their current host bind sources."""
+    targets = {f"/mnt/extra-addons-{name}": name for name in repo_names}
+    sources: dict[str, str] = {}
+    for bind in container.attrs.get("HostConfig", {}).get("Binds") or []:
+        parts = bind.rsplit(":", 2)
+        if len(parts) < 2:
+            continue
+        host_path, container_path = parts[0], parts[1]
+        repo_name = targets.get(container_path)
+        if repo_name:
+            sources[repo_name] = host_path
+    return sources
+
+
+def _replace_extra_checkout_mounts(
+    volumes: dict[str, dict[str, str]],
+    labels: dict[str, str],
+    checkouts: dict[str, str],
+    revisions: dict[str, str],
+) -> None:
+    """Replace extra-addons bind sources while keeping container paths stable."""
+    targets = {f"/mnt/extra-addons-{name}" for name in checkouts}
+    for source, spec in list(volumes.items()):
+        if spec.get("bind") in targets:
+            del volumes[source]
+    for repo_name, source in checkouts.items():
+        volumes[source] = {
+            "bind": f"/mnt/extra-addons-{repo_name}",
+            "mode": "ro",
+        }
+    labels["oduflow.extra_addons_revisions"] = json.dumps(revisions)
+
+
+def _cleanup_legacy_extra_worktrees(
+    team: TeamSettings, env_name: str, repo_names: Iterator[str]
+) -> None:
+    """Remove old per-environment worktrees after their mounts were migrated."""
+    extra_dir = os.path.join(get_workspace_path(env_name, team.workspaces_dir), "extra")
+    if not os.path.isdir(extra_dir):
+        return
+    from oduflow.extra_addons import remove_worktree
+
+    for repo_name in repo_names:
+        path = os.path.join(extra_dir, repo_name)
+        if os.path.isdir(path):
+            remove_worktree(team, repo_name, path)
+    with contextlib.suppress(OSError):
+        os.rmdir(extra_dir)
+
+
 def _redact_repo_urls(text: str, *urls: str) -> str:
     """Remove embedded credentials from known repository URLs in output."""
     redacted = text
@@ -998,18 +1051,18 @@ def create_environment(
             git_user=git_user,
         )
 
-    # --- Extra addons worktrees ---
-    extra_mount_paths = []
+    # --- Shared immutable extra-addons checkouts ---
+    extra_mount_paths: list[tuple[str, str]] = []
+    extra_revisions: dict[str, str] = {}
     if extra_addons:
-        from oduflow.extra_addons import create_worktree
+        from oduflow.extra_addons import ensure_shared_checkout
 
-        extra_dir = os.path.join(workspace_path, "extra")
-        os.makedirs(extra_dir, exist_ok=True)
         for repo_name, addon_branch in extra_addons.items():
-            wt_path = os.path.join(extra_dir, repo_name)
-            create_worktree(team, repo_name, addon_branch, wt_path)
+            checkout = ensure_shared_checkout(team, repo_name, addon_branch)
             container_path = f"/mnt/extra-addons-{repo_name}"
-            extra_mount_paths.append((wt_path, container_path))
+            extra_mount_paths.append((checkout["path"], container_path))
+            extra_revisions[repo_name] = checkout["revision"]
+        labels["oduflow.extra_addons_revisions"] = json.dumps(extra_revisions)
 
     ts_name = ensure_team_tablespace(client, settings, team)
     if template_name is not None:
@@ -1289,6 +1342,7 @@ def create_environment(
         "setup_logs": setup_logs,
     }
     result["extra_addons"] = extra_addons or {}
+    result["extra_addons_revisions"] = extra_revisions
     result["local_path"] = repo_path if local_mount else ""
     result["elapsed_seconds"] = round(time.time() - start_time, 1)
     activity.touch(team, env_name)
@@ -2003,6 +2057,9 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                 "extra_addons": _normalize_extra_addons(
                     json.loads(container.labels.get("oduflow.extra_addons", "{}")),
                 ),
+                "extra_addons_revisions": json.loads(
+                    container.labels.get("oduflow.extra_addons_revisions", "{}")
+                ),
                 "db_name": get_db_name(env_name, team.team_id),
                 "protected": is_protected(settings, team, env_name),
                 "auto_install_modules": container.labels.get(
@@ -2285,6 +2342,9 @@ def get_environment_info(
         result["extra_addons"] = _normalize_extra_addons(
             json.loads(labels.get("oduflow.extra_addons", "{}")),
         )
+        result["extra_addons_revisions"] = json.loads(
+            labels.get("oduflow.extra_addons_revisions", "{}")
+        )
         result["auto_install_modules"] = labels.get("oduflow.auto_install_modules", "")
         result["env_vars"] = json.loads(labels.get("oduflow.env_vars", "{}"))
         result["created_at"] = labels.get(
@@ -2464,7 +2524,9 @@ def _reapply_odoo_conf(
         return reapply_prod_odoo_conf(
             settings, team, labels.get("oduflow.prod_name", ""), container
         )
-    repo_path = get_repo_path(env_name, team.workspaces_dir)
+    repo_path = labels.get("oduflow.local_path") or get_repo_path(
+        env_name, team.workspaces_dir
+    )
     workspace_path = get_workspace_path(env_name, team.workspaces_dir)
     repo_odoo_conf = os.path.join(repo_path, ".oduflow", "odoo.conf")
     if os.path.isfile(repo_odoo_conf):
@@ -2620,8 +2682,9 @@ def pull_environment(
 
     Code-delivery mode is chosen from the env's labels:
 
-    * **git** (default) — ``git pull`` the branch (and extra-addon worktrees)
-      into the managed clone, which is bind-mounted into the container.
+    * **git** (default) — ``git pull`` the branch into the managed clone. Dev
+      extra-addons resolve to immutable shared SHA checkouts; production keeps
+      its private mutable worktrees for independent rollback.
     * **live-mount** (``oduflow.local_path`` label, gated by allow_local_path) — the
       agent's checkout is already bind-mounted, so there is nothing to pull;
       changes are detected from Oduflow's last successful local snapshot.
@@ -2666,9 +2729,12 @@ def pull_environment(
 
     # --- 1. Sync code + detect changed files and a diff base ---
     # Each (repo_path, base_ref, files) unit is classified against its OWN repo
-    # and old HEAD; extra-addon worktrees must not be classified against the main
+    # and old HEAD; extra-addon checkouts must not be classified against the main
     # repo's tree or their changes are misread (issue #51).
     classify_units: list[tuple[str, str | None, list[str]]] = []
+    pending_extra_checkouts: dict[str, str] = {}
+    pending_extra_revisions: dict[str, str] = {}
+    extra_mount_switch_needed = False
     if is_local:
         _trace("pull_environment(%s): live-mount, detecting local changes", env_name)
         base_ref, all_changed = _detect_local_changes(repo_path, env_name, team)
@@ -2683,14 +2749,24 @@ def pull_environment(
         base_ref = old_head
         classify_units.append((repo_path, old_head, changed_files))
 
-        extra_changed_files: list[str] = []
-        try:
-            extra_addons = json.loads(
-                container_obj.labels.get("oduflow.extra_addons", "{}")
-            )
-        except (json.JSONDecodeError, TypeError):
-            extra_addons = {}
-        if extra_addons:
+        all_changed = changed_files
+        # Dependency reinstall keys off the MAIN repo only: the pip/apt install
+        # helpers read only the main repo_path, never extra-addons checkouts.
+        main_changed_files = changed_files
+
+    try:
+        extra_addons = _normalize_extra_addons(
+            json.loads(container_obj.labels.get("oduflow.extra_addons", "{}"))
+        )
+    except (json.JSONDecodeError, TypeError):
+        extra_addons = {}
+
+    extra_changed_files: list[str] = []
+    if extra_addons:
+        is_production = container_obj.labels.get("oduflow.prod") == "true"
+        if is_production:
+            # Production retains one mutable worktree per deployment. Its
+            # deploy log records these HEADs and rollback resets them in place.
             from oduflow.extra_addons import pull_extra_worktree
 
             extra_dir = os.path.join(
@@ -2705,12 +2781,45 @@ def pull_environment(
                 )
                 extra_changed_files.extend(extra_files)
                 if extra_files:
-                    # Classify this worktree against its own path + old HEAD.
                     classify_units.append((wt_path, extra_old, extra_files))
-        all_changed = changed_files + extra_changed_files
-        # Dependency reinstall keys off the MAIN repo only: the pip/apt install
-        # helpers read only the main repo_path, never the extra-addon worktrees.
-        main_changed_files = changed_files
+        else:
+            from oduflow.extra_addons import checkout_revision, ensure_shared_checkout
+
+            try:
+                stored_revisions = json.loads(
+                    container_obj.labels.get("oduflow.extra_addons_revisions", "{}")
+                )
+            except (json.JSONDecodeError, TypeError):
+                stored_revisions = {}
+            if not isinstance(stored_revisions, dict):
+                stored_revisions = {}
+            current_sources = _extra_checkout_sources(container_obj, iter(extra_addons))
+            for repo_name, branch in extra_addons.items():
+                source = current_sources.get(repo_name, "")
+                current_revision = str(stored_revisions.get(repo_name, ""))
+                if not current_revision and source:
+                    current_revision = checkout_revision(source)
+                checkout = ensure_shared_checkout(
+                    team,
+                    repo_name,
+                    branch,
+                    current_revision=current_revision,
+                )
+                checkout_path = str(checkout["path"])
+                revision = str(checkout["revision"])
+                pending_extra_checkouts[repo_name] = checkout_path
+                pending_extra_revisions[repo_name] = revision
+                extra_mount_switch_needed = extra_mount_switch_needed or (
+                    source != checkout_path or current_revision != revision
+                )
+                extra_files = list(checkout["changed_files"])
+                extra_changed_files.extend(extra_files)
+                if extra_files:
+                    classify_units.append(
+                        (checkout_path, current_revision or None, extra_files)
+                    )
+
+    all_changed = all_changed + extra_changed_files
 
     _trace(
         "pull_environment(%s): %d changed files: %s",
@@ -2760,6 +2869,27 @@ def pull_environment(
             }
     else:
         if not all_changed:
+            if extra_mount_switch_needed:
+                update_environment(
+                    settings,
+                    team,
+                    env_name,
+                    extra_checkout_overrides=pending_extra_checkouts,
+                    extra_revision_overrides=pending_extra_revisions,
+                    pull_image=False,
+                    install_dependencies=False,
+                )
+                _cleanup_legacy_extra_worktrees(
+                    team, env_name, iter(pending_extra_checkouts)
+                )
+                return {
+                    "action": "none",
+                    "extra_addons_cache_migrated": True,
+                    "message": (
+                        "Already up to date. Extra-addons mounts now use the "
+                        "shared immutable checkout cache."
+                    ),
+                }
             return {
                 "action": "none",
                 "message": (
@@ -2770,7 +2900,22 @@ def pull_environment(
         to_upgrade = list(recommended.get("modules_to_upgrade", []))
         do_restart = recommended.get("action") == "restart"
 
-    # --- 3. Execute ---
+    # --- 3. Switch immutable mounts, then execute ---
+    # Do this only after strict guardrails have accepted the requested action.
+    # The checkout itself was prepared off to the side and is safe to cache even
+    # when strict mode blocks without touching the running container.
+    if extra_mount_switch_needed:
+        update_environment(
+            settings,
+            team,
+            env_name,
+            extra_checkout_overrides=pending_extra_checkouts,
+            extra_revision_overrides=pending_extra_revisions,
+            pull_image=False,
+            install_dependencies=False,
+        )
+        _cleanup_legacy_extra_worktrees(team, env_name, iter(pending_extra_checkouts))
+
     result = _apply_actions(
         client,
         settings,
@@ -2799,6 +2944,10 @@ def update_environment(
     *,
     env_override: dict[str, str] | None = None,
     image_override: str | None = None,
+    extra_checkout_overrides: dict[str, str] | None = None,
+    extra_revision_overrides: dict[str, str] | None = None,
+    pull_image: bool = True,
+    install_dependencies: bool = True,
 ) -> dict[str, Any]:
     """Re-create an environment's container, preserving DB, repo and filestore.
 
@@ -2806,9 +2955,11 @@ def update_environment(
     and configuration (useful when the container is broken). Optionally pulls a
     different ``image_override`` and/or fully replaces the user-supplied
     environment variables with ``env_override`` (an explicit dict; an empty dict
-    clears them). The PostgreSQL connection variables (HOST/USER/PASSWORD) are
-    always re-derived from the environment credentials, and image-baked env
-    comes from the image itself.
+    clears them). Internal extra-checkout overrides atomically switch immutable
+    SHA mounts during pull_and_apply; that path disables image pulls and the
+    redundant dependency reinstall. The PostgreSQL connection variables
+    (HOST/USER/PASSWORD) are always re-derived from the environment credentials,
+    and image-baked env comes from the image itself.
     """
     client = get_client()
     odoo_container_name = get_resource_name(
@@ -2825,20 +2976,29 @@ def update_environment(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
 
-    # Image (current → target). Capture the current digest so we can report
-    # whether the running image actually changed after the pull.
+    # Labels
+    labels = dict(container.labels)
+
+    # Image (current → target). A digest-pinned recreation leaves Config.Image
+    # as sha256:..., so prefer the persisted tag before falling back to it.
+    # Capture the current digest so we can report whether the running image
+    # actually changed after the pull.
     try:
         current_image = container.image.tags[0]
     except (IndexError, Exception):
-        current_image = container.attrs["Config"]["Image"]
+        current_image = labels.get(settings.image_label) or container.attrs["Config"][
+            "Image"
+        ]
     odoo_image = image_override or current_image
     try:
         old_digest = container.image.id
     except Exception:
         old_digest = container.attrs.get("Image", "")
-
-    # Labels
-    labels = dict(container.labels)
+    run_image = (
+        old_digest
+        if not pull_image and not image_override and old_digest
+        else odoo_image
+    )
 
     # User-supplied environment variables: an explicit override wins (full
     # replace), otherwise restore from the persisted label. The DB connection
@@ -2857,6 +3017,14 @@ def update_environment(
             volumes[parts[0]] = {"bind": parts[1], "mode": parts[2]}
         elif len(parts) == 2:
             volumes[parts[0]] = {"bind": parts[1], "mode": "rw"}
+
+    if extra_checkout_overrides is not None:
+        _replace_extra_checkout_mounts(
+            volumes,
+            labels,
+            extra_checkout_overrides,
+            extra_revision_overrides or {},
+        )
 
     # Command
     raw_cmd = container.attrs["Config"].get("Cmd") or []
@@ -2882,19 +3050,20 @@ def update_environment(
     # at all (#49). If the pull fails, fall back to a local copy; if there is
     # none, abort with the existing environment left untouched.
     image_updated = False
-    try:
-        logger.info("Pulling image %s", odoo_image)
-        new_image_obj = client.images.pull(odoo_image)
-        image_updated = bool(old_digest) and new_image_obj.id != old_digest
-    except Exception as exc:
-        logger.warning("Could not pull image %s: %s", odoo_image, exc)
+    if pull_image:
         try:
-            client.images.get(odoo_image)
-        except docker.errors.ImageNotFound:
-            raise PrerequisiteNotMetError(
-                f"Image '{odoo_image}' could not be pulled and is not available "
-                "locally; leaving the existing environment untouched."
-            ) from exc
+            logger.info("Pulling image %s", odoo_image)
+            new_image_obj = client.images.pull(odoo_image)
+            image_updated = bool(old_digest) and new_image_obj.id != old_digest
+        except Exception as exc:
+            logger.warning("Could not pull image %s: %s", odoo_image, exc)
+            try:
+                client.images.get(odoo_image)
+            except docker.errors.ImageNotFound:
+                raise PrerequisiteNotMetError(
+                    f"Image '{odoo_image}' could not be pulled and is not available "
+                    "locally; leaving the existing environment untouched."
+                ) from exc
 
     logger.info(
         "Updating environment – stopping old container",
@@ -2934,7 +3103,7 @@ def update_environment(
                     team,
                     env_name,
                     env_db,
-                    odoo_image,
+                    run_image,
                     _tmp_vols,
                     template_name=template_name,
                 )
@@ -2980,18 +3149,26 @@ def update_environment(
         # a previous port-mode life so the slot is reusable.
         release_port(team.port_registry_path, env_name)
 
-    # Verify extra addons worktrees are intact
+    # Verify extra addons checkouts are intact. New environments use persistent
+    # SHA-keyed shared paths; legacy environments keep per-workspace worktrees
+    # until their next pull_and_apply migrates the mounts.
     extra_addons_json = labels.get("oduflow.extra_addons", "")
     if extra_addons_json:
         parsed = json.loads(extra_addons_json)
         extra_dict = _normalize_extra_addons(parsed)
+        revisions = json.loads(labels.get("oduflow.extra_addons_revisions", "{}"))
         extra_dir = os.path.join(
             get_workspace_path(env_name, team.workspaces_dir), "extra"
         )
         for rn in extra_dict:
-            wt = os.path.join(extra_dir, rn)
+            revision = revisions.get(rn, "") if isinstance(revisions, dict) else ""
+            wt = (
+                os.path.join(team.shared_extra_checkouts_dir, rn, revision)
+                if revision
+                else os.path.join(extra_dir, rn)
+            )
             if not os.path.isdir(wt):
-                logger.warning("Extra addons worktree missing: %s", wt)
+                logger.warning("Extra addons checkout missing: %s", wt)
 
     # Switching into port mode (was traefik) or a legacy container that never
     # published a port: allocate one now, right before recreation, so any
@@ -3011,7 +3188,7 @@ def update_environment(
     # 4. Re-create the container with the same settings
     # ------------------------------------------------------------------
     run_kwargs: dict[str, Any] = dict(
-        image=odoo_image,
+        image=run_image,
         name=odoo_container_name,
         detach=True,
         network=get_team_network_name(team.team_id, settings.prefix),
@@ -3037,19 +3214,22 @@ def update_environment(
 
     # Regenerate and copy odoo.conf into the new container (repo .oduflow/ takes
     # priority over the instance conf; extra-addons paths merged from labels).
-    repo_path = get_repo_path(env_name, team.workspaces_dir)
+    repo_path = labels.get("oduflow.local_path") or get_repo_path(
+        env_name, team.workspaces_dir
+    )
     _reapply_odoo_conf(settings, team, env_name, new_container)
 
     # ------------------------------------------------------------------
     # 5. Re-install apt packages and pip requirements
     # ------------------------------------------------------------------
     setup_logs: list[str] = []
-    apt_log = _install_apt_packages(new_container, repo_path)
-    if apt_log:
-        setup_logs.append(apt_log)
-    _, pip_log = _install_pip_requirements(new_container, repo_path)
-    if pip_log:
-        setup_logs.append(pip_log)
+    if install_dependencies:
+        apt_log = _install_apt_packages(new_container, repo_path)
+        if apt_log:
+            setup_logs.append(apt_log)
+        _, pip_log = _install_pip_requirements(new_container, repo_path)
+        if pip_log:
+            setup_logs.append(pip_log)
 
     # ------------------------------------------------------------------
     # 6. Build URL and return result

--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -6,6 +6,9 @@ import re
 import shutil
 import subprocess
 import tempfile
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 from oduflow.docker_ops.client import get_client
@@ -25,6 +28,10 @@ logger = logging.getLogger("oduflow")
 GIT_ENV = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
 
 _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]{1,63}$")
+_REVISION_RE = re.compile(r"^[0-9a-f]{40,64}$")
+
+_REPO_LOCKS_GUARD = threading.Lock()
+_REPO_LOCKS: dict[str, threading.RLock] = {}
 
 _AUTH_ERROR_KEYWORDS = (
     "Authentication failed",
@@ -34,6 +41,22 @@ _AUTH_ERROR_KEYWORDS = (
     "terminal prompts disabled",
     "Invalid username or password",
 )
+
+
+@contextmanager
+def _repo_operation_lock(team: TeamSettings, repo_name: str) -> Iterator[None]:
+    """Serialize fetch/worktree/cache mutations for one team's extra repo.
+
+    Environment locks intentionally allow different environments to run in
+    parallel. Extra repositories are shared between those environments, so Git
+    operations need their own, narrower lock. RLock keeps composed helpers
+    (ensure checkout -> fetch) safe without widening the lock to the whole team.
+    """
+    key = os.path.realpath(os.path.join(team.shared_repos_dir, repo_name))
+    with _REPO_LOCKS_GUARD:
+        lock = _REPO_LOCKS.setdefault(key, threading.RLock())
+    with lock:
+        yield
 
 
 def clone_extra_repo(
@@ -294,7 +317,7 @@ def unprotect_extra_repo(team: TeamSettings, name: str) -> dict[str, Any]:
     return {"name": name, "protected": False}
 
 
-def delete_extra_repo(
+def _delete_extra_repo_unlocked(
     settings: Settings, team: TeamSettings, name: str
 ) -> dict[str, Any]:
     path = os.path.join(team.shared_repos_dir, name)
@@ -332,9 +355,22 @@ def delete_extra_repo(
             f"{', '.join(dependent)}"
         )
 
+    # Cached SHA checkouts intentionally outlive environments. They disappear
+    # only with the owning extra repo, after the dependency guard above proves
+    # that no running/stopped managed container still mounts them.
+    checkout_root = os.path.join(team.shared_extra_checkouts_dir, name)
+    if os.path.isdir(checkout_root):
+        shutil.rmtree(checkout_root)
     shutil.rmtree(path)
     logger.info("Deleted extra repo '%s'", name)
     return {"name": name, "deleted": True}
+
+
+def delete_extra_repo(
+    settings: Settings, team: TeamSettings, name: str
+) -> dict[str, Any]:
+    with _repo_operation_lock(team, name):
+        return _delete_extra_repo_unlocked(settings, team, name)
 
 
 def _get_branch_refs(repo_path: str) -> dict[str, str]:
@@ -365,7 +401,7 @@ def _get_branch_refs(repo_path: str) -> dict[str, str]:
     return refs
 
 
-def fetch_extra_repo(
+def _fetch_extra_repo_unlocked(
     team: TeamSettings, name: str, branch: str | None = None
 ) -> dict[str, Any]:
     """Fetch latest changes and return a summary of what changed.
@@ -512,7 +548,14 @@ def fetch_extra_repo(
     }
 
 
-def create_worktree(
+def fetch_extra_repo(
+    team: TeamSettings, name: str, branch: str | None = None
+) -> dict[str, Any]:
+    with _repo_operation_lock(team, name):
+        return _fetch_extra_repo_unlocked(team, name, branch)
+
+
+def _create_worktree_unlocked(
     team: TeamSettings, repo_name: str, branch: str, target_path: str
 ) -> str:
     # A blank branch would produce `git worktree add ... ""` → the cryptic
@@ -573,7 +616,17 @@ def create_worktree(
     return target_path
 
 
-def remove_worktree(team: TeamSettings, repo_name: str, target_path: str) -> None:
+def create_worktree(
+    team: TeamSettings, repo_name: str, branch: str, target_path: str
+) -> str:
+    """Create a mutable per-consumer worktree (currently production only)."""
+    with _repo_operation_lock(team, repo_name):
+        return _create_worktree_unlocked(team, repo_name, branch, target_path)
+
+
+def _remove_worktree_unlocked(
+    team: TeamSettings, repo_name: str, target_path: str
+) -> None:
     bare_path = os.path.join(team.shared_repos_dir, repo_name)
     try:
         subprocess.run(
@@ -596,7 +649,192 @@ def remove_worktree(team: TeamSettings, repo_name: str, target_path: str) -> Non
         )
 
 
-def pull_extra_worktree(
+def remove_worktree(team: TeamSettings, repo_name: str, target_path: str) -> None:
+    with _repo_operation_lock(team, repo_name):
+        _remove_worktree_unlocked(team, repo_name, target_path)
+
+
+def _resolve_branch_revision(bare_path: str, repo_name: str, branch: str) -> str:
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                bare_path,
+                "rev-parse",
+                "--verify",
+                f"refs/heads/{branch}^{{commit}}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=GIT_ENV,
+        )
+    except subprocess.CalledProcessError as e:
+        raise NotFoundError(
+            f"Branch '{branch}' not found in extra repo '{repo_name}'."
+        ) from e
+    except subprocess.TimeoutExpired:
+        raise ExternalCommandError("git rev-parse", -1, "Command timed out (10s).")
+    revision = result.stdout.strip().lower()
+    if not _REVISION_RE.fullmatch(revision):
+        raise ExternalCommandError(
+            "git rev-parse", -1, f"Unexpected commit id for branch '{branch}'."
+        )
+    return revision
+
+
+def _checkout_head(path: str) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--verify", "HEAD^{commit}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=GIT_ENV,
+        )
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
+        return ""
+    revision = result.stdout.strip().lower()
+    return revision if _REVISION_RE.fullmatch(revision) else ""
+
+
+def checkout_revision(path: str) -> str:
+    """Best-effort commit SHA for a mutable or shared extra checkout."""
+    return _checkout_head(path)
+
+
+def _changed_files_between(
+    bare_path: str, old_revision: str, new_revision: str
+) -> list[str]:
+    if old_revision == new_revision:
+        return []
+    if not _REVISION_RE.fullmatch(old_revision):
+        return []
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                bare_path,
+                "diff",
+                "--name-only",
+                f"{old_revision}..{new_revision}",
+                "--",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=GIT_ENV,
+        )
+    except subprocess.CalledProcessError as e:
+        raise ExternalCommandError("git diff --name-only", e.returncode, e.stderr or "")
+    except subprocess.TimeoutExpired:
+        raise ExternalCommandError(
+            "git diff --name-only", -1, "Command timed out (30s)."
+        )
+    return [path for path in result.stdout.splitlines() if path]
+
+
+def ensure_shared_checkout(
+    team: TeamSettings,
+    repo_name: str,
+    branch: str,
+    *,
+    current_revision: str = "",
+) -> dict[str, Any]:
+    """Return a persistent immutable checkout for the branch's current SHA.
+
+    Checkouts are shared by all development environments in the team and are
+    never reset in place. Moving a branch creates (or reuses) another SHA-keyed
+    checkout, so environments pinned to the old revision remain isolated.
+    """
+    if not branch or not branch.strip():
+        raise PrerequisiteNotMetError(
+            f"Extra addon repo '{repo_name}' requires a branch (e.g. '18.0'); "
+            "none was given."
+        )
+    bare_path = os.path.join(team.shared_repos_dir, repo_name)
+    if not os.path.isdir(bare_path):
+        raise NotFoundError(f"Extra repo '{repo_name}' not found. Add it first.")
+
+    with _repo_operation_lock(team, repo_name):
+        _fetch_extra_repo_unlocked(team, repo_name, branch)
+        revision = _resolve_branch_revision(bare_path, repo_name, branch)
+        repo_cache_dir = os.path.join(team.shared_extra_checkouts_dir, repo_name)
+        checkout_path = os.path.join(repo_cache_dir, revision)
+
+        existing_head = (
+            _checkout_head(checkout_path) if os.path.isdir(checkout_path) else ""
+        )
+        if existing_head != revision:
+            if os.path.exists(checkout_path):
+                _remove_worktree_unlocked(team, repo_name, checkout_path)
+                shutil.rmtree(checkout_path, ignore_errors=True)
+            os.makedirs(repo_cache_dir, exist_ok=True)
+            subprocess.run(
+                ["git", "-C", bare_path, "worktree", "prune"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=GIT_ENV,
+            )
+            try:
+                subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        bare_path,
+                        "worktree",
+                        "add",
+                        "--detach",
+                        checkout_path,
+                        revision,
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                    env=GIT_ENV,
+                )
+            except subprocess.CalledProcessError as e:
+                raise ExternalCommandError(
+                    "git worktree add",
+                    e.returncode,
+                    f"Failed to create shared checkout for '{repo_name}' at "
+                    f"{revision}: {e.stderr or ''}",
+                )
+            except subprocess.TimeoutExpired:
+                raise ExternalCommandError(
+                    "git worktree add", -1, "Command timed out (60s)."
+                )
+            logger.info(
+                "Created shared extra-addons checkout %s/%s at %s",
+                repo_name,
+                revision,
+                checkout_path,
+            )
+
+        changed_files = _changed_files_between(
+            bare_path, current_revision.lower(), revision
+        )
+        return {
+            "name": repo_name,
+            "branch": branch,
+            "revision": revision,
+            "path": checkout_path,
+            "changed_files": changed_files,
+        }
+
+
+def _pull_extra_worktree_unlocked(
     team: TeamSettings, repo_name: str, branch: str, worktree_path: str
 ) -> tuple[str, list[str]]:
     """Fetch the bare repo and reset the worktree to the branch tip.
@@ -652,6 +890,14 @@ def pull_extra_worktree(
         len(changed),
     )
     return old_head, changed
+
+
+def pull_extra_worktree(
+    team: TeamSettings, repo_name: str, branch: str, worktree_path: str
+) -> tuple[str, list[str]]:
+    """Update a mutable per-consumer worktree (currently production only)."""
+    with _repo_operation_lock(team, repo_name):
+        return _pull_extra_worktree_unlocked(team, repo_name, branch, worktree_path)
 
 
 def resolve_main_addons_path(repo_path: str) -> str:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1420,7 +1420,8 @@ def pull_and_apply(
     Sync the latest code into an environment and apply the right Odoo action.
 
     Works for both code-delivery modes (chosen automatically per environment):
-    - git: pulls the branch (and extra-addon worktrees) into the managed clone.
+    - git: pulls the branch and resolves extra-addons to shared immutable
+      SHA checkouts before applying changes.
     - live-mount (from create_environment(local_path=...)): your
       edits are already live on disk; this just applies them — no git needed.
 

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -62,6 +62,11 @@ class TeamSettings:
     def shared_repos_dir(self) -> str:
         return os.path.join(self.data_dir, "shared_repos")
 
+    @property
+    def shared_extra_checkouts_dir(self) -> str:
+        """Persistent immutable extra-addons checkouts, keyed by repo/SHA."""
+        return os.path.join(self.data_dir, "shared_extra_checkouts")
+
     def get_template_dir(self, template_name: str) -> str:
         # Reject names that could escape the templates directory (path
         # traversal) before they reach rmtree / file writes.

--- a/tests/test_extra_addons_clone.py
+++ b/tests/test_extra_addons_clone.py
@@ -6,12 +6,22 @@ keeps every branch (--depth 1 --no-single-branch), so one bare repo still serves
 worktrees for any Odoo version.
 """
 
+import os
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from oduflow.extra_addons import clone_extra_repo, create_worktree, list_extra_repos
-from oduflow.settings import TeamSettings
+from oduflow.extra_addons import (
+    clone_extra_repo,
+    create_worktree,
+    delete_extra_repo,
+    ensure_shared_checkout,
+    list_extra_repos,
+)
+from oduflow.settings import Settings, TeamSettings
 
 _GIT_ID = [
     "-c",
@@ -126,3 +136,84 @@ class TestCloneExtraRepoShallow:
 
         # new.xml was committed after the clone → only present if fetched.
         assert (wt / "sale_enterprise" / "new.xml").is_file()
+
+
+class TestSharedCheckoutCache:
+    def test_same_revision_reuses_one_checkout(self, team, tmp_path):
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+
+        first = ensure_shared_checkout(team, "enterprise", "18.0")
+        second = ensure_shared_checkout(team, "enterprise", "18.0")
+
+        assert first["path"] == second["path"]
+        assert first["revision"] == second["revision"]
+        assert first["path"].endswith(first["revision"])
+        assert (tmp_path / "data" / "shared_extra_checkouts").is_dir()
+
+    def test_branch_update_creates_new_checkout_and_keeps_old_immutable(
+        self, team, tmp_path
+    ):
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+        first = ensure_shared_checkout(team, "enterprise", "18.0")
+
+        src = tmp_path / "source"
+        subprocess.run(
+            ["git", "-C", str(src), "checkout", "18.0"],
+            check=True,
+            capture_output=True,
+        )
+        new_file = src / "sale_enterprise" / "new.xml"
+        new_file.write_text("<odoo/>")
+        subprocess.run(
+            ["git", "-C", str(src), "add", "-A"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(src), *_GIT_ID, "commit", "-m", "update"],
+            check=True,
+            capture_output=True,
+        )
+
+        second = ensure_shared_checkout(
+            team,
+            "enterprise",
+            "18.0",
+            current_revision=first["revision"],
+        )
+
+        assert second["path"] != first["path"]
+        assert second["revision"] != first["revision"]
+        assert "sale_enterprise/new.xml" in second["changed_files"]
+        assert not (Path(first["path"]) / "sale_enterprise" / "new.xml").exists()
+        assert (Path(second["path"]) / "sale_enterprise" / "new.xml").is_file()
+
+    def test_concurrent_requests_share_checkout(self, team, tmp_path):
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(
+                pool.map(
+                    lambda _index: ensure_shared_checkout(team, "enterprise", "18.0"),
+                    range(2),
+                )
+            )
+
+        assert results[0]["path"] == results[1]["path"]
+
+    def test_delete_repo_removes_all_cached_revisions(self, team, tmp_path):
+        url = _make_git_source(tmp_path)
+        clone_extra_repo(team, "enterprise", url)
+        checkout = ensure_shared_checkout(team, "enterprise", "18.0")
+        cache_root = tmp_path / "data" / "shared_extra_checkouts" / "enterprise"
+        assert cache_root.is_dir()
+
+        client = MagicMock()
+        client.containers.list.return_value = []
+        with patch("oduflow.extra_addons.get_client", return_value=client):
+            delete_extra_repo(Settings(), team, "enterprise")
+
+        assert not cache_root.exists()
+        assert not (tmp_path / "data" / "shared_repos" / "enterprise").exists()
+        assert not os.path.exists(checkout["path"])

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -719,7 +719,7 @@ class TestReloadTemplate:
         assert cleanup_paths == {f"/tmp/{name}" for name in archive_names}
 
 
-class TestPullEnvironmentLocal:
+class TestLocalSnapshotBasics:
     def test_local_snapshot_detects_added_modified_deleted(self, tmp_path):
         repo = tmp_path / "repo"
         repo.mkdir()
@@ -773,6 +773,147 @@ class TestPullEnvironmentLocal:
         ]
         env_ops._write_local_snapshot(str(repo), "env", team)
         assert env_ops._detect_local_changes(str(repo), "env", team)[1] == []
+
+
+class TestPullEnvironmentLocalAndSharedExtraCheckouts:
+    def test_replace_mount_sources_and_persist_revisions(self):
+        volumes = {
+            "/workspace/repo": {"bind": "/mnt/extra-addons", "mode": "rw"},
+            "/workspace/extra/enterprise": {
+                "bind": "/mnt/extra-addons-enterprise",
+                "mode": "ro",
+            },
+        }
+        labels = {"oduflow.extra_addons": '{"enterprise": "18.0"}'}
+
+        env_ops._replace_extra_checkout_mounts(
+            volumes,
+            labels,
+            {"enterprise": "/cache/enterprise/newsha"},
+            {"enterprise": "newsha"},
+        )
+
+        assert "/workspace/extra/enterprise" not in volumes
+        assert volumes["/cache/enterprise/newsha"] == {
+            "bind": "/mnt/extra-addons-enterprise",
+            "mode": "ro",
+        }
+        assert json.loads(labels["oduflow.extra_addons_revisions"]) == {
+            "enterprise": "newsha"
+        }
+
+    def test_pull_lazily_migrates_legacy_mount_without_code_change(
+        self, mock_docker_client, tmp_path
+    ):
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        settings = Settings(teams={"1": team})
+        repo = tmp_path / "team" / "workspaces" / "env" / "repo"
+        repo.mkdir(parents=True)
+        legacy = tmp_path / "team" / "workspaces" / "env" / "extra" / "enterprise"
+        legacy.mkdir(parents=True)
+        shared = tmp_path / "team" / "shared_extra_checkouts" / "enterprise" / "a"
+        shared.mkdir(parents=True)
+
+        container = MagicMock()
+        container.labels = {
+            "oduflow.git_branch": "main",
+            "oduflow.extra_addons": json.dumps({"enterprise": "18.0"}),
+        }
+        container.attrs = {
+            "HostConfig": {
+                "Binds": [
+                    f"{repo}:/mnt/extra-addons:rw",
+                    f"{legacy}:/mnt/extra-addons-enterprise:ro",
+                ]
+            }
+        }
+        mock_docker_client.containers.get.return_value = container
+
+        with (
+            patch("oduflow.git_ops.pull_repo", return_value=("main-old", [])),
+            patch("oduflow.extra_addons.checkout_revision", return_value="a" * 40),
+            patch(
+                "oduflow.extra_addons.ensure_shared_checkout",
+                return_value={
+                    "path": str(shared),
+                    "revision": "a" * 40,
+                    "changed_files": [],
+                },
+            ),
+            patch("oduflow.docker_ops.env_ops.update_environment") as update,
+            patch("oduflow.docker_ops.env_ops._cleanup_legacy_extra_worktrees"),
+        ):
+            result = env_ops.pull_environment(settings, team, "env")
+
+        assert result["extra_addons_cache_migrated"] is True
+        update.assert_called_once_with(
+            settings,
+            team,
+            "env",
+            extra_checkout_overrides={"enterprise": str(shared)},
+            extra_revision_overrides={"enterprise": "a" * 40},
+            pull_image=False,
+            install_dependencies=False,
+        )
+
+    def test_strict_guardrail_does_not_switch_running_mount(
+        self, mock_docker_client, tmp_path
+    ):
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        settings = Settings(teams={"1": team})
+        repo = tmp_path / "team" / "workspaces" / "env" / "repo"
+        repo.mkdir(parents=True)
+        shared = tmp_path / "team" / "shared_extra_checkouts" / "enterprise" / "b"
+        shared.mkdir(parents=True)
+
+        container = MagicMock()
+        container.labels = {
+            "oduflow.git_branch": "main",
+            "oduflow.extra_addons": json.dumps({"enterprise": "18.0"}),
+            "oduflow.extra_addons_revisions": json.dumps({"enterprise": "a" * 40}),
+        }
+        container.attrs = {
+            "HostConfig": {
+                "Binds": [
+                    f"{repo}:/mnt/extra-addons:rw",
+                    f"/cache/enterprise/{'a' * 40}:/mnt/extra-addons-enterprise:ro",
+                ]
+            }
+        }
+        mock_docker_client.containers.get.return_value = container
+
+        with (
+            patch("oduflow.git_ops.pull_repo", return_value=("main-old", [])),
+            patch(
+                "oduflow.extra_addons.ensure_shared_checkout",
+                return_value={
+                    "path": str(shared),
+                    "revision": "b" * 40,
+                    "changed_files": ["sale/security/rules.xml"],
+                },
+            ),
+            patch(
+                "oduflow.git_analysis.merge_recommendations",
+                return_value={
+                    "action": "upgrade",
+                    "modules_to_install": [],
+                    "modules_to_upgrade": ["sale"],
+                },
+            ),
+            patch(
+                "oduflow.git_analysis.guardrail_warnings",
+                return_value=["upgrade sale is required"],
+            ),
+            patch("oduflow.docker_ops.env_ops.update_environment") as update,
+            patch("oduflow.docker_ops.env_ops._apply_actions") as apply,
+        ):
+            result = env_ops.pull_environment(
+                settings, team, "env", restart=True, strict=True
+            )
+
+        assert result["action"] == "blocked"
+        update.assert_not_called()
+        apply.assert_not_called()
 
     @patch("oduflow.docker_ops.env_ops._apply_actions")
     def test_local_auto_uses_path_only_classification(
@@ -1154,7 +1295,7 @@ class TestUpdateEnvironment:
         "oduflow.docker_ops.env_ops.load_credentials",
         return_value={"pg_user": "u_1_main", "pg_password": "pw"},
     )
-    def test_update_no_overrides_keeps_label_env(
+    def test_update_no_overrides_keeps_persisted_image_tag_and_env(
         self,
         mock_creds,
         mock_role,
@@ -1167,6 +1308,11 @@ class TestUpdateEnvironment:
     ):
         mock_resolve_conf.return_value.exists.return_value = False
         container = self._make_container()
+        # A previous digest-pinned recreation can leave the container without
+        # image tags and with Config.Image set to the digest. The persisted
+        # Oduflow label must remain the source for future image pulls.
+        container.image.tags = []
+        container.attrs["Config"]["Image"] = "sha256:old"
         mock_docker_client.containers.get.return_value = container
         same_image = MagicMock()
         same_image.id = "sha256:old"
@@ -1179,10 +1325,62 @@ class TestUpdateEnvironment:
         # No image override → current image is reused and re-pulled
         assert run_kwargs["image"] == "odoo:15.0"
         mock_docker_client.images.pull.assert_called_once_with("odoo:15.0")
+        assert run_kwargs["labels"][TEST_SETTINGS.image_label] == "odoo:15.0"
         # No env override → env restored from the persisted label
         assert run_kwargs["environment"]["OLD"] == "1"
+        assert result["image"] == "odoo:15.0"
         assert result["env_vars"] == {"OLD": "1"}
         assert result["image_updated"] is False
+
+    def test_extra_checkout_switch_reuses_exact_image_and_skips_dependencies(
+        self, mock_docker_client
+    ):
+        container = self._make_container()
+        container.labels.update(
+            {
+                "oduflow.extra_addons": json.dumps({"enterprise": "18.0"}),
+                "oduflow.extra_addons_revisions": json.dumps({"enterprise": "a" * 40}),
+            }
+        )
+        container.attrs["HostConfig"]["Binds"].append(
+            "/old/enterprise:/mnt/extra-addons-enterprise:ro"
+        )
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        with (
+            patch(
+                "oduflow.docker_ops.env_ops.load_credentials",
+                return_value={"pg_user": "u_1_main", "pg_password": "pw"},
+            ),
+            patch("oduflow.docker_ops.env_ops._create_pg_role"),
+            patch("oduflow.docker_ops.env_ops._reapply_odoo_conf"),
+            patch("oduflow.docker_ops.env_ops._install_apt_packages") as apt,
+            patch("oduflow.docker_ops.env_ops._install_pip_requirements") as pip,
+        ):
+            env_ops.update_environment(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "main",
+                extra_checkout_overrides={"enterprise": "/cache/enterprise/new"},
+                extra_revision_overrides={"enterprise": "b" * 40},
+                pull_image=False,
+                install_dependencies=False,
+            )
+
+        run_kwargs = mock_docker_client.containers.run.call_args.kwargs
+        assert run_kwargs["image"] == "sha256:old"
+        assert "/old/enterprise" not in run_kwargs["volumes"]
+        assert run_kwargs["volumes"]["/cache/enterprise/new"] == {
+            "bind": "/mnt/extra-addons-enterprise",
+            "mode": "ro",
+        }
+        assert json.loads(run_kwargs["labels"]["oduflow.extra_addons_revisions"]) == {
+            "enterprise": "b" * 40
+        }
+        mock_docker_client.images.pull.assert_not_called()
+        apt.assert_not_called()
+        pip.assert_not_called()
 
     @patch(
         "oduflow.docker_ops.env_ops.load_credentials",
@@ -1543,12 +1741,8 @@ class TestConnectAsUser:
 
         container.put_archive.side_effect = capture_archive
 
-        odoo_ops.connect_as_user(
-            TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com"
-        )
-        odoo_ops.connect_as_user(
-            TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com"
-        )
+        odoo_ops.connect_as_user(TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com")
+        odoo_ops.connect_as_user(TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com")
 
         shell_calls = [
             call
@@ -1583,9 +1777,7 @@ class TestConnectAsUser:
         mock_docker_client.containers.get.return_value = container
 
         with pytest.raises(RuntimeError, match="exec failed"):
-            odoo_ops.connect_as_user(
-                TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com"
-            )
+            odoo_ops.connect_as_user(TEST_SETTINGS, TEST_TEAM, "main", "jane@acme.com")
 
         assert container.exec_run.call_args_list[0].args[0][0:2] == ["sh", "-c"]
         assert container.exec_run.call_args_list[1].args[0] == [

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -239,6 +239,10 @@ class TestTeamSettings:
         t = TeamSettings(team_id="1", data_dir="/srv/data")
         assert t.shared_repos_dir == "/srv/data/shared_repos"
 
+    def test_shared_extra_checkouts_dir(self):
+        t = TeamSettings(team_id="1", data_dir="/srv/data")
+        assert t.shared_extra_checkouts_dir == "/srv/data/shared_extra_checkouts"
+
     def test_frozen(self):
         t = TeamSettings(team_id="1")
         with pytest.raises(AttributeError):


### PR DESCRIPTION
## Summary

- cache development extra-addons checkouts by resolved commit SHA at team scope
- switch environments between immutable read-only mounts while preserving independent state
- lazily migrate existing development environments and retain private production worktrees for rollback
- document the architecture in decision record 0039 and update user-facing docs
- preserve the configured image tag across digest-pinned container recreations so later image updates continue to work

## Why

Per-environment extra-addons worktrees duplicated identical repositories and made branch movement part of each environment's mutable state. Shared SHA-keyed checkouts reduce duplication while keeping each environment pinned to an immutable revision. Production remains unchanged because its deploy rollback requires private mutable worktrees.

During review, the mount-switch recreation path exposed an image update regression: recreating from a digest can leave `Config.Image` as `sha256:...`. A later plain update now falls back to the persisted Oduflow image label before using that digest.

## Impact

Development environments sharing an extra-addons commit reuse one checkout. Existing environments migrate on their next sync. Cached revisions persist until the extra repository is deleted. Normal image updates continue to pull the configured tag after a digest-pinned mount switch.

## Validation

- `pytest tests/test_extra_addons_clone.py tests/test_odoo_manager.py tests/test_settings.py -q` — 162 passed
- `ruff check` on all changed Python source and test files
- `git diff --check`