### PR TITLE
Add curl and coding-agent shell tools to coder image

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -12,9 +12,9 @@
 # alive.
 #
 # LICENSING: the published image contains redistributable open-source software.
-# Codex CLI, codex-acp and agent-browser are Apache-2.0; Debian's Chromium
-# package carries its upstream BSD-style/component licenses and preserves the
-# corresponding notices under /usr/share/doc. Claude Code
+# Codex CLI, codex-acp and agent-browser are Apache-2.0; ruff is MIT/Apache-2.0;
+# Debian's Chromium package carries its upstream BSD-style/component licenses and
+# preserves the corresponding notices under /usr/share/doc. Claude Code
 # (@anthropic-ai/claude-code) and its ACP adapter are PROPRIETARY-adjacent
 # (Anthropic Commercial Terms; the adapter pulls Anthropic's closed SDK), so
 # they are NOT part of the published image: entrypoint.sh npm-installs them at
@@ -28,18 +28,36 @@
 
 FROM node:24-bookworm-slim
 
-ARG CODER_VERSION=0.2.1
+ARG CODER_VERSION=0.2.2
 LABEL org.opencontainers.image.title="oduflow-coder" \
       org.opencontainers.image.version="${CODER_VERSION}" \
       org.opencontainers.image.source="https://github.com/oduist/oduflow"
 
+# Shell tools the coding agent reaches for from Bash: curl (ad-hoc HTTP), less
+# (pager other CLIs shell out to), ripgrep (rg; fast code search), fd-find +
+# tree (file find + dir overview), and python3/pip (host for ruff, below).
+# fd-find installs its binary as `fdfind` on Debian to avoid a name clash, so
+# symlink `fd` onto PATH for the command name agents expect.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
         ca-certificates \
+        curl \
+        fd-find \
         jq \
+        less \
+        python3 \
+        python3-pip \
+        ripgrep \
+        tree \
         chromium \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s "$(command -v fdfind)" /usr/local/bin/fd
+
+# Ruff: fast lint + format for Odoo Python, so the agent can validate a change
+# locally before git push + pull_and_apply. Self-contained binary; Debian marks
+# the system env externally-managed (PEP 668), hence --break-system-packages.
+RUN python3 -m pip install --no-cache-dir --break-system-packages ruff
 
 # The upstream Node image already reserves uid/gid 1000 for its `node` user.
 # Rename that account instead of inventing another numeric identity: files in


### PR DESCRIPTION
## What

Adds `curl` — and the small set of shell tools an interactive coding agent most often reaches for — to the per-team `oduflow-coder` image (`docker/agent/Dockerfile`), which previously shipped only `git`/`ca-certificates`/`jq`/`chromium`.

New tools (all standard Debian packages except `ruff`):

- **`curl`, `less`, `ripgrep`** — ad-hoc HTTP from the shell, pager other CLIs shell out to, fast code search.
- **`fd-find` + `tree`** — file find + directory overview. `fd-find` installs its binary as `fdfind` on Debian (name clash), so a `/usr/local/bin/fd` symlink gives the agent the expected command.
- **`python3` + `python3-pip`, plus `ruff`** — so the agent can lint/format Odoo Python locally **before** `git push` + `pull_and_apply` instead of round-tripping through the environment. `ruff` is pip-installed with `--break-system-packages` (Debian bookworm PEP 668).

## Why

The coder is a thin host: the agent edits code, `git push`es, and drives Odoo through the Oduflow MCP server — it never runs Odoo itself. These are the tools that make its Bash shell productive without pulling in weight it won't use (editors, ssh, network/archive tools were deliberately left out).

## Housekeeping

- Bumped `ARG CODER_VERSION` `0.2.1` → `0.2.2` so CI republishes `oduist/oduflow-coder:<version>` + `:latest` on merge (`.github/workflows/publish-coder.yml`).
- Updated the Dockerfile licensing header to list `ruff` (MIT/Apache-2.0) among the redistributable baked-in components.

## Verification

Built locally (`docker build --build-arg CODER_VERSION=0.2.2 -t oduist/oduflow-coder:dev-local docker/agent`, exit 0) and smoke-tested every binary on PATH:

`curl` 7.88.1 · `rg` 13.0.0 · `less` 590 · `fd` → `fdfind` 8.6.0 · `tree` 2.1.0 · `python3` 3.11.2 · `ruff` 0.15.22