### PR TITLE
Handle service image pull errors

### DIFF
--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -12,7 +12,7 @@ import docker
 from oduflow.docker_ops.client import get_client
 from oduflow.docker_ops import service_presets
 from oduflow.docker_ops import volume_ops
-from oduflow.errors import ConflictError, NotFoundError
+from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
 from oduflow.naming import get_service_container_name
 from oduflow.settings import Settings, TeamSettings
 
@@ -54,6 +54,22 @@ _SYSTEM_ENV_KEYS = {
     "SSH_AGENT_PID",
     "DBUS_SESSION_BUS_ADDRESS",
 }
+
+
+def _pull_service_image(client: Any, image: str) -> Any:
+    """Pull a service image and expose only safe, actionable failures."""
+    try:
+        return client.images.pull(image)
+    except docker.errors.NotFound as exc:
+        raise NotFoundError(
+            f"Docker image '{image}' was not found or is not accessible. "
+            "Check the image name, tag, and registry permissions."
+        ) from exc
+    except docker.errors.DockerException as exc:
+        raise PrerequisiteNotMetError(
+            f"Could not pull Docker image '{image}'. Check Docker connectivity, "
+            "registry availability, and registry credentials."
+        ) from exc
 
 
 def normalize_http_routes(
@@ -371,7 +387,7 @@ def create_service(
         run_kwargs["cap_add"] = list(cap_add)
 
     logger.info("Pulling image %s for service %s", image, name)
-    client.images.pull(image)
+    _pull_service_image(client, image)
 
     client.containers.run(**run_kwargs)
     logger.info("Created service container %s from image %s", container_name, image)
@@ -844,7 +860,7 @@ def update_service(
 
     # Pull the latest image
     logger.info("Pulling latest image %s for service %s", target_image, name)
-    new_image_obj = client.images.pull(target_image)
+    new_image_obj = _pull_service_image(client, target_image)
     new_digest = new_image_obj.id
     image_updated = old_digest != new_digest
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -436,6 +436,25 @@ def _get_tool_fn(tool_name: str):
 
 class TestCreateServiceTool:
     @patch("oduflow.docker_ops.service_ops.create_service")
+    def test_pull_error_is_returned_as_safe_tool_error(self, mock_create):
+        from oduflow.errors import PrerequisiteNotMetError
+
+        message = (
+            "Could not pull Docker image 'registry.example.com/redis:7'. Check "
+            "Docker connectivity, registry availability, and registry credentials."
+        )
+        mock_create.side_effect = PrerequisiteNotMetError(message)
+
+        with pytest.raises(ToolError, match="Could not pull Docker image") as exc_info:
+            _get_tool_fn("create_service")(
+                name="redis",
+                image="registry.example.com/redis:7",
+                port=6379,
+            )
+
+        assert message in str(exc_info.value)
+
+    @patch("oduflow.docker_ops.service_ops.create_service")
     def test_create(self, mock_create):
         mock_create.return_value = {
             "name": "redis",

--- a/tests/test_service_image_errors_web.py
+++ b/tests/test_service_image_errors_web.py
@@ -1,0 +1,91 @@
+"""Regression tests for safe auxiliary-service image pull errors."""
+
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.errors import NotFoundError, PrerequisiteNotMetError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+IMAGE = "example/missing:0.7.2"
+NOT_FOUND_MESSAGE = (
+    f"Docker image '{IMAGE}' was not found or is not accessible. "
+    "Check the image name, tag, and registry permissions."
+)
+
+
+def _client(tmp_path) -> TestClient:
+    settings = Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1")},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["/api/services/create", "/api/service-presets/restore"],
+)
+def test_missing_image_returns_safe_404_for_create_and_restore(tmp_path, endpoint):
+    client = _client(tmp_path)
+    internal_detail = "http+docker://localhost/v1.53/images/create?secret=token"
+
+    with patch(
+        "oduflow.web_ui.service_ops.create_service",
+        side_effect=NotFoundError(NOT_FOUND_MESSAGE),
+    ):
+        response = client.post(
+            endpoint,
+            json={"name": "missing", "image": IMAGE, "port": 8080},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"ok": False, "error": NOT_FOUND_MESSAGE}
+    assert internal_detail not in response.text
+    assert "http+docker" not in response.text
+
+
+def test_registry_failure_returns_safe_400(tmp_path):
+    client = _client(tmp_path)
+    message = (
+        f"Could not pull Docker image '{IMAGE}'. Check Docker connectivity, "
+        "registry availability, and registry credentials."
+    )
+
+    with patch(
+        "oduflow.web_ui.service_ops.create_service",
+        side_effect=PrerequisiteNotMetError(message),
+    ):
+        response = client.post(
+            "/api/services/create",
+            json={"name": "missing", "image": IMAGE, "port": 8080},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"ok": False, "error": message}
+
+
+def test_unexpected_service_error_stays_masked(tmp_path):
+    client = _client(tmp_path)
+    internal_detail = "registry failure with secret credentials"
+
+    with patch(
+        "oduflow.web_ui.service_ops.create_service",
+        side_effect=RuntimeError(internal_detail),
+    ):
+        response = client.post(
+            "/api/services/create",
+            json={"name": "missing", "image": IMAGE, "port": 8080},
+        )
+
+    assert response.status_code == 500
+    assert response.json() == {"ok": False, "error": "Internal server error."}
+    assert internal_detail not in response.text

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -3,7 +3,11 @@ import docker
 from unittest.mock import MagicMock, patch
 
 from oduflow.docker_ops import service_ops, system_ops
-from oduflow.errors import ConflictError, NotFoundError
+from oduflow.errors import (
+    ConflictError,
+    NotFoundError,
+    PrerequisiteNotMetError,
+)
 from oduflow.settings import Settings, TeamSettings
 
 TEST_TEAM = TeamSettings(
@@ -66,6 +70,51 @@ def mock_docker_client():
 
 
 class TestCreateService:
+    def test_missing_image_returns_safe_not_found(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.images.pull.side_effect = docker.errors.NotFound(
+            "404 for http+docker://localhost/v1.53/images/create?secret=token"
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
+            service_ops.create_service(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "missing",
+                "example/missing:0.7.2",
+                8080,
+            )
+
+        assert str(exc_info.value) == (
+            "Docker image 'example/missing:0.7.2' was not found or is not "
+            "accessible. Check the image name, tag, and registry permissions."
+        )
+        assert "http+docker" not in str(exc_info.value)
+        assert "secret" not in str(exc_info.value)
+        mock_docker_client.containers.run.assert_not_called()
+
+    def test_other_pull_error_returns_safe_prerequisite_error(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.images.pull.side_effect = docker.errors.APIError(
+            "registry failure with secret credentials"
+        )
+
+        with pytest.raises(PrerequisiteNotMetError) as exc_info:
+            service_ops.create_service(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "redis",
+                "registry.example.com/redis:7",
+                6379,
+            )
+
+        assert str(exc_info.value) == (
+            "Could not pull Docker image 'registry.example.com/redis:7'. Check "
+            "Docker connectivity, registry availability, and registry credentials."
+        )
+        assert "secret" not in str(exc_info.value)
+        mock_docker_client.containers.run.assert_not_called()
+
     def test_create_port_mode(self, mock_docker_client):
         # Network exists
         mock_docker_client.networks.get.return_value = MagicMock()
@@ -573,6 +622,38 @@ class TestUpdateService:
         container.labels = labels
         container.attrs = attrs
         return container
+
+    def test_pull_failure_keeps_existing_container(self, mock_docker_client):
+        container = self._make_container(
+            image_tags=["redis:7"],
+            labels={"oduflow.managed": "true", "oduflow.service": "redis"},
+            attrs={"Config": {"Env": []}},
+        )
+        container.image.id = "sha256:old"
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.images.pull.side_effect = docker.errors.APIError(
+            "registry unavailable"
+        )
+        preset = {
+            "name": "redis",
+            "image": "redis:7",
+            "port": 6379,
+            "hostname": "",
+            "env_vars": {},
+        }
+
+        with (
+            patch(
+                "oduflow.docker_ops.service_ops.service_presets.get_preset",
+                return_value=preset,
+            ),
+            pytest.raises(PrerequisiteNotMetError),
+        ):
+            service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
+
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
 
     def test_update_uses_preset(self, mock_docker_client):
         """When a preset exists, update_service reads options from it (not the container)."""


### PR DESCRIPTION
## Summary

- translate missing service images into a safe, actionable 404 response
- translate other Docker pull failures into a safe prerequisite error for REST and MCP
- keep existing service containers untouched when an update pull fails
- add service-layer, web API, and MCP regression coverage

## Root cause

`service_ops.create_service()` and `update_service()` allowed Docker SDK pull exceptions to escape the domain layer. The web handlers treated those exceptions as unexpected and intentionally scrubbed them to `Internal server error.`, so users could not see that an image or tag was missing.

## User impact

Create and restore now report that the requested image was not found or is inaccessible. Registry, authentication, and Docker connectivity failures receive safe troubleshooting guidance without exposing Docker API URLs or internal details.

## Validation

- `pytest -m 'not integration and not heavyweight' -q` — 1206 passed, 15 deselected
- `mypy src/oduflow` — no issues in 62 source files
- `ruff check src/oduflow tests` — passed
- changed-file `ruff format --check` — passed