### PR TITLE
Run Claude agents approval-free with versioned coder images

### DIFF
--- a/.github/workflows/publish-coder.yml
+++ b/.github/workflows/publish-coder.yml
@@ -4,7 +4,7 @@ name: Publish Coder Image
 # Docker Hub. Publication is tied to *merge*: it runs only when docker/agent/**
 # lands on main — never from a feature branch. The version is read from the
 # Dockerfile's CODER_VERSION arg, so bumping it there is what ships a new
-# :<version> (both :<version> and :latest are pushed).
+# immutable :<version>. Oduflow pins this exact tag; no rolling tag is published.
 #
 # Requires repo secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN (a Docker Hub access
 # token with push rights to the oduist org).
@@ -54,6 +54,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Refuse to overwrite an existing version
+        run: |
+          image="oduist/oduflow-coder:${{ steps.ver.outputs.version }}"
+          url="https://hub.docker.com/v2/repositories/oduist/oduflow-coder/tags/${{ steps.ver.outputs.version }}"
+          status="$(curl --silent --show-error --output /tmp/coder-tag.json --write-out '%{http_code}' "$url")"
+          case "$status" in
+            404) ;;
+            200)
+              echo "$image already exists; bump CODER_VERSION instead of replacing an immutable tag" >&2
+              exit 1
+              ;;
+            *)
+              echo "could not verify whether $image exists (Docker Hub HTTP $status)" >&2
+              cat /tmp/coder-tag.json >&2
+              exit 1
+              ;;
+          esac
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -65,6 +83,4 @@ jobs:
           push: true
           build-args: |
             CODER_VERSION=${{ steps.ver.outputs.version }}
-          tags: |
-            oduist/oduflow-coder:${{ steps.ver.outputs.version }}
-            oduist/oduflow-coder:latest
+          tags: oduist/oduflow-coder:${{ steps.ver.outputs.version }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,36 +260,24 @@ the persistent home volume. Keep it that way when editing the Dockerfile.
 **Publication is automatic and merge-gated — never publish from a feature
 branch.** The CI workflow `.github/workflows/publish-coder.yml` builds and pushes
 `oduist/oduflow-coder` when a change under `docker/agent/**` lands on `main`.
-It reads the version from the Dockerfile's `ARG CODER_VERSION` and pushes both
-`:<version>` and `:latest` as a **multi-arch manifest (`linux/amd64` +
+It reads the version from the Dockerfile's `ARG CODER_VERSION` and pushes only
+the immutable `:<version>` tag as a **multi-arch manifest (`linux/amd64` +
 `linux/arm64`)**, so the image pulls on both x86_64 servers and Apple Silicon
-dev machines. So the flow is:
+dev machines. Oduflow's `DEFAULT_AGENT_IMAGE` pins that exact tag; no rolling
+`:latest` tag is published. So the flow is:
 
 1. Edit `docker/agent/` (Dockerfile / `entrypoint.sh` / `clone-env.sh`).
 2. **Bump `ARG CODER_VERSION`** in `docker/agent/Dockerfile` — that value is what
-   CI ships (a new `:<version>`); forgetting to bump republishes the same tag.
-3. Merge to `main` → CI builds and pushes. (A manual run is available via the
+   CI ships (a new `:<version>`); CI refuses to overwrite an existing tag.
+3. Update `DEFAULT_AGENT_IMAGE` in `src/oduflow/settings.py` to the same tag;
+   the unit suite checks that both versions match.
+4. Merge to `main` → CI builds and pushes. (A manual run is available via the
    workflow's `workflow_dispatch` trigger.)
 
 Do NOT run `docker push` for the coder image by hand from a working branch — that
 would ship an image built from unmerged code. The workflow needs repo secrets
 `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (a Docker Hub token with push rights to
 the `oduist` org).
-
-**Testing coder changes locally (no publish needed).** The agent container's
-image pull is best-effort (`contextlib.suppress` in `_ensure_agent_container`),
-so a locally-built image is used when the tag is not pulled from the registry.
-Build with a **local-only tag** and point `[agent].image` at it, then restart
-the Oduflow server — the agent container is recreated automatically whenever
-its configured image/env changed:
-
-```bash
-docker build --build-arg CODER_VERSION=<VERSION> \
-  -t oduist/oduflow-coder:dev-local docker/agent
-# set [agent].image = "oduist/oduflow-coder:dev-local" in oduflow.toml,
-# then restart the Oduflow server.
-```
-
-(Using a distinct tag like `:dev-local` avoids a registry pull overwriting your
-local build, which can happen if you reuse `:latest`.) Registry:
-hub.docker.com, repository: `oduist/oduflow-coder`.
+The runtime requires the configured image to be pullable before it replaces an
+existing agent container. Registry: hub.docker.com, repository:
+`oduist/oduflow-coder`.

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -22,13 +22,13 @@
 # end user downloads them from npm directly (like npx) -- we never
 # redistribute them.
 #
-# Bump CODER_VERSION on every change and push :<version> + :latest
-# (see AGENTS.md "Publishing the Coder Image").
+# Bump CODER_VERSION on every change; CI publishes the immutable :<version>
+# tag only (see AGENTS.md "Publishing the Coder Image").
 # See specs/0029-agent-console-and-chat.md.
 
 FROM node:24-bookworm-slim
 
-ARG CODER_VERSION=0.2.2
+ARG CODER_VERSION=0.2.3
 LABEL org.opencontainers.image.title="oduflow-coder" \
       org.opencontainers.image.version="${CODER_VERSION}" \
       org.opencontainers.image.source="https://github.com/oduist/oduflow"

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -70,11 +70,18 @@ fi
 # NPM_CONFIG_PREFIX points at $HOME/.npm-global (persistent volume), so this
 # downloads once per volume, not once per container. Failure is non-fatal:
 # Codex still works; Claude consoles/chats will report the missing binary.
-if command -v claude >/dev/null 2>&1 && command -v claude-code-acp >/dev/null 2>&1; then
+if command -v claude >/dev/null 2>&1 && command -v claude-agent-acp >/dev/null 2>&1; then
     log "Claude Code present ($(command -v claude))"
 else
     log "installing Claude Code + ACP adapter from npm (first start; persists on the home volume)"
-    if npm install -g @anthropic-ai/claude-code @zed-industries/claude-code-acp >/dev/null 2>&1; then
+    # The ACP adapter moved orgs: @zed-industries/claude-code-acp is deprecated
+    # and frozen; @agentclientprotocol/claude-agent-acp (bin: claude-agent-acp)
+    # is the maintained successor. The presence check above looks for the new
+    # bin, so a home volume seeded with the old adapter reinstalls onto the new
+    # one on its next start. Drop the deprecated package so its stale
+    # claude-code-acp bin doesn't linger on PATH (best-effort).
+    npm uninstall -g @zed-industries/claude-code-acp >/dev/null 2>&1 || true
+    if npm install -g @anthropic-ai/claude-code @agentclientprotocol/claude-agent-acp >/dev/null 2>&1; then
         log "Claude Code installed"
     else
         log "WARNING: Claude Code install failed (no network?); Claude consoles/chats will not work until it succeeds on a restart"
@@ -213,6 +220,50 @@ elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
 else
     log "Claude auth: NONE configured (use an interactive login; it persists on the home volume)"
 fi
+
+# --- 4a-bis. Claude approval-free browser chat -------------------------------
+# Browser Agent Chat/CLI run without per-tool approval prompts, exactly like
+# Codex (agent-full-access): Docker + the unprivileged `agent` user are the
+# security boundary. The maintained ACP adapter honors permissions.defaultMode
+# from the USER-tier settings file ($CLAUDE_CONFIG_DIR/settings.json) — escalating
+# modes are stripped only from committed project-tier settings, not this one. The
+# CLI console additionally passes --dangerously-skip-permissions. Merge (never
+# clobber) so an operator's own settings survive; only the defaultMode key is set.
+seed_claude_settings() {
+    local claude_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    local settings_json="$claude_dir/settings.json"
+    local tmp_json
+    local jq_failed=false
+    local jq_filter='
+        .permissions = (
+            if (.permissions | type) == "object" then .permissions else {} end
+        )
+        | .permissions.defaultMode = "bypassPermissions"
+    '
+
+    mkdir -p "$claude_dir"
+    tmp_json="$(mktemp "${settings_json}.tmp.XXXXXX")"
+
+    if [ -f "$settings_json" ] && jq -e 'type == "object"' "$settings_json" >/dev/null 2>&1; then
+        jq "$jq_filter" "$settings_json" > "$tmp_json" || jq_failed=true
+    else
+        if [ -e "$settings_json" ]; then
+            log "WARNING: replacing invalid Claude settings at $settings_json"
+        fi
+        jq --null-input "$jq_filter" > "$tmp_json" || jq_failed=true
+    fi
+
+    if [ "$jq_failed" = true ]; then
+        rm -f "$tmp_json"
+        log "WARNING: could not seed Claude approval-free settings"
+        return
+    fi
+
+    chmod 600 "$tmp_json"
+    mv -f "$tmp_json" "$settings_json"
+    log "Claude approval-free settings seeded (permissions.defaultMode=bypassPermissions)"
+}
+seed_claude_settings
 
 # --- 4b. Codex auth ----------------------------------------------------------
 # API key is the reliable path. Subscription via auth.json is seed-if-missing

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -58,7 +58,7 @@ enablement and credentials live in the `[team.*]` sections:
 ```toml
 # Deployment-wide (optional)
 [agent]
-image = "oduist/oduflow-coder:latest"
+image = "oduist/oduflow-coder:0.2.3"
 # claude_model = ""     # optional Claude model override; empty = CLI default
 # codex_model = ""      # optional Codex model override; empty = CLI default
 
@@ -74,6 +74,12 @@ CLAUDE_CODE_OAUTH_TOKEN = ""   # Claude subscription token (`claude setup-token`
 ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
 OPENAI_API_KEY = ""            # Codex API key
 ```
+
+The default coder image is an immutable versioned tag coupled to this Oduflow
+release. Oduflow pulls a changed tag before replacing the running container; a
+failed pull leaves the previous container intact. The former official
+`oduist/oduflow-coder:latest` value resolves to the current pinned default
+when the configuration is loaded.
 
 When `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured, the
 container automatically marks Claude Code's first-run onboarding as complete,
@@ -113,11 +119,16 @@ reference.
   only in single-team deployments; with several teams, each team sets its own
   keys in `[team.X.agent_env]` so an operator credential never leaks to
   tenants.
-- **Codex sandbox and approvals.** Codex CLI uses
-  `--dangerously-bypass-approvals-and-sandbox`, and Codex ACP starts in
-  `agent-full-access`, so installed MCP tools run without interactive
-  permission prompts or a nested Bubblewrap sandbox. The security boundary is
-  the unprivileged `agent` user inside the per-team Docker container.
+- **Sandbox and approvals.** Both agents run approval-free — the security
+  boundary is the unprivileged `agent` user inside the per-team Docker
+  container, not per-tool prompts. Codex CLI uses
+  `--dangerously-bypass-approvals-and-sandbox` and Codex ACP starts in
+  `agent-full-access` (no nested Bubblewrap sandbox). Claude matches this: the
+  Agent CLI console runs `claude --dangerously-skip-permissions`, and Agent
+  Chat's ACP adapter (`claude-agent-acp`) starts in `bypassPermissions`, seeded
+  via the container's user-tier `~/.claude/settings.json`
+  (`permissions.defaultMode`). So installed MCP tools run without interactive
+  permission prompts for either agent.
 
 ## Limitations
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **Versioned coder runtime contract** — hosted agents now use the immutable `oduist/oduflow-coder:0.2.3` image instead of a rolling `:latest` tag. The publish workflow emits only versioned multi-architecture tags, legacy official `:latest` configuration resolves to the release's pinned image, and Oduflow pulls a changed image before replacing a working container. Container recreation is derived from the actual Docker run specification rather than a manually bumped runtime epoch.
 - **Shared immutable extra-addons checkouts** — development environments using the same extra-addons commit now mount one persistent team-level checkout instead of materialising identical per-environment worktrees. Branch updates create a new SHA-keyed checkout and `pull_and_apply` switches only the requested environment, preserving independent database state; production keeps private worktrees for rollback. Existing environments migrate lazily on their next sync, and cached revisions remain until the extra repository is deleted.
 
 ### Dashboard
@@ -23,6 +24,7 @@
 
 ### Documentation
 
+- **Record the versioned coder-image contract** — specs/0040 documents immutable image publication, server/image version coupling, safe replacement ordering, and removal of the rolling `:latest` channel.
 - **Document the short transport flag** — HTTP server startup examples now show `oduflow -t http` / `uvx oduflow -t http` as the short form of `--transport http`.
 - **Record the shared extra-addons cache decision** — specs/0039 documents SHA-keyed checkout sharing, isolation from moving branches, persistent cache lifecycle, and why production remains on private worktrees.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,7 +162,7 @@ auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 di
 # One agent container per team (Claude Code + OpenAI Codex), driven from the
 # dashboard (Agent Chat / Agent CLI). Opt-in per team via agent_enabled below.
 # [agent]
-# image = "oduist/oduflow-coder:latest"
+# image = "oduist/oduflow-coder:0.2.3"
 # claude_model = ""         # optional Claude model override; empty = CLI default
 # codex_model = ""          # optional Codex model override; empty = CLI default
 
@@ -232,7 +232,7 @@ The global `[agent]` section holds deployment-wide settings for the per-team cod
 
 | Key | Default | Description |
 |---|---|---|
-| `[agent].image` | `oduist/oduflow-coder:latest` | Image for the per-team coding-agent container (Claude Code + OpenAI Codex) |
+| `[agent].image` | `oduist/oduflow-coder:0.2.3` | Immutable image for the per-team coding-agent container (Claude Code + OpenAI Codex); the default is coupled to the Oduflow release |
 | `[agent].claude_model` | *(empty)* | Optional Claude model override for the agent; empty = CLI default |
 | `[agent].codex_model` | *(empty)* | Optional Codex model override for the agent; empty = CLI default |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -62,7 +62,7 @@ auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disabl
 
 # Per-team coding agent (dashboard Agent Chat / Agent CLI); opt-in, off by default.
 # [agent]
-# image = "oduist/oduflow-coder:latest"
+# image = "oduist/oduflow-coder:0.2.3"
 
 [team.1]
 hostname = "localhost"
@@ -424,7 +424,7 @@ auto_delete_hours = 0                # auto-delete stopped environments after N 
 # One agent container per team (Claude Code + OpenAI Codex), driven from the
 # dashboard (Agent Chat / Agent CLI). Opt-in per team via agent_enabled below.
 # [agent]
-# image = "oduist/oduflow-coder:latest"
+# image = "oduist/oduflow-coder:0.2.3"
 # claude_model = ""         # optional Claude model override; empty = CLI default
 # codex_model = ""          # optional Codex model override; empty = CLI default
 
@@ -492,7 +492,7 @@ The global `[agent]` section holds deployment-wide settings for the per-team cod
 
 | Key | Default | Description |
 |---|---|---|
-| `[agent].image` | `oduist/oduflow-coder:latest` | Image for the per-team coding-agent container (Claude Code + OpenAI Codex) |
+| `[agent].image` | `oduist/oduflow-coder:0.2.3` | Immutable image for the per-team coding-agent container (Claude Code + OpenAI Codex); the default is coupled to the Oduflow release |
 | `[agent].claude_model` | *(empty)* | Optional Claude model override for the agent; empty = CLI default |
 | `[agent].codex_model` | *(empty)* | Optional Codex model override for the agent; empty = CLI default |
 
@@ -1431,7 +1431,7 @@ Configuration lives entirely in `oduflow.toml` — there is no runtime editing. 
 ```toml
 # Deployment-wide (optional)
 [agent]
-image = "oduist/oduflow-coder:latest"
+image = "oduist/oduflow-coder:0.2.3"
 # claude_model = ""     # optional Claude model override; empty = CLI default
 # codex_model = ""      # optional Codex model override; empty = CLI default
 
@@ -1447,6 +1447,12 @@ CLAUDE_CODE_OAUTH_TOKEN = ""   # Claude subscription token (`claude setup-token`
 ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
 OPENAI_API_KEY = ""            # Codex API key
 ```
+
+The default coder image is an immutable versioned tag coupled to this Oduflow
+release. Oduflow pulls a changed tag before replacing the running container; a
+failed pull leaves the previous container intact. The former official
+`oduist/oduflow-coder:latest` value resolves to the current pinned default when
+the configuration is loaded.
 
 When `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is configured, the
 container automatically marks Claude Code's first-run onboarding as complete,

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -65,7 +65,7 @@ auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disabl
 
 # Per-team coding agent (dashboard Agent Chat / Agent CLI); opt-in, off by default.
 # [agent]
-# image = "oduist/oduflow-coder:latest"
+# image = "oduist/oduflow-coder:0.2.3"
 
 [team.1]
 hostname = "localhost"

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -113,4 +113,4 @@ The per-team coding agent (see [Coding Agent](agent.md)) exposes one status endp
 |---|---|---|
 | `GET` | `/api/agent` | Whether the coding agent is enabled for the team and its default type (`claude` / `codex`) |
 | `WebSocket` | `/api/environments/{branch}/agent` | **Agent CLI** — the agent's interactive TUI, bridged from a PTY `docker exec` in the team's agent container (used by the dashboard console) |
-| `WebSocket` | `/api/environments/{branch}/agent-acp` | **Agent Chat** — a line-framed relay to the agent's ACP adapter (`claude-code-acp` / `codex-acp`), rendered by the browser chat client with per-environment conversation history |
+| `WebSocket` | `/api/environments/{branch}/agent-acp` | **Agent Chat** — a line-framed relay to the agent's ACP adapter (`claude-agent-acp` / `codex-acp`), rendered by the browser chat client with per-environment conversation history |

--- a/specs/0029-agent-console-and-chat.md
+++ b/specs/0029-agent-console-and-chat.md
@@ -38,7 +38,7 @@ WebSocket↔`docker exec` bridge:
 - **Agent CLI** (`ws_agent_console`): the agent's own TUI in xterm.js, exec'd
   with a PTY at the environment's checkout.
 - **Agent Chat** (`ws_agent_acp`): a TTY-less, line-framed relay to the agent's
-  ACP adapter (`claude-code-acp` / `codex-acp`), rendered by a vendored,
+  ACP adapter (`claude-agent-acp` / `codex-acp`), rendered by a vendored,
   framework-free browser client (`acp-client.js` + `chat.js`). A current
   session and bounded recent history per (environment, agent) are persisted;
   any selected conversation resumes via ACP `session/load`. Chats minimize to
@@ -148,6 +148,9 @@ history loading remains best-effort while its adapter matures.
 
 ## History
 
+- 2026-07-22 — replaced the rolling coder-image tag and manual runtime epoch
+  with the immutable, release-coupled image contract in
+  [[0040-versioned-coder-image-contract]].
 - 2026-07-21 — evolved durable chat state from one session id to a bounded MRU
   conversation history with first-prompt titles and dashboard switching;
   legacy values normalize on read and resume still goes exclusively through

--- a/specs/0040-versioned-coder-image-contract.md
+++ b/specs/0040-versioned-coder-image-contract.md
@@ -1,0 +1,69 @@
+# 0040 — Versioned coder image contract
+
+**Status:** Adopted
+**Type:** Architecture — runtime delivery and compatibility
+**First introduced:** this change (2026-07-22)
+**Key code:** `docker/agent/Dockerfile`; `.github/workflows/publish-coder.yml`; `settings.py`; `docker_ops/env_ops.py`
+
+## Context
+
+The hosted agent server and its coder image form one runtime: Python launches
+specific CLI/ACP binaries while the image supplies the entrypoint, operating
+system packages, user, and persistent-volume layout. The original deployment
+published and configured a rolling `:latest` image. Because that tag did not
+change when its contents changed, Oduflow also carried a manually incremented
+runtime epoch solely to invalidate the container configuration hash.
+
+That split version signal was fragile. A server could start invoking a new
+binary while an existing container still ran the previous entrypoint, and a
+failed pull could delete the working container before Docker discovered that
+the replacement was unavailable. The rolling tag also made rollback and the
+server/image compatibility pair implicit.
+
+## Decision
+
+Coder images are published only under immutable version tags. Each Oduflow
+release pins one exact `oduist/oduflow-coder:<version>` default; no `:latest`
+tag is published. A change to `docker/agent/**` must bump `CODER_VERSION` and
+the server's pinned default in the same change.
+
+The exact image tag is part of a declarative Docker run configuration. That
+same configuration is both hashed into the container label and passed to
+Docker, removing the separate runtime epoch. Before replacing a mismatched
+container, Oduflow must successfully pull the desired image. Pull failure
+leaves the working container and its old hash intact so the next startup can
+retry.
+
+The former official `oduist/oduflow-coder:latest` configuration value resolves
+to the current pinned default with a warning. Other configured image names
+remain explicit operator overrides, but they must be available from a registry;
+the runtime no longer falls back to an unpullable local development tag.
+
+## How it works
+
+- CI reads `CODER_VERSION` from the Dockerfile and publishes one amd64/arm64
+  manifest under that version only. Publication fails if the tag already
+  exists, so a forgotten version bump cannot replace an immutable artifact.
+- `DEFAULT_AGENT_IMAGE` carries the compatible image tag for the Python server;
+  a unit test keeps it equal to the Dockerfile version.
+- The container hash covers the image, environment, volumes, user, network,
+  host mapping, shared-memory size, and restart policy. Changing any of those
+  fields recreates the container without a manual compatibility counter.
+- Persistent HOME and workspace volumes remain outside the container lifecycle,
+  so image upgrades retain authentication, transcripts, browser state, and
+  checkouts.
+
+## Consequences
+
+- Server/image compatibility and rollback are explicit and reproducible.
+- Publishing an image and selecting it in Oduflow are one coordinated change;
+  forgetting either version bump fails the unit suite or leaves the old default.
+- A registry outage delays an upgrade instead of destroying the working agent.
+- Operators who intentionally override `[agent].image` own the availability and
+  compatibility of that immutable tag.
+- Local-only coder tags are no longer a supported runtime path.
+
+## History
+
+- 2026-07-22 — replace rolling `:latest` publication and the manual agent
+  runtime epoch with immutable, release-coupled tags and pull-before-replace.

--- a/specs/README.md
+++ b/specs/README.md
@@ -58,6 +58,7 @@ precursors).
 | [0037](0037-built-in-agent-browser-and-noninteractive-codex.md) | 2026-07-21 | Built-in Agent Browser MCP and non-interactive Codex trust model |
 | [0038](0038-agent-chat-file-attachments.md) | 2026-07-22 | Agent Chat file attachments through persistent workspace resources |
 | [0039](0039-shared-immutable-extra-addons-checkouts.md) | 2026-07-22 | Shared immutable extra-addons checkouts for development environments |
+| [0040](0040-versioned-coder-image-contract.md) | 2026-07-22 | Immutable, release-coupled coder image tags replace the rolling runtime |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -68,7 +68,6 @@ logger = logging.getLogger("oduflow")
 
 AGENT_USER = "agent"
 AGENT_HOME = "/home/agent"
-_AGENT_RUNTIME_VERSION = "3"  # browser MCP + non-root runtime
 
 
 def _trace(msg: str, *args: object) -> None:
@@ -1487,26 +1486,57 @@ mv "$tmp_path" "$config_path"
         )
 
 
+def _agent_container_config(
+    settings: Settings, team: TeamSettings, env: dict[str, str]
+) -> dict[str, Any]:
+    """Docker run configuration for the long-lived per-team agent container.
+
+    This dictionary is both hashed and passed to ``containers.run``. Keeping a
+    single declarative representation makes every material container-spec
+    change trigger recreation without a separately maintained runtime epoch.
+    """
+    return {
+        "image": settings.agent_image,
+        "detach": True,
+        "user": AGENT_USER,
+        "network": get_team_network_name(team.team_id, settings.prefix),
+        "environment": env,
+        "volumes": {
+            get_agent_home_volume_name(team.team_id, settings.prefix): {
+                "bind": AGENT_HOME,
+                "mode": "rw",
+            },
+            get_agent_workspace_volume_name(team.team_id, settings.prefix): {
+                "bind": "/workspace",
+                "mode": "rw",
+            },
+        },
+        "extra_hosts": {"host.docker.internal": "host-gateway"},
+        "shm_size": "1g",
+        "restart_policy": {"Name": "unless-stopped"},
+    }
+
+
 def _agent_config_hash(
-    image: str, env: dict[str, str], has_git_credentials: bool
+    container_config: dict[str, Any], has_git_credentials: bool
 ) -> str:
     """Fingerprint of the config the agent container was created with.
 
-    Stored as a container label; a mismatch on ensure means oduflow.toml
-    changed (credentials, image, port), so the container is recreated. HOME
-    and /workspace are volumes — nothing is lost. Git credentials are copied
-    into HOME by the volume init step at container creation, so their presence
-    is part of the fingerprint: a container created before setup_repo_auth
-    would otherwise keep matching forever and never pick up the file."""
+    Stored as a container label; a mismatch on ensure means the image, injected
+    config, or Docker run specification changed, so the container is recreated.
+    HOME and /workspace are volumes — nothing is lost. Git credentials are
+    copied into HOME by the volume init step at container creation, so their
+    presence is also part of the fingerprint: a container created before
+    setup_repo_auth would otherwise keep matching forever and never pick up the
+    file."""
     import hashlib
 
     payload = json.dumps(
-        [
-            _AGENT_RUNTIME_VERSION,
-            image,
-            sorted(env.items()),
-            has_git_credentials,
-        ],
+        {
+            "container": container_config,
+            "has_git_credentials": has_git_credentials,
+        },
+        sort_keys=True,
         separators=(",", ":"),
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
@@ -1613,34 +1643,53 @@ def _ensure_agent_container(
         agent_env = dict(_agent_env_vars(settings, team))
         cred_file = team.git_credentials_file()
         has_git_credentials = os.path.isfile(cred_file)
-        config_hash = _agent_config_hash(
-            settings.agent_image, agent_env, has_git_credentials
-        )
+        container_config = _agent_container_config(settings, team, agent_env)
+        config_hash = _agent_config_hash(container_config, has_git_credentials)
 
         container_name = get_agent_container_name(team.team_id, settings.prefix)
+        existing_container = None
         try:
-            container = client.containers.get(container_name)
-            if container.labels.get("oduflow.agent_config_hash", "") == config_hash:
-                if container.status != "running":
-                    container.start()
+            existing_container = client.containers.get(container_name)
+            if (
+                existing_container.labels.get("oduflow.agent_config_hash", "")
+                == config_hash
+            ):
+                if existing_container.status != "running":
+                    existing_container.start()
                 return
-            # Config changed in oduflow.toml — recreate with the new env/image.
-            # HOME and /workspace are volumes, so auth, sessions and every
-            # checkout survive.
+        except docker.errors.NotFound:
+            pass
+
+        # Resolve the exact immutable image before touching a working
+        # container. A failed pull therefore leaves the previous agent
+        # available and its old config hash ensures a later restart retries.
+        try:
+            client.images.pull(settings.agent_image)
+        except Exception:
+            outcome = (
+                "keeping existing container"
+                if existing_container is not None
+                else "agent container was not created"
+            )
+            logger.warning(
+                "Could not pull agent image %s; %s",
+                settings.agent_image,
+                outcome,
+                extra={"container": container_name},
+                exc_info=True,
+            )
+            return
+
+        if existing_container is not None:
+            # Config changed — recreate with the already-pulled image. HOME and
+            # /workspace are volumes, so auth, sessions and checkouts survive.
             logger.info(
                 "Agent config changed; recreating container",
                 extra={"container": container_name},
             )
-            container.remove(force=True)
-        except docker.errors.NotFound:
-            pass
+            existing_container.remove(force=True)
 
         ensure_team_network(client, settings, team)
-
-        volumes: dict[str, dict[str, str]] = {
-            home_volume: {"bind": AGENT_HOME, "mode": "rw"},
-            workspace_volume: {"bind": "/workspace", "mode": "rw"},
-        }
 
         labels = dict(agent_labels)
         labels.update(
@@ -1653,8 +1702,6 @@ def _ensure_agent_container(
             }
         )
 
-        with contextlib.suppress(Exception):
-            client.images.pull(settings.agent_image)
         _prepare_agent_volumes(
             client,
             settings.agent_image,
@@ -1663,17 +1710,9 @@ def _ensure_agent_container(
             cred_file if has_git_credentials else None,
         )
         client.containers.run(
-            image=settings.agent_image,
             name=container_name,
-            detach=True,
-            user=AGENT_USER,
-            network=get_team_network_name(team.team_id, settings.prefix),
-            environment=agent_env,
             labels=labels,
-            volumes=volumes,
-            extra_hosts={"host.docker.internal": "host-gateway"},
-            shm_size="1g",
-            restart_policy={"Name": "unless-stopped"},
+            **container_config,
         )
         logger.info("Agent container ensured", extra={"container": container_name})
         # Report which Claude credential the (re)created container will use, so

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -17,10 +17,25 @@ logger = logging.getLogger("oduflow")
 
 TRACE: bool = False
 
+DEFAULT_AGENT_IMAGE = "oduist/oduflow-coder:0.2.3"
+_LEGACY_AGENT_IMAGE = "oduist/oduflow-coder:latest"
+
 # Active MCP transport for the running server ("stdio" | "http").
 # Set in server.main() before the server starts. Mostly informational;
 # local_path is gated by the allow_local_path setting.
 TRANSPORT: str = "stdio"
+
+
+def _normalize_agent_image(value: object) -> str:
+    image = str(value or "").strip() or DEFAULT_AGENT_IMAGE
+    if image == _LEGACY_AGENT_IMAGE:
+        logger.warning(
+            "[agent].image %s is deprecated; using pinned image %s",
+            _LEGACY_AGENT_IMAGE,
+            DEFAULT_AGENT_IMAGE,
+        )
+        return DEFAULT_AGENT_IMAGE
+    return image
 
 
 @dataclass(frozen=True)
@@ -209,7 +224,7 @@ class Settings:
     # driving environments only through the Oduflow MCP server. Container and
     # volume names are derived per team in naming.py.
     # See specs/0029-agent-console-and-chat.md.
-    agent_image: str = "oduist/oduflow-coder:latest"
+    agent_image: str = DEFAULT_AGENT_IMAGE
     agent_claude_model: str = ""  # optional; empty = CLI default
     agent_codex_model: str = ""  # optional; empty = CLI default
 
@@ -573,8 +588,7 @@ class Settings:
             postgres_image=str(database.get("image", "postgres:15")),
             base_data_dir=base_data_dir,
             overlay_threshold_mb=int(storage.get("overlay_threshold_mb", 50)),
-            agent_image=str(agent.get("image", "oduist/oduflow-coder:latest")).strip()
-            or "oduist/oduflow-coder:latest",
+            agent_image=_normalize_agent_image(agent.get("image")),
             agent_claude_model=str(agent.get("claude_model", "")).strip(),
             agent_codex_model=str(agent.get("codex_model", "")).strip(),
             auto_stop_hours=int(lifecycle.get("auto_stop_hours", 48)),

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -60,7 +60,7 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 # deployment-wide bits; changes apply on server restart (the agent container
 # is recreated automatically when its config changed).
 # [agent]
-# image = "oduist/oduflow-coder:latest"
+# image = "oduist/oduflow-coder:0.2.3"
 # claude_model = ""                # optional model override; empty = CLI default
 # codex_model = ""                 # optional model override; empty = CLI default
 

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -398,7 +398,7 @@ def _acp_adapter_cmd(agent_type: str) -> list[str]:
     ``docker/agent/Dockerfile``."""
     if agent_type == "codex":
         return ["codex-acp"]
-    return ["claude-code-acp"]
+    return ["claude-agent-acp"]
 
 
 _CLAUDE_AUTH_GUIDANCE_MARKER = "Oduflow authentication guidance:"
@@ -3348,7 +3348,12 @@ def _build_routes(
                 # Codex does not attempt a nested bubblewrap sandbox.
                 cmd = _codex_cli_cmd(mcp_url, settings.agent_codex_model)
             else:
-                cmd = ["claude"]
+                # Approval-free like Codex: Docker + the unprivileged `agent`
+                # user are the security boundary, so the console skips per-tool
+                # prompts. Safe under the non-root agent user (the CLI's own root
+                # guard on this flag does not trip). Agent Chat gets the same via
+                # the seeded user-tier settings.json (permissions.defaultMode).
+                cmd = ["claude", "--dangerously-skip-permissions"]
                 if settings.agent_claude_model:
                     cmd += ["--model", settings.agent_claude_model]
 

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -164,10 +164,10 @@ def test_file_permissions_are_restrictive(tmp_path):
 
 
 def test_acp_adapter_cmd():
-    assert _acp_adapter_cmd("claude") == ["claude-code-acp"]
+    assert _acp_adapter_cmd("claude") == ["claude-agent-acp"]
     assert _acp_adapter_cmd("codex") == ["codex-acp"]
     # Unknown agent falls back to Claude (the configured default agent).
-    assert _acp_adapter_cmd("something-else") == ["claude-code-acp"]
+    assert _acp_adapter_cmd("something-else") == ["claude-agent-acp"]
 
 
 def test_codex_cli_cmd_uses_docker_as_the_sandbox():

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 from oduflow.docker_ops import system_ops, env_ops, odoo_ops
 from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
-from oduflow.settings import Settings, TeamSettings
+from oduflow.settings import DEFAULT_AGENT_IMAGE, Settings, TeamSettings
 
 TEST_TEAM = TeamSettings(
     team_id="1",
@@ -2095,7 +2095,7 @@ class TestAgentContainer:
             base_data_dir="/tmp/flow-test",
             etc_dir="/tmp/flow-test/etc",
             port=8000,
-            agent_image="oduist/oduflow-coder:latest",
+            agent_image=DEFAULT_AGENT_IMAGE,
             teams={team.team_id: team},
         )
         base.update(kw)
@@ -2289,8 +2289,7 @@ class TestAgentContainer:
         existing.status = "running"
         existing.labels = {
             "oduflow.agent_config_hash": env_ops._agent_config_hash(
-                settings.agent_image,
-                env,
+                env_ops._agent_container_config(settings, team, env),
                 os.path.isfile(team.git_credentials_file()),
             )
         }
@@ -2360,7 +2359,7 @@ class TestAgentContainer:
         existing.status = "running"
         existing.labels = {
             "oduflow.agent_config_hash": env_ops._agent_config_hash(
-                s.agent_image, env, False
+                env_ops._agent_container_config(s, team, env), False
             )
         }
         mock_docker_client.volumes.get.return_value = MagicMock()
@@ -2372,6 +2371,49 @@ class TestAgentContainer:
         existing.remove.assert_called_once_with(force=True)
         vols = mock_docker_client.containers.run.call_args_list[0].kwargs["volumes"]
         assert any(v["bind"] == "/run/oduflow/git-credentials" for v in vols.values())
+
+    def test_ensure_recreates_when_pinned_image_changes(
+        self, monkeypatch, mock_docker_client
+    ):
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        team = self._team()
+        old_settings = self._settings(
+            team=team, agent_image="oduist/oduflow-coder:0.2.1"
+        )
+        new_settings = self._settings(team=team)
+        existing = self._existing_container(old_settings, team, monkeypatch)
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.get.return_value = existing
+
+        env_ops._ensure_agent_container(mock_docker_client, new_settings, team)
+
+        mock_docker_client.images.pull.assert_called_once_with(DEFAULT_AGENT_IMAGE)
+        existing.remove.assert_called_once_with(force=True)
+        assert mock_docker_client.containers.run.call_args.kwargs["image"] == (
+            DEFAULT_AGENT_IMAGE
+        )
+
+    def test_failed_image_pull_preserves_existing_container(
+        self, monkeypatch, mock_docker_client
+    ):
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        team = self._team(agent_env={"OPENAI_API_KEY": "new-key"})
+        settings = self._settings(team=team)
+        existing = MagicMock()
+        existing.status = "running"
+        existing.labels = {"oduflow.agent_config_hash": "stale"}
+        mock_docker_client.volumes.get.return_value = MagicMock()
+        mock_docker_client.containers.get.return_value = existing
+        mock_docker_client.images.pull.side_effect = RuntimeError("registry down")
+
+        env_ops._ensure_agent_container(mock_docker_client, settings, team)
+
+        existing.remove.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
 
     def test_api_key_when_no_subscription(self, monkeypatch, mock_docker_client):
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,6 @@
 import pytest
 from pathlib import Path
-from oduflow.settings import Settings, TeamSettings, find_toml
+from oduflow.settings import DEFAULT_AGENT_IMAGE, Settings, TeamSettings, find_toml
 
 
 class TestSettings:
@@ -321,9 +321,18 @@ class TestQuotas:
 class TestAgentSettings:
     def test_global_defaults(self):
         s = Settings()
-        assert s.agent_image == "oduist/oduflow-coder:latest"
+        assert s.agent_image == "oduist/oduflow-coder:0.2.3"
         assert s.agent_claude_model == ""
         assert s.agent_codex_model == ""
+
+    def test_default_image_matches_dockerfile_version(self):
+        dockerfile = Path(__file__).parents[1] / "docker" / "agent" / "Dockerfile"
+        version = next(
+            line.removeprefix("ARG CODER_VERSION=")
+            for line in dockerfile.read_text().splitlines()
+            if line.startswith("ARG CODER_VERSION=")
+        )
+        assert DEFAULT_AGENT_IMAGE == f"oduist/oduflow-coder:{version}"
 
     def test_team_defaults_agent_off(self):
         # The agent is a hosting feature; a team must opt in explicitly.
@@ -360,9 +369,21 @@ class TestAgentSettings:
         toml = tmp_path / "oduflow.toml"
         toml.write_text('[team.1]\nhostname = "localhost"\n')
         s = Settings.from_toml(str(toml))
-        assert s.agent_image == "oduist/oduflow-coder:latest"
+        assert s.agent_image == DEFAULT_AGENT_IMAGE
         assert s.teams["1"].agent_enabled is False
         assert s.teams["1"].agent_env == {}
+
+    def test_legacy_latest_image_migrates_to_pinned_default(self, tmp_path, caplog):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[agent]\nimage = "oduist/oduflow-coder:latest"\n'
+            '[team.1]\nhostname = "localhost"\n'
+        )
+
+        s = Settings.from_toml(str(toml))
+
+        assert s.agent_image == DEFAULT_AGENT_IMAGE
+        assert "is deprecated; using pinned image" in caplog.text
 
     def test_agent_env_must_be_table(self, tmp_path):
         toml = tmp_path / "oduflow.toml"


### PR DESCRIPTION
## Summary

- migrate hosted Claude chat to the maintained claude-agent-acp adapter and run Claude CLI/ACP approval-free inside the non-root coder container
- replace the rolling coder image with an immutable 0.2.3 contract, pull before replacing a live container, normalize legacy latest configs, and prevent CI from overwriting published tags
- document the architecture decision and add lifecycle/settings regression coverage

## Validation

- pytest -m "not integration and not heavyweight" -q — 1210 passed, 15 deselected
- ruff check src/oduflow tests
- mypy src/oduflow
- mkdocs build --strict
- bash -n docker/agent/entrypoint.sh
- git diff --check origin/main...HEAD