### PR TITLE
Keep filesystem path on inlined Agent Chat image attachments

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@
 
 ### Bug Fixes
 
+- **Agent Chat image uploads keep their filesystem path** — small images still
+  reach multimodal agents as inline visual input, but now also retain the
+  persisted `/workspace/.oduflow-uploads/...` resource link. Claude and Codex
+  can therefore use the exact uploaded file with shell and Odoo tools instead
+  of guessing temporary upload locations.
 - **Hosted agents use the reachable scoped MCP endpoint** — Agent CLI and Agent Chat now use the team's public HTTPS `/mcp/<environment>` URL in Traefik mode (and an explicit `oauth_base_url` in port mode), matching the dashboard's **MCP Access** dialog. Local port-mode deployments retain the `host.docker.internal` fallback.
 - **Claude Agent Chat explains rejected credentials** — provider credentials copied into `[team.*.agent_env]` now have surrounding whitespace removed before they reach the coder container. When Claude ACP returns a recognizable authentication failure, Agent Chat preserves the provider error and adds recovery specific to the active setup-token, API-key, or interactive-login mode. Oduflow still fails closed instead of silently switching accounts or billing methods.
 - **claude.ai OAuth connector reaches the authorization endpoint** — a claude.ai custom connector derives its OAuth endpoints path-relative to the MCP URL (requesting `https://<host>/mcp/authorize` and `/mcp/token`) instead of following the root endpoints advertised by discovery. The outer scoped-access shim treated `authorize`/`token` as an environment name and rewrote the request onto the auth-protected `/mcp` endpoint, so the flow failed with `401 invalid_token` before it could start. Oduflow now routes the reserved OAuth/discovery sub-paths requested under `/mcp/` (`/mcp/authorize`, `/mcp/token`, `/mcp/register`, `/mcp/.well-known/*`) to the real root routes. Scoped `/mcp/<env>` connectors remain Bearer-only.

--- a/specs/0038-agent-chat-file-attachments.md
+++ b/specs/0038-agent-chat-file-attachments.md
@@ -35,10 +35,12 @@ available to resumed conversations and agent tools until the environment is
 deleted. Environment deletion removes both its checkout and attachment tree.
 
 Small images take a capability-aware fast path: when the ACP agent advertises
-`promptCapabilities.image`, the prompt carries an ACP `image` block with the
-stored file URI and inline image data so the model receives visual context
-directly. Other files, large images, and agents without that capability use the
-baseline `resource_link` representation.
+`promptCapabilities.image`, the prompt carries both the baseline
+`resource_link` and an ACP `image` block with inline image data. The link keeps
+the exact stored path visible to filesystem tools even when an ACP adapter
+discards image-block URI metadata; the image block gives the model direct visual
+context. Other files, large images, and agents without that capability use only
+the baseline `resource_link` representation.
 
 ## How it works
 
@@ -79,3 +81,5 @@ baseline `resource_link` representation.
 - 2026-07-22 — introduced authenticated uploads, persistent workspace storage,
   ACP resource/image blocks, composer attachment states and environment-scoped
   cleanup.
+- 2026-07-23 — kept a `resource_link` alongside inline image data so ACP
+  adapters cannot hide the persisted filesystem path from the agent.

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -4948,7 +4948,7 @@ function ensureChatAssets() {
   // chat.js and acp-client.js are an interdependent pair of our own code; bump
   // this shared CHAT_V whenever either one changes (see AGENTS.md). One version
   // busts both at once, preventing a stale chat.js/acp-client.js mismatch.
-  var CHAT_V = '4';
+  var CHAT_V = '5';
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
     loadScript('/static/acp-client.js?v=' + CHAT_V)

--- a/src/oduflow/templates/static/chat.js
+++ b/src/oduflow/templates/static/chat.js
@@ -906,36 +906,42 @@
     };
   }
 
-  function attachmentPromptBlock(attachment, canInlineImage) {
-    if (!canInlineImage) return Promise.resolve(resourceLinkBlock(attachment));
+  function attachmentPromptBlocks(attachment, canInlineImage) {
+    var resourceLink = resourceLinkBlock(attachment);
+    if (!canInlineImage) return Promise.resolve([resourceLink]);
+    // Keep the link even when image bytes are inlined: ACP adapters commonly
+    // discard image URI/_meta fields, but preserve resource links as text.
     return new Promise(function (resolve) {
       var reader = new FileReader();
       reader.onload = function () {
         var dataUrl = String(reader.result || '');
         var comma = dataUrl.indexOf(',');
-        if (comma === -1) { resolve(resourceLinkBlock(attachment)); return; }
-        resolve({
-          type: 'image',
-          data: dataUrl.slice(comma + 1),
-          mimeType: attachment.mimeType,
-          uri: attachment.uri,
-          _meta: {
-            oduflow: {
-              id: attachment.id,
-              name: attachment.name,
-              path: attachment.path,
-              size: attachment.size
+        if (comma === -1) { resolve([resourceLink]); return; }
+        resolve([
+          resourceLink,
+          {
+            type: 'image',
+            data: dataUrl.slice(comma + 1),
+            mimeType: attachment.mimeType,
+            uri: attachment.uri,
+            _meta: {
+              oduflow: {
+                id: attachment.id,
+                name: attachment.name,
+                path: attachment.path,
+                size: attachment.size
+              }
             }
           }
-        });
+        ]);
       };
-      reader.onerror = function () { resolve(resourceLinkBlock(attachment)); };
+      reader.onerror = function () { resolve([resourceLink]); };
       reader.readAsDataURL(attachment.file);
     });
   }
 
   function buildPromptBlocks(inst, text, attachments) {
-    var blocks = [Promise.resolve({ type: 'text', text: text })];
+    var groups = [Promise.resolve([{ type: 'text', text: text }])];
     var inlineImageBytes = 0;
     for (var i = 0; i < attachments.length; i++) {
       var attachment = attachments[i];
@@ -943,9 +949,18 @@
         attachment.mimeType.indexOf('image/') === 0 && attachment.file &&
         inlineImageBytes + attachment.size <= INLINE_IMAGE_MAX_BYTES;
       if (canInlineImage) inlineImageBytes += attachment.size;
-      blocks.push(attachmentPromptBlock(attachment, canInlineImage));
+      groups.push(attachmentPromptBlocks(attachment, canInlineImage));
     }
-    return Promise.all(blocks);
+    return Promise.all(groups).then(function (resolvedGroups) {
+      var blocks = [];
+      for (var groupIndex = 0; groupIndex < resolvedGroups.length; groupIndex++) {
+        var group = resolvedGroups[groupIndex];
+        for (var blockIndex = 0; blockIndex < group.length; blockIndex++) {
+          blocks.push(group[blockIndex]);
+        }
+      }
+      return blocks;
+    });
   }
 
   function refreshHistory(inst, res) {

--- a/tests/test_chat_prompt_attachments.py
+++ b/tests/test_chat_prompt_attachments.py
@@ -1,0 +1,99 @@
+"""Behavioral coverage for Agent Chat attachment prompt construction."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_CHAT_JS = (
+    Path(__file__).parents[1] / "src" / "oduflow" / "templates" / "static" / "chat.js"
+)
+
+
+def _prompt_scenarios() -> dict[str, list[dict[str, object]]]:
+    source = _CHAT_JS.read_text(encoding="utf-8")
+    marker = "})();"
+    body, separator, trailer = source.rpartition(marker)
+    assert separator, "chat.js IIFE terminator not found"
+    instrumented = (
+        body
+        + "\nwindow.__chatPromptTest = { buildPromptBlocks: buildPromptBlocks };\n"
+        + separator
+        + trailer
+    )
+
+    harness = (
+        "global.window = {};\n"
+        "global.document = {};\n"
+        "global.FileReader = function () {};\n"
+        "global.FileReader.prototype.readAsDataURL = function (file) {\n"
+        "  if (file.fail) { this.onerror(); return; }\n"
+        "  this.result = file.dataUrl;\n"
+        "  this.onload();\n"
+        "};\n" + instrumented + "\n(async function () {\n"
+        "  var attachment = {\n"
+        "    id: 'abc123',\n"
+        "    name: 'pool.png',\n"
+        "    path: '/workspace/.oduflow-uploads/main/abc123/pool.png',\n"
+        "    uri: 'file:///workspace/.oduflow-uploads/main/abc123/pool.png',\n"
+        "    mimeType: 'image/png',\n"
+        "    size: 3,\n"
+        "    file: { dataUrl: 'data:image/png;base64,aW1n' }\n"
+        "  };\n"
+        "  var build = window.__chatPromptTest.buildPromptBlocks;\n"
+        "  var inline = await build(\n"
+        "    { promptCapabilities: { image: true } }, 'Use this image', [attachment]\n"
+        "  );\n"
+        "  var fallback = await build(\n"
+        "    { promptCapabilities: {} }, 'Use this image', [attachment]\n"
+        "  );\n"
+        "  attachment.file = { fail: true };\n"
+        "  var readFailure = await build(\n"
+        "    { promptCapabilities: { image: true } }, 'Use this image', [attachment]\n"
+        "  );\n"
+        "  process.stdout.write(JSON.stringify({ inline, fallback, readFailure }));\n"
+        "})().catch(function (error) {\n"
+        "  process.stderr.write(String(error && error.stack || error));\n"
+        "  process.exit(1);\n"
+        "});\n"
+    )
+    result = subprocess.run(
+        ["node", "-"],
+        input=harness,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_inline_image_keeps_resource_link_and_visual_block():
+    scenarios = _prompt_scenarios()
+
+    inline = scenarios["inline"]
+    assert [block["type"] for block in inline] == ["text", "resource_link", "image"]
+    assert inline[1]["uri"] == inline[2]["uri"]
+    assert (
+        inline[1]["_meta"]["oduflow"]["path"] == inline[2]["_meta"]["oduflow"]["path"]
+    )
+    assert inline[2]["data"] == "aW1n"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_non_inline_and_failed_image_reads_emit_one_resource_link():
+    scenarios = _prompt_scenarios()
+
+    assert [block["type"] for block in scenarios["fallback"]] == [
+        "text",
+        "resource_link",
+    ]
+    assert [block["type"] for block in scenarios["readFailure"]] == [
+        "text",
+        "resource_link",
+    ]


### PR DESCRIPTION
## Problem

When a small image was uploaded in Agent Chat and inlined for a multimodal
agent (Claude/Codex advertising `promptCapabilities.image`), the prompt sent
**only** the ACP `image` block and dropped the `resource_link`. Many ACP
adapters discard image-block `uri`/`_meta` fields, so the agent lost the
persisted `/workspace/.oduflow-uploads/...` filesystem path — it could *see*
the picture but could not open the exact uploaded file with shell or Odoo
tools, and would guess at temporary upload locations instead.

## Fix

`attachmentPromptBlocks` now emits **both**:
- the `resource_link` (path survives as text even when adapters strip image
  metadata), and
- the inline `image` block (direct visual context).

Non-inlined files, large images, and non-multimodal agents still emit a single
`resource_link`, unchanged.

## Changes

- `src/oduflow/templates/static/chat.js` — `attachmentPromptBlock` →
  `attachmentPromptBlocks` (returns an array); `buildPromptBlocks` flattens the
  per-attachment block groups.
- `src/oduflow/templates/dashboard.html` — `CHAT_V` bumped `4` → `5` (required
  cache-bust per AGENTS.md, since `chat.js` changed).
- `specs/0038-agent-chat-file-attachments.md` — spec + history updated.
- `docs/changelog.md` — new Bug Fixes bullet under Unreleased.
- `tests/test_chat_prompt_attachments.py` — **new** Node-driven behavioral test
  asserting `[text, resource_link, image]` for the inline path and
  `[text, resource_link]` for fallback / image-read-failure.

## Verification

- `pytest tests/test_chat_prompt_attachments.py` → 2 passed
- `ruff check` + `ruff format --check` on the new test → clean