### PR TITLE
Reject invalid auxiliary service names

### DIFF
--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse, urlunparse
 # path traversal) and contain only [a-zA-Z0-9_.-] (which rules out quotes,
 # semicolons and whitespace — i.e. SQL-identifier break-out).
 _TEMPLATE_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+_SERVICE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 
 
 def validate_template_name(template_name: str) -> str:
@@ -76,6 +77,24 @@ def validate_env_name(env_name: str) -> str:
         raise ValueError(
             f"Invalid environment name '{env_name}': must contain at least one "
             "alphanumeric, '_' or '-' character."
+        )
+    return name
+
+
+def validate_service_name(name: str) -> str:
+    """Validate an auxiliary-service name and return it unchanged.
+
+    Service names become Docker container names directly, so silently
+    normalizing them would make the identifier shown to the user differ from
+    the resource Docker created. Reject unsupported names at the shared naming
+    chokepoint instead.
+    """
+    if not name or not _SERVICE_NAME_RE.fullmatch(name):
+        raise ValueError(
+            f"Invalid service name '{name}': must start with a letter or digit "
+            "and contain only letters, digits, dots, hyphens, and underscores. "
+            "Spaces are not allowed; use hyphens instead (for example, "
+            "'odoo-mcp-server')."
         )
     return name
 
@@ -164,6 +183,7 @@ def get_resource_name(
 def get_service_container_name(name: str, prefix: str, team_id: str) -> str:
     """Docker container name for an auxiliary service (team-scoped, see
     get_resource_name)."""
+    validate_service_name(name)
     return f"{prefix}{team_id}-svc-{name}"
 
 

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,13 +1,15 @@
 import pytest
 
 from oduflow.naming import (
-    slugify_branch,
     get_db_name,
+    get_filestore_paths,
+    get_repo_path,
     get_resource_name,
+    get_service_container_name,
     get_template_db_name,
     get_workspace_path,
-    get_repo_path,
-    get_filestore_paths,
+    slugify_branch,
+    validate_service_name,
     validate_template_name,
 )
 
@@ -75,6 +77,50 @@ class TestGetResourceName:
 
     def test_custom_prefix(self):
         assert get_resource_name("main", "odoo", "test-", "2") == "test-2-main-odoo"
+
+
+class TestServiceNaming:
+    @pytest.mark.parametrize(
+        "good",
+        ["redis", "Odoo-MCP-server", "service_1", "service.v2", "1-service"],
+    )
+    def test_accepts_docker_safe_names(self, good):
+        assert validate_service_name(good) == good
+        assert (
+            get_service_container_name(good, "oduflow-", "1")
+            == f"oduflow-1-svc-{good}"
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "Odoo MCP server",
+            "-service",
+            "_service",
+            ".service",
+            "service/name",
+            "service:name",
+            "service@host",
+            "service\n",
+        ],
+    )
+    def test_rejects_names_docker_would_reject(self, bad):
+        with pytest.raises(ValueError, match="Invalid service name"):
+            validate_service_name(bad)
+        with pytest.raises(ValueError, match="Invalid service name"):
+            get_service_container_name(bad, "oduflow-", "1")
+
+    def test_error_explains_how_to_replace_spaces(self):
+        with pytest.raises(ValueError) as exc_info:
+            get_service_container_name("Odoo MCP server", "oduflow-", "1")
+
+        assert str(exc_info.value) == (
+            "Invalid service name 'Odoo MCP server': must start with a letter "
+            "or digit and contain only letters, digits, dots, hyphens, and "
+            "underscores. Spaces are not allowed; use hyphens instead (for "
+            "example, 'odoo-mcp-server')."
+        )
 
 
 class TestGetWorkspacePath:

--- a/tests/test_service_routes_web.py
+++ b/tests/test_service_routes_web.py
@@ -43,6 +43,26 @@ def test_create_service_accepts_structured_routes(tmp_path):
     assert create.call_args.kwargs["routes"] == routes
 
 
+def test_create_service_rejects_invalid_name_with_explanation(tmp_path):
+    client = _client(tmp_path)
+
+    response = client.post(
+        "/api/services/create",
+        json={"name": "Odoo MCP server", "image": "example/mcp:1", "port": 8080},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "ok": False,
+        "error": (
+            "Invalid service name 'Odoo MCP server': must start with a letter "
+            "or digit and contain only letters, digits, dots, hyphens, and "
+            "underscores. Spaces are not allowed; use hyphens instead (for "
+            "example, 'odoo-mcp-server')."
+        ),
+    }
+
+
 def test_update_service_distinguishes_missing_and_empty_routes(tmp_path):
     client = _client(tmp_path)
     result = {


### PR DESCRIPTION
Reject auxiliary service identifiers that Docker cannot use instead of silently normalizing them.

Validation now happens at the shared container-name derivation boundary, so dashboard requests return an actionable `400` before Docker is contacted.

This fixes the raw Docker `400` surfacing as an Internal Server Error while keeping the identifier shown to the user unchanged.

Validated with 1,228 unit tests, focused Ruff checks, `git diff --check`, and an agent-browser dashboard submission.