### PR TITLE
Resolve project sanitize scripts from the live-mount checkout

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,11 @@
 
 ### Bug Fixes
 
+- **Live-mount project sanitization uses the active checkout** — project scripts
+  now live under `.oduflow/odoo_sanitize` and resolve against the actual
+  `local_path` checkout instead of the empty managed-clone location. Existing
+  repositories keep running with an explicit migration warning, and
+  `get_environment_info` plus the dashboard now show the live-mount source path.
 - **Agent Chat image uploads keep their filesystem path** — small images still
   reach multimodal agents as inline visual input, but now also retain the
   persisted `/workspace/.oduflow-uploads/...` resource link. Claude and Codex
@@ -24,6 +29,10 @@
 
 ### Security
 
+- **Live-mount startup warning** — every server start with
+  `allow_local_path=true` now warns that environment creators can bind host
+  directories read/write and that hosted, remote, and multi-user deployments
+  should disable the trusted local-development mode.
 - **OAuth `client_id` is no longer the secret** — a team's OAuth `client_id` is now the non-secret identifier `team_<id>` (e.g. `team_1`); the team's `auth_token` is the `client_secret` and remains the issued access token. Previously `client_id == client_secret == auth_token`, so the secret appeared in the `/authorize` query string (and thus in server logs, browser history, and the `Referer`). The secret now travels only in the POST `/token` body. **Breaking:** re-enter any existing claude.ai connector as `Client ID = team_<id>`, `Client Secret = auth_token`.
 - **OAuth issues independent, expiring, revocable tokens** — completing the previous item, the OAuth Authorization Code / refresh exchange now mints an *independent, opaque* `access_token` (with a rotating refresh token) instead of handing back the team's `auth_token`. A minted access token expires (~1h) and can be revoked via the now-enabled `/revoke` endpoint; using a refresh token rotates the pair so a leaked refresh token is single-use. The OAuth client (claude.ai/IDE) therefore never stores the team's long-lived master secret. Minted tokens are persisted (`oauth_token_store.py`) so live connections survive an Oduflow restart. The `auth_token` still works as a non-expiring direct Bearer credential for curl/CLI, and per-environment tokens remain Bearer-only. (#83)
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -74,7 +74,7 @@ For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutra
 Custom sanitization then uses a **two-tier** approach:
 
 1. **Team-level scripts** from `{team_data_dir}/odoo_sanitize/` — managed by the administrator, shared across all environments in the team
-2. **Per-project scripts** from `.odoo_sanitize/` in the repository root — managed by the developer, specific to the project
+2. **Per-project scripts** from `.oduflow/odoo_sanitize/` in the repository root — managed by the developer, specific to the project
 
 Both folders support `.sql` and `.py` files, executed in alphabetical order (first all `.sql`, then all `.py`). Team-level scripts run first, then per-project scripts.
 
@@ -102,20 +102,20 @@ The team administrator can add, modify, or remove scripts in this folder to cont
 
 ### Per-project sanitization
 
-You can add project-specific sanitization by placing scripts in a `.odoo_sanitize/` folder in your repository root:
+You can add project-specific sanitization under `.oduflow/odoo_sanitize/` in your repository root:
 
 | File type | Execution method |
 |-----------|-----------------|
 | `*.sql`   | Executed directly against the environment database via `psql` |
 | `*.py`    | Executed inside the Odoo container via `python3 -c` |
 
-**Example SQL script** (`.odoo_sanitize/01_clean_partners.sql`):
+**Example SQL script** (`.oduflow/odoo_sanitize/01_clean_partners.sql`):
 
 ```sql
 UPDATE res_partner SET email = 'test@example.com' WHERE email IS NOT NULL;
 ```
 
-**Example Python script** (`.odoo_sanitize/02_reset_passwords.py`):
+**Example Python script** (`.oduflow/odoo_sanitize/02_reset_passwords.py`):
 
 ```python
 import os, psycopg2

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -120,7 +120,7 @@ hostname = "localhost"
 [server]
 host = "0.0.0.0"           # HTTP server bind address
 port = 8000                 # HTTP server port
-allow_local_path = true     # allow live-mount (bind local checkout) environments
+allow_local_path = true     # trusted single-user local development; disable on hosted/multi-user servers
 # allow_insecure_http = false  # serve /mcp over HTTP with NO auth (only behind your own proxy)
 # trace = false             # verbose tracing for git analysis & env ops
 
@@ -189,7 +189,7 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[server].host` | `0.0.0.0` | HTTP server bind address |
 | `[server].port` | `8000` | HTTP server port |
-| `[server].allow_local_path` | `true` | Allow live-mount (`local_path`) environments that bind-mount a local checkout instead of cloning. Set `false` to force git-clone delivery only |
+| `[server].allow_local_path` | `true` | Allow trusted local-development live-mounts that bind a host checkout read/write. Set `false` on hosted, remote, or multi-user servers, or whenever only git-clone delivery is required |
 | `[server].allow_insecure_http` | `false` | Serve the `/mcp` endpoint over plain HTTP with **no** authentication. Only enable behind your own authenticating proxy |
 | `[server].trace` | `false` | Enable detailed trace logging for git analysis and environment operations |
 | `[server].disable_telemetry` | `false` | Disable anonymous usage telemetry (see [Telemetry](#telemetry)) |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1121,7 +1121,7 @@ For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutra
 Custom sanitization then uses a **two-tier** approach:
 
 1. **Team-level scripts** from `{team_data_dir}/odoo_sanitize/` — managed by the administrator, shared across all environments in the team
-2. **Per-project scripts** from `.odoo_sanitize/` in the repository root — managed by the developer, specific to the project
+2. **Per-project scripts** from `.oduflow/odoo_sanitize/` in the repository root — managed by the developer, specific to the project
 
 Both folders support `.sql` and `.py` files, executed in alphabetical order (first all `.sql`, then all `.py`). Team-level scripts run first, then per-project scripts.
 
@@ -1149,20 +1149,20 @@ The team administrator can add, modify, or remove scripts in this folder to cont
 
 ### Per-project sanitization
 
-You can add project-specific sanitization by placing scripts in a `.odoo_sanitize/` folder in your repository root:
+You can add project-specific sanitization under `.oduflow/odoo_sanitize/` in your repository root:
 
 | File type | Execution method |
 |-----------|-----------------|
 | `*.sql`   | Executed directly against the environment database via `psql` |
 | `*.py`    | Executed inside the Odoo container via `python3 -c` |
 
-**Example SQL script** (`.odoo_sanitize/01_clean_partners.sql`):
+**Example SQL script** (`.oduflow/odoo_sanitize/01_clean_partners.sql`):
 
 ```sql
 UPDATE res_partner SET email = 'test@example.com' WHERE email IS NOT NULL;
 ```
 
-**Example Python script** (`.odoo_sanitize/02_reset_passwords.py`):
+**Example Python script** (`.oduflow/odoo_sanitize/02_reset_passwords.py`):
 
 ```python
 import os, psycopg2

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -186,6 +186,12 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 
 An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with per-environment conversation history). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to both agents, with one persistent profile per environment. Codex runs installed MCP methods without interactive approval prompts. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
 
+## Database Sanitization
+
+Template-based environments are neutralized by default, then run team-level
+sanitization scripts followed by project scripts from
+`.oduflow/odoo_sanitize/`. Both SQL and Python scripts are supported.
+
 ## Typical Agent Workflow
 
 1. Call `list_environments` to check if an environment for the branch exists

--- a/specs/0013-per-environment-db-credentials-and-sanitization.md
+++ b/specs/0013-per-environment-db-credentials-and-sanitization.md
@@ -62,11 +62,14 @@ Two related decisions, both about confining blast radius at the database layer.
   Odoo can recreate them cleanly on first start. This is the load-bearing glue
   that makes a cloned DB usable under a non-superuser owner.
 - **Sanitization tiers.** `sanitize_environment` runs scripts from the team's
-  `{data_dir}/odoo_sanitize/` first (seeded on `oduflow init` with a bundled
-  `01_disable_mail.sql`), then from the repo's `.odoo_sanitize/` folder. `.sql`
-  runs against the env DB; `.py` runs *inside* the Odoo container using the
-  per-env credentials, so repo rules can use the Odoo ORM. Failures are logged as
-  warnings, not fatal — sanitization is best-effort hardening, not a gate.
+  `{data_dir}/odoo_sanitize/` first (seeded with a bundled
+  `01_disable_mail.sql`), then from the active checkout's
+  `.oduflow/odoo_sanitize/` folder. The checkout is resolved from
+  `oduflow.local_path` for live-mount environments and from the managed workspace
+  otherwise. `.sql` runs against the env DB; `.py` runs *inside* the Odoo
+  container using the per-env credentials, so repo rules can use the Odoo ORM.
+  Failures are logged as warnings, not fatal — sanitization is best-effort
+  hardening, not a gate.
 
 ## Consequences
 
@@ -152,7 +155,7 @@ native neutralization, rather than re-implementing what Odoo already ships:
 
 - `cd0b9ec` (2026-02-24) — two-tier sanitization: drop hardcoded built-in queries;
   bundle `01_disable_mail.sql`; create `/etc/oduflow/odoo_sanitize/` on init; run
-  system-wide then per-repo `.odoo_sanitize/` scripts; add `sanitize` param to
+  system-wide then per-repo sanitization scripts; add `sanitize` param to
   `create_environment` (default True).
 - `e4949b0` (2026-02-26) — per-environment PostgreSQL credentials: `env_credentials.py`,
   `_create_pg_role`/`_drop_pg_role`, env role as DB owner, global user kept for
@@ -168,4 +171,4 @@ native neutralization, rather than re-implementing what Odoo already ships:
   the bootstrap injects a random secret into the generated config (see Evolution).
 - (2026-07-07) — **native neutralization baseline:** `neutralize_environment` runs
   `odoo-bin neutralize` inside the serving container as the first step of the
-  sanitize gate, ahead of the team/repo `.odoo_sanitize` tiers (see Evolution).
+  sanitize gate, ahead of the team/repo custom-script tiers (see Evolution).

--- a/specs/0021-code-delivery-modes.md
+++ b/specs/0021-code-delivery-modes.md
@@ -16,11 +16,12 @@ by **pushing code to a branch** and asking the environment to pull and apply it
 server runs elsewhere, code can only reach it over git, and pushing is the audit
 trail.
 
-But for a developer running Oduflow **locally over stdio**, the git round-trip is
-pure friction. The agent already has the checkout open on the same host as the
-Docker daemon; making it commit and push to GitHub just so Oduflow can pull the
-change back onto the same disk is a slow, noisy dev loop for what is conceptually
-"edit a file and reload".
+But for a developer running Oduflow **locally**, the git round-trip is pure
+friction. The agent already has the checkout open on the same host as the Docker
+daemon; making it commit and push to GitHub just so Oduflow can pull the change
+back onto the same disk is a slow, noisy dev loop for what is conceptually "edit
+a file and reload". Local operators may use stdio or run the HTTP transport to
+get the dashboard; code delivery should behave the same in both.
 
 A second force: when the agent *authored* the edits, it already knows what they
 are. Forcing every change through pure auto-classification is both unnecessary
@@ -33,17 +34,18 @@ heuristic). Yet leaving the agent fully in charge invites the classic mistake of
 Support **two code-delivery modes**, chosen per environment, and make applying
 changes an **explicit, classified step** in both.
 
-- **`repo_url` (git mode) — default, the only mode for remote/HTTP.** The agent
+- **`repo_url` (git mode) — default.** The agent
   pushes to its branch; `create_environment(repo_url=...)` clones it; later
   `pull_and_apply` pulls the branch into the managed clone and applies the right
   Odoo action. This is the multi-user CI path and stays the default.
-- **`local_path` (live-mount) — local fast-path, stdio only.**
+- **`local_path` (live-mount) — trusted local fast-path.**
   `create_environment(local_path=<abs path>)` **bind-mounts the agent's own
   checkout** straight into the container instead of cloning. Edits are visible
   inside Odoo instantly; there is no push, no pull, no second copy on disk. It is
-  **gated to the stdio transport** (recorded in `settings.TRANSPORT`) and to an
-  `allow_local_path` setting, and is **rejected over HTTP** — a remote tenant
-  must never be able to mount an arbitrary host path.
+  gated by `allow_local_path` and works through both stdio and HTTP so a local
+  developer can use the dashboard. Because the mount is read/write and names a
+  host path, it is a trusted single-user feature; hosted, remote, and multi-user
+  operators disable it.
 - **`pull_and_apply` as an explicit guardrail, not implicit auto-sync.** Applying
   is always a deliberate tool call, never a hidden file-watcher. The tool is
   transport-agnostic and parameterised: the agent passes explicit
@@ -70,8 +72,9 @@ changes an **explicit, classified step** in both.
   non-git directories. Either way the guardrail and the classifier see a
   `changed_files` set and recommend the minimal correct action.
 - **Safety boundary on the live-mount.** Live-mount is the fast path *because* it
-  trusts the caller's host — so it is confined to stdio, where caller and host
-  are the same trust domain. The HTTP transport never exposes it.
+  trusts the caller with host-filesystem access. `allow_local_path` is enabled
+  for the local single-user workflow and must be disabled for hosted, remote, or
+  multi-user deployments; startup emits a security warning while it is enabled.
 
 ## Consequences
 
@@ -86,7 +89,7 @@ changes an **explicit, classified step** in both.
   path.
 - The two modes share almost all machinery (`pull_and_apply`, classification,
   the environment lifecycle); the difference is localized to *clone vs
-  bind-mount* and a transport gate, keeping the surface small.
+  bind-mount*, keeping the surface small.
 - Templates had to learn about the mode too: a template saved from a
   live-mounted environment carries a `local_path` instead of a `repo_url` and
   recreates the live-mount on use (when `allow_local_path` is enabled).

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1301,8 +1301,9 @@ def create_environment(
         # third-party credentials scrubbed, database.is_neutralized=true). Runs
         # in the serving container so it sees the full addons_path.
         setup_logs.extend(neutralize_environment(client, settings, team, env_name))
-        # Layer 2: custom team/repo .odoo_sanitize scripts (e.g. PII scrubbing)
-        # run on top of the neutralized database.
+        # Layer 2: custom team/repo sanitization scripts (e.g. PII scrubbing)
+        # run on top of the neutralized database. Project scripts live under
+        # .oduflow/odoo_sanitize in the active checkout.
         sanitize_logs = sanitize_environment(client, settings, team, env_name)
         setup_logs.extend(sanitize_logs)
 
@@ -2375,6 +2376,7 @@ def get_environment_info(
         labels = odoo_container.labels
         result["template_name"] = labels.get("oduflow.template", "none")
         result["repo_url"] = sanitize_repo_url(labels.get(settings.repo_label, ""))
+        result["local_path"] = labels.get("oduflow.local_path", "")
         result["odoo_image"] = labels.get(settings.image_label, "")
         result["git_branch"] = labels.get("oduflow.git_branch", env_name)
         result["git_user"] = labels.get("oduflow.git_user", "")
@@ -3025,9 +3027,9 @@ def update_environment(
     try:
         current_image = container.image.tags[0]
     except (IndexError, Exception):
-        current_image = labels.get(settings.image_label) or container.attrs["Config"][
-            "Image"
-        ]
+        current_image = (
+            labels.get(settings.image_label) or container.attrs["Config"]["Image"]
+        )
     odoo_image = image_override or current_image
     try:
         old_digest = container.image.id

--- a/src/oduflow/sanitizer.py
+++ b/src/oduflow/sanitizer.py
@@ -3,6 +3,7 @@ import os
 import glob as glob_mod
 import re
 
+import docker
 from docker import DockerClient
 
 from oduflow.docker_ops.system_ops import _exec_sql
@@ -142,8 +143,8 @@ def neutralize_environment(
     covered too — a partial ``addons_path`` would silently skip them.
 
     This is the baseline sanitization layer (block anything going out / phoning
-    home); per-project and per-team ``.odoo_sanitize`` scripts (e.g. PII
-    anonymization) run on top of it via :func:`sanitize_environment`.
+    home); per-project ``.oduflow/odoo_sanitize`` and per-team scripts (e.g.
+    PII anonymization) run on top of it via :func:`sanitize_environment`.
 
     Note: neutralization leaves ``database.uuid`` and ``database.enterprise_code``
     untouched — it only stops transmission by disabling crons; it does not
@@ -218,9 +219,9 @@ def sanitize_environment(
 
     Runs sanitization scripts in two tiers:
     1. Team-level scripts from ``{data_dir}/odoo_sanitize/`` (managed by the
-       team administrator, created during ``oduflow init``).
-    2. Per-project scripts from the repository's ``.odoo_sanitize/`` folder
-       (managed by the developer).
+       team administrator, created during startup).
+    2. Per-project scripts from the repository's
+       ``.oduflow/odoo_sanitize/`` folder (managed by the developer).
 
     Both folders support ``.sql`` and ``.py`` files executed in alphabetical
     order.
@@ -239,8 +240,46 @@ def sanitize_environment(
     )
 
     # --- Per-project sanitization from repo ---
+    # Managed-clone environments keep their checkout under the Oduflow
+    # workspace. Live-mount environments keep it elsewhere and record the real
+    # host path on the serving container.
     repo_path = get_repo_path(env_name, team.workspaces_dir)
-    repo_dir = os.path.join(repo_path, ".odoo_sanitize")
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
+    try:
+        container = client.containers.get(odoo_container_name)
+        labels = container.labels if isinstance(container.labels, dict) else {}
+        repo_path = labels.get("oduflow.local_path") or repo_path
+    except docker.errors.NotFound:
+        logger.debug(
+            "Could not resolve live-mount path for sanitize; using managed path",
+        )
+
+    # Compatibility for repositories created before project sanitization moved
+    # under .oduflow/. Keep this runtime-only: new documentation points solely
+    # at the canonical path.
+    legacy_repo_dir = os.path.join(repo_path, ".odoo_sanitize")
+    if os.path.isdir(legacy_repo_dir):
+        warning = (
+            "[SANITIZE:repo] WARNING: Project sanitize scripts moved to "
+            ".oduflow/odoo_sanitize; move scripts from .odoo_sanitize there."
+        )
+        logger.warning(warning)
+        logs.append(warning)
+        logs.extend(
+            _run_scripts_from_dir(
+                legacy_repo_dir,
+                "repo-legacy",
+                client,
+                settings,
+                team,
+                env_db,
+                env_name,
+            )
+        )
+
+    repo_dir = os.path.join(repo_path, ".oduflow", "odoo_sanitize")
     logs.extend(
         _run_scripts_from_dir(
             repo_dir, "repo", client, settings, team, env_db, env_name

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -508,7 +508,7 @@ def create_environment(
         repo_url: URL of the git repository to clone. Optional when template_name is specified (loaded from template metadata).
         odoo_image: Full Docker image name with tag (e.g. "odoo:19.0"). Optional when template_name is specified (loaded from template metadata).
         extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:19.0,custom-themes:main"). Each entry must include a branch after a colon.
-        sanitize: Sanitize the database after provisioning (default: True). Runs Odoo's native neutralization (deactivates outgoing mail servers and crons, disables payment providers, scrubs third-party API credentials, sets database.is_neutralized) and then any custom scripts from the .odoo_sanitize/ folder in the repository. Only applies to environments created from a template.
+        sanitize: Sanitize the database after provisioning (default: True). Runs Odoo's native neutralization (deactivates outgoing mail servers and crons, disables payment providers, scrubs third-party API credentials, sets database.is_neutralized) and then any custom scripts from the .oduflow/odoo_sanitize/ folder in the repository. Only applies to environments created from a template.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
         env_vars: Comma-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). These are added on top of the database connection variables (HOST/USER/PASSWORD).
         local_path: LOCAL FAST-PATH. Absolute path to a checkout on THIS host. When set, Oduflow skips git clone and bind-mounts the directory live into the container — your file edits are visible instantly, no git push/pull needed. After editing, call pull_and_apply with explicit install/upgrade/restart to apply. repo_url is not required in this mode. Gated by allow_local_path (default: true).
@@ -1143,7 +1143,7 @@ def list_environments(ctx: Context | None = None) -> str:
             output += f"  Database: {env['db_name']}\n"
         if env.get("odoo_image"):
             output += f"  Image: {env['odoo_image']}\n"
-        if env.get("repo_url"):
+        if env.get("repo_url") and not env.get("local_path"):
             output += f"  Repo: {env['repo_url']}\n"
         if env.get("local_path"):
             output += f"  Live-mount: {env['local_path']}\n"
@@ -1329,8 +1329,11 @@ def get_environment_info(env_name: str, ctx: Context | None = None) -> str:
     lines.append(f"Database: {info['db_name']}")
     if info.get("url"):
         lines.append(f"URL: {info['url']}")
-    if info.get("repo_url"):
+    if info.get("repo_url") and not info.get("local_path"):
         lines.append(f"Repo: {info['repo_url']}")
+    if info.get("local_path"):
+        lines.append("Code delivery: live-mount")
+        lines.append(f"Live-mount: {info['local_path']}")
     if info.get("odoo_image"):
         lines.append(f"Image: {info['odoo_image']}")
     if info.get("template_name"):
@@ -4553,12 +4556,30 @@ def _run_cli() -> None:
         return
 
 
+def _warn_local_path_security(settings: Settings) -> None:
+    """Warn operators about the host-filesystem trust granted by live-mount."""
+    if not settings.allow_local_path:
+        return
+    logger.warning(
+        "SECURITY WARNING: local_path live-mount mode is ENABLED "
+        "([server].allow_local_path = true).\n"
+        "Clients allowed to create environments can bind-mount any existing "
+        "directory from the Oduflow host into an Odoo container with read/write "
+        "access.\n"
+        "Use live-mount only for trusted, single-user local development. For "
+        "hosted, remote, or multi-user deployments, set "
+        "[server].allow_local_path = false and restart Oduflow."
+    )
+
+
 def _start_stdio() -> None:
     """Start the MCP server (stdio transport)."""
     import asyncio
 
     from oduflow.backup_scheduler import start_backup_scheduler
 
+    settings = _get_settings()
+    _warn_local_path_security(settings)
     reaper.start_reaper(_get_settings, _locks)
     start_backup_scheduler(_get_settings, _locks)
     try:
@@ -4607,6 +4628,7 @@ def _start_http() -> None:
     # ui_password for existing configs that still have none. The fail-closed
     # check below only trips if this could not write the config.
     settings = _ensure_web_ui_password(settings)
+    _warn_local_path_security(settings)
     host = "0.0.0.0" if settings.routing_mode == "traefik" else settings.host
     port = settings.port
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2379,12 +2379,13 @@ function renderEnvironments(envs, force) {
       '</span>';
     })();
 
-    const metaHtml = (env.odoo_image || env.repo_url || env.db_name || env.template_name)
+    const metaHtml = (env.odoo_image || env.repo_url || env.local_path || env.db_name || env.template_name)
       ? '<div class="env-meta">' +
           (env.db_name ? '<span>DB: <strong class="copy-db" role="button" tabindex="0" title="Copy database name" aria-label="Copy database name" onclick="copyToClipboard(\'' + esc(env.db_name).replace(/'/g, "\\'") + '\')">' + esc(env.db_name) + '</strong></span>' : '') +
           (env.template_name && env.template_name !== 'none' ? '<span>Template: <strong>' + esc(env.template_name) + '</strong></span>' : '') +
           (env.odoo_image ? '<span>Image: <strong>' + esc(env.odoo_image) + '</strong></span>' : '') +
-          (env.repo_url ? '<span>Repo: <strong>' + esc(env.repo_url) + '</strong></span>' : '') +
+          (env.repo_url && !env.local_path ? '<span>Repo: <strong>' + esc(env.repo_url) + '</strong></span>' : '') +
+          (env.local_path ? '<span>Live-mount: <strong>' + esc(env.local_path) + '</strong></span>' : '') +
           (env.created_at ? '<span>Created: <strong>' + formatDate(env.created_at) + '</strong></span>' : '') +
           (env.last_activity ? '<span title="Last MCP call or dashboard action for this environment">Active: <strong>' + formatDate(env.last_activity) + '</strong></span>' : '') +
           (env.stopped_at ? '<span>Stopped: <strong>' + formatDate(env.stopped_at) + (env.auto_stopped ? ' (auto)' : '') + '</strong></span>' : '') +

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -2,7 +2,7 @@
 [server]
 host = "0.0.0.0"
 port = 8000
-allow_local_path = true        # allow live-mount (bind local checkout) workflows
+allow_local_path = true        # trusted single-user local development; disable on hosted/multi-user servers
 # allow_insecure_http = false  # serve HTTP /mcp with NO auth (only behind your own proxy)
 # trace = false                    # verbose tracing for git analysis & env ops
 

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1544,8 +1544,38 @@ class TestGetEnvironmentInfo:
         assert result["db_name"] == "oduflow_1_main"
         assert result["db_user"] == "u_1_main"
         assert result["repo_url"] == "https://github.com/example/repo.git"
+        assert result["local_path"] == ""
         assert result["odoo_image"] == "odoo:17.0"
         assert result["template_name"] == "default"
+
+    @patch(
+        "oduflow.docker_ops.env_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_live_mount_path(self, mock_load_creds, mock_docker_client):
+        odoo = MagicMock()
+        odoo.status = "running"
+        odoo.labels = {
+            "oduflow.template": "default",
+            "oduflow.repo": "/Users/dev/addons",
+            "oduflow.local_path": "/Users/dev/addons",
+            "oduflow.image": "odoo:17.0",
+            "oduflow.extra_addons": "{}",
+        }
+        odoo.attrs = {"NetworkSettings": {"Ports": {}}}
+        db = MagicMock()
+        db.status = "running"
+
+        def get_container(name):
+            if name == "oduflow-db":
+                return db
+            return odoo
+
+        mock_docker_client.containers.get.side_effect = get_container
+
+        result = env_ops.get_environment_info(TEST_SETTINGS, TEST_TEAM, "main")
+
+        assert result["local_path"] == "/Users/dev/addons"
 
 
 class TestInstallModules:

--- a/tests/test_sanitizer_paths.py
+++ b/tests/test_sanitizer_paths.py
@@ -1,0 +1,104 @@
+"""Project sanitization path resolution and compatibility coverage."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from oduflow import sanitizer
+
+
+def _settings() -> MagicMock:
+    settings = MagicMock()
+    settings.prefix = "oduflow"
+    return settings
+
+
+def _team(tmp_path) -> MagicMock:
+    team = MagicMock()
+    team.team_id = "1"
+    team.data_dir = str(tmp_path / "team")
+    team.workspaces_dir = str(tmp_path / "workspaces")
+    return team
+
+
+def _client(labels: dict[str, str]) -> MagicMock:
+    container = MagicMock()
+    container.labels = labels
+    client = MagicMock()
+    client.containers.get.return_value = container
+    return client
+
+
+def _recorded_runner(path, label, *_args):
+    return [f"ran:{label}:{path}"]
+
+
+def test_managed_checkout_uses_canonical_project_path(tmp_path):
+    settings = _settings()
+    team = _team(tmp_path)
+    client = _client({})
+    managed_repo = tmp_path / "workspaces" / "main" / "repo"
+    canonical = managed_repo / ".oduflow" / "odoo_sanitize"
+    canonical.mkdir(parents=True)
+
+    with patch.object(
+        sanitizer, "_run_scripts_from_dir", side_effect=_recorded_runner
+    ) as run:
+        logs = sanitizer.sanitize_environment(client, settings, team, env_name="main")
+
+    assert [call.args[0] for call in run.call_args_list] == [
+        str(tmp_path / "team" / "odoo_sanitize"),
+        str(canonical),
+    ]
+    assert not any("moved to" in line for line in logs)
+
+
+def test_live_mount_uses_mounted_checkout_and_runs_legacy_first(tmp_path, caplog):
+    settings = _settings()
+    team = _team(tmp_path)
+    live_repo = tmp_path / "checkout"
+    legacy = live_repo / ".odoo_sanitize"
+    canonical = live_repo / ".oduflow" / "odoo_sanitize"
+    legacy.mkdir(parents=True)
+    canonical.mkdir(parents=True)
+    client = _client({"oduflow.local_path": str(live_repo)})
+
+    with (
+        caplog.at_level(logging.WARNING, logger="oduflow"),
+        patch.object(
+            sanitizer, "_run_scripts_from_dir", side_effect=_recorded_runner
+        ) as run,
+    ):
+        logs = sanitizer.sanitize_environment(client, settings, team, env_name="main")
+
+    assert [call.args[0] for call in run.call_args_list] == [
+        str(tmp_path / "team" / "odoo_sanitize"),
+        str(legacy),
+        str(canonical),
+    ]
+    assert [call.args[1] for call in run.call_args_list] == [
+        "system",
+        "repo-legacy",
+        "repo",
+    ]
+    assert any(".oduflow/odoo_sanitize" in line for line in logs)
+    assert ".oduflow/odoo_sanitize" in caplog.text
+
+
+def test_canonical_live_mount_path_does_not_warn(tmp_path, caplog):
+    settings = _settings()
+    team = _team(tmp_path)
+    live_repo = tmp_path / "checkout"
+    canonical = live_repo / ".oduflow" / "odoo_sanitize"
+    canonical.mkdir(parents=True)
+    client = _client({"oduflow.local_path": str(live_repo)})
+
+    with (
+        caplog.at_level(logging.WARNING, logger="oduflow"),
+        patch.object(sanitizer, "_run_scripts_from_dir", side_effect=_recorded_runner),
+    ):
+        logs = sanitizer.sanitize_environment(client, settings, team, env_name="main")
+
+    assert not any("moved to" in line for line in logs)
+    assert "moved to" not in caplog.text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from unittest.mock import patch
 
@@ -303,6 +304,7 @@ class TestListEnvironmentsTool:
                 "env_name": "local",
                 "status": "running",
                 "url": "http://localhost:50000",
+                "repo_url": "/Users/dev/addons",
                 "local_path": "/Users/dev/addons",
                 "containers": [],
             }
@@ -311,6 +313,7 @@ class TestListEnvironmentsTool:
         result = _call_tool("list_environments")
 
         assert "Live-mount: /Users/dev/addons" in result
+        assert "Repo:" not in result
 
 
 class TestAgentInstructionsTool:
@@ -362,6 +365,29 @@ class TestInfoTool:
         assert "All containers running" in result
         assert "Database: oduflow_1_main" in result
         assert "DB (shared)" in result
+
+    @patch("oduflow.docker_ops.env_ops.get_environment_info")
+    def test_info_shows_live_mount(self, mock_info):
+        mock_info.return_value = {
+            "env_name": "main",
+            "db_name": "oduflow_1_main",
+            "workspace": "/srv/oduflow/instance_1/workspaces/main",
+            "all_running": True,
+            "repo_url": "/Users/dev/addons",
+            "local_path": "/Users/dev/addons",
+            "odoo_image": "odoo:17.0",
+            "template_name": "default",
+            "extra_addons": {},
+            "git_user": "",
+            "odoo": {"status": "running", "running": True},
+            "db": {"status": "running", "running": True},
+        }
+
+        result = _call_tool("get_environment_info", env_name="main")
+
+        assert "Code delivery: live-mount" in result
+        assert "Live-mount: /Users/dev/addons" in result
+        assert "Repo:" not in result
 
 
 class TestErrorHandling:
@@ -969,6 +995,28 @@ class TestRestoreServiceTool:
 
 
 class TestHttpFailClosed:
+    def test_live_mount_security_warning_when_enabled(self, caplog):
+        from oduflow import server
+
+        settings = Settings(allow_local_path=True)
+
+        with caplog.at_level(logging.WARNING, logger="oduflow"):
+            server._warn_local_path_security(settings)
+
+        assert "local_path live-mount mode is ENABLED" in caplog.text
+        assert "read/write access" in caplog.text
+        assert "allow_local_path = false" in caplog.text
+
+    def test_live_mount_security_warning_skipped_when_disabled(self, caplog):
+        from oduflow import server
+
+        settings = Settings(allow_local_path=False)
+
+        with caplog.at_level(logging.WARNING, logger="oduflow"):
+            server._warn_local_path_security(settings)
+
+        assert "local_path live-mount mode is ENABLED" not in caplog.text
+
     def test_start_http_refuses_without_auth(self):
         # Issue #37: HTTP transport must not serve /mcp unauthenticated.
         from oduflow import server

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -47,3 +47,11 @@ def test_chat_assets_share_one_positive_integer_cache_version(tmp_path):
         assert versioned.headers["content-type"].startswith("application/javascript")
         assert versioned.headers["cache-control"] == "public, max-age=86400"
         assert versioned.content == unversioned.content
+
+
+def test_environment_metadata_shows_live_mount_path(tmp_path):
+    client = _client(tmp_path)
+    dashboard = client.get("/")
+
+    assert dashboard.status_code == 200
+    assert "env.local_path ? '<span>Live-mount:" in dashboard.text


### PR DESCRIPTION
Project sanitization scripts now live under `.oduflow/odoo_sanitize` and resolve against the environment's active checkout — for live-mount environments the path is taken from the `oduflow.local_path` label instead of the empty managed-clone location, fixing per-project scripts that previously never ran; repos still using the old `.odoo_sanitize/` folder keep working with a one-time migration warning. `get_environment_info`, `list_environments`, and the dashboard now surface the live-mount source path and hide the redundant `Repo:` line. Every server start with `allow_local_path=true` emits a security warning that the trusted single-user mode should be disabled on hosted/multi-user deployments. Docs and decision records 0013/0021 are updated to match, and new/updated tests cover path resolution, the info/list output, and the warning.