### PR TITLE
Upgrade the owning module when .po translations change

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -283,6 +283,7 @@ After `git pull --rebase`, Oduflow compares `HEAD` before and after, then classi
 | `*.py` with `fields.*` changes | Field definitions added/removed/modified | **Upgrade** the module |
 | `*.py` (no field changes) | Business logic change | **Restart** the container |
 | `security/*.xml` | Access control or record rules | **Upgrade** the module |
+| `i18n/*.po` | Translation terms, loaded into the database on upgrade | **Upgrade** the module |
 | `*.xml` (not in security/) | Views, actions, data | **Refresh** (hot-reloaded via `--dev=xml`) |
 | `*.js` | Frontend assets | **Refresh** (hot-reloaded via `--dev=xml`) |
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1278,6 +1278,7 @@ After `git pull --rebase`, Oduflow compares `HEAD` before and after, then classi
 | `*.py` with `fields.*` changes | Field definitions added/removed/modified | **Upgrade** the module |
 | `*.py` (no field changes) | Business logic change | **Restart** the container |
 | `security/*.xml` | Access control or record rules | **Upgrade** the module |
+| `i18n/*.po` | Translation terms, loaded into the database on upgrade | **Upgrade** the module |
 | `*.xml` (not in security/) | Views, actions, data | **Refresh** (hot-reloaded via `--dev=xml`) |
 | `*.js` | Frontend assets | **Refresh** (hot-reloaded via `--dev=xml`) |
 

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -167,6 +167,16 @@ def _is_dep_file(file_path: str) -> bool:
     return file_path.replace(os.sep, "/") in DEP_FILE_PATHS
 
 
+def _is_translation_file(file_path: str) -> bool:
+    """Return True for a translation catalog Odoo loads into the database.
+
+    Only ``.po`` files count: Odoo loads them on module install/upgrade, so a
+    changed catalog needs an upgrade to reach the database. A ``.pot`` is the
+    translator template and is never loaded, so it is not upgrade-worthy.
+    """
+    return os.path.splitext(file_path)[1].lower() == ".po"
+
+
 def classify_changes(
     changed_files: list[str], repo_path: str, base_ref: str = "HEAD~1"
 ) -> dict[str, Any]:
@@ -184,6 +194,7 @@ def classify_changes(
                 "xml_security": [...],   # xml in security/
                 "manifest_upgrade": [...], # modules needing upgrade due to manifest
                 "js_changed": [...],
+                "i18n_changed": [...],   # .po catalogs (module upgrade)
                 "restart_required": [...],
                 "deps_changed": [...],   # dependency descriptors (requirements/apt)
             }
@@ -204,6 +215,7 @@ def classify_changes(
     xml_hot = []
     xml_security = []
     js_changed = []
+    i18n_changed: list[str] = []
     restart_required = []
     deps_changed: list[str] = []
     modules_to_upgrade: set[str] = set()
@@ -289,6 +301,13 @@ def classify_changes(
             _trace("  file=%s ext=.js module=%s -> hot-reload JS", f, module)
             continue
 
+        if _is_translation_file(f) and module:
+            i18n_changed.append(f)
+            if module not in modules_to_install:
+                modules_to_upgrade.add(module)
+            _trace("  file=%s ext=.po module=%s -> translations, UPGRADE", f, module)
+            continue
+
         _trace("  file=%s ext=%s module=%s -> ignored", f, ext, module)
 
     modules_to_upgrade -= modules_to_install
@@ -300,6 +319,7 @@ def classify_changes(
         "manifest_upgrade": sorted(modules_to_upgrade),
         "manifest_install": sorted(modules_to_install),
         "js_changed": js_changed,
+        "i18n_changed": i18n_changed,
         "restart_required": restart_required,
         "deps_changed": deps_changed,
     }
@@ -417,6 +437,7 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict[str,
     xml_hot: list[str] = []
     xml_security: list[str] = []
     js_changed: list[str] = []
+    i18n_changed: list[str] = []
     restart_required: list[str] = []
     deps_changed: list[str] = []
     modules_to_upgrade: set[str] = set()
@@ -446,6 +467,10 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict[str,
             continue
         if ext == ".js":
             js_changed.append(f)
+            continue
+        if _is_translation_file(f) and module:
+            i18n_changed.append(f)
+            modules_to_upgrade.add(module)
 
     details = {
         "py_changed": py_changed,
@@ -454,6 +479,7 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict[str,
         "manifest_upgrade": sorted(modules_to_upgrade),
         "manifest_install": [],
         "js_changed": js_changed,
+        "i18n_changed": i18n_changed,
         "restart_required": restart_required,
         "deps_changed": deps_changed,
     }
@@ -503,6 +529,7 @@ _DETAIL_LIST_KEYS = (
     "manifest_upgrade",
     "manifest_install",
     "js_changed",
+    "i18n_changed",
 )
 
 
@@ -573,9 +600,9 @@ def guardrail_warnings(
         )
     for m in sorted(rec_upgrade - requested):
         warnings.append(
-            f"Module '{m}' has data/schema changes (manifest, security/data XML, or a "
-            f"changed field) — consider upgrade='{m}' (-u); a restart won't load "
-            "them into the database."
+            f"Module '{m}' has data/schema changes (manifest, security/data XML, "
+            f"translations, or a changed field) — consider upgrade='{m}' (-u); a "
+            "restart won't load them into the database."
         )
     if recommended.get("action") == "restart" and not do_restart and not requested:
         warnings.append(

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -970,7 +970,7 @@ def get_agent_instructions(ctx: Context | None = None) -> str:
                 "Use the local live-mount workflow for these environments:\n"
                 "1. Edit files directly in the mounted local folder; no git push is required.\n"
                 "2. Call `pull_and_apply` after edits. Prefer explicit actions when you authored the changes.\n"
-                '3. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`.\n'
+                '3. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, `i18n/*.po` translations, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`.\n'
                 '4. If you add a new module, call `pull_and_apply(..., install="module")`.\n'
                 "5. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.\n"
                 "6. Git commits are optional in live-mount mode and are not used by Oduflow to detect applied changes.\n\n"

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -16,7 +16,7 @@ Before editing, identify how the environment receives code:
 - **`repo_url` mode:** Oduflow owns a managed clone. Edit locally, commit, push, then call `pull_and_apply` so Oduflow can pull the pushed commits.
 - **`local_path` live-mount mode:** Oduflow bind-mounts a local folder. Edit files directly in that folder; no push is required. Git commits are optional and are not used by Oduflow to decide what was applied.
 
-In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
+In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, `i18n/*.po` translations, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
 
 ---
 
@@ -314,7 +314,7 @@ When Oduflow runs on the same machine as the code, skip the GitHub round-trip en
 Notes:
 - `local_path` is controlled by `[server].allow_local_path` (default: `true`). Set it to `false` to disable live-mounts.
 - Live-mount change detection is snapshot-based and independent of Git. Oduflow records which local file state was last successfully applied and compares later calls against that snapshot.
-- In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
+- In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, `i18n/*.po` translations, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
 - Git is optional in live-mount mode. Commit whenever you want for your own workflow; Oduflow does not require commits, create commits, or read Git state to apply local changes.
 - With `repo_url` mode, use the normal remote workflow: edit locally, commit, push, then call `pull_and_apply` so the managed clone can pull the pushed commits.
 

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -9,6 +9,7 @@ from oduflow.git_analysis import (
     _is_security_path,
     _is_data_path,
     _is_dep_file,
+    _is_translation_file,
     _extract_field_lines,
     _extract_view_tag_attrs,
 )
@@ -67,6 +68,21 @@ class TestIsDepFile:
     def test_root_apt_packages_is_not_a_dep_file(self):
         # apt_packages.txt is only read from .oduflow/, never the repo root.
         assert _is_dep_file("apt_packages.txt") is False
+
+
+class TestIsTranslationFile:
+    def test_po_catalog(self):
+        assert _is_translation_file("sale/i18n/ru.po") is True
+
+    def test_uppercase_extension(self):
+        assert _is_translation_file("sale/i18n/RU.PO") is True
+
+    def test_pot_template_is_not_loaded(self):
+        # .pot is the translator template; Odoo never loads it into the DB.
+        assert _is_translation_file("sale/i18n/sale.pot") is False
+
+    def test_other_file(self):
+        assert _is_translation_file("sale/views/sale_order.xml") is False
 
 
 class TestClassifyChanges:
@@ -177,6 +193,52 @@ class TestClassifyChanges:
         result = classify_changes(files, "/tmp")
         assert result["action"] == "upgrade"
         assert "connect_elevenlabs" in result["modules_to_upgrade"]
+
+    def test_po_triggers_upgrade(self):
+        # Translations only reach the database through a module upgrade.
+        files = ["sale/i18n/ru.po"]
+        result = classify_changes(files, "/tmp")
+        assert result["action"] == "upgrade"
+        assert result["modules_to_upgrade"] == ["sale"]
+        assert result["details"]["i18n_changed"] == ["sale/i18n/ru.po"]
+
+    def test_po_beats_hot_reload_xml(self):
+        files = ["sale/views/sale_order.xml", "sale/i18n/ru.po"]
+        result = classify_changes(files, "/tmp")
+        assert result["action"] == "upgrade"
+        assert result["modules_to_upgrade"] == ["sale"]
+        assert result["details"]["xml_hot"] == ["sale/views/sale_order.xml"]
+
+    def test_pot_only_stays_refresh(self):
+        files = ["sale/views/sale_order.xml", "sale/i18n/sale.pot"]
+        result = classify_changes(files, "/tmp")
+        assert result["action"] == "refresh"
+        assert result["modules_to_upgrade"] == []
+        assert result["details"]["i18n_changed"] == []
+
+    def test_po_in_new_module_stays_install(self, tmp_path):
+        module_dir = tmp_path / "addons_veles" / "customer_code"
+        (module_dir / "i18n").mkdir(parents=True)
+        (module_dir / "__manifest__.py").write_text(
+            "{'name': 'Customer Code', 'version': '17.0.1.0.0', 'data': []}"
+        )
+        (module_dir / "i18n" / "ru.po").write_text('msgid ""\nmsgstr ""\n')
+
+        import subprocess
+        from unittest.mock import patch
+
+        def mock_subprocess_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(128, cmd)
+
+        with patch("subprocess.run", side_effect=mock_subprocess_run):
+            files = [
+                "addons_veles/customer_code/__manifest__.py",
+                "addons_veles/customer_code/i18n/ru.po",
+            ]
+            result = classify_changes(files, str(tmp_path))
+            assert result["action"] == "install"
+            assert result["modules_to_install"] == ["customer_code"]
+            assert result["modules_to_upgrade"] == []
 
     def test_js_only(self):
         files = ["web/static/src/js/app.js"]
@@ -639,6 +701,18 @@ class TestShallowClassify:
     def test_only_xml_still_refresh(self):
         result = shallow_classify(["sale/views/sale_order.xml"], "/tmp")
         assert result["action"] == "refresh"
+
+    def test_po_triggers_upgrade(self):
+        result = shallow_classify(["sale/i18n/ru.po"], "/tmp")
+        assert result["action"] == "upgrade"
+        assert result["modules_to_upgrade"] == ["sale"]
+        assert result["details"]["i18n_changed"] == ["sale/i18n/ru.po"]
+
+    def test_pot_only_stays_refresh(self):
+        files = ["sale/views/sale_order.xml", "sale/i18n/sale.pot"]
+        result = shallow_classify(files, "/tmp")
+        assert result["action"] == "refresh"
+        assert result["modules_to_upgrade"] == []
 
 
 class TestMergeRecommendations:


### PR DESCRIPTION
## Problem

Translation catalogs only reach the database through a module install or upgrade. But `classify_changes` / `shallow_classify` dropped `.po` files into the "ignored" branch, so a pull that only touched translations was classified as `refresh` (or `restart` if Python also changed) and the new terms never landed in the DB.

## Change

- `.po` inside a module → **upgrade** of the owning module (module resolved by the existing walk-up to the nearest `__manifest__.py`), recorded in the new `details["i18n_changed"]` list.
- Same rule in `shallow_classify` (live-mount, path-only), and `i18n_changed` added to `_DETAIL_LIST_KEYS` so it merges across the main repo and extra-addon worktrees.
- `.pot` stays ignored — it is the translator template and Odoo never loads it, so it is not upgrade-worthy on its own.
- A `.po` in a module that is new in the same push keeps the stronger `install` action (no duplicate in `modules_to_upgrade`).
- Guardrail hint and the live-mount agent instructions now mention `i18n/*.po` among the things that need `upgrade=`.
- Docs: new `i18n/*.po` row in the Smart Pull table (`docs/environments.md`, `docs/llms-full.txt`).

## Tests

9 new cases in `tests/test_git_analysis.py` (`_is_translation_file`, `.po` → upgrade in both classifiers, `.po` beating hot-reload XML, `.pot`-only staying `refresh`, `.po` in a new module staying `install`).

`pytest -m "not integration and not heavyweight"` → 1249 passed. `mypy src/oduflow` clean.
