### PR TITLE
Extend mutation testing coverage and fix a malformed-JSON crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ uv.lock
 run.sh
 oduflow_data_*/
 .vscode/
+
+# mutmut mutation testing workspace + result cache
+mutants/
+.mutmut-cache

--- a/None
+++ b/None
@@ -1,0 +1,2 @@
+https://ghp_TOKENONLY:@github.com
+https://alice:secret@git.example.com

--- a/None
+++ b/None
@@ -1,3 +1,0 @@
-https://alice:ghp_SECRET123@github.com
-https://ghp_TOKENONLY:@github.com
-https://alice:secret@git.example.com

--- a/None
+++ b/None
@@ -1,2 +1,3 @@
+https://alice:ghp_SECRET123@github.com
 https://ghp_TOKENONLY:@github.com
 https://alice:secret@git.example.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,31 @@ ignore_missing_imports = true
 # `import docker` resolve to site-packages.
 namespace_packages = false
 
+# Mutation testing (`mutmut run`). Scoped to the pure-logic modules: the Docker
+# orchestration layer (server.py, web_ui.py, docker_ops/) is exercised through
+# mocks in the unit suite, so mutants there mostly time out or survive without
+# telling us anything about test quality.
+[tool.mutmut]
+source_paths = ["src/oduflow"]
+only_mutate = [
+    "src/oduflow/naming.py",
+    "src/oduflow/git_analysis.py",
+    "src/oduflow/port_registry.py",
+    "src/oduflow/prod_tune.py",
+    "src/oduflow/pg_tune.py",
+    "src/oduflow/sanitizer.py",
+    "src/oduflow/quotas.py",
+    "src/oduflow/health.py",
+    "src/oduflow/settings.py",
+]
+pytest_add_cli_args_test_selection = ["tests/"]
+# Docker-backed tests can't run against the mutant tree, and `heavyweight` is
+# already excluded by the pytest addopts.
+pytest_add_cli_args = ["-m", "not integration and not heavyweight"]
+# mutmut copies only *.py into mutants/; these paths carry package data and repo
+# files that tests read (bundled oduflow.toml, dashboard assets, coder Dockerfile).
+also_copy = ["src/oduflow/templates", "docker"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,27 @@ only_mutate = [
     "src/oduflow/webhooks.py",
     "src/oduflow/s3_client.py",
     "src/oduflow/reaper.py",
+    "src/oduflow/chunkstore/chunker.py",
+    "src/oduflow/chunkstore/format.py",
+    "src/oduflow/chunkstore/storage.py",
+    "src/oduflow/chunkstore/backup.py",
+    "src/oduflow/chunkstore/restore.py",
+    "src/oduflow/chunkstore/prune.py",
+    "src/oduflow/oauth_provider.py",
+    "src/oduflow/git_ops.py",
+    "src/oduflow/locking.py",
+    "src/oduflow/env_tokens.py",
+    "src/oduflow/output_cache.py",
+    "src/oduflow/mcp_log_filters.py",
+    "src/oduflow/telemetry.py",
+    "src/oduflow/url_safety.py",
+    "src/oduflow/connect_tokens.py",
+    "src/oduflow/prereqs.py",
+    "src/oduflow/agent_config.py",
+    "src/oduflow/errors.py",
+    # Deliberately NOT mutated: systemd.py has no tests (so every mutant would
+    # be an uninformative "no tests") and its code writes to
+    # /etc/systemd/system and shells out to `systemctl stop/disable`.
 ]
 pytest_add_cli_args_test_selection = ["tests/"]
 # Docker-backed tests can't run against the mutant tree, and `heavyweight` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,18 @@ only_mutate = [
     "src/oduflow/quotas.py",
     "src/oduflow/health.py",
     "src/oduflow/settings.py",
+    "src/oduflow/production_registry.py",
+    "src/oduflow/env_credentials.py",
+    "src/oduflow/import_tokens.py",
+    "src/oduflow/licensing.py",
+    "src/oduflow/scoped_access.py",
+    "src/oduflow/agent_sessions.py",
+    "src/oduflow/oauth_token_store.py",
+    "src/oduflow/activity.py",
+    "src/oduflow/migrations.py",
+    "src/oduflow/webhooks.py",
+    "src/oduflow/s3_client.py",
+    "src/oduflow/reaper.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/"]
 # Docker-backed tests can't run against the mutant tree, and `heavyweight` is

--- a/src/oduflow/activity.py
+++ b/src/oduflow/activity.py
@@ -92,6 +92,13 @@ def _load(path: str) -> dict[str, dict[str, Any]]:
     try:
         with open(path) as f:
             data = json.load(f)
+        if not isinstance(data, dict):
+            # Valid JSON but the wrong shape (a truncated write leaving `null`,
+            # a hand-edit). Without this guard `.items()` raises AttributeError
+            # out of the caller — and activity tracking must never break the
+            # operation it rides on.
+            logger.warning("Ignoring malformed activity file %s", path)
+            return {}
         return {k: dict(v) for k, v in data.items() if isinstance(v, dict)}
     except (json.JSONDecodeError, ValueError, OSError) as e:
         logger.warning("Could not load activity file %s: %s", path, e)

--- a/src/oduflow/port_registry.py
+++ b/src/oduflow/port_registry.py
@@ -49,6 +49,11 @@ def _load_registry(registry_path: str) -> dict[str, int]:
     try:
         with open(registry_path) as f:
             data = json.load(f)
+        if not isinstance(data, dict):
+            # Valid JSON of the wrong shape (a truncated write leaving `null`,
+            # a hand-edit) would raise AttributeError past the handlers below.
+            logger.warning("Ignoring malformed port registry %s", registry_path)
+            return {}
         return {k: int(v) for k, v in data.items()}
     except (json.JSONDecodeError, ValueError, OSError) as e:
         logger.warning("Could not load port registry %s: %s", registry_path, e)

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,179 @@
+"""Per-environment activity records that drive the reaper.
+
+The module had no test file: it is exercised incidentally by other suites but
+nothing asserted its behaviour. What matters here is that the timestamps the
+reaper compares are correct — a naive timestamp read as host-local time
+shifts every auto-stop/auto-delete decision by the UTC offset — and that
+``mark_stopped`` does not restart the delete clock on a re-mark.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from oduflow import activity
+from oduflow.settings import TeamSettings
+
+
+def _team(tmp_path) -> TeamSettings:
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _read(tmp_path) -> dict:
+    with open(tmp_path / "activity.json") as f:
+        return json.load(f)
+
+
+class TestParseTs:
+    def test_round_trips_an_aware_timestamp(self):
+        moment = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+
+        assert activity.parse_ts(moment.isoformat()) == moment.timestamp()
+
+    def test_a_naive_timestamp_is_read_as_utc(self):
+        # Reading it as host-local time would move every reaper deadline by
+        # the machine's UTC offset.
+        naive = "2026-03-01T12:00:00"
+        expected = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc).timestamp()
+
+        assert activity.parse_ts(naive) == expected
+
+    def test_a_non_utc_offset_is_honoured(self):
+        assert activity.parse_ts("2026-03-01T14:00:00+02:00") == (
+            datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc).timestamp()
+        )
+
+    def test_missing_or_unparsable_values_yield_none(self):
+        assert activity.parse_ts(None) is None
+        assert activity.parse_ts("") is None
+        assert activity.parse_ts("last tuesday") is None
+
+
+class TestRecords:
+    def test_touch_creates_a_record(self, tmp_path):
+        activity.touch(_team(tmp_path), "main")
+
+        assert "last_activity" in _read(tmp_path)["main"]
+
+    def test_get_all_returns_what_was_written(self, tmp_path):
+        team = _team(tmp_path)
+        activity.touch(team, "main")
+
+        assert set(activity.get_all(team)) == {"main"}
+
+    def test_mark_stopped_records_when_and_how(self, tmp_path):
+        activity.mark_stopped(_team(tmp_path), "main", by="auto")
+
+        rec = _read(tmp_path)["main"]
+        assert rec["stopped_by"] == "auto"
+        assert activity.parse_ts(rec["stopped_at"]) is not None
+
+    def test_re_marking_keeps_the_original_stop_time(self, tmp_path):
+        # Otherwise every sweep would push the auto-delete deadline forward
+        # and a stopped environment would never be reaped.
+        team = _team(tmp_path)
+        activity.mark_stopped(team, "main", by="observed")
+        first = _read(tmp_path)["main"]["stopped_at"]
+
+        activity.mark_stopped(team, "main", by="auto")
+
+        rec = _read(tmp_path)["main"]
+        assert rec["stopped_at"] == first
+        assert rec["stopped_by"] == "auto"  # attribution still upgrades
+
+    def test_mark_started_clears_the_stop_clock(self, tmp_path):
+        team = _team(tmp_path)
+        activity.mark_stopped(team, "main")
+
+        activity.mark_started(team, "main")
+
+        rec = _read(tmp_path)["main"]
+        assert "stopped_at" not in rec
+        assert "stopped_by" not in rec
+        assert "last_activity" in rec
+
+    def test_remove_drops_only_the_named_environment(self, tmp_path):
+        team = _team(tmp_path)
+        activity.touch(team, "main")
+        activity.touch(team, "other")
+
+        activity.remove(team, "main")
+
+        assert set(_read(tmp_path)) == {"other"}
+
+    def test_prune_drops_records_of_vanished_environments(self, tmp_path):
+        team = _team(tmp_path)
+        activity.touch(team, "main")
+        activity.touch(team, "gone")
+
+        activity.prune(team, {"main"})
+
+        assert set(_read(tmp_path)) == {"main"}
+
+    def test_prune_keeps_everything_that_still_exists(self, tmp_path):
+        team = _team(tmp_path)
+        activity.touch(team, "main")
+
+        activity.prune(team, {"main", "not-yet-recorded"})
+
+        assert set(_read(tmp_path)) == {"main"}
+
+
+class TestResilience:
+    def test_a_team_without_a_data_dir_is_a_no_op(self):
+        team = TeamSettings(team_id="1", data_dir="")
+
+        activity.touch(team, "main")  # must not raise
+
+        assert activity.get_all(team) == {}
+
+    def test_a_corrupt_file_reads_as_empty(self, tmp_path):
+        (tmp_path / "activity.json").write_text("{not json")
+
+        assert activity.get_all(_team(tmp_path)) == {}
+
+    def test_a_corrupt_file_is_overwritten_by_the_next_write(self, tmp_path):
+        team = _team(tmp_path)
+        (tmp_path / "activity.json").write_text("{not json")
+
+        activity.touch(team, "main")
+
+        assert set(_read(tmp_path)) == {"main"}
+
+    @pytest.mark.parametrize("doc", ["null", "[1, 2]", '"a string"', "42"])
+    def test_a_json_document_of_the_wrong_shape_reads_as_empty(self, tmp_path, doc):
+        # A truncated write can leave a valid-JSON `null` behind. Activity
+        # tracking rides on stop/start/delete, so it must degrade instead of
+        # raising an AttributeError out of the operation.
+        (tmp_path / "activity.json").write_text(doc)
+
+        assert activity.get_all(_team(tmp_path)) == {}
+
+    def test_a_wrong_shaped_file_does_not_break_a_write(self, tmp_path):
+        team = _team(tmp_path)
+        (tmp_path / "activity.json").write_text("null")
+
+        activity.mark_stopped(team, "main")  # must not raise
+
+        assert set(_read(tmp_path)) == {"main"}
+
+    def test_non_dict_entries_are_dropped_on_load(self, tmp_path):
+        (tmp_path / "activity.json").write_text(
+            json.dumps({"main": {"last_activity": "x"}, "junk": "not-a-dict"})
+        )
+
+        assert set(activity.get_all(_team(tmp_path))) == {"main"}
+
+
+class TestTimestampsAreUsable:
+    def test_a_written_timestamp_parses_back_to_roughly_now(self, tmp_path):
+        team = _team(tmp_path)
+        activity.touch(team, "main")
+
+        written = activity.parse_ts(_read(tmp_path)["main"]["last_activity"])
+        now = datetime.now(timezone.utc).timestamp()
+
+        assert abs(now - written) < timedelta(minutes=1).total_seconds()

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -311,3 +311,43 @@ def test_delete_environment_clears_chat_sessions(tmp_path, monkeypatch):
     assert agent_sessions.get_session(team, "feature/x", "claude") is None
     assert agent_sessions.get_session(team, "feature/x", "codex") is None
     assert agent_sessions.get_session(team, "other", "claude") == "keep-me"
+
+
+def _normalize_history(entries):
+    state = agent_sessions._normalize({"current": None, "history": entries})
+    return [e["session_id"] for e in (state or {}).get("history", [])]
+
+
+def test_history_entries_must_be_dicts_with_a_session_id():
+    # Both halves of the guard matter: a bare string entry has no .get, and a
+    # dict without session_id would land in history as a KeyError waiting to
+    # happen.
+    assert _normalize_history(
+        [
+            {"session_id": "keep"},
+            "a bare string",
+            {"title": "no id"},
+            {"session_id": ""},
+            None,
+            {"session_id": "keep2"},
+        ]
+    ) == ["keep", "keep2"]
+
+
+def test_duplicate_session_ids_are_collapsed():
+    assert _normalize_history(
+        [{"session_id": "a"}, {"session_id": "a"}, {"session_id": "b"}]
+    ) == ["a", "b"]
+
+
+def test_a_non_list_history_yields_no_entries():
+    assert _normalize_history("not a list") == []
+
+
+def test_a_non_dict_non_str_value_normalizes_to_nothing():
+    assert agent_sessions._normalize(42) is None
+    assert agent_sessions._normalize(None) is None
+
+
+def test_an_empty_legacy_string_normalizes_to_nothing():
+    assert agent_sessions._normalize("") is None

--- a/tests/test_chunkstore.py
+++ b/tests/test_chunkstore.py
@@ -3,6 +3,7 @@
 import datetime
 import os
 import random
+from unittest.mock import patch
 
 import pytest
 
@@ -502,3 +503,646 @@ class TestCountingStorage:
         storage = self._counting(tmp_path)
 
         assert storage.exists("absent") is False
+
+
+class TestChunkerParameters:
+    """Constructor validation and the size invariants it protects.
+
+    Every emitted chunk must be >= min_size (except the last of a stream) and
+    <= max_size: a chunker that can emit a 0-byte or oversized chunk breaks
+    both dedup and the restore-side buffer bound.
+    """
+
+    def test_min_size_must_be_positive(self):
+        with pytest.raises(ValueError, match="min_size"):
+            Chunker(b"seed", min_size=0, avg_size=4096, max_size=16384)
+
+    def test_min_size_of_one_is_accepted(self):
+        # The bound is `0 < min_size`, not `1 < min_size`.
+        Chunker(b"seed", min_size=1, avg_size=4096, max_size=16384)
+
+    def test_min_size_may_equal_avg_size(self):
+        Chunker(b"seed", min_size=4096, avg_size=4096, max_size=16384)
+
+    def test_avg_size_may_equal_max_size(self):
+        Chunker(b"seed", min_size=1024, avg_size=4096, max_size=4096)
+
+    def test_min_size_above_avg_size_is_rejected(self):
+        with pytest.raises(ValueError):
+            Chunker(b"seed", min_size=8192, avg_size=4096, max_size=16384)
+
+    def test_avg_size_above_max_size_is_rejected(self):
+        with pytest.raises(ValueError):
+            Chunker(b"seed", min_size=1024, avg_size=16384, max_size=4096)
+
+    @pytest.mark.parametrize("avg", [3000, 4095, 5000, 6144])
+    def test_non_power_of_two_avg_is_rejected(self, avg):
+        with pytest.raises(ValueError, match="power of two"):
+            Chunker(b"seed", min_size=1024, avg_size=avg, max_size=65536)
+
+    @pytest.mark.parametrize("avg", [1, 2, 1024, 4096])
+    def test_powers_of_two_are_accepted(self, avg):
+        Chunker(b"seed", min_size=1, avg_size=avg, max_size=65536)
+
+    def test_the_boundary_mask_is_avg_size_minus_one(self):
+        # A wrong mask changes the average chunk size, silently degrading the
+        # dedup ratio without any test failing.
+        assert Chunker(b"seed", min_size=1024, avg_size=4096, max_size=16384)._mask == (
+            4095
+        )
+
+    def test_no_chunk_is_smaller_than_min_size_except_the_last(self):
+        data = random.Random(7).randbytes(300_000)
+        chunks = _chunk_all(Chunker(b"seed", **SMALL), data)
+
+        assert all(len(c) >= SMALL["min_size"] for c in chunks[:-1])
+        assert chunks[-1]
+
+    def test_no_chunk_exceeds_max_size(self):
+        # Incompressible random data rarely hits a boundary naturally, so the
+        # forced cut at max_size is what bounds it.
+        data = random.Random(8).randbytes(300_000)
+        chunks = _chunk_all(Chunker(b"seed", **SMALL), data)
+
+        assert max(len(c) for c in chunks) <= SMALL["max_size"]
+
+    def test_uniform_input_stays_within_the_size_bounds(self):
+        # All-zero input gives the rolling hash nothing to vary, so the cut
+        # position is whatever the fixed window hash dictates — but it must
+        # still respect both bounds and lose no bytes.
+        chunks = _chunk_all(Chunker(b"seed", **SMALL), b"\x00" * 100_000)
+
+        assert all(SMALL["min_size"] <= len(c) <= SMALL["max_size"] for c in chunks[:-1])
+        assert sum(len(c) for c in chunks) == 100_000
+        assert b"".join(chunks) == b"\x00" * 100_000
+
+    def test_the_stream_is_reassembled_exactly(self):
+        data = random.Random(9).randbytes(250_000)
+        chunks = _chunk_all(Chunker(b"seed", **SMALL), data)
+
+        assert b"".join(chunks) == data
+
+    def test_an_empty_stream_emits_no_chunk(self):
+        assert _chunk_all(Chunker(b"seed", **SMALL), b"") == []
+
+    def test_input_shorter_than_min_size_is_one_chunk(self):
+        chunks = _chunk_all(Chunker(b"seed", **SMALL), b"x" * 100)
+
+        assert chunks == [b"x" * 100]
+
+    def test_flush_cuts_the_stream_at_the_call_site(self):
+        # Callers rely on this to reuse an unchanged file's chunks verbatim.
+        chunker = Chunker(b"seed", **SMALL)
+        first = list(chunker.update(b"a" * 500)) + list(chunker.flush())
+        second = list(chunker.update(b"b" * 500)) + list(chunker.flush())
+
+        assert first == [b"a" * 500]
+        assert second == [b"b" * 500]
+
+
+class TestDeriveTable:
+    def test_yields_exactly_256_entries(self):
+        # One entry per byte value; 255 or 257 would index out of range or
+        # leave a byte unmapped.
+        assert len(derive_table(b"seed")) == 256
+
+    def test_every_entry_is_a_64_bit_value(self):
+        assert all(0 <= v < 2**64 for v in derive_table(b"seed"))
+
+    def test_entries_are_distinct(self):
+        # A repeated entry would make two byte values interchangeable to the
+        # rolling hash, weakening the boundary distribution.
+        assert len(set(derive_table(b"seed"))) == 256
+
+    def test_different_seeds_give_unrelated_tables(self):
+        a, b = derive_table(b"seed-a"), derive_table(b"seed-b")
+
+        assert a != b
+        assert len(set(a) & set(b)) == 0
+
+    def test_the_same_seed_always_gives_the_same_table(self):
+        assert derive_table(b"seed") == derive_table(b"seed")
+
+    def test_the_first_entry_comes_from_counter_zero(self):
+        # Pins the counter start and the 8-byte little-endian slicing: any
+        # drift here silently re-chunks every existing storage.
+        import hashlib
+
+        block = hashlib.blake2b(
+            (0).to_bytes(8, "little"), key=b"seed", digest_size=64
+        ).digest()
+
+        table = derive_table(b"seed")
+        assert table[0] == int.from_bytes(block[0:8], "little")
+        assert table[7] == int.from_bytes(block[56:64], "little")
+
+    def test_the_ninth_entry_comes_from_counter_one(self):
+        import hashlib
+
+        block = hashlib.blake2b(
+            (1).to_bytes(8, "little"), key=b"seed", digest_size=64
+        ).digest()
+
+        assert derive_table(b"seed")[8] == int.from_bytes(block[0:8], "little")
+
+
+class TestChunkContainer:
+    def test_the_header_is_magic_version_flags(self):
+        blob = encode_chunk(b"payload")
+
+        assert blob[:4] == b"ODCK"
+        assert blob[4] == 1
+
+    def test_compressible_data_sets_the_zstd_flag(self):
+        blob = encode_chunk(b"a" * 10_000)
+
+        assert blob[5] & 0x01
+        assert len(blob) < 10_000
+
+    def test_incompressible_data_is_stored_raw(self):
+        data = random.Random(3).randbytes(2048)
+        blob = encode_chunk(data)
+
+        assert blob[5] == 0
+        assert blob[6:] == data
+
+    def test_a_truncated_blob_is_corrupt(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+
+        for length in (0, 3, 5):
+            with pytest.raises(ChunkCorruptedError, match="magic"):
+                decode_chunk(b"ODCK12"[:length], config, "deadbeef")
+
+    def test_a_six_byte_header_is_long_enough(self, tmp_path):
+        # The check is `len < 6`; a header-only chunk of an empty payload is
+        # valid and must fail on the hash, not the length.
+        config = ensure_config(LocalStorage(str(tmp_path)))
+        blob = encode_chunk(b"")
+
+        assert len(blob) == 6
+        assert decode_chunk(blob, config, config.chunk_hash(b"")) == b""
+
+    def test_wrong_magic_is_corrupt(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+        blob = b"XXXX" + encode_chunk(b"payload")[4:]
+
+        with pytest.raises(ChunkCorruptedError, match="magic"):
+            decode_chunk(blob, config, "deadbeef")
+
+    def test_an_unknown_version_is_refused(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+        blob = bytearray(encode_chunk(b"payload"))
+        blob[4] = 99
+
+        with pytest.raises(ChunkCorruptedError, match="version"):
+            decode_chunk(bytes(blob), config, "deadbeef")
+
+    def test_the_reserved_encryption_flag_is_refused(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+        blob = bytearray(encode_chunk(b"payload"))
+        blob[5] |= 0x02
+
+        with pytest.raises(ChunkCorruptedError, match="encrypted"):
+            decode_chunk(bytes(blob), config, "deadbeef")
+
+    def test_a_damaged_zstd_payload_is_corrupt(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+        blob = bytearray(encode_chunk(b"a" * 10_000))
+        blob[10] ^= 0xFF
+
+        with pytest.raises(ChunkCorruptedError):
+            decode_chunk(bytes(blob), config, config.chunk_hash(b"a" * 10_000))
+
+
+class TestContentAddressing:
+    def test_the_hash_is_keyed_by_the_storage(self, tmp_path):
+        # Two storages must not produce the same chunk hash for the same
+        # bytes, or a listing would confirm known plaintext.
+        one = ensure_config(LocalStorage(str(tmp_path / "a")))
+        two = ensure_config(LocalStorage(str(tmp_path / "b")))
+
+        assert one.chunk_hash(b"payload") != two.chunk_hash(b"payload")
+
+    def test_the_id_is_derived_from_the_hash_not_the_content(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+        digest = config.chunk_hash(b"payload")
+
+        assert config.chunk_id(digest) != digest
+        assert config.chunk_id(digest) == config.chunk_id(digest)
+
+    def test_keys_are_32_bytes(self, tmp_path):
+        config = ensure_config(LocalStorage(str(tmp_path)))
+
+        assert len(config.seed) == 32
+        assert len(config.hash_key) == 32
+        assert len(config.id_key) == 32
+
+    def test_a_new_storage_gets_fresh_keys(self, tmp_path):
+        one = ensure_config(LocalStorage(str(tmp_path / "a")))
+        two = ensure_config(LocalStorage(str(tmp_path / "b")))
+
+        assert one.seed != two.seed
+        assert one.hash_key != two.hash_key
+        assert one.id_key != two.id_key
+
+    def test_the_config_survives_a_reload(self, tmp_path):
+        storage = LocalStorage(str(tmp_path))
+        first = ensure_config(storage)
+
+        assert ensure_config(storage) == first
+
+
+class TestRetentionBoundaries:
+    """Retention decides what is deleted forever, so the age comparison and
+    the bucket arithmetic both need pinning."""
+
+    _NOW = datetime.datetime(2026, 7, 10, tzinfo=datetime.timezone.utc)
+
+    def _rev(self, revision: int, days: float):
+        return (revision, self._NOW - datetime.timedelta(days=days))
+
+    def test_a_revision_exactly_at_the_age_is_still_recent(self):
+        # The rule fires on `age_days > age`, so a 7-day-old revision under a
+        # 1:7 policy is kept unconditionally rather than thinned.
+        revs = [self._rev(1, 7), self._rev(2, 7.5), self._rev(3, 0)]
+
+        kept = select_revisions_to_keep(revs, parse_keep(["1:7"]), self._NOW)
+
+        assert 1 in kept
+
+    def test_two_revisions_on_the_same_old_day_collapse_to_one(self):
+        # Both are 8 days old (past the 7-day age) and fall on the same
+        # calendar day, so the 1-day interval keeps exactly one.
+        revs = [self._rev(1, 8.5), self._rev(2, 8.9), self._rev(3, 0)]
+
+        kept = select_revisions_to_keep(revs, parse_keep(["1:7"]), self._NOW)
+
+        assert len(kept & {1, 2}) == 1
+        assert 3 in kept
+
+    def test_an_empty_revision_list_keeps_nothing(self):
+        assert select_revisions_to_keep([], parse_keep(["1:7"]), self._NOW) == set()
+
+    def test_without_any_rule_everything_is_kept(self):
+        revs = [self._rev(1, 900), self._rev(2, 0)]
+
+        assert select_revisions_to_keep(revs, [], self._NOW) == {1, 2}
+
+    def test_the_oldest_matching_rule_wins(self):
+        # 0:365 must beat 1:7 for a 400-day-old revision, dropping it rather
+        # than thinning it to one per day.
+        revs = [self._rev(1, 400), self._rev(2, 401), self._rev(3, 0)]
+
+        kept = select_revisions_to_keep(
+            revs, parse_keep(["1:7", "0:365"]), self._NOW
+        )
+
+        assert kept == {3}
+
+    def test_a_wider_interval_never_keeps_more_revisions(self):
+        # Buckets are absolute epoch windows, so the exact survivors depend on
+        # where the dates fall — but widening the interval can only thin more.
+        revs = [self._rev(i, 10 + i * 1.3) for i in range(12)]
+
+        counts = [
+            len(select_revisions_to_keep(revs, parse_keep([f"{i}:7"]), self._NOW))
+            for i in (1, 3, 7, 30)
+        ]
+
+        assert counts == sorted(counts, reverse=True)
+        assert counts[-1] < counts[0]
+
+    def test_thinning_only_touches_revisions_past_the_age(self):
+        # Six revisions in one recent day: none is older than 7 days, so the
+        # 1-day interval must not collapse them.
+        revs = [self._rev(i, 1 + i * 0.1) for i in range(6)]
+
+        kept = select_revisions_to_keep(revs, parse_keep(["1:7"]), self._NOW)
+
+        assert len(kept) == 6
+
+
+class TestParseIso:
+    def test_a_naive_timestamp_is_read_as_utc(self):
+        # Revision timestamps decide retention; reading a naive one as
+        # host-local time would shift every deadline by the UTC offset.
+        from oduflow.chunkstore.prune import _parse_iso
+
+        parsed = _parse_iso("2026-03-01T12:00:00")
+
+        assert parsed.tzinfo is datetime.timezone.utc
+        assert parsed.hour == 12
+
+    def test_an_explicit_offset_is_preserved(self):
+        from oduflow.chunkstore.prune import _parse_iso
+
+        parsed = _parse_iso("2026-03-01T14:00:00+02:00")
+
+        assert parsed.astimezone(datetime.timezone.utc).hour == 12
+
+
+class TestRestoreDetails:
+    def _restore_roundtrip(self, storage, tmp_path, spec):
+        src = tmp_path / "src"
+        _make_tree(str(src), spec)
+        chunkstore.backup(str(src), storage, "erp")
+        dst = tmp_path / "dst"
+        info = chunkstore.restore(storage, "erp", None, str(dst))
+        return src, dst, info
+
+    def test_the_byte_count_matches_the_tree(self, small_config_storage, tmp_path):
+        spec = {"a.bin": b"x" * 1000, "b.bin": b"y" * 2500}
+
+        _, _, info = self._restore_roundtrip(small_config_storage, tmp_path, spec)
+
+        assert info["bytes"] == 3500
+        assert info["files"] == 2
+
+    def test_an_empty_file_is_restored_without_reading_a_chunk(
+        self, small_config_storage, tmp_path
+    ):
+        # size == 0 must skip the chunk range entirely; a mutant reading
+        # chunk 0 would corrupt the file with foreign bytes.
+        _, dst, info = self._restore_roundtrip(
+            small_config_storage, tmp_path, {"empty.txt": b"", "other.bin": b"z" * 500}
+        )
+
+        assert (dst / "empty.txt").read_bytes() == b""
+        assert info["bytes"] == 500
+
+    def test_a_missing_snapshot_raises(self, small_config_storage, tmp_path):
+        with pytest.raises(FileNotFoundError, match="No revisions"):
+            chunkstore.restore(
+                small_config_storage, "never-backed-up", None, str(tmp_path / "dst")
+            )
+
+    def test_an_explicit_revision_is_honoured(self, small_config_storage, tmp_path):
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.txt": b"first"})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+        with open(src / "a.txt", "wb") as f:
+            f.write(b"second")
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        dst = tmp_path / "dst"
+        info = chunkstore.restore(small_config_storage, "erp", 1, str(dst))
+
+        assert info["revision"] == 1
+        assert (dst / "a.txt").read_bytes() == b"first"
+
+    def test_a_path_escaping_the_target_is_refused(
+        self, small_config_storage, tmp_path
+    ):
+        # A tampered revision must not be able to write outside target_dir.
+        from oduflow.chunkstore.backup import load_revision
+        from oduflow.chunkstore.format import ensure_config as _ensure
+
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.txt": b"payload"})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        config = _ensure(small_config_storage)
+        _meta, files, _hashes, _lengths = load_revision(
+            small_config_storage, config, "erp", 1
+        )
+        files[0]["path"] = "../escaped.txt"
+
+        with (
+            patch(
+                "oduflow.chunkstore.restore.load_revision",
+                return_value=(_meta, files, _hashes, _lengths),
+            ),
+            pytest.raises(ValueError, match="escapes target dir"),
+        ):
+            chunkstore.restore(small_config_storage, "erp", 1, str(tmp_path / "dst"))
+
+        assert not (tmp_path / "escaped.txt").exists()
+
+
+class TestBackupMetadata:
+    """The revision file is the backup's index: wrong counters or chunk spans
+    mean a restore that silently produces different bytes."""
+
+    def _meta(self, storage, snapshot_id, revision):
+        import json as _json
+
+        key = f"snapshots/{snapshot_id}/{revision}"
+        return _json.loads(storage.get(key).decode())
+
+    def test_the_schema_version_is_recorded(self, small_config_storage, tmp_path):
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.txt": b"x"})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        assert self._meta(small_config_storage, "erp", 1)["version"] == 1
+
+    def test_counters_match_the_tree(self, small_config_storage, tmp_path):
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.bin": b"x" * 700, "b.bin": b"y" * 300})
+
+        result = chunkstore.backup(str(src), small_config_storage, "erp")
+
+        assert result.files == 2
+        assert result.total_bytes == 1000
+        assert result.unchanged_files == 0
+        meta = self._meta(small_config_storage, "erp", 1)
+        assert meta["files"] == 2
+        assert meta["total_bytes"] == 1000
+
+    def test_an_empty_file_gets_a_zero_length_chunk_span(
+        self, small_config_storage, tmp_path
+    ):
+        # sc/so/ec/eo must all be 0 so restore writes nothing; any non-zero
+        # value would splice in a neighbouring file's bytes.
+        from oduflow.chunkstore.backup import load_revision
+        from oduflow.chunkstore.format import ensure_config as _ensure
+
+        src = tmp_path / "src"
+        _make_tree(str(src), {"empty.txt": b"", "other.bin": b"z" * 5000})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        config = _ensure(small_config_storage)
+        _meta, files, _h, _l = load_revision(small_config_storage, config, "erp", 1)
+        empty = next(f for f in files if f["path"] == "empty.txt")
+
+        assert (empty["sc"], empty["so"], empty["ec"], empty["eo"]) == (0, 0, 0, 0)
+        assert empty["size"] == 0
+
+    def test_unchanged_files_are_counted_on_the_second_revision(
+        self, small_config_storage, tmp_path
+    ):
+        src = tmp_path / "src"
+        _make_tree(str(src), {f"f{i}.bin": bytes([i]) * 5000 for i in range(4)})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+        with open(src / "f1.bin", "wb") as f:
+            f.write(b"changed" * 800)
+
+        result = chunkstore.backup(str(src), small_config_storage, "erp")
+
+        assert result.unchanged_files == 3
+        assert result.files == 4
+
+    def test_an_unchanged_empty_file_still_counts_as_unchanged(
+        self, small_config_storage, tmp_path
+    ):
+        # Zero-size files take the early-return path, which has its own
+        # unchanged_count increment.
+        src = tmp_path / "src"
+        _make_tree(str(src), {"empty.txt": b"", "a.bin": b"x" * 100})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        result = chunkstore.backup(str(src), small_config_storage, "erp")
+
+        assert result.unchanged_files == 2
+
+    def test_entries_are_sorted_by_path(self, small_config_storage, tmp_path):
+        # Restore reconstructs in path order and relies on consecutive small
+        # files sharing chunks; unsorted entries break the one-slot cache.
+        from oduflow.chunkstore.backup import load_revision
+        from oduflow.chunkstore.format import ensure_config as _ensure
+
+        src = tmp_path / "src"
+        _make_tree(str(src), {"z.bin": b"z", "a.bin": b"a", "m/n.bin": b"n"})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        config = _ensure(small_config_storage)
+        _meta, files, _h, _l = load_revision(small_config_storage, config, "erp", 1)
+        paths = [f["path"] for f in files]
+
+        assert paths == sorted(paths)
+
+    def test_an_explicit_prev_revision_is_used_as_the_base(
+        self, small_config_storage, tmp_path
+    ):
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.bin": b"x" * 5000})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        result = chunkstore.backup(
+            str(src), small_config_storage, "erp", prev_revision=1
+        )
+
+        assert result.unchanged_files == 1
+
+    def test_an_unknown_prev_revision_falls_back_to_a_full_backup(
+        self, small_config_storage, tmp_path
+    ):
+        # Not to "the latest": an explicitly requested base that does not
+        # exist must not silently become an incremental against something else.
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.bin": b"x" * 5000})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        result = chunkstore.backup(
+            str(src), small_config_storage, "erp", prev_revision=99
+        )
+
+        assert result.unchanged_files == 0
+
+    def test_revision_numbers_increment_from_one(
+        self, small_config_storage, tmp_path
+    ):
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.txt": b"x"})
+
+        first = chunkstore.backup(str(src), small_config_storage, "erp")
+        second = chunkstore.backup(str(src), small_config_storage, "erp")
+
+        assert (first.revision, second.revision) == (1, 2)
+        assert list_revisions(small_config_storage, "erp") == [1, 2]
+
+    def test_a_missing_source_directory_raises(self, small_config_storage, tmp_path):
+        with pytest.raises(FileNotFoundError, match="source_dir"):
+            chunkstore.backup(str(tmp_path / "nope"), small_config_storage, "erp")
+
+
+class TestPruneCounters:
+    """PruneResult is what the dashboard and the scheduler log; an off-by-one
+    there is how a broken prune looks healthy."""
+
+    def _aged_backup(self, storage, src, snapshot_id, days):
+        import json as _json
+
+        result = chunkstore.backup(str(src), storage, snapshot_id)
+        key = f"snapshots/{snapshot_id}/{result.revision}"
+        meta = _json.loads(storage.get(key).decode())
+        meta["created_at"] = (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(days=days)
+        ).isoformat()
+        storage.put(key, _json.dumps(meta).encode())
+        return result
+
+    def test_a_clean_store_reports_all_zeroes(self, small_config_storage, tmp_path):
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.bin": b"x" * 5000})
+        chunkstore.backup(str(src), small_config_storage, "erp")
+
+        result = chunkstore.prune(small_config_storage, keep=parse_keep(["1:7"]))
+
+        assert result.deleted_revisions == []
+        assert result.deleted_chunks == 0
+        assert result.resurrected_chunks == 0
+
+    def test_dropping_one_revision_fossilizes_its_unique_chunks(
+        self, small_config_storage, tmp_path
+    ):
+        rng = random.Random(21)
+        storage = small_config_storage
+        src = tmp_path / "src"
+        _make_tree(str(src), {"a.bin": rng.randbytes(30_000)})
+        self._aged_backup(storage, src, "erp", 400)
+        with open(src / "a.bin", "wb") as f:
+            f.write(rng.randbytes(30_000))
+        chunkstore.backup(str(src), storage, "erp")
+
+        result = chunkstore.prune(storage, keep=parse_keep(["0:365"]))
+
+        assert result.deleted_revisions == ["erp/1"]
+        assert result.fossilized_chunks > 0
+        assert result.collections_written == 1
+
+    def _fossilize(self, storage, src, rng):
+        """Leave one aged collection of fossils behind, then move the latest
+        revision forward so only maturity blocks the sweep."""
+        _make_tree(str(src), {"a.bin": rng.randbytes(30_000)})
+        self._aged_backup(storage, src, "erp", 400)
+        with open(src / "a.bin", "wb") as f:
+            f.write(rng.randbytes(30_000))
+        chunkstore.backup(str(src), storage, "erp")
+        first = chunkstore.prune(storage, keep=parse_keep(["0:365"]))
+        with open(src / "a.bin", "ab") as f:
+            f.write(b"more")
+        chunkstore.backup(str(src), storage, "erp")
+        return first
+
+    def test_a_fresh_collection_is_not_swept(self, small_config_storage, tmp_path):
+        # Fossils must age past _COLLECTION_MIN_AGE before deletion, so a
+        # concurrent restore cannot lose a chunk mid-read.
+        storage = small_config_storage
+        first = self._fossilize(storage, tmp_path / "src", random.Random(22))
+
+        second = chunkstore.prune(storage, keep=parse_keep(["0:365"]))
+
+        assert first.fossilized_chunks > 0
+        assert second.deleted_chunks == 0
+        assert second.collections_deleted == 0
+
+    def test_a_matured_collection_is_swept(self, small_config_storage, tmp_path):
+        storage = small_config_storage
+        first = self._fossilize(storage, tmp_path / "src", random.Random(23))
+        later = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+            hours=2
+        )
+
+        second = chunkstore.prune(storage, keep=parse_keep(["0:365"]), now=later)
+
+        assert first.fossilized_chunks > 0
+        assert second.deleted_chunks == first.fossilized_chunks
+        assert second.collections_deleted == 1
+        assert not [k for k in storage.list("chunks/") if k.endswith(".fsl")]
+
+    def test_prune_without_a_policy_is_refused(self, small_config_storage):
+        with pytest.raises(ValueError, match="keep or keep_revisions"):
+            chunkstore.prune(small_config_storage)

--- a/tests/test_chunkstore.py
+++ b/tests/test_chunkstore.py
@@ -434,3 +434,71 @@ class TestPruneKeepRevisions:
     def test_prune_requires_a_policy(self, small_config_storage):
         with pytest.raises(ValueError, match="keep"):
             chunkstore.prune(small_config_storage)
+
+
+class TestCountingStorage:
+    """The dedup tests' instrument: if its counters lie, every "how many PUTs
+    did this incremental backup do?" assertion silently passes."""
+
+    def _counting(self, tmp_path):
+        return CountingStorage(LocalStorage(str(tmp_path / "store")))
+
+    def test_every_operation_is_counted_once(self, tmp_path):
+        storage = self._counting(tmp_path)
+
+        storage.put("k", b"v")
+        storage.exists("k")
+        storage.get("k")
+        storage.list("")
+        storage.rename("k", "k2")
+        storage.delete("k2")
+
+        assert storage.counts == {
+            "exists": 1,
+            "get": 1,
+            "put": 1,
+            "list": 1,
+            "rename": 1,
+            "delete": 1,
+        }
+
+    def test_counters_start_at_zero(self, tmp_path):
+        assert set(self._counting(tmp_path).counts.values()) == {0}
+
+    def test_repeated_calls_accumulate(self, tmp_path):
+        storage = self._counting(tmp_path)
+        storage.put("a", b"1")
+        storage.put("b", b"2")
+
+        assert storage.counts["put"] == 2
+
+    def test_every_call_is_delegated_to_the_inner_storage(self, tmp_path):
+        storage = self._counting(tmp_path)
+
+        storage.put("k", b"payload")
+
+        assert storage.exists("k") is True
+        assert storage.get("k") == b"payload"
+        assert storage.list("") == ["k"]
+
+    def test_rename_moves_the_object_in_the_inner_storage(self, tmp_path):
+        storage = self._counting(tmp_path)
+        storage.put("old", b"payload")
+
+        storage.rename("old", "new")
+
+        assert storage.inner.exists("new") is True
+        assert storage.inner.exists("old") is False
+
+    def test_delete_removes_from_the_inner_storage(self, tmp_path):
+        storage = self._counting(tmp_path)
+        storage.put("k", b"v")
+
+        storage.delete("k")
+
+        assert storage.inner.exists("k") is False
+
+    def test_exists_reports_the_inner_answer(self, tmp_path):
+        storage = self._counting(tmp_path)
+
+        assert storage.exists("absent") is False

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 import textwrap
 
@@ -910,3 +911,225 @@ class TestTemplateLineage:
         result = template_lineage(self._repo(tmp_path), "snapshot1", "prod")
         assert result["status"] == "ahead"
         assert result["message"] == ""
+
+
+class TestModuleScoping:
+    """Files that belong to no module must never produce a module action.
+
+    ``_get_module_name`` returns None for a repo-root file. Every classifier
+    branch guards on that; dropping the guard would add ``None`` to the module
+    lists and send an unusable ``-u None`` to Odoo.
+    """
+
+    def test_root_level_py_with_fields_stays_restart(self, tmp_path):
+        # A repo-root .py cannot belong to a module even if it defines fields.
+        (tmp_path / "conftest.py").write_text("x = fields.Char()\n")
+
+        result = classify_changes(["conftest.py"], str(tmp_path))
+
+        assert result["action"] == "restart"
+        assert result["modules_to_upgrade"] == []
+        assert result["details"]["py_changed"] is True
+
+    def test_root_level_po_is_ignored(self, tmp_path):
+        result = classify_changes(["messages.po"], str(tmp_path))
+
+        assert result["action"] == "refresh"
+        assert result["modules_to_upgrade"] == []
+        assert result["details"]["i18n_changed"] == []
+
+    def test_root_level_security_xml_is_hot_reload_only(self, tmp_path):
+        result = classify_changes(["security.xml"], str(tmp_path))
+
+        assert result["action"] == "refresh"
+        assert result["modules_to_upgrade"] == []
+
+    def test_root_level_manifest_is_ignored(self, tmp_path):
+        (tmp_path / "__manifest__.py").write_text("{'name': 'x'}")
+
+        result = classify_changes(["__manifest__.py"], str(tmp_path))
+
+        assert result["modules_to_install"] == []
+        assert result["modules_to_upgrade"] == []
+
+    def test_shallow_classify_ignores_root_level_files(self):
+        assert shallow_classify(["messages.po"], "/tmp")["modules_to_upgrade"] == []
+        assert shallow_classify(["security.xml"], "/tmp")["modules_to_upgrade"] == []
+        assert shallow_classify(["__manifest__.py"], "/tmp")["modules_to_upgrade"] == []
+
+
+class TestInstallSupersedesUpgrade:
+    """A module being installed is never also listed for upgrade.
+
+    Install already loads everything; listing the same module twice would make
+    Odoo run an upgrade right after the install.
+    """
+
+    def _new_module(self, tmp_path):
+        module = tmp_path / "sale"
+        (module / "security").mkdir(parents=True)
+        (module / "i18n").mkdir()
+        (module / "__manifest__.py").write_text(
+            "{'name': 'Sale', 'version': '17.0.1.0.0'}"
+        )
+        (module / "security" / "groups.xml").write_text("<odoo/>")
+        (module / "i18n" / "ru.po").write_text("msgid \"\"\n")
+        return module
+
+    def test_security_xml_in_a_new_module_stays_install_only(self, tmp_path):
+        from unittest.mock import patch
+
+        self._new_module(tmp_path)
+        files = ["sale/__manifest__.py", "sale/security/groups.xml"]
+
+        # No previous manifest -> the module is new -> install.
+        with patch("subprocess.run", side_effect=Exception("no such ref")):
+            result = classify_changes(files, str(tmp_path))
+
+        assert result["action"] == "install"
+        assert result["modules_to_install"] == ["sale"]
+        assert result["modules_to_upgrade"] == []
+
+    def test_order_of_files_does_not_matter(self, tmp_path):
+        # The security XML is classified before the manifest here, so the
+        # install is only known later; the final subtraction must still win.
+        from unittest.mock import patch
+
+        self._new_module(tmp_path)
+        files = ["sale/security/groups.xml", "sale/__manifest__.py"]
+
+        with patch("subprocess.run", side_effect=Exception("no such ref")):
+            result = classify_changes(files, str(tmp_path))
+
+        assert result["action"] == "install"
+        assert result["modules_to_upgrade"] == []
+
+
+class TestManifestChangeDetection:
+    def _module(self, tmp_path, manifest: str):
+        module = tmp_path / "sale"
+        module.mkdir(parents=True)
+        (module / "__manifest__.py").write_text(manifest)
+        return "sale/__manifest__.py"
+
+    def _classify(self, tmp_path, rel_path, old_manifest):
+        from unittest.mock import patch
+
+        with patch("subprocess.run") as run:
+            run.return_value = type("R", (), {"stdout": old_manifest})()
+            return classify_changes([rel_path], str(tmp_path))
+
+    def test_every_file_bearing_key_triggers_an_upgrade(self, tmp_path):
+        # data/demo/assets/qweb all list files Odoo loads at upgrade time.
+        for key in ("data", "demo", "assets", "qweb"):
+            module_root = tmp_path / key
+            module_root.mkdir()
+            (module_root / "sale").mkdir()
+            (module_root / "sale" / "__manifest__.py").write_text(
+                f"{{'name': 'Sale', 'version': '1.0', '{key}': ['a.xml', 'b.xml']}}"
+            )
+            from unittest.mock import patch
+
+            old = f"{{'name': 'Sale', 'version': '1.0', '{key}': ['a.xml']}}"
+            with patch("subprocess.run") as run:
+                run.return_value = type("R", (), {"stdout": old})()
+                result = classify_changes(["sale/__manifest__.py"], str(module_root))
+
+            assert result["action"] == "upgrade", key
+            assert result["modules_to_upgrade"] == ["sale"], key
+
+    def test_cosmetic_manifest_edit_needs_no_action(self, tmp_path):
+        rel = self._module(
+            tmp_path, "{'name': 'Sale', 'version': '1.0', 'author': 'New Author'}"
+        )
+        result = self._classify(
+            tmp_path, rel, "{'name': 'Sale', 'version': '1.0', 'author': 'Old Author'}"
+        )
+
+        assert result["action"] == "refresh"
+        assert result["modules_to_upgrade"] == []
+        assert result["modules_to_install"] == []
+
+    def test_unparsable_new_manifest_falls_back_to_upgrade(self, tmp_path):
+        # Better to upgrade needlessly than to skip a real schema change.
+        rel = self._module(tmp_path, "{'name': 'Sale', this is not python")
+        result = self._classify(tmp_path, rel, "{'name': 'Sale', 'version': '1.0'}")
+
+        assert result["action"] == "upgrade"
+        assert result["modules_to_upgrade"] == ["sale"]
+
+    def test_manifest_deleted_from_the_worktree_is_skipped(self, tmp_path):
+        # The file is in the changed list but no longer on disk (deleted).
+        (tmp_path / "sale").mkdir()
+        result = self._classify(
+            tmp_path, "sale/__manifest__.py", "{'name': 'Sale', 'version': '1.0'}"
+        )
+
+        assert result["modules_to_upgrade"] == []
+        assert result["modules_to_install"] == []
+
+    def test_version_bump_triggers_upgrade_even_when_lists_match(self, tmp_path):
+        rel = self._module(
+            tmp_path, "{'name': 'Sale', 'version': '1.1', 'data': ['a.xml']}"
+        )
+        result = self._classify(
+            tmp_path, rel, "{'name': 'Sale', 'version': '1.0', 'data': ['a.xml']}"
+        )
+
+        assert result["action"] == "upgrade"
+
+
+class TestMergeRecommendationPriority:
+    def test_full_priority_order(self):
+        # none < refresh < restart < upgrade < install
+        order = ["none", "refresh", "restart", "upgrade", "install"]
+        for lower, higher in itertools.pairwise(order):
+            merged = merge_recommendations([{"action": lower}, {"action": higher}])
+            assert merged["action"] == higher, (lower, higher)
+
+    def test_unknown_action_ranks_below_every_known_one(self):
+        # An unrecognised action maps to 0, below "refresh". Listed first so a
+        # wrong default cannot hide behind max()'s first-wins tie-breaking.
+        merged = merge_recommendations(
+            [{"action": "something-new"}, {"action": "refresh"}]
+        )
+        assert merged["action"] == "refresh"
+
+    def test_falsy_recommendations_are_dropped(self):
+        merged = merge_recommendations([None, {}, {"action": "restart"}])
+        assert merged["action"] == "restart"
+
+    def test_detail_lists_are_unioned_and_sorted(self):
+        merged = merge_recommendations(
+            [
+                {"action": "refresh", "details": {"xml_hot": ["b.xml", "a.xml"]}},
+                {"action": "refresh", "details": {"xml_hot": ["a.xml", "c.xml"]}},
+            ]
+        )
+        assert merged["details"]["xml_hot"] == ["a.xml", "b.xml", "c.xml"]
+
+    def test_none_detail_lists_do_not_break_the_merge(self):
+        merged = merge_recommendations(
+            [
+                {"action": "refresh", "details": {"xml_hot": None}},
+                {"action": "refresh", "details": {"xml_hot": ["a.xml"]}},
+            ]
+        )
+        assert merged["details"]["xml_hot"] == ["a.xml"]
+
+    def test_restart_required_is_ored_across_units(self):
+        merged = merge_recommendations(
+            [
+                {"action": "refresh", "details": {"restart_required": []}},
+                {"action": "refresh", "details": {"restart_required": [".oduflow/odoo.conf"]}},
+            ]
+        )
+        assert merged["details"]["restart_required"] is True
+
+        neither = merge_recommendations(
+            [
+                {"action": "refresh", "details": {"restart_required": []}},
+                {"action": "refresh", "details": {}},
+            ]
+        )
+        assert neither["details"]["restart_required"] is False

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,0 +1,508 @@
+"""Git plumbing: credential store, pull, and history.
+
+The module had no test file, leaving 402 uncovered mutants. The parts that
+matter are the ones handling secrets — the credential file holds plaintext
+tokens, so listing must mask them, deletion must remove exactly the matching
+line, and validation must not report a token as good when the host says
+otherwise — plus ``pull_repo``, whose ``old_head`` return value is what the
+change classifier and the production rollback both key off.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from oduflow import git_ops
+from oduflow.errors import ExternalCommandError
+
+
+@pytest.fixture
+def cred_file(tmp_path):
+    path = tmp_path / "git-credentials"
+    path.write_text(
+        "https://ada:ghp_abcdef123456@github.com\n"
+        "https://bob:glpat_secret@gitlab.com\n"
+    )
+    return str(path)
+
+
+class TestListCredentials:
+    def test_lists_host_and_username_per_entry(self, cred_file):
+        entries = git_ops.list_credentials(cred_file)
+
+        assert [(e["host"], e["username"]) for e in entries] == [
+            ("github.com", "ada"),
+            ("gitlab.com", "bob"),
+        ]
+
+    def test_the_token_is_masked_to_its_first_four_characters(self, cred_file):
+        entries = git_ops.list_credentials(cred_file)
+
+        assert entries[0]["token_masked"] == "ghp_****"
+        assert "abcdef123456" not in str(entries)
+
+    def test_a_short_token_is_masked_completely(self, tmp_path):
+        path = tmp_path / "creds"
+        path.write_text("https://ada:tiny@github.com\n")
+
+        assert git_ops.list_credentials(str(path))[0]["token_masked"] == "****"
+
+    def test_a_four_character_token_is_masked_completely(self, tmp_path):
+        # The check is `len > 4`, so a 4-char token reveals nothing.
+        path = tmp_path / "creds"
+        path.write_text("https://ada:abcd@github.com\n")
+
+        assert git_ops.list_credentials(str(path))[0]["token_masked"] == "****"
+
+    def test_a_five_character_token_reveals_four(self, tmp_path):
+        path = tmp_path / "creds"
+        path.write_text("https://ada:abcde@github.com\n")
+
+        assert git_ops.list_credentials(str(path))[0]["token_masked"] == "abcd****"
+
+    def test_a_missing_file_lists_nothing(self, tmp_path):
+        assert git_ops.list_credentials(str(tmp_path / "nope")) == []
+
+    def test_blank_lines_are_skipped(self, tmp_path):
+        path = tmp_path / "creds"
+        path.write_text("\n\nhttps://ada:tok12345@github.com\n\n")
+
+        assert len(git_ops.list_credentials(str(path))) == 1
+
+    def test_entries_without_a_host_or_user_are_skipped(self, tmp_path):
+        path = tmp_path / "creds"
+        path.write_text(
+            "not-a-url\n"
+            "https://github.com\n"
+            "https://ada:tok12345@github.com\n"
+        )
+
+        entries = git_ops.list_credentials(str(path))
+        assert [e["username"] for e in entries] == ["ada"]
+
+
+class TestDeleteCredential:
+    def test_removes_only_the_matching_entry(self, cred_file):
+        assert git_ops.delete_credential("github.com", "ada", cred_file) is True
+
+        remaining = git_ops.list_credentials(cred_file)
+        assert [(e["host"], e["username"]) for e in remaining] == [
+            ("gitlab.com", "bob")
+        ]
+
+    def test_the_username_must_match_too(self, cred_file):
+        # Same host, different user: deleting one must not take the other.
+        assert git_ops.delete_credential("github.com", "eve", cred_file) is False
+        assert len(git_ops.list_credentials(cred_file)) == 2
+
+    def test_the_host_must_match_too(self, cred_file):
+        assert git_ops.delete_credential("bitbucket.org", "ada", cred_file) is False
+        assert len(git_ops.list_credentials(cred_file)) == 2
+
+    def test_an_unknown_entry_reports_nothing_removed(self, cred_file):
+        assert git_ops.delete_credential("example.com", "nobody", cred_file) is False
+
+    def test_a_missing_file_reports_nothing_removed(self, tmp_path):
+        assert (
+            git_ops.delete_credential("github.com", "ada", str(tmp_path / "nope"))
+            is False
+        )
+
+    def test_the_file_is_left_untouched_when_nothing_matched(self, cred_file):
+        with open(cred_file) as f:
+            before = f.read()
+
+        git_ops.delete_credential("example.com", "nobody", cred_file)
+
+        with open(cred_file) as f:
+            assert f.read() == before
+
+    def test_deleting_the_last_entry_empties_the_file(self, tmp_path):
+        path = tmp_path / "creds"
+        path.write_text("https://ada:tok12345@github.com\n")
+
+        assert git_ops.delete_credential("github.com", "ada", str(path)) is True
+        assert git_ops.list_credentials(str(path)) == []
+
+
+class TestValidateCredential:
+    def _urlopen(self, status=200):
+        response = MagicMock()
+        response.status = status
+        return patch("urllib.request.urlopen", return_value=response)
+
+    def test_a_missing_file_is_invalid(self, tmp_path):
+        assert (
+            git_ops.validate_credential("github.com", "ada", str(tmp_path / "nope"))
+            == "invalid"
+        )
+
+    def test_an_absent_entry_is_invalid(self, cred_file):
+        assert git_ops.validate_credential("example.com", "ada", cred_file) == (
+            "invalid"
+        )
+
+    def test_a_matching_entry_with_a_good_token_is_valid(self, cred_file):
+        with self._urlopen(200):
+            assert git_ops.validate_credential("github.com", "ada", cred_file) == (
+                "valid"
+            )
+
+    def test_the_username_must_match_the_entry(self, cred_file):
+        assert git_ops.validate_credential("github.com", "eve", cred_file) == (
+            "invalid"
+        )
+
+    def test_an_unknown_host_is_trusted_without_a_probe(self, tmp_path):
+        # There is no API to ask, so a stored credential is taken at face
+        # value rather than reported broken.
+        path = tmp_path / "creds"
+        path.write_text("https://ada:tok12345@git.internal\n")
+
+        with patch("urllib.request.urlopen") as urlopen:
+            assert git_ops.validate_credential("git.internal", "ada", str(path)) == (
+                "valid"
+            )
+        urlopen.assert_not_called()
+
+    @pytest.mark.parametrize("code", [401, 403])
+    def test_a_rejected_token_is_invalid(self, cred_file, code):
+        error = HTTPError("u", code, "denied", {}, None)
+        with patch("urllib.request.urlopen", side_effect=error):
+            assert git_ops.validate_credential("github.com", "ada", cred_file) == (
+                "invalid"
+            )
+
+    @pytest.mark.parametrize("code", [500, 502])
+    def test_a_server_error_is_unknown_not_invalid(self, cred_file, code):
+        # Reporting "invalid" on a GitHub outage would tell the user to
+        # re-enter a token that is actually fine.
+        error = HTTPError("u", code, "boom", {}, None)
+        with patch("urllib.request.urlopen", side_effect=error):
+            assert git_ops.validate_credential("github.com", "ada", cred_file) == (
+                "unknown"
+            )
+
+    def test_a_network_failure_is_unknown(self, cred_file):
+        with patch("urllib.request.urlopen", side_effect=URLError("offline")):
+            assert git_ops.validate_credential("github.com", "ada", cred_file) == (
+                "unknown"
+            )
+
+    def test_a_non_200_response_is_invalid(self, cred_file):
+        with self._urlopen(204):
+            assert git_ops.validate_credential("github.com", "ada", cred_file) == (
+                "invalid"
+            )
+
+    def test_github_is_probed_with_a_token_header(self, cred_file):
+        with self._urlopen(200) as urlopen:
+            git_ops.validate_credential("github.com", "ada", cred_file)
+
+        request = urlopen.call_args.args[0]
+        assert request.full_url == "https://api.github.com/user"
+        assert request.get_header("Authorization") == "token ghp_abcdef123456"
+
+    def test_gitlab_is_probed_with_its_own_header(self, cred_file):
+        with self._urlopen(200) as urlopen:
+            git_ops.validate_credential("gitlab.com", "bob", cred_file)
+
+        request = urlopen.call_args.args[0]
+        assert request.full_url == "https://gitlab.com/api/v4/user"
+        assert request.get_header("Private-token") == "glpat_secret"
+
+    def test_bitbucket_is_probed_with_basic_auth(self, tmp_path):
+        import base64
+
+        path = tmp_path / "creds"
+        path.write_text("https://ada:tok12345@bitbucket.org\n")
+
+        with self._urlopen(200) as urlopen:
+            git_ops.validate_credential("bitbucket.org", "ada", str(path))
+
+        request = urlopen.call_args.args[0]
+        expected = base64.b64encode(b"ada:tok12345").decode()
+        assert request.get_header("Authorization") == f"Basic {expected}"
+
+
+class TestPullRepo:
+    def _runner(self, heads, changed="a.py\nb.xml\n"):
+        """Fake subprocess.run: rev-parse yields heads in order."""
+        calls = []
+        pending = list(heads)
+
+        def run(argv, **kwargs):
+            calls.append(argv)
+            out = ""
+            if "rev-parse" in argv:
+                out = pending.pop(0)
+            elif "diff" in argv:
+                out = changed
+            return MagicMock(stdout=out, returncode=0)
+
+        return run, calls
+
+    def test_returns_the_old_head_and_the_changed_files(self):
+        run, _ = self._runner(["old123", "new456"])
+
+        with patch("subprocess.run", side_effect=run):
+            old_head, changed = git_ops.pull_repo("/repo", "main")
+
+        assert old_head == "old123"
+        assert changed == ["a.py", "b.xml"]
+
+    def test_an_unchanged_head_reports_no_files_and_skips_the_diff(self):
+        run, calls = self._runner(["same", "same"])
+
+        with patch("subprocess.run", side_effect=run):
+            old_head, changed = git_ops.pull_repo("/repo", "main")
+
+        assert (old_head, changed) == ("same", [])
+        assert not any("diff" in argv for argv in calls)
+
+    def test_the_branch_is_fetched_into_its_remote_ref(self):
+        run, calls = self._runner(["old", "new"])
+
+        with patch("subprocess.run", side_effect=run):
+            git_ops.pull_repo("/repo", "feature/x")
+
+        fetch = next(argv for argv in calls if "fetch" in argv)
+        assert "+refs/heads/feature/x:refs/remotes/origin/feature/x" in fetch
+
+    def test_the_checkout_is_reset_to_the_fetched_branch(self):
+        run, calls = self._runner(["old", "new"])
+
+        with patch("subprocess.run", side_effect=run):
+            git_ops.pull_repo("/repo", "main")
+
+        reset = next(argv for argv in calls if "reset" in argv)
+        assert reset[-2:] == ["--hard", "origin/main"]
+
+    def test_the_diff_spans_the_whole_pulled_range(self):
+        # Not just the last commit: the classifier needs every file touched
+        # between the old and the new head.
+        run, calls = self._runner(["old", "new"])
+
+        with patch("subprocess.run", side_effect=run):
+            git_ops.pull_repo("/repo", "main")
+
+        diff = next(argv for argv in calls if "diff" in argv)
+        assert "old..new" in diff
+
+    def test_blank_diff_lines_are_dropped(self):
+        run, _ = self._runner(["old", "new"], changed="a.py\n\n\nb.py\n")
+
+        with patch("subprocess.run", side_effect=run):
+            _, changed = git_ops.pull_repo("/repo", "main")
+
+        assert changed == ["a.py", "b.py"]
+
+    def test_a_failed_fetch_raises_with_the_credentials_scrubbed(self):
+        # git echoes the full remote, token included, in its stderr.
+        error = subprocess.CalledProcessError(
+            128, "git", stderr="fatal: https://ada:ghp_secret@github.com/x.git denied"
+        )
+
+        def run(argv, **kwargs):
+            if "rev-parse" in argv:
+                return MagicMock(stdout="old", returncode=0)
+            raise error
+
+        with (
+            patch("subprocess.run", side_effect=run),
+            pytest.raises(ExternalCommandError) as excinfo,
+        ):
+            git_ops.pull_repo("/repo", "main")
+
+        message = str(excinfo.value)
+        assert "ghp_secret" not in message
+        assert "***@github.com" in message
+
+    def test_a_fetch_timeout_is_reported_as_such(self):
+        def run(argv, **kwargs):
+            if "rev-parse" in argv:
+                return MagicMock(stdout="old", returncode=0)
+            raise subprocess.TimeoutExpired("git", 60)
+
+        with (
+            patch("subprocess.run", side_effect=run),
+            pytest.raises(ExternalCommandError, match="timed out"),
+        ):
+            git_ops.pull_repo("/repo", "main")
+
+    def test_the_fetch_is_bounded_by_a_timeout(self):
+        run, _ = self._runner(["old", "new"])
+        seen = {}
+
+        def wrapped(argv, **kwargs):
+            if "fetch" in argv:
+                seen["timeout"] = kwargs.get("timeout")
+            return run(argv, **kwargs)
+
+        with patch("subprocess.run", side_effect=wrapped):
+            git_ops.pull_repo("/repo", "main")
+
+        assert seen["timeout"] == 60
+
+    def test_a_credential_file_switches_the_git_environment(self):
+        run, _ = self._runner(["old", "new"])
+        envs = []
+
+        def wrapped(argv, **kwargs):
+            envs.append(kwargs.get("env"))
+            return run(argv, **kwargs)
+
+        with patch("subprocess.run", side_effect=wrapped):
+            git_ops.pull_repo("/repo", "main", cred_file="/creds")
+
+        assert envs and all(
+            e["GIT_CONFIG_VALUE_0"] == "store --file /creds" for e in envs
+        )
+        assert all(e["GIT_CONFIG_KEY_0"] == "credential.helper" for e in envs)
+
+    def test_without_a_credential_file_the_base_environment_is_used(self):
+        run, _ = self._runner(["old", "new"])
+        envs = []
+
+        def wrapped(argv, **kwargs):
+            envs.append(kwargs.get("env"))
+            return run(argv, **kwargs)
+
+        with patch("subprocess.run", side_effect=wrapped):
+            git_ops.pull_repo("/repo", "main")
+
+        assert envs and all("GIT_CONFIG_VALUE_0" not in e for e in envs)
+
+    def test_git_never_prompts_for_credentials(self):
+        # An interactive prompt inside a server thread would hang the pull.
+        run, _ = self._runner(["old", "new"])
+        envs = []
+
+        def wrapped(argv, **kwargs):
+            envs.append(kwargs.get("env"))
+            return run(argv, **kwargs)
+
+        with patch("subprocess.run", side_effect=wrapped):
+            git_ops.pull_repo("/repo", "main")
+
+        assert all(e["GIT_TERMINAL_PROMPT"] == "0" for e in envs)
+
+
+class TestRevParseAndReset:
+    def test_rev_parse_returns_the_stripped_hash(self):
+        with patch("subprocess.run", return_value=MagicMock(stdout="abc123\n")):
+            assert git_ops.rev_parse("/repo") == "abc123"
+
+    def test_rev_parse_defaults_to_head(self):
+        with patch("subprocess.run", return_value=MagicMock(stdout="x")) as run:
+            git_ops.rev_parse("/repo")
+
+        assert run.call_args.args[0][-1] == "HEAD"
+
+    def test_rev_parse_failure_raises(self):
+        error = subprocess.CalledProcessError(128, "git", stderr="unknown revision")
+        with (
+            patch("subprocess.run", side_effect=error),
+            pytest.raises(ExternalCommandError, match="rev-parse"),
+        ):
+            git_ops.rev_parse("/repo", "nope")
+
+    def test_reset_hard_targets_the_given_ref(self):
+        with patch("subprocess.run") as run:
+            git_ops.reset_hard("/repo", "abc123")
+
+        assert run.call_args.args[0] == [
+            "git",
+            "-C",
+            "/repo",
+            "reset",
+            "--hard",
+            "abc123",
+        ]
+
+    def test_reset_hard_failure_raises(self):
+        error = subprocess.CalledProcessError(1, "git", stderr="cannot reset")
+        with (
+            patch("subprocess.run", side_effect=error),
+            pytest.raises(ExternalCommandError, match="reset"),
+        ):
+            git_ops.reset_hard("/repo", "abc123")
+
+
+class TestLogCommits:
+    _SEP = "\x1f"
+
+    def _out(self, *rows):
+        return "\n".join(self._SEP.join(r) for r in rows)
+
+    def test_parses_every_field(self):
+        out = self._out(
+            ("full-sha", "short", "the subject", "Ada", "2026-01-02T03:04:05+00:00")
+        )
+        with patch("subprocess.run", return_value=MagicMock(stdout=out)):
+            commits = git_ops.log_commits("/repo")
+
+        assert commits == [
+            {
+                "sha": "full-sha",
+                "short": "short",
+                "subject": "the subject",
+                "author": "Ada",
+                "date": "2026-01-02T03:04:05+00:00",
+            }
+        ]
+
+    def test_the_default_limit_is_twenty(self):
+        with patch("subprocess.run", return_value=MagicMock(stdout="")) as run:
+            git_ops.log_commits("/repo")
+
+        assert "-20" in run.call_args.args[0]
+
+    def test_the_limit_is_configurable(self):
+        with patch("subprocess.run", return_value=MagicMock(stdout="")) as run:
+            git_ops.log_commits("/repo", n=5)
+
+        assert "-5" in run.call_args.args[0]
+
+    def test_malformed_rows_are_skipped(self):
+        # A subject containing the separator would otherwise shift every field.
+        out = self._out(("a", "b", "c"), ("s", "sh", "subj", "au", "date"))
+        with patch("subprocess.run", return_value=MagicMock(stdout=out)):
+            commits = git_ops.log_commits("/repo")
+
+        assert [c["sha"] for c in commits] == ["s"]
+
+    def test_an_empty_history_yields_no_commits(self):
+        with patch("subprocess.run", return_value=MagicMock(stdout="")):
+            assert git_ops.log_commits("/repo") == []
+
+    def test_failure_raises(self):
+        error = subprocess.CalledProcessError(128, "git", stderr="not a repository")
+        with (
+            patch("subprocess.run", side_effect=error),
+            pytest.raises(ExternalCommandError, match="git log"),
+        ):
+            git_ops.log_commits("/repo")
+
+
+class TestParseManifest:
+    def test_reads_the_literal_dict(self, tmp_path):
+        path = tmp_path / "__manifest__.py"
+        path.write_text("{'name': 'Sale', 'version': '17.0.1.0.0'}")
+
+        assert git_ops.parse_manifest(str(path)) == {
+            "name": "Sale",
+            "version": "17.0.1.0.0",
+        }
+
+    def test_executable_content_is_refused(self, tmp_path):
+        # literal_eval, not eval: a manifest is data, never code.
+        path = tmp_path / "__manifest__.py"
+        path.write_text("__import__('os').system('echo pwned')")
+
+        with pytest.raises(ValueError):
+            git_ops.parse_manifest(str(path))

--- a/tests/test_guardrail.py
+++ b/tests/test_guardrail.py
@@ -118,3 +118,30 @@ class TestGuardrailWarnings:
             "modules_to_upgrade": [],
         }
         assert guardrail_warnings(rec, [], ["sale"], False) == []
+
+    def test_explicit_restart_silences_the_restart_warning(self):
+        rec = {
+            "action": "restart",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+        assert guardrail_warnings(rec, [], [], True) == []
+
+    def test_an_install_implies_a_restart(self):
+        # Installing or upgrading a module restarts the container anyway, so a
+        # recommended restart that is already covered must not warn.
+        rec = {
+            "action": "restart",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+        assert guardrail_warnings(rec, ["sale"], [], False) == []
+        assert guardrail_warnings(rec, [], ["sale"], False) == []
+
+    def test_non_restart_recommendation_never_warns_about_restart(self):
+        rec = {
+            "action": "refresh",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+        assert guardrail_warnings(rec, [], [], False) == []

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -165,3 +165,125 @@ class TestCollectHealth:
             first_calls = getter.call_count
             health.collect_health(settings)  # cached
             assert getter.call_count == first_calls
+
+    def test_expired_cache_is_refreshed(self, settings, monkeypatch):
+        client = _client(
+            {"oduflow-db": True, "oduflow-prod-db": True, "oduflow-traefik": True}
+        )
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(health.time, "monotonic", lambda: clock["now"])
+
+        with patch(
+            "oduflow.docker_ops.client.get_client", return_value=client
+        ) as getter:
+            health.collect_health(settings, force=True)
+            calls_after_first = getter.call_count
+
+            clock["now"] += health._CACHE_TTL_SECONDS - 0.1
+            health.collect_health(settings)
+            assert getter.call_count == calls_after_first  # still inside the TTL
+
+            clock["now"] += 0.2  # now past the TTL
+            health.collect_health(settings)
+            assert getter.call_count > calls_after_first
+
+    def test_cache_expires_exactly_at_the_ttl(self, settings, monkeypatch):
+        # The check is `age < TTL`, so an age of exactly TTL is already stale.
+        client = _client(
+            {"oduflow-db": True, "oduflow-prod-db": True, "oduflow-traefik": True}
+        )
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(health.time, "monotonic", lambda: clock["now"])
+
+        with patch(
+            "oduflow.docker_ops.client.get_client", return_value=client
+        ) as getter:
+            health.collect_health(settings, force=True)
+            calls_after_first = getter.call_count
+
+            clock["now"] += health._CACHE_TTL_SECONDS
+            health.collect_health(settings)
+            assert getter.call_count > calls_after_first
+
+    def test_force_bypasses_a_fresh_cache(self, settings, monkeypatch):
+        client = _client(
+            {"oduflow-db": True, "oduflow-prod-db": True, "oduflow-traefik": True}
+        )
+        monkeypatch.setattr(health.time, "monotonic", lambda: 1000.0)
+
+        with patch(
+            "oduflow.docker_ops.client.get_client", return_value=client
+        ) as getter:
+            health.collect_health(settings, force=True)
+            calls_after_first = getter.call_count
+            health.collect_health(settings, force=True)
+            assert getter.call_count > calls_after_first
+
+    def test_empty_cache_is_never_served(self, settings, monkeypatch):
+        # A zero timestamp with no stored result must not be mistaken for a
+        # fresh entry: the very first call has to do real work.
+        client = _client(
+            {"oduflow-db": True, "oduflow-prod-db": True, "oduflow-traefik": True}
+        )
+        monkeypatch.setattr(health.time, "monotonic", lambda: 0.0)
+
+        with patch("oduflow.docker_ops.client.get_client", return_value=client):
+            result = health.collect_health(settings)
+
+        assert result["checks"]  # real checks ran, not an empty cached value
+
+
+class TestDiskCheck:
+    def _disk(self, settings, total, used, free):
+        with patch(
+            "shutil.disk_usage", return_value=MagicMock(total=total, used=used, free=free)
+        ):
+            return health._check_disk(settings)
+
+    def test_warn_threshold_is_inclusive(self, settings):
+        # Exactly DISK_WARN_PERCENT must already warn, one below must not.
+        at_threshold = self._disk(settings, 100, health.DISK_WARN_PERCENT, 100)
+        assert at_threshold["percent"] == health.DISK_WARN_PERCENT
+        assert at_threshold["status"] == "warn"
+
+        below = self._disk(settings, 100, health.DISK_WARN_PERCENT - 1, 100)
+        assert below["status"] == "ok"
+
+    def test_percent_is_used_over_total(self, settings):
+        assert self._disk(settings, 200, 50, 150)["percent"] == 25
+
+    def test_the_configured_data_dir_is_the_one_measured(self, settings):
+        # Not the filesystem root: a data dir on a separate volume is exactly
+        # the case where the two differ.
+        with patch(
+            "shutil.disk_usage", return_value=MagicMock(total=100, used=10, free=90)
+        ) as disk_usage:
+            health._check_disk(settings)
+
+        disk_usage.assert_called_once_with(settings.base_data_dir)
+
+    def test_root_is_measured_when_no_data_dir_is_configured(self):
+        empty = Settings(base_data_dir="", teams={})
+        with patch(
+            "shutil.disk_usage", return_value=MagicMock(total=100, used=10, free=90)
+        ) as disk_usage:
+            health._check_disk(empty)
+
+        disk_usage.assert_called_once_with("/")
+
+    def test_free_space_is_reported_in_gib(self, settings):
+        result = self._disk(settings, 100 * 1024**3, 25 * 1024**3, 75 * 1024**3)
+        assert result["free_gb"] == 75.0
+
+    def test_free_space_is_rounded_to_one_decimal(self, settings):
+        # 1.25 GiB free -> 1.2 (banker's rounding), not 1.25 or 1.3.
+        result = self._disk(settings, 10 * 1024**3, 0, int(1.25 * 1024**3))
+        assert result["free_gb"] == 1.2
+
+    def test_unreadable_path_reports_error_with_zero_percent(self, settings):
+        with patch("shutil.disk_usage", side_effect=OSError("gone")):
+            result = health._check_disk(settings)
+
+        assert result["status"] == "error"
+        assert result["percent"] == 0
+        assert "gone" in result["detail"]

--- a/tests/test_import_tokens.py
+++ b/tests/test_import_tokens.py
@@ -1,5 +1,6 @@
 """Unit tests for the short-lived Odoo.sh import tokens."""
 
+import json
 import os
 
 import pytest
@@ -71,3 +72,133 @@ def test_invalid_template_name_rejected(tmp_path):
     team = _team(tmp_path)
     with pytest.raises(ValueError):
         import_tokens.create_token(team, "../escape")
+
+
+class TestTokenShape:
+    def test_a_minted_token_is_32_url_safe_chars(self, tmp_path):
+        # The regex below is what keeps a token out of a path-traversal
+        # position, so the minted shape has to stay inside it.
+        rec = import_tokens.create_token(_team(tmp_path), "zipfit")
+
+        token = str(rec["token"])
+        assert len(token) == 32
+        assert import_tokens._TOKEN_RE.match(token)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "../../etc/passwd",
+            "a/b",
+            "short",
+            "with space",
+            "with.dot",
+            "x" * 65,
+        ],
+    )
+    def test_malformed_tokens_are_rejected_before_touching_the_disk(
+        self, tmp_path, bad
+    ):
+        # A non-empty but malformed token must still be refused; only checking
+        # for emptiness would let a traversal segment reach _token_path.
+        settings = _settings(_team(tmp_path))
+
+        with pytest.raises(NotFoundError):
+            import_tokens.load_token(settings, bad)
+
+    def test_an_empty_token_is_rejected(self, tmp_path):
+        with pytest.raises(NotFoundError):
+            import_tokens.load_token(_settings(_team(tmp_path)), "")
+
+
+class TestExpiryBoundary:
+    def test_a_token_is_valid_up_to_its_expiry_instant(self, tmp_path):
+        # The check is `expires_at < now`, so the token survives the exact
+        # second it expires.
+        team = _team(tmp_path)
+        rec = import_tokens.create_token(team, "zipfit", ttl_seconds=100, now=1000.0)
+
+        _, loaded = import_tokens.load_token(
+            _settings(team), str(rec["token"]), now=1100.0
+        )
+
+        assert loaded["token"] == rec["token"]
+
+    def test_a_token_is_dead_one_second_later(self, tmp_path):
+        team = _team(tmp_path)
+        rec = import_tokens.create_token(team, "zipfit", ttl_seconds=100, now=1000.0)
+
+        with pytest.raises(PrerequisiteNotMetError):
+            import_tokens.load_token(_settings(team), str(rec["token"]), now=1101.0)
+
+    def test_a_record_without_an_expiry_is_treated_as_expired(self, tmp_path):
+        # Default 0, not 1: a hand-written record missing expires_at must not
+        # be honoured indefinitely.
+        team = _team(tmp_path)
+        rec = import_tokens.create_token(team, "zipfit")
+        path = import_tokens._token_path(team, str(rec["token"]))
+        with open(path, "w") as f:
+            json.dump({"token": rec["token"], "template_name": "zipfit"}, f)
+
+        with pytest.raises(PrerequisiteNotMetError):
+            import_tokens.load_token(_settings(team), str(rec["token"]))
+
+
+class TestCleanupExpired:
+    def test_a_token_at_its_expiry_instant_survives_the_reap(self, tmp_path):
+        team = _team(tmp_path)
+        rec = import_tokens.create_token(team, "zipfit", ttl_seconds=100, now=1000.0)
+
+        import_tokens._cleanup_expired(team, now=1100.0)
+
+        assert os.path.isfile(import_tokens._token_path(team, str(rec["token"])))
+
+    def test_a_token_past_its_expiry_is_reaped(self, tmp_path):
+        team = _team(tmp_path)
+        rec = import_tokens.create_token(team, "zipfit", ttl_seconds=100, now=1000.0)
+
+        import_tokens._cleanup_expired(team, now=1101.0)
+
+        assert not os.path.isfile(import_tokens._token_path(team, str(rec["token"])))
+
+    def test_an_unreadable_token_file_is_dropped(self, tmp_path):
+        team = _team(tmp_path)
+        import_tokens.create_token(team, "zipfit")
+        junk = os.path.join(import_tokens._tokens_dir(team), "garbage.json")
+        with open(junk, "w") as f:
+            f.write("{not json")
+
+        import_tokens._cleanup_expired(team, now=0.0)
+
+        assert not os.path.isfile(junk)
+
+    def test_non_json_files_are_left_alone(self, tmp_path):
+        team = _team(tmp_path)
+        import_tokens.create_token(team, "zipfit")
+        other = os.path.join(import_tokens._tokens_dir(team), "README.txt")
+        with open(other, "w") as f:
+            f.write("keep me")
+
+        import_tokens._cleanup_expired(team, now=10**9)
+
+        assert os.path.isfile(other)
+
+    def test_a_missing_directory_is_not_an_error(self, tmp_path):
+        import_tokens._cleanup_expired(_team(tmp_path), now=0.0)  # must not raise
+
+
+class TestCrossTeamLookup:
+    def test_a_token_is_found_in_the_team_that_minted_it(self, tmp_path):
+        first = TeamSettings(team_id="1", data_dir=str(tmp_path / "t1"))
+        second = TeamSettings(
+            team_id="2",
+            data_dir=str(tmp_path / "t2"),
+            port_range_start=50100,
+            port_range_end=50200,
+        )
+        settings = Settings(teams={"1": first, "2": second})
+        rec = import_tokens.create_token(second, "zipfit")
+
+        team, loaded = import_tokens.load_token(settings, str(rec["token"]))
+
+        assert team.team_id == "2"
+        assert loaded["template_name"] == "zipfit"

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -1,3 +1,6 @@
+import pytest
+from cryptography.exceptions import InvalidSignature
+
 from oduflow import licensing
 from oduflow.licensing import TYPE_BUSINESS, TYPE_INDIVIDUAL, LicenseInfo
 
@@ -50,3 +53,184 @@ def test_install_license_copies_to_etc_dir(tmp_path, monkeypatch):
 
     assert licensing.install_license(str(source), etc_dir=str(dest_dir)) == expected
     assert (dest_dir / "license.key").read_text(encoding="utf-8") == "fake-file-key"
+
+
+class TestVerifyLicenseText:
+    """Signature verification for the license key.
+
+    Every other test in this module patches ``_verify_license_text`` out, so
+    the actual crypto had no coverage: a mutant that skipped the signature
+    check, or accepted an unknown license type, passed unnoticed. The tests
+    below swap in a throwaway RSA key pair so real signatures can be produced
+    and the genuine failure paths exercised.
+    """
+
+    @staticmethod
+    def _keypair():
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            PublicFormat,
+        )
+
+        private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private.public_key().public_bytes(
+            Encoding.PEM, PublicFormat.SubjectPublicKeyInfo
+        )
+        return private, pem.decode()
+
+    @staticmethod
+    def _sign(private, payload: dict) -> str:
+        import base64
+        import json
+
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        payload_bytes = json.dumps(payload).encode()
+        signature = private.sign(
+            payload_bytes,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+        return (
+            base64.b64encode(signature).decode()
+            + "."
+            + base64.b64encode(payload_bytes).decode()
+        )
+
+    @pytest.fixture
+    def signer(self, monkeypatch):
+        private, pem = self._keypair()
+        monkeypatch.setattr(licensing, "_PUBLIC_KEY_PEM", pem)
+        return lambda payload: self._sign(private, payload)
+
+    def test_valid_license_is_accepted(self, signer):
+        key = signer(
+            {"type": "business", "name": "Acme", "email": "ops@acme.example"}
+        )
+
+        info = licensing._verify_license_text(key)
+
+        assert info == LicenseInfo(
+            type="business", name="Acme", email="ops@acme.example"
+        )
+
+    def test_surrounding_whitespace_is_tolerated(self, signer):
+        key = signer({"type": "individual", "name": "Ada", "email": "a@b.co"})
+
+        assert licensing._verify_license_text(f"\n  {key}  \n").name == "Ada"
+
+    def test_missing_fields_default_to_empty_strings(self, signer):
+        info = licensing._verify_license_text(signer({"type": "individual"}))
+
+        assert info.name == ""
+        assert info.email == ""
+
+    def test_a_tampered_payload_is_rejected(self, signer):
+        # The whole point of the signature: edit the payload, keep the
+        # signature, and verification must fail.
+        import base64
+        import json
+
+        key = signer({"type": "individual", "name": "Ada", "email": "a@b.co"})
+        sig_b64, _ = key.split(".", 1)
+        forged = json.dumps(
+            {"type": "integrator", "name": "Mallory", "email": "m@evil.example"}
+        ).encode()
+        tampered = sig_b64 + "." + base64.b64encode(forged).decode()
+
+        with pytest.raises(InvalidSignature):
+            licensing._verify_license_text(tampered)
+
+    def test_a_license_signed_by_another_key_is_rejected(self, monkeypatch):
+        other_private, _ = self._keypair()
+        _, our_pem = self._keypair()
+        monkeypatch.setattr(licensing, "_PUBLIC_KEY_PEM", our_pem)
+        key = self._sign(other_private, {"type": "business", "name": "Acme"})
+
+        with pytest.raises(InvalidSignature):
+            licensing._verify_license_text(key)
+
+    def test_unknown_license_type_is_rejected(self, signer):
+        key = signer({"type": "enterprise-plus", "name": "Acme"})
+
+        with pytest.raises(ValueError, match="Unknown license type"):
+            licensing._verify_license_text(key)
+
+    def test_missing_type_is_rejected(self, signer):
+        with pytest.raises(ValueError, match="Unknown license type"):
+            licensing._verify_license_text(signer({"name": "Acme"}))
+
+    @pytest.mark.parametrize("valid_type", ["individual", "business", "integrator"])
+    def test_all_three_license_types_are_accepted(self, signer, valid_type):
+        info = licensing._verify_license_text(signer({"type": valid_type}))
+
+        assert info.type == valid_type
+
+    def test_text_without_a_separator_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid license format"):
+            licensing._verify_license_text("not-a-license")
+
+    def test_empty_text_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid license format"):
+            licensing._verify_license_text("   \n ")
+
+    def test_only_the_first_separator_splits_signature_from_payload(self, signer):
+        # Base64 payloads never contain '.', but splitting on the last one
+        # would still be wrong; pin the behaviour.
+        key = signer({"type": "individual", "name": "Ada"})
+        assert key.count(".") == 1
+        assert licensing._verify_license_text(key).name == "Ada"
+
+    def test_get_license_info_downgrades_an_invalid_file(self, tmp_path, caplog):
+        # An unreadable or forged license must not crash the server; it falls
+        # back to unlicensed.
+        (tmp_path / "license.key").write_text("garbage", encoding="utf-8")
+
+        info = licensing.get_license_info(etc_dir=str(tmp_path))
+
+        assert info.type == licensing.TYPE_UNLICENSED
+
+    def test_install_license_from_text_rejects_a_bad_key(self, tmp_path):
+        with pytest.raises(ValueError):
+            licensing.install_license_from_text("garbage", etc_dir=str(tmp_path))
+
+        assert not (tmp_path / "license.key").exists()
+
+
+class TestLicenseLabel:
+    def test_unlicensed_label_has_no_name(self):
+        assert licensing.LicenseInfo("unlicensed", "Ada", "a@b.co").label == (
+            "UNLICENSED — NON-COMMERCIAL USE ONLY"
+        )
+
+    def test_business_label_carries_the_internal_use_suffix(self):
+        assert licensing.LicenseInfo("business", "Acme", "a@b.co").label == (
+            "Licensed to company: Acme (internal use only)"
+        )
+
+    def test_individual_and_integrator_labels_have_no_suffix(self):
+        assert licensing.LicenseInfo("individual", "Ada", "a@b.co").label == (
+            "Licensed to individual: Ada"
+        )
+        assert licensing.LicenseInfo("integrator", "Acme", "a@b.co").label == (
+            "Licensed to Odoo integrator: Acme"
+        )
+
+    def test_unknown_type_falls_back_to_the_unlicensed_label(self):
+        assert licensing.LicenseInfo("bogus", "Ada", "a@b.co").label.startswith(
+            "UNLICENSED"
+        )
+
+    def test_to_dict_includes_the_rendered_label(self):
+        info = licensing.LicenseInfo("individual", "Ada", "a@b.co")
+        assert info.to_dict() == {
+            "type": "individual",
+            "name": "Ada",
+            "email": "a@b.co",
+            "label": "Licensed to individual: Ada",
+        }

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -5,6 +5,10 @@ reaches for restarts and recreations; the message therefore names the operation
 that holds the lock and how long it has held it.
 """
 
+from __future__ import annotations
+
+import threading
+
 import pytest
 
 from oduflow.errors import BusyError
@@ -94,3 +98,139 @@ class TestSystemLockDiagnostics:
         assert "init_system" in str(exc.value)
         locks.release_system()
         locks.acquire_system()  # released cleanly
+
+
+class TestEnvLocks:
+    def test_a_second_acquire_of_the_same_env_is_busy(self):
+        locks = LockManager()
+        locks.acquire_env("main")
+
+        with pytest.raises(BusyError):
+            locks.acquire_env("main")
+
+    def test_different_environments_do_not_contend(self):
+        locks = LockManager()
+        locks.acquire_env("main")
+
+        locks.acquire_env("other")  # must not raise
+
+    def test_release_makes_the_env_available_again(self):
+        locks = LockManager()
+        locks.acquire_env("main")
+        locks.release_env("main")
+
+        locks.acquire_env("main")  # must not raise
+
+    def test_releasing_an_unheld_env_is_a_no_op(self):
+        LockManager().release_env("never-locked")  # must not raise
+
+    def test_a_double_release_is_a_no_op(self):
+        locks = LockManager()
+        locks.acquire_env("main")
+        locks.release_env("main")
+
+        locks.release_env("main")  # must not raise
+
+    def test_blocking_acquire_succeeds_when_free(self):
+        assert LockManager().acquire_env_blocking("main", 0.1) is True
+
+    def test_blocking_acquire_times_out_when_held(self):
+        locks = LockManager()
+        locks.acquire_env_blocking("main", 0.1)
+
+        assert locks.acquire_env_blocking("main", 0.05) is False
+
+    def test_blocking_acquire_waits_for_a_release(self):
+        locks = LockManager()
+        locks.acquire_env_blocking("main", 0.1)
+        threading.Timer(0.05, lambda: locks.release_env("main")).start()
+
+        assert locks.acquire_env_blocking("main", 5) is True
+        locks.release_env("main")
+
+
+class TestTeamLocks:
+    def test_a_team_operation_blocks_that_team_s_environments(self):
+        locks = LockManager()
+        locks.acquire_team("1")
+
+        with pytest.raises(BusyError, match="team"):
+            locks.acquire_env("main", team_id="1")
+
+    def test_another_team_is_unaffected(self):
+        locks = LockManager()
+        locks.acquire_team("1")
+
+        locks.acquire_env("main", team_id="2")  # must not raise
+
+    def test_an_env_operation_blocks_its_team_lock(self):
+        locks = LockManager()
+        locks.acquire_env("main", team_id="1")
+
+        with pytest.raises(BusyError):
+            locks.acquire_team("1")
+
+    def test_a_second_team_acquire_is_busy(self):
+        locks = LockManager()
+        locks.acquire_team("1")
+
+        with pytest.raises(BusyError):
+            locks.acquire_team("1")
+
+    def test_releasing_the_env_frees_the_team_lock(self):
+        # The team is remembered at acquire time, so release needs no team_id.
+        locks = LockManager()
+        locks.acquire_env("main", team_id="1")
+        locks.release_env("main")
+
+        locks.acquire_team("1")  # must not raise
+
+    def test_the_team_stays_blocked_while_any_of_its_envs_is_busy(self):
+        locks = LockManager()
+        locks.acquire_env("main", team_id="1")
+        locks.acquire_env("other", team_id="1")
+        locks.release_env("main")
+
+        with pytest.raises(BusyError):
+            locks.acquire_team("1")
+
+        locks.release_env("other")
+        locks.acquire_team("1")  # now free
+
+    def test_an_untagged_env_lock_does_not_block_a_team(self):
+        # Only team-scoped acquires participate in the team accounting.
+        locks = LockManager()
+        locks.acquire_env("main")
+
+        locks.acquire_team("1")  # must not raise
+
+
+class TestSystemLock:
+    def test_a_second_system_acquire_is_busy(self):
+        locks = LockManager()
+        locks.acquire_system()
+
+        with pytest.raises(BusyError, match="system-level"):
+            locks.acquire_system()
+
+    def test_release_makes_the_system_lock_available_again(self):
+        locks = LockManager()
+        locks.acquire_system()
+        locks.release_system()
+
+        locks.acquire_system()  # must not raise
+
+    def test_releasing_an_unheld_system_lock_is_a_no_op(self):
+        LockManager().release_system()  # must not raise
+
+    def test_a_double_release_is_a_no_op(self):
+        locks = LockManager()
+        locks.acquire_system()
+        locks.release_system()
+
+        locks.release_system()  # must not raise
+
+    def test_two_managers_do_not_share_state(self):
+        LockManager().acquire_system()
+
+        LockManager().acquire_system()  # must not raise

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 import os
 
 import pytest
@@ -260,3 +261,78 @@ class TestResourceLimitsMigration:
         monkeypatch.setattr("oduflow.docker_ops.client.get_client", lambda: client)
 
         _migrate_env_resource_limits(Settings(teams={"1": TeamSettings(team_id="1")}))
+
+
+class TestTraefikYmlConfigMigration:
+    """Recreate Traefik when it still mounts the rejected ``.json`` config.
+
+    ``_ensure_traefik`` never rewrites an existing container's args, so a
+    stale container would keep serving with a dynamic config Traefik refuses
+    to load. The migration removes it; system init recreates it.
+    """
+
+    _OLD = "--providers.file.filename=/etc/traefik/dynamic/oduflow.json"
+    _NEW = "--providers.file.filename=/etc/traefik/dynamic/oduflow.yml"
+
+    def _run(self, monkeypatch, container, routing_mode="traefik"):
+        import docker as _docker
+
+        from oduflow.migrations import _migrate_traefik_yml_config
+
+        client = MagicMock()
+        if container is None:
+            client.containers.get.side_effect = _docker.errors.NotFound("nope")
+        else:
+            client.containers.get.return_value = container
+        monkeypatch.setattr("oduflow.docker_ops.client.get_client", lambda: client)
+        settings = Settings(routing_mode=routing_mode)
+        _migrate_traefik_yml_config(settings)
+        return client
+
+    def _container(self, cmd):
+        container = MagicMock()
+        container.attrs = {"Config": {"Cmd": cmd}}
+        return container
+
+    def test_stale_json_container_is_removed(self, monkeypatch):
+        container = self._container(["traefik", self._OLD])
+
+        self._run(monkeypatch, container)
+
+        container.stop.assert_called_once()
+        container.remove.assert_called_once()
+
+    def test_already_migrated_container_is_left_alone(self, monkeypatch):
+        container = self._container(["traefik", self._NEW])
+
+        self._run(monkeypatch, container)
+
+        container.stop.assert_not_called()
+        container.remove.assert_not_called()
+
+    def test_container_without_a_cmd_is_left_alone(self, monkeypatch):
+        container = MagicMock()
+        container.attrs = {}
+
+        self._run(monkeypatch, container)
+
+        container.remove.assert_not_called()
+
+    def test_null_cmd_is_left_alone(self, monkeypatch):
+        # Docker reports Cmd as null, not [], for some images.
+        container = self._container(None)
+
+        self._run(monkeypatch, container)
+
+        container.remove.assert_not_called()
+
+    def test_port_mode_skips_docker_entirely(self, monkeypatch):
+        container = self._container(["traefik", self._OLD])
+
+        client = self._run(monkeypatch, container, routing_mode="port")
+
+        client.containers.get.assert_not_called()
+        container.remove.assert_not_called()
+
+    def test_absent_traefik_is_not_an_error(self, monkeypatch):
+        self._run(monkeypatch, None)  # must not raise

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -255,3 +255,120 @@ class TestProdNaming:
             "oduflow-2-prod-erp-odoo"
         )
         assert get_workspace_path(env, "/data/ws") == "/data/ws/prod-erp"
+
+
+class TestValidateDomain:
+    def test_normalizes_case_whitespace_and_trailing_dot(self):
+        from oduflow.naming import validate_domain
+
+        assert validate_domain("  ERP.Example.COM.  ") == "erp.example.com"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "   ",
+            ".",
+            "https://erp.example.com",
+            "erp.example.com:8069",
+            "erp.example.com/path",
+            "*.example.com",
+            "erp example.com",
+        ],
+    )
+    def test_rejects_non_hostnames(self, bad):
+        from oduflow.naming import validate_domain
+
+        with pytest.raises(ValueError, match="Invalid domain"):
+            validate_domain(bad)
+
+    def test_length_boundary_is_253(self):
+        # A 253-char FQDN is the DNS maximum and must be accepted; 254 must not.
+        from oduflow.naming import validate_domain
+
+        # 63 + 63 + 63 + 61 chars + 3 dots = 253 (63 is the per-label maximum).
+        longest = ".".join(["a" * 63, "a" * 63, "a" * 63, "a" * 61])
+        assert len(longest) == 253
+        assert validate_domain(longest) == longest
+
+        too_long = longest + "a"
+        assert len(too_long) == 254
+        with pytest.raises(ValueError, match="Invalid domain"):
+            validate_domain(too_long)
+
+    def test_trailing_dot_is_stripped_before_the_length_check(self):
+        # The root dot is not part of the name, so a 253-char name written as an
+        # absolute FQDN (254 chars incl. the dot) is still valid.
+        from oduflow.naming import validate_domain
+
+        absolute = ".".join(["a" * 63, "a" * 63, "a" * 63, "a" * 61]) + "."
+        assert len(absolute) == 254
+        assert validate_domain(absolute) == absolute.rstrip(".")
+
+
+class TestSanitizeRepoUrl:
+    def test_strips_userinfo_but_keeps_host_and_port(self):
+        from oduflow.naming import sanitize_repo_url
+
+        assert (
+            sanitize_repo_url("https://user:pat@git.example.com:8443/acme/repo.git")
+            == "https://git.example.com:8443/acme/repo.git"
+        )
+
+    def test_at_sign_inside_the_password_is_still_fully_stripped(self):
+        # A PAT or password may itself contain '@'; only the LAST '@' separates
+        # userinfo from the host, so everything before it must go.
+        from oduflow.naming import sanitize_repo_url
+
+        assert (
+            sanitize_repo_url("https://user:p@ss@git.example.com/acme/repo.git")
+            == "https://git.example.com/acme/repo.git"
+        )
+
+    def test_url_without_credentials_is_untouched(self):
+        from oduflow.naming import sanitize_repo_url
+
+        url = "https://git.example.com/acme/repo.git"
+        assert sanitize_repo_url(url) == url
+
+    def test_empty_input_passes_through(self):
+        from oduflow.naming import sanitize_repo_url
+
+        assert sanitize_repo_url("") == ""
+
+
+class TestRedactUrlCredentials:
+    """Guards the scrubber applied to git stderr before it reaches an agent."""
+
+    def test_redacts_credentials_embedded_in_free_text(self):
+        from oduflow.naming import redact_url_credentials
+
+        text = (
+            "fatal: could not read from "
+            "https://user:ghp_secret@github.com/acme/repo.git\n"
+        )
+        redacted = redact_url_credentials(text)
+
+        assert "ghp_secret" not in redacted
+        assert "user" not in redacted
+        assert "https://***@github.com/acme/repo.git" in redacted
+
+    def test_redacts_every_occurrence(self):
+        from oduflow.naming import redact_url_credentials
+
+        text = "a https://u:p1@host/x b ssh://u:p2@host/y"
+        redacted = redact_url_credentials(text)
+
+        assert "p1" not in redacted and "p2" not in redacted
+        assert redacted == "a https://***@host/x b ssh://***@host/y"
+
+    def test_leaves_credential_free_urls_alone(self):
+        from oduflow.naming import redact_url_credentials
+
+        text = "cloning https://github.com/acme/repo.git"
+        assert redact_url_credentials(text) == text
+
+    def test_empty_input_passes_through(self):
+        from oduflow.naming import redact_url_credentials
+
+        assert redact_url_credentials("") == ""

--- a/tests/test_neutralize.py
+++ b/tests/test_neutralize.py
@@ -51,6 +51,51 @@ class TestNeutralizeEnvironment:
         assert any("Skipped" in line and "Odoo 15" in line for line in logs)
         assert not any("WARNING" in line for line in logs)
 
+    def test_odoo_16_is_the_first_version_that_neutralizes(self):
+        # 15 is the last release without the native CLI command; 16 must run it.
+        # Guards the `major <= 15` boundary from both sides.
+        container = MagicMock()
+        container.labels = {"oduflow.image": "odoo:16.0"}
+        container.exec_run.return_value = (0, b"Neutralization finished")
+        client = MagicMock()
+        client.containers.get.return_value = container
+
+        logs = sanitizer.neutralize_environment(
+            client, _settings(), _team(), "feature/foo"
+        )
+
+        assert _neutralize_cmd(container) is not None
+        assert not any("Skipped" in line for line in logs)
+
+    def test_odoo_14_is_also_skipped(self):
+        container = MagicMock()
+        container.labels = {"oduflow.image": "odoo:14.0"}
+        client = MagicMock()
+        client.containers.get.return_value = container
+
+        logs = sanitizer.neutralize_environment(
+            client, _settings(), _team(), "feature/foo"
+        )
+
+        container.exec_run.assert_not_called()
+        assert any("Skipped" in line for line in logs)
+
+    def test_unknown_version_still_attempts_neutralize(self):
+        # No usable image label -> major is None -> do not skip. Neutralizing
+        # and failing is safer than silently leaving a live database.
+        container = MagicMock()
+        container.labels = {}
+        container.exec_run.return_value = (0, b"Neutralization finished")
+        client = MagicMock()
+        client.containers.get.return_value = container
+
+        logs = sanitizer.neutralize_environment(
+            client, _settings(), _team(), "feature/foo"
+        )
+
+        assert _neutralize_cmd(container) is not None
+        assert not any("Skipped" in line for line in logs)
+
     def test_runs_neutralize_command_in_container(self):
         container = MagicMock()
         container.exec_run.return_value = (0, b"Neutralization finished")

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -505,3 +505,112 @@ class TestOduflowOAuthProvider:
         hdr = dict(start["headers"])[b"www-authenticate"].decode()
         assert "team-a.example.com" in hdr  # unchanged
         assert "evil.com" not in hdr
+
+
+class TestRedirectUriValidation:
+    """The redirect_uri is where the authorization code is delivered, so an
+    over-permissive check hands the code to an attacker."""
+
+    def _client(self):
+        return _run(OduflowOAuthProvider(_settings()).get_client("team_1"))
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "javascript://claude.ai/%0aalert(1)",
+            "data://text/html,<script>",
+            "vbscript://x",
+            "file://localhost/etc/passwd",
+        ],
+    )
+    def test_dangerous_schemes_are_refused(self, uri):
+        from mcp.shared.auth import InvalidRedirectUriError
+        from pydantic import AnyUrl
+
+        with pytest.raises(InvalidRedirectUriError, match="not allowed"):
+            self._client().validate_redirect_uri(AnyUrl(uri))
+
+    @pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "[::1]"])
+    def test_cleartext_http_is_allowed_only_on_loopback(self, host):
+        from pydantic import AnyUrl
+
+        uri = f"http://{host}:8976/cb"
+        assert str(self._client().validate_redirect_uri(AnyUrl(uri))) == uri
+
+    @pytest.mark.parametrize(
+        "host", ["evil.example", "claude.ai", "127.0.0.2", "localhost.evil.example"]
+    )
+    def test_cleartext_http_elsewhere_is_refused(self, host):
+        from mcp.shared.auth import InvalidRedirectUriError
+        from pydantic import AnyUrl
+
+        with pytest.raises(InvalidRedirectUriError, match="loopback"):
+            self._client().validate_redirect_uri(AnyUrl(f"http://{host}/cb"))
+
+    def test_https_to_any_host_is_allowed(self):
+        from pydantic import AnyUrl
+
+        assert self._client().validate_redirect_uri(AnyUrl("https://evil.example/cb"))
+
+    def test_a_custom_app_scheme_is_allowed(self):
+        # Native IDE clients register their own scheme (cursor://, vscode://).
+        from pydantic import AnyUrl
+
+        assert self._client().validate_redirect_uri(AnyUrl("cursor://callback/oauth"))
+
+    def test_omitting_the_uri_falls_back_to_the_first_registered_one(self):
+        client = self._client()
+
+        assert client.redirect_uris
+        assert client.validate_redirect_uri(None) == client.redirect_uris[0]
+
+
+class TestForwardedSchemeHost:
+    """Behind Traefik the advertised OAuth URLs come from forwarded headers;
+    getting them wrong makes discovery point at an unreachable origin."""
+
+    def _call(self, headers, fallback=None):
+        from oduflow.oauth_provider import _forwarded_scheme_host
+
+        raw = [(k.encode(), v.encode()) for k, v in headers.items()]
+        return _forwarded_scheme_host(raw, fallback)
+
+    def test_the_forwarded_host_wins_over_the_host_header(self):
+        assert self._call(
+            {"host": "internal:8000", "x-forwarded-host": "erp.example.com"}
+        ) == ("https", "erp.example.com")
+
+    def test_the_host_header_is_used_when_nothing_is_forwarded(self):
+        assert self._call({"host": "erp.example.com"}) == ("https", "erp.example.com")
+
+    def test_the_forwarded_proto_is_reflected(self):
+        assert self._call({"host": "h", "x-forwarded-proto": "http"})[0] == "http"
+
+    def test_only_the_first_hop_is_taken(self):
+        # A proxy chain appends; the client-facing hop is first.
+        scheme, host = self._call(
+            {
+                "x-forwarded-host": "erp.example.com, internal",
+                "x-forwarded-proto": "https, http",
+            }
+        )
+
+        assert (scheme, host) == ("https", "erp.example.com")
+
+    def test_the_fallback_scheme_applies_only_without_a_forwarded_proto(self):
+        assert self._call({"host": "h"}, fallback="http")[0] == "http"
+        assert self._call({"host": "h", "x-forwarded-proto": "https"}, "http")[0] == (
+            "https"
+        )
+
+    def test_https_is_the_last_resort(self):
+        # Never downgrade to http when nothing says otherwise.
+        assert self._call({"host": "h"})[0] == "https"
+
+    def test_header_names_are_matched_case_insensitively(self):
+        assert self._call({"Host": "erp.example.com", "X-Forwarded-Proto": "HTTP"}) == (
+            ("http", "erp.example.com")
+        )
+
+    def test_no_headers_at_all_yields_an_empty_host(self):
+        assert self._call({}) == ("https", "")

--- a/tests/test_oauth_token_store.py
+++ b/tests/test_oauth_token_store.py
@@ -1,0 +1,342 @@
+"""Persistent store for minted OAuth access/refresh tokens.
+
+The module had no test file. It holds bearer secrets and decides whether a
+request is authenticated, so the rules worth pinning are the asymmetries:
+expiry drops only the access record (its refresh partner must survive to
+rotate), revocation and rotation drop both sides, and the cache re-reads from
+disk when a sibling process rewrites the file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import time
+
+import pytest
+
+from oduflow import oauth_token_store as store_mod
+from oduflow.oauth_token_store import OAuthTokenStore
+
+
+@pytest.fixture
+def path(tmp_path):
+    return str(tmp_path / "oauth_tokens.json")
+
+
+@pytest.fixture
+def store(path):
+    return OAuthTokenStore(path, access_ttl=3600)
+
+
+def _read(path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+class TestMintPair:
+    def test_both_tokens_resolve(self, store):
+        access, refresh, expires_at = store.mint_pair("1", ["openid"])
+
+        assert store.get_access(access)["client_id"] == "1"
+        assert store.get_refresh(refresh)["client_id"] == "1"
+        assert expires_at > time.time()
+
+    def test_scopes_are_stored_on_both_sides(self, store):
+        access, refresh, _ = store.mint_pair("1", ["oduflow_env:main"])
+
+        assert store.get_access(access)["scopes"] == ["oduflow_env:main"]
+        assert store.get_refresh(refresh)["scopes"] == ["oduflow_env:main"]
+
+    def test_expiry_is_now_plus_the_configured_ttl(self, path):
+        store = OAuthTokenStore(path, access_ttl=120)
+        before = int(time.time())
+
+        _, _, expires_at = store.mint_pair("1", [])
+
+        assert before + 120 <= expires_at <= int(time.time()) + 120
+
+    def test_the_pair_records_point_at_each_other(self, store):
+        access, refresh, _ = store.mint_pair("1", [])
+
+        assert store.get_access(access)["refresh"] == refresh
+        assert store.get_refresh(refresh)["access"] == access
+
+    def test_tokens_are_unique_per_mint(self, store):
+        first = store.mint_pair("1", [])
+        second = store.mint_pair("1", [])
+
+        assert first[0] != second[0]
+        assert first[1] != second[1]
+
+    def test_the_file_is_written_owner_only(self, store, path):
+        store.mint_pair("1", [])
+
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        assert mode == 0o600
+
+    def test_an_unknown_token_resolves_to_nothing(self, store):
+        assert store.get_access("nope") is None
+        assert store.get_refresh("nope") is None
+
+    def test_the_returned_record_is_a_copy(self, store):
+        access, _, _ = store.mint_pair("1", [])
+
+        store.get_access(access)["client_id"] = "tampered"
+
+        assert store.get_access(access)["client_id"] == "1"
+
+
+class TestExpiry:
+    def test_an_expired_access_token_stops_resolving(self, path):
+        store = OAuthTokenStore(path, access_ttl=-1)
+        access, _, _ = store.mint_pair("1", [])
+
+        assert store.get_access(access) is None
+
+    def test_expiry_preserves_the_refresh_partner(self, path):
+        # The whole point of refresh: an expired access token must still be
+        # exchangeable for a new pair.
+        store = OAuthTokenStore(path, access_ttl=-1)
+        access, refresh, _ = store.mint_pair("1", [])
+
+        assert store.get_access(access) is None
+        assert store.get_refresh(refresh) is not None
+
+    def test_a_token_expiring_exactly_now_is_still_valid(self, store, path, monkeypatch):
+        # The check is `expires_at < now`, so the token survives its own
+        # expiry second.
+        access, _, expires_at = store.mint_pair("1", [])
+        monkeypatch.setattr(store_mod.time, "time", lambda: float(expires_at))
+
+        assert store.get_access(access) is not None
+
+    def test_a_token_expiring_a_second_ago_is_gone(self, store, monkeypatch):
+        access, _, expires_at = store.mint_pair("1", [])
+        monkeypatch.setattr(store_mod.time, "time", lambda: expires_at + 1.0)
+
+        assert store.get_access(access) is None
+
+    def test_a_record_without_an_expiry_never_expires(self, store, path):
+        # Hand-written or legacy records carry no expires_at.
+        with open(path, "w") as f:
+            json.dump({"access": {"tok": {"client_id": "1"}}, "refresh": {}}, f)
+        store._reload()
+
+        assert store.get_access("tok")["client_id"] == "1"
+
+    def test_pruning_removes_the_expired_record_from_disk(self, path):
+        store = OAuthTokenStore(path, access_ttl=-1)
+        access, refresh, _ = store.mint_pair("1", [])
+
+        store.get_access(access)  # triggers the prune
+
+        data = _read(path)
+        assert access not in data["access"]
+        assert refresh in data["refresh"]
+
+
+class TestRotate:
+    def test_rotation_returns_a_fresh_pair_with_the_same_identity(self, store):
+        _, refresh, _ = store.mint_pair("7", ["oduflow_env:main"])
+
+        result = store.rotate(refresh)
+
+        assert result is not None
+        new_access, new_refresh, expires_at, client_id, scopes = result
+        assert client_id == "7"
+        assert scopes == ["oduflow_env:main"]
+        assert expires_at > time.time()
+        assert store.get_access(new_access)["client_id"] == "7"
+        assert store.get_refresh(new_refresh) is not None
+
+    def test_rotation_invalidates_the_whole_old_pair(self, store):
+        old_access, old_refresh, _ = store.mint_pair("1", [])
+
+        store.rotate(old_refresh)
+
+        assert store.get_refresh(old_refresh) is None
+        assert store.get_access(old_access) is None
+
+    def test_replaying_a_rotated_refresh_token_fails(self, store):
+        _, refresh, _ = store.mint_pair("1", [])
+        store.rotate(refresh)
+
+        assert store.rotate(refresh) is None
+
+    def test_an_unknown_refresh_token_rotates_to_nothing(self, store):
+        assert store.rotate("never-issued") is None
+
+    def test_a_failed_rotation_leaves_existing_tokens_alone(self, store):
+        access, refresh, _ = store.mint_pair("1", [])
+
+        store.rotate("never-issued")
+
+        assert store.get_access(access) is not None
+        assert store.get_refresh(refresh) is not None
+
+    def test_the_new_access_token_carries_a_real_expiry(self, path):
+        store = OAuthTokenStore(path, access_ttl=60)
+        _, refresh, _ = store.mint_pair("1", [])
+
+        new_access, _, expires_at, _, _ = store.rotate(refresh)
+
+        assert store.get_access(new_access)["expires_at"] == expires_at
+        assert expires_at >= int(time.time())
+
+
+class TestRevoke:
+    def test_revoking_an_access_token_kills_its_refresh_partner(self, store):
+        access, refresh, _ = store.mint_pair("1", [])
+
+        store.revoke(access)
+
+        assert store.get_access(access) is None
+        assert store.get_refresh(refresh) is None
+
+    def test_revoking_a_refresh_token_kills_its_access_partner(self, store):
+        access, refresh, _ = store.mint_pair("1", [])
+
+        store.revoke(refresh)
+
+        assert store.get_access(access) is None
+        assert store.get_refresh(refresh) is None
+
+    def test_revoking_an_unknown_token_is_a_no_op(self, store):
+        access, _, _ = store.mint_pair("1", [])
+
+        store.revoke("never-issued")
+
+        assert store.get_access(access) is not None
+
+    def test_other_pairs_survive_a_revocation(self, store):
+        keep_access, keep_refresh, _ = store.mint_pair("1", [])
+        drop_access, _, _ = store.mint_pair("2", [])
+
+        store.revoke(drop_access)
+
+        assert store.get_access(keep_access) is not None
+        assert store.get_refresh(keep_refresh) is not None
+
+
+class TestPersistenceAndCache:
+    def test_tokens_survive_a_restart(self, path):
+        access, refresh, _ = OAuthTokenStore(path, 3600).mint_pair("1", [])
+
+        restarted = OAuthTokenStore(path, 3600)
+
+        assert restarted.get_access(access)["client_id"] == "1"
+        assert restarted.get_refresh(refresh) is not None
+
+    def test_a_token_minted_by_a_sibling_process_is_picked_up(self, path):
+        reader = OAuthTokenStore(path, 3600)
+        writer = OAuthTokenStore(path, 3600)
+
+        access, _, _ = writer.mint_pair("1", [])
+
+        # The reader's cache predates the mint; a miss must re-read the file.
+        assert reader.get_access(access)["client_id"] == "1"
+
+    def test_a_refresh_token_minted_elsewhere_is_picked_up(self, path):
+        reader = OAuthTokenStore(path, 3600)
+        writer = OAuthTokenStore(path, 3600)
+
+        _, refresh, _ = writer.mint_pair("1", [])
+
+        assert reader.get_refresh(refresh) is not None
+
+    def test_an_unchanged_file_is_not_re_read(self, path, monkeypatch):
+        store = OAuthTokenStore(path, 3600)
+        store.mint_pair("1", [])
+        reloads = []
+        monkeypatch.setattr(
+            OAuthTokenStore, "_reload", lambda self: reloads.append(1)
+        )
+
+        store.get_access("unknown")
+        store.get_access("unknown")
+
+        # A miss triggers _maybe_reload, but the mtime is unchanged, so the
+        # expensive path must stay untaken.
+        assert reloads == []
+
+    def test_a_missing_file_starts_empty(self, path):
+        assert OAuthTokenStore(path, 3600).get_access("anything") is None
+
+    def test_a_corrupt_file_starts_empty_instead_of_crashing(self, path):
+        with open(path, "w") as f:
+            f.write("{not json")
+
+        assert OAuthTokenStore(path, 3600).get_access("anything") is None
+
+    def test_a_store_can_recover_from_corruption(self, path):
+        with open(path, "w") as f:
+            f.write("{not json")
+        store = OAuthTokenStore(path, 3600)
+
+        access, _, _ = store.mint_pair("1", [])
+
+        assert store.get_access(access) is not None
+
+
+class TestLoadFile:
+    def test_wrong_shaped_sections_are_rejected(self, tmp_path):
+        path = str(tmp_path / "s.json")
+        with open(path, "w") as f:
+            json.dump({"access": [], "refresh": {}}, f)
+
+        assert store_mod._load_file(path) == {"access": {}, "refresh": {}}
+
+    def test_a_bad_refresh_section_alone_is_enough_to_reject(self, tmp_path):
+        # Both sections must be dicts; accepting a half-valid file would let a
+        # later write persist a broken structure.
+        path = str(tmp_path / "s.json")
+        with open(path, "w") as f:
+            json.dump({"access": {"t": {}}, "refresh": "nope"}, f)
+
+        assert store_mod._load_file(path) == {"access": {}, "refresh": {}}
+
+    def test_a_non_dict_document_is_rejected(self, tmp_path):
+        path = str(tmp_path / "s.json")
+        with open(path, "w") as f:
+            json.dump(["not", "a", "store"], f)
+
+        assert store_mod._load_file(path) == {"access": {}, "refresh": {}}
+
+    def test_missing_sections_default_to_empty(self, tmp_path):
+        path = str(tmp_path / "s.json")
+        with open(path, "w") as f:
+            json.dump({}, f)
+
+        assert store_mod._load_file(path) == {"access": {}, "refresh": {}}
+
+
+class TestPruneExpired:
+    def test_reports_whether_anything_was_removed(self):
+        data = {"access": {"a": {"expires_at": 1}}, "refresh": {}}
+
+        assert store_mod._prune_expired(data, now=100) is True
+        assert store_mod._prune_expired(data, now=100) is False
+
+    def test_a_record_expiring_exactly_now_is_kept(self):
+        data = {"access": {"a": {"expires_at": 100}}, "refresh": {}}
+
+        assert store_mod._prune_expired(data, now=100) is False
+        assert "a" in data["access"]
+
+    def test_records_without_an_expiry_are_kept(self):
+        data = {"access": {"a": {}}, "refresh": {}}
+
+        assert store_mod._prune_expired(data, now=10**9) is False
+        assert "a" in data["access"]
+
+    def test_refresh_records_are_never_pruned(self):
+        data = {
+            "access": {"a": {"expires_at": 1}},
+            "refresh": {"r": {"expires_at": 1}},
+        }
+
+        store_mod._prune_expired(data, now=100)
+
+        assert data["refresh"] == {"r": {"expires_at": 1}}

--- a/tests/test_output_cache.py
+++ b/tests/test_output_cache.py
@@ -1,0 +1,165 @@
+"""In-memory cache for large tool outputs.
+
+The module had no test file. It is what lets an agent page through a long
+Odoo log instead of drowning in it, so the rules worth pinning are: ids never
+collide (two outputs sharing a 1000-char prefix within one clock tick used
+to), error lines are indexed so the agent can jump to them, and neither the
+entry count nor a single output can grow without bound.
+"""
+
+from __future__ import annotations
+
+from oduflow import output_cache as cache_mod
+from oduflow.output_cache import OutputCache
+
+
+class TestStore:
+    def test_returns_an_entry_describing_the_output(self):
+        entry = OutputCache().store("a\nb\nc", "run_odoo_tests", "-m sale")
+
+        assert entry.lines == ["a", "b", "c"]
+        assert entry.total_lines == 3
+        assert entry.total_chars == 5
+        assert entry.source_tool == "run_odoo_tests"
+        assert entry.source_args == "-m sale"
+
+    def test_the_entry_is_retrievable_by_its_id(self):
+        cache = OutputCache()
+        entry = cache.store("payload", "tool", "")
+
+        assert cache.get(entry.output_id) is entry
+
+    def test_an_unknown_id_returns_nothing(self):
+        assert OutputCache().get("deadbeef") is None
+
+    def test_ids_are_unique_for_identical_output(self):
+        # Same text, same second, same 1000-char prefix: without the sequence
+        # counter the second store would overwrite the first.
+        cache = OutputCache()
+        first = cache.store("x" * 2000, "tool", "")
+        second = cache.store("x" * 2000, "tool", "")
+
+        assert first.output_id != second.output_id
+        assert cache.get(first.output_id) is first
+        assert cache.get(second.output_id) is second
+
+    def test_an_oversized_output_is_truncated(self):
+        entry = OutputCache().store("x" * (cache_mod._MAX_OUTPUT_SIZE + 500), "t", "")
+
+        assert entry.total_chars == cache_mod._MAX_OUTPUT_SIZE
+
+    def test_an_output_at_the_limit_is_kept_whole(self):
+        entry = OutputCache().store("x" * cache_mod._MAX_OUTPUT_SIZE, "t", "")
+
+        assert entry.total_chars == cache_mod._MAX_OUTPUT_SIZE
+
+    def test_empty_output_is_storable(self):
+        entry = OutputCache().store("", "t", "")
+
+        assert entry.lines == []
+        assert entry.total_lines == 0
+
+
+class TestErrorDetection:
+    def _indices(self, text: str) -> list[int]:
+        return OutputCache().store(text, "t", "").error_line_indices
+
+    def test_error_and_warning_lines_are_indexed(self):
+        text = "ok\n2026-01-01 ERROR something broke\nfine\n2026 WARNING careful"
+
+        assert self._indices(text) == [1, 3]
+
+    def test_detection_is_case_insensitive(self):
+        assert self._indices("2026 error lowercase") == [0]
+
+    def test_tracebacks_and_exceptions_are_flagged(self):
+        text = "Traceback (most recent call last):\nValueError exception here"
+
+        assert self._indices(text) == [0, 1]
+
+    def test_a_clean_log_flags_nothing(self):
+        entry = OutputCache().store("all\nfine\nhere", "t", "")
+
+        assert entry.error_line_indices == []
+        assert entry.has_errors is False
+
+    def test_has_errors_reflects_the_indices(self):
+        assert OutputCache().store("x ERROR y", "t", "").has_errors is True
+
+    def test_a_substring_of_a_word_does_not_count(self):
+        # The markers are space-delimited so "TERRORISM" is not an error.
+        assert self._indices("mentions TERRORISM in passing") == []
+
+
+class TestExpiry:
+    def test_an_expired_entry_is_not_returned(self, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(cache_mod.time, "time", lambda: clock["t"])
+        cache = OutputCache()
+        entry = cache.store("payload", "t", "")
+
+        clock["t"] += cache_mod._CACHE_TTL + 1
+
+        assert cache.get(entry.output_id) is None
+
+    def test_an_entry_at_exactly_the_ttl_is_still_returned(self, monkeypatch):
+        # The check is `age > TTL`, so the entry survives its own deadline.
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(cache_mod.time, "time", lambda: clock["t"])
+        cache = OutputCache()
+        entry = cache.store("payload", "t", "")
+
+        clock["t"] += cache_mod._CACHE_TTL
+
+        assert cache.get(entry.output_id) is entry
+
+    def test_an_expired_entry_is_dropped_from_the_store(self, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(cache_mod.time, "time", lambda: clock["t"])
+        cache = OutputCache()
+        entry = cache.store("payload", "t", "")
+
+        clock["t"] += cache_mod._CACHE_TTL + 1
+        cache.get(entry.output_id)
+
+        assert entry.output_id not in cache._store
+
+
+class TestEviction:
+    def test_the_entry_count_stays_bounded(self):
+        cache = OutputCache()
+
+        for i in range(cache_mod._MAX_ENTRIES + 10):
+            cache.store(f"output {i}", "t", "")
+
+        assert len(cache._store) <= cache_mod._MAX_ENTRIES
+
+    def test_the_newest_entry_survives_eviction(self):
+        cache = OutputCache()
+        for i in range(cache_mod._MAX_ENTRIES + 5):
+            newest = cache.store(f"output {i}", "t", "")
+
+        assert cache.get(newest.output_id) is newest
+
+    def test_the_oldest_entry_is_evicted_first(self, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(cache_mod.time, "time", lambda: clock["t"])
+        cache = OutputCache()
+
+        oldest = cache.store("first", "t", "")
+        for i in range(cache_mod._MAX_ENTRIES):
+            clock["t"] += 1
+            cache.store(f"output {i}", "t", "")
+
+        assert cache.get(oldest.output_id) is None
+
+    def test_expired_entries_are_swept_on_store(self, monkeypatch):
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(cache_mod.time, "time", lambda: clock["t"])
+        cache = OutputCache()
+        stale = cache.store("stale", "t", "")
+
+        clock["t"] += cache_mod._CACHE_TTL + 1
+        cache.store("fresh", "t", "")
+
+        assert stale.output_id not in cache._store

--- a/tests/test_pg_tune.py
+++ b/tests/test_pg_tune.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import MagicMock
 
 from oduflow import pg_tune
 
@@ -87,6 +88,43 @@ class TestMemoryScaling:
         assert _mb(cfg["effective_cache_size"]) == 819
         assert cfg["max_worker_processes"] == "2"
 
+    def test_work_mem_cap(self):
+        # shared_buffers 1024MB / 50 connections = 20 -> capped at 16.
+        cfg = _parse(pg_tune.generate_postgresql_conf(32768, 16, max_connections=50))
+        assert _mb(cfg["work_mem"]) == 16
+
+    def test_maintenance_work_mem_is_half_the_shared_buffers(self):
+        cfg = _parse(pg_tune.generate_postgresql_conf(4096, 2))
+        assert _mb(cfg["shared_buffers"]) == 410
+        assert _mb(cfg["maintenance_work_mem"]) == 205
+
+    def test_maintenance_work_mem_floor(self):
+        cfg = _parse(pg_tune.generate_postgresql_conf(1024, 1))
+        assert _mb(cfg["maintenance_work_mem"]) == 64
+
+    def test_wal_buffers_is_three_percent_of_shared_buffers(self):
+        cfg = _parse(pg_tune.generate_postgresql_conf(4096, 2))
+        assert _mb(cfg["wal_buffers"]) == 12  # round(410 * 0.03)
+
+    def test_wal_buffers_floor_and_cap(self):
+        floored = _parse(pg_tune.generate_postgresql_conf(1024, 1))
+        assert _mb(floored["wal_buffers"]) == 4  # round(128 * 0.03) = 4
+        capped = _parse(pg_tune.generate_postgresql_conf(32768, 16))
+        assert _mb(capped["wal_buffers"]) == 16  # round(1024 * 0.03) = 31 -> 16
+
+    def test_effective_cache_is_three_times_shared_buffers(self):
+        cfg = _parse(pg_tune.generate_postgresql_conf(32768, 16))
+        assert _mb(cfg["effective_cache_size"]) == 1024 * 3
+
+    def test_degenerate_resources_still_produce_a_valid_conf(self):
+        cfg = _parse(pg_tune.generate_postgresql_conf(0, 0))
+        assert _mb(cfg["shared_buffers"]) == 128
+        assert cfg["max_worker_processes"] == "1"
+
+    def test_max_connections_floor(self):
+        cfg = _parse(pg_tune.generate_postgresql_conf(8192, 4, max_connections=0))
+        assert cfg["max_connections"] == "1"
+
 
 class TestParallelism:
     def test_no_parallel_gather_on_single_cpu(self):
@@ -102,6 +140,38 @@ class TestParallelism:
     def test_autovacuum_workers_capped_at_three(self):
         cfg = _parse(pg_tune.generate_postgresql_conf(16384, 32))
         assert cfg["autovacuum_max_workers"] == "3"
+
+    def test_parallel_gather_is_half_the_cpus_up_to_two(self):
+        def gather(cpu):
+            return _parse(
+                pg_tune.generate_postgresql_conf(16384, cpu)
+            )["max_parallel_workers_per_gather"]
+
+        assert gather(1) == "0"
+        assert gather(2) == "1"
+        assert gather(4) == "2"
+        assert gather(8) == "2"  # capped
+
+    def test_parallel_maintenance_workers_track_cpus_with_a_floor(self):
+        def maint(cpu):
+            return _parse(
+                pg_tune.generate_postgresql_conf(16384, cpu)
+            )["max_parallel_maintenance_workers"]
+
+        assert maint(1) == "1"  # floor
+        assert maint(2) == "1"
+        assert maint(4) == "2"
+        assert maint(16) == "2"  # capped
+
+    def test_autovacuum_workers_scale_below_the_cap(self):
+        def workers(cpu):
+            return _parse(
+                pg_tune.generate_postgresql_conf(16384, cpu)
+            )["autovacuum_max_workers"]
+
+        assert workers(1) == "1"
+        assert workers(2) == "2"
+        assert workers(3) == "3"
 
 
 class TestSsdAndConnections:
@@ -136,4 +206,130 @@ class TestDetectResources:
             "cpu_count": 2,
             "total_ram_mb": 4096.0,
             "source": "defaults",
+        }
+
+    def _docker(self, monkeypatch, info):
+        import oduflow.docker_ops.client as client_mod
+
+        client = MagicMock()
+        client.info.return_value = info
+        monkeypatch.setattr(client_mod, "get_client", lambda: client)
+
+    def _host(self, monkeypatch, stats):
+        import oduflow.docker_ops.stats as stats_mod
+
+        monkeypatch.setattr(stats_mod, "get_system_stats", lambda: stats)
+
+    def test_docker_info_is_preferred_and_converted_to_mib(self, monkeypatch):
+        self._docker(monkeypatch, {"NCPU": 8, "MemTotal": 16 * 1024**3})
+        self._host(monkeypatch, {"cpu_count": 99, "mem_total_mb": 99999.0})
+
+        assert pg_tune.detect_resources() == {
+            "cpu_count": 8,
+            "total_ram_mb": 16384.0,
+            "source": "docker",
+        }
+
+    def test_falls_back_to_host_stats_when_docker_reports_nothing(self, monkeypatch):
+        # A daemon that answers but reports zeroes is as useless as no daemon.
+        self._docker(monkeypatch, {"NCPU": 0, "MemTotal": 0})
+        self._host(monkeypatch, {"cpu_count": 4, "mem_total_mb": 8192.0})
+
+        assert pg_tune.detect_resources() == {
+            "cpu_count": 4,
+            "total_ram_mb": 8192.0,
+            "source": "host",
+        }
+
+    def test_partial_docker_info_is_rejected(self, monkeypatch):
+        # Both values are required; CPUs without RAM (or vice versa) would
+        # otherwise tune against a zero.
+        self._docker(monkeypatch, {"NCPU": 8, "MemTotal": 0})
+        self._host(monkeypatch, {"cpu_count": 4, "mem_total_mb": 8192.0})
+        assert pg_tune.detect_resources()["source"] == "host"
+
+        self._docker(monkeypatch, {"NCPU": 0, "MemTotal": 16 * 1024**3})
+        assert pg_tune.detect_resources()["source"] == "host"
+
+    def test_missing_docker_keys_are_treated_as_zero(self, monkeypatch):
+        self._docker(monkeypatch, {})
+        self._host(monkeypatch, {"cpu_count": 4, "mem_total_mb": 8192.0})
+
+        assert pg_tune.detect_resources()["source"] == "host"
+
+    def test_partial_host_stats_fall_through_to_defaults(self, monkeypatch):
+        import oduflow.docker_ops.client as client_mod
+
+        monkeypatch.setattr(
+            client_mod, "get_client", MagicMock(side_effect=RuntimeError("no docker"))
+        )
+        self._host(monkeypatch, {"cpu_count": 4, "mem_total_mb": 0.0})
+
+        assert pg_tune.detect_resources()["source"] == "defaults"
+
+    def test_single_cpu_and_one_mib_are_accepted(self, monkeypatch):
+        # The guard is `> 0`, not `> 1`: a 1-CPU host is a real host.
+        self._docker(monkeypatch, {"NCPU": 1, "MemTotal": 1024**2})
+
+        assert pg_tune.detect_resources() == {
+            "cpu_count": 1,
+            "total_ram_mb": 1.0,
+            "source": "docker",
+        }
+
+    def test_docker_reporting_one_byte_of_ram_is_still_accepted(self, monkeypatch):
+        # `mem_bytes > 0`: any positive value is real data from the daemon.
+        self._docker(monkeypatch, {"NCPU": 2, "MemTotal": 1})
+
+        assert pg_tune.detect_resources()["source"] == "docker"
+
+    def test_host_stats_with_zero_cpu_fall_through_to_defaults(self, monkeypatch):
+        # Mirror of the RAM-only case: CPUs missing means the reading is
+        # unusable, whatever RAM says.
+        import oduflow.docker_ops.client as client_mod
+
+        monkeypatch.setattr(
+            client_mod, "get_client", MagicMock(side_effect=RuntimeError("no docker"))
+        )
+        self._host(monkeypatch, {"cpu_count": 0, "mem_total_mb": 8192.0})
+
+        assert pg_tune.detect_resources()["source"] == "defaults"
+
+    def test_missing_host_cpu_key_is_zero_not_one(self, monkeypatch):
+        import oduflow.docker_ops.client as client_mod
+
+        monkeypatch.setattr(
+            client_mod, "get_client", MagicMock(side_effect=RuntimeError("no docker"))
+        )
+        self._host(monkeypatch, {"mem_total_mb": 8192.0})
+
+        assert pg_tune.detect_resources()["source"] == "defaults"
+
+    def test_single_cpu_host_stats_are_accepted(self, monkeypatch):
+        import oduflow.docker_ops.client as client_mod
+
+        monkeypatch.setattr(
+            client_mod, "get_client", MagicMock(side_effect=RuntimeError("no docker"))
+        )
+        self._host(monkeypatch, {"cpu_count": 1, "mem_total_mb": 8192.0})
+
+        assert pg_tune.detect_resources() == {
+            "cpu_count": 1,
+            "total_ram_mb": 8192.0,
+            "source": "host",
+        }
+
+    def test_sub_mib_host_ram_is_accepted(self, monkeypatch):
+        # `ram > 0`, not `> 1`: a fractional MB reading is still a reading.
+        import oduflow.docker_ops.client as client_mod
+
+        monkeypatch.setattr(
+            client_mod, "get_client", MagicMock(side_effect=RuntimeError("no docker"))
+        )
+        self._host(monkeypatch, {"cpu_count": 4, "mem_total_mb": 0.5})
+
+        assert pg_tune.detect_resources() == {
+            "cpu_count": 4,
+            "total_ram_mb": 0.5,
+            "source": "host",
         }

--- a/tests/test_port_registry_allocate.py
+++ b/tests/test_port_registry_allocate.py
@@ -1,0 +1,138 @@
+"""Allocation semantics of the port registry.
+
+``allocate_port`` gives an environment a *stable* port: the same one across
+restarts, unless that port is out of the configured range or already taken by
+another environment's container. Getting the reuse condition wrong hands out a
+port that is already bound, so both halves of it — range membership and the
+``used_ports`` conflict check — are pinned here, boundaries included.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from oduflow.errors import FlowError
+from oduflow.port_registry import allocate_port, get_port, release_port
+
+
+def _path(tmp_path) -> str:
+    return str(tmp_path / "ports.json")
+
+
+def _seed(tmp_path, registry: dict[str, int]) -> str:
+    path = _path(tmp_path)
+    with open(path, "w") as f:
+        json.dump(registry, f)
+    return path
+
+
+class TestFreshAllocation:
+    def test_first_environment_gets_the_range_start(self, tmp_path):
+        assert allocate_port(_path(tmp_path), "main", 50_000, 50_100) == 50_000
+
+    def test_next_environment_gets_the_next_free_port(self, tmp_path):
+        path = _path(tmp_path)
+        assert allocate_port(path, "a", 50_000, 50_100) == 50_000
+        assert allocate_port(path, "b", 50_000, 50_100) == 50_001
+
+    def test_allocation_is_persisted(self, tmp_path):
+        path = _path(tmp_path)
+        allocate_port(path, "main", 50_000, 50_100)
+        assert get_port(path, "main") == 50_000
+
+    def test_docker_used_ports_are_skipped(self, tmp_path):
+        port = allocate_port(
+            _path(tmp_path), "main", 50_000, 50_100, used_ports={50_000, 50_001}
+        )
+        assert port == 50_002
+
+    def test_released_port_becomes_available_again(self, tmp_path):
+        path = _path(tmp_path)
+        allocate_port(path, "a", 50_000, 50_100)
+        release_port(path, "a")
+        assert get_port(path, "a") is None
+        assert allocate_port(path, "b", 50_000, 50_100) == 50_000
+
+
+class TestReuse:
+    def test_existing_assignment_is_reused(self, tmp_path):
+        path = _seed(tmp_path, {"main": 50_042})
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_042
+
+    def test_port_taken_by_another_container_is_not_reused(self, tmp_path):
+        # The core conflict check: the registry still says 50_042, but Docker
+        # reports it bound elsewhere, so a *different* port must be handed out.
+        path = _seed(tmp_path, {"main": 50_042})
+
+        port = allocate_port(path, "main", 50_000, 50_100, used_ports={50_042})
+
+        assert port != 50_042
+        assert get_port(path, "main") == port
+
+    def test_reuse_requires_both_conditions(self, tmp_path):
+        # In range but used -> reallocate; free but out of range -> reallocate.
+        in_range_but_used = _seed(tmp_path, {"main": 50_042})
+        assert (
+            allocate_port(
+                in_range_but_used, "main", 50_000, 50_100, used_ports={50_042}
+            )
+            != 50_042
+        )
+
+        out_of_range_but_free = _seed(tmp_path, {"other": 60_000})
+        assert (
+            allocate_port(out_of_range_but_free, "other", 50_000, 50_100) != 60_000
+        )
+
+    def test_assignment_below_the_range_is_reallocated(self, tmp_path):
+        path = _seed(tmp_path, {"main": 49_999})
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_000
+
+    def test_range_start_is_inclusive(self, tmp_path):
+        path = _seed(tmp_path, {"main": 50_000})
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_000
+
+    def test_range_end_is_exclusive(self, tmp_path):
+        # 50_100 is past the end of [50_000, 50_100), so it must not be reused.
+        path = _seed(tmp_path, {"main": 50_100})
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_000
+
+    def test_last_port_in_the_range_is_reusable(self, tmp_path):
+        path = _seed(tmp_path, {"main": 50_099})
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_099
+
+
+class TestExhaustion:
+    def test_full_range_raises(self, tmp_path):
+        path = _seed(tmp_path, {f"env-{p}": p for p in range(50_000, 50_003)})
+
+        with pytest.raises(FlowError, match="No free ports"):
+            allocate_port(path, "new", 50_000, 50_003)
+
+    def test_docker_can_exhaust_the_range_on_its_own(self, tmp_path):
+        with pytest.raises(FlowError, match="No free ports"):
+            allocate_port(
+                _path(tmp_path),
+                "new",
+                50_000,
+                50_003,
+                used_ports={50_000, 50_001, 50_002},
+            )
+
+
+class TestCorruptRegistry:
+    def test_unreadable_registry_is_treated_as_empty(self, tmp_path):
+        path = _path(tmp_path)
+        with open(path, "w") as f:
+            f.write("{not json")
+
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_000
+
+    def test_registry_is_written_as_readable_json(self, tmp_path):
+        path = _path(tmp_path)
+        allocate_port(path, "main", 50_000, 50_100)
+
+        with open(path) as f:
+            assert json.load(f) == {"main": 50_000}

--- a/tests/test_port_registry_allocate.py
+++ b/tests/test_port_registry_allocate.py
@@ -130,6 +130,18 @@ class TestCorruptRegistry:
 
         assert allocate_port(path, "main", 50_000, 50_100) == 50_000
 
+    @pytest.mark.parametrize("doc", ["null", "[1, 2]", '"a string"'])
+    def test_a_json_document_of_the_wrong_shape_is_treated_as_empty(
+        self, tmp_path, doc
+    ):
+        # Valid JSON of the wrong shape used to raise AttributeError past the
+        # error handling and abort environment creation.
+        path = _path(tmp_path)
+        with open(path, "w") as f:
+            f.write(doc)
+
+        assert allocate_port(path, "main", 50_000, 50_100) == 50_000
+
     def test_registry_is_written_as_readable_json(self, tmp_path):
         path = _path(tmp_path)
         allocate_port(path, "main", 50_000, 50_100)

--- a/tests/test_prod_tune.py
+++ b/tests/test_prod_tune.py
@@ -99,19 +99,21 @@ class TestProdPostgresConf:
         huge = _parse(prod_tune.generate_prod_postgresql_conf(128 * 1024, 32))
         assert _mb(huge["wal_buffers"]) == 64
 
-    def test_parallel_gather_switches_at_four_cpus(self):
-        # Below 4 CPUs: min(cpu, 2). From 4 up: max(cpu // 2, 2).
+    def test_parallel_gather_uses_the_production_cpu_budget(self):
+        # The unified plan gives production PostgreSQL roughly half the host
+        # CPUs, then applies the below-4 / 4-and-up parallelism formula.
         def gather(cpu):
             return _parse(
                 prod_tune.generate_prod_postgresql_conf(16384, cpu)
             )["max_parallel_workers_per_gather"]
 
         assert gather(1) == "1"
-        assert gather(2) == "2"
+        assert gather(2) == "1"
         assert gather(3) == "2"
         assert gather(4) == "2"  # max(2, 2)
-        assert gather(8) == "4"
-        assert gather(32) == "16"
+        assert gather(8) == "2"
+        assert gather(12) == "3"
+        assert gather(32) == "8"
 
     def test_parallel_maintenance_workers_are_capped_at_four(self):
         def maint(cpu):
@@ -120,8 +122,8 @@ class TestProdPostgresConf:
             )["max_parallel_maintenance_workers"]
 
         assert maint(1) == "1"
-        assert maint(4) == "2"
-        assert maint(8) == "4"
+        assert maint(4) == "1"
+        assert maint(8) == "2"
         assert maint(32) == "4"  # capped
 
     def test_autovacuum_workers_are_clamped_between_three_and_six(self):
@@ -131,14 +133,15 @@ class TestProdPostgresConf:
             )["autovacuum_max_workers"]
 
         assert workers(1) == "3"  # floor
-        assert workers(8) == "4"
-        assert workers(12) == "6"
+        assert workers(8) == "3"
+        assert workers(16) == "4"
+        assert workers(24) == "6"
         assert workers(32) == "6"  # cap
 
-    def test_worker_processes_track_cpu_count(self):
+    def test_worker_processes_track_the_production_cpu_budget(self):
         settings = _parse(prod_tune.generate_prod_postgresql_conf(16384, 8))
-        assert settings["max_worker_processes"] == "8"
-        assert settings["max_parallel_workers"] == "8"
+        assert settings["max_worker_processes"] == "4"
+        assert settings["max_parallel_workers"] == "4"
 
     def test_degenerate_resources_still_produce_a_valid_conf(self):
         # Detection can fail and report zeroes; the file must still be usable.
@@ -180,10 +183,10 @@ class TestOdooWorkerSettings:
         assert opts["workers"] == "20"
 
     def test_db_maxconn_scales_with_workers(self):
-        # 8 workers -> 2*8+3 = 19 connections.
+        # Unified plan gives this host 7 workers -> 2*7+3 = 17 connections.
         opts = prod_tune.compute_odoo_worker_settings(4, 32768)
-        assert opts["workers"] == "8"
-        assert opts["db_maxconn"] == "19"
+        assert opts["workers"] == "7"
+        assert opts["db_maxconn"] == "17"
 
     def test_db_maxconn_has_a_floor_of_16(self):
         # 2 workers -> 2*2+3 = 7, raised to the 16-connection floor.
@@ -218,5 +221,5 @@ class TestOdooWorkerSettings:
 
     def test_ram_budget_is_one_worker_per_gib_of_the_45_percent_share(self):
         # 6827 MB * 0.45 = 3072 MB -> exactly 3 GiB -> 3 workers, below both
-        # the CPU formula (17) and the cap (8).
+        # the planned-CPU formula (13) and the cap (8).
         assert prod_tune.compute_odoo_worker_settings(8, 6827)["workers"] == "3"

--- a/tests/test_prod_tune.py
+++ b/tests/test_prod_tune.py
@@ -50,6 +50,116 @@ class TestProdPostgresConf:
         settings = _parse(prod_tune.generate_prod_postgresql_conf(8192, 4))
         assert settings["max_connections"] == "200"
 
+    def test_full_memory_profile_for_a_16gb_8cpu_host(self):
+        # One reference host pinned end to end. Derivations: shared_buffers
+        # 20% of 16384; effective_cache 45%; work_mem sb//(mc//4) capped at 64;
+        # maintenance sb//4; wal_buffers 3% of sb capped at 64.
+        settings = _parse(prod_tune.generate_prod_postgresql_conf(16384, 8))
+        assert _mb(settings["shared_buffers"]) == 3277
+        assert _mb(settings["effective_cache_size"]) == 7373
+        assert _mb(settings["work_mem"]) == 64
+        assert _mb(settings["maintenance_work_mem"]) == 819
+        assert _mb(settings["wal_buffers"]) == 64
+
+    def test_full_memory_profile_for_a_small_host(self):
+        # 2 GB: every value lands on its floor except the derived ones.
+        settings = _parse(prod_tune.generate_prod_postgresql_conf(2048, 2))
+        assert _mb(settings["shared_buffers"]) == 512
+        assert _mb(settings["effective_cache_size"]) == 1024
+        assert _mb(settings["work_mem"]) == 10
+        assert _mb(settings["maintenance_work_mem"]) == 128
+        assert _mb(settings["wal_buffers"]) == 15
+
+    def test_effective_cache_floor_and_cap(self):
+        assert _mb(_parse(prod_tune.generate_prod_postgresql_conf(1024, 2))[
+            "effective_cache_size"
+        ]) == 1024
+        assert _mb(_parse(prod_tune.generate_prod_postgresql_conf(512 * 1024, 32))[
+            "effective_cache_size"
+        ]) == 65536
+
+    def test_work_mem_floor_and_cap(self):
+        # Floor 8 MB with a tiny shared_buffers, cap 64 MB with a large one.
+        tiny = _parse(
+            prod_tune.generate_prod_postgresql_conf(1024, 2, max_connections=4000)
+        )
+        assert _mb(tiny["work_mem"]) == 8
+        big = _parse(prod_tune.generate_prod_postgresql_conf(128 * 1024, 32))
+        assert _mb(big["work_mem"]) == 64
+
+    def test_maintenance_work_mem_floor_and_cap(self):
+        small = _parse(prod_tune.generate_prod_postgresql_conf(1024, 2))
+        assert _mb(small["maintenance_work_mem"]) == 128
+        huge = _parse(prod_tune.generate_prod_postgresql_conf(128 * 1024, 32))
+        assert _mb(huge["maintenance_work_mem"]) == 1024
+
+    def test_wal_buffers_floor_and_cap(self):
+        small = _parse(prod_tune.generate_prod_postgresql_conf(1024, 2))
+        assert _mb(small["wal_buffers"]) == 15
+        huge = _parse(prod_tune.generate_prod_postgresql_conf(128 * 1024, 32))
+        assert _mb(huge["wal_buffers"]) == 64
+
+    def test_parallel_gather_switches_at_four_cpus(self):
+        # Below 4 CPUs: min(cpu, 2). From 4 up: max(cpu // 2, 2).
+        def gather(cpu):
+            return _parse(
+                prod_tune.generate_prod_postgresql_conf(16384, cpu)
+            )["max_parallel_workers_per_gather"]
+
+        assert gather(1) == "1"
+        assert gather(2) == "2"
+        assert gather(3) == "2"
+        assert gather(4) == "2"  # max(2, 2)
+        assert gather(8) == "4"
+        assert gather(32) == "16"
+
+    def test_parallel_maintenance_workers_are_capped_at_four(self):
+        def maint(cpu):
+            return _parse(
+                prod_tune.generate_prod_postgresql_conf(16384, cpu)
+            )["max_parallel_maintenance_workers"]
+
+        assert maint(1) == "1"
+        assert maint(4) == "2"
+        assert maint(8) == "4"
+        assert maint(32) == "4"  # capped
+
+    def test_autovacuum_workers_are_clamped_between_three_and_six(self):
+        def workers(cpu):
+            return _parse(
+                prod_tune.generate_prod_postgresql_conf(16384, cpu)
+            )["autovacuum_max_workers"]
+
+        assert workers(1) == "3"  # floor
+        assert workers(8) == "4"
+        assert workers(12) == "6"
+        assert workers(32) == "6"  # cap
+
+    def test_worker_processes_track_cpu_count(self):
+        settings = _parse(prod_tune.generate_prod_postgresql_conf(16384, 8))
+        assert settings["max_worker_processes"] == "8"
+        assert settings["max_parallel_workers"] == "8"
+
+    def test_degenerate_resources_still_produce_a_valid_conf(self):
+        # Detection can fail and report zeroes; the file must still be usable.
+        settings = _parse(prod_tune.generate_prod_postgresql_conf(0, 0))
+        assert _mb(settings["shared_buffers"]) == 512
+        assert settings["max_worker_processes"] == "1"
+        assert settings["max_parallel_maintenance_workers"] == "1"
+
+    def test_max_connections_floor(self):
+        settings = _parse(
+            prod_tune.generate_prod_postgresql_conf(8192, 4, max_connections=0)
+        )
+        assert settings["max_connections"] == "1"
+
+    def test_header_reports_detected_resources_and_version(self):
+        conf = prod_tune.generate_prod_postgresql_conf(
+            8192, 4, source="docker", oduflow_version="9.9.9"
+        )
+        assert "4 vCPU, 8192 MB RAM (source: docker)" in conf
+        assert "9.9.9" in conf
+
 
 class TestOdooWorkerSettings:
     def test_standard_formula(self):
@@ -70,9 +180,43 @@ class TestOdooWorkerSettings:
         assert opts["workers"] == "20"
 
     def test_db_maxconn_scales_with_workers(self):
+        # 8 workers -> 2*8+3 = 19 connections.
         opts = prod_tune.compute_odoo_worker_settings(4, 32768)
-        assert int(opts["db_maxconn"]) == max(2 * int(opts["workers"]) + 3, 16)
+        assert opts["workers"] == "8"
+        assert opts["db_maxconn"] == "19"
+
+    def test_db_maxconn_has_a_floor_of_16(self):
+        # 2 workers -> 2*2+3 = 7, raised to the 16-connection floor.
+        opts = prod_tune.compute_odoo_worker_settings(1, 2048)
+        assert opts["workers"] == "2"
+        assert opts["db_maxconn"] == "16"
 
     def test_minimum_two_workers(self):
         opts = prod_tune.compute_odoo_worker_settings(1, 2048)
         assert int(opts["workers"]) >= 2
+
+    def test_workers_follow_two_cpu_plus_one_when_unconstrained(self):
+        # 2 CPU, 8 GB: 2*2+1 = 5 wanted, RAM budget allows 3 (8192*0.45//1024).
+        assert prod_tune.compute_odoo_worker_settings(2, 8192)["workers"] == "3"
+
+    def test_memory_limits_are_explicit_odoo_defaults_in_bytes(self):
+        opts = prod_tune.compute_odoo_worker_settings(4, 32768)
+        assert opts["limit_memory_soft"] == str(2048 * 1024 * 1024)
+        assert opts["limit_memory_hard"] == str(2560 * 1024 * 1024)
+        assert opts["limit_time_cpu"] == "600"
+        assert opts["limit_time_real"] == "1200"
+        assert opts["limit_request"] == "65536"
+
+    def test_ram_budget_has_a_floor_of_two_workers(self):
+        # Even a host with no detectable RAM must not compute zero workers.
+        assert prod_tune.compute_odoo_worker_settings(8, 0)["workers"] == "2"
+
+    def test_single_cpu_host_uses_the_formula_not_a_floor(self):
+        # 1 CPU with plenty of RAM: 2*1+1 = 3 workers, nothing binding.
+        # Pins both the CPU floor (1, not 2) and the 2*cpu+1 coefficients.
+        assert prod_tune.compute_odoo_worker_settings(1, 32768)["workers"] == "3"
+
+    def test_ram_budget_is_one_worker_per_gib_of_the_45_percent_share(self):
+        # 6827 MB * 0.45 = 3072 MB -> exactly 3 GiB -> 3 workers, below both
+        # the CPU formula (17) and the cap (8).
+        assert prod_tune.compute_odoo_worker_settings(8, 6827)["workers"] == "3"

--- a/tests/test_production_registry.py
+++ b/tests/test_production_registry.py
@@ -110,3 +110,58 @@ class TestRobustness:
         # State on disk is valid JSON with all records.
         with open(reg.registry_path(team)) as f:
             assert len(json.load(f)["productions"]) == 10
+
+
+class TestStateShape:
+    def test_a_fresh_registry_declares_schema_version_1(self, team):
+        # The version gates future migrations; a wrong value would make an
+        # upgrade skip or re-run them.
+        reg.create_production(team, "erp", {})
+
+        with open(reg.registry_path(team)) as f:
+            assert json.load(f)["version"] == 1
+
+    def test_a_legacy_registry_without_a_version_is_stamped_as_1(self, team):
+        path = reg.registry_path(team)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump({"productions": {}}, f)
+
+        assert reg._load_state(path)["version"] == 1
+
+    def test_the_webhook_secret_is_43_url_safe_chars(self, team):
+        # token_urlsafe(32) -> 43 chars; the value is a shared HMAC secret, so
+        # its entropy is worth pinning.
+        reg.create_production(team, "erp", {})
+
+        secret = reg.get_webhook_secret(team)
+        assert len(secret) == 43
+
+    def test_a_registry_missing_the_productions_map_is_rejected(self, team):
+        # Both halves of the shape check matter: a dict without "productions"
+        # must not be accepted and then written back as a valid registry.
+        path = reg.registry_path(team)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump({"version": 1, "webhook_secret": "s"}, f)
+
+        with pytest.raises(RuntimeError, match="Malformed"):
+            reg._load_state(path)
+
+    def test_a_non_dict_registry_is_rejected(self, team):
+        path = reg.registry_path(team)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(["not", "a", "registry"], f)
+
+        with pytest.raises(RuntimeError, match="Malformed"):
+            reg._load_state(path)
+
+    def test_a_productions_value_of_the_wrong_type_is_rejected(self, team):
+        path = reg.registry_path(team)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump({"version": 1, "productions": []}, f)
+
+        with pytest.raises(RuntimeError, match="Malformed"):
+            reg._load_state(path)

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -1,4 +1,6 @@
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, mock_open, patch
+
+import pytest
 
 from oduflow import quotas
 from oduflow.settings import Settings, TeamSettings
@@ -116,3 +118,167 @@ class TestApplyAll:
         monkeypatch.setattr(quotas, "apply_team_disk_quota", apply_one)
         quotas.apply_all(settings)
         assert applied == ["2"]
+
+    def test_quota_of_one_gb_is_enforced(self, tmp_path, monkeypatch):
+        # `disk_quota_gb > 0` selects the teams to enforce; 1 GB is the smallest
+        # real quota and must not be treated as "unset".
+        monkeypatch.setattr(quotas, "quota_support", lambda s: (True, "/srv"))
+        with patch.object(quotas, "_xfs_quota") as xfs:
+            quotas.apply_all(_settings(tmp_path, quota_gb=1))
+
+        assert call("/srv", "limit -p bhard=1g 1001") in xfs.call_args_list
+
+    def test_teams_without_a_quota_are_filtered_out(self, tmp_path, monkeypatch):
+        quota_team = TeamSettings(
+            team_id="1", data_dir=str(tmp_path / "team_1"), disk_quota_gb=5
+        )
+        free_team = TeamSettings(
+            team_id="2",
+            data_dir=str(tmp_path / "team_2"),
+            disk_quota_gb=0,
+            port_range_start=50100,
+            port_range_end=50200,
+        )
+        settings = Settings(
+            base_data_dir=str(tmp_path), teams={"1": quota_team, "2": free_team}
+        )
+        monkeypatch.setattr(quotas, "quota_support", lambda s: (True, "/srv"))
+        applied = []
+        monkeypatch.setattr(
+            quotas,
+            "apply_team_disk_quota",
+            lambda s, team, mp: applied.append(team.team_id),
+        )
+
+        quotas.apply_all(settings)
+
+        assert applied == ["1"]
+
+
+class TestReadMounts:
+    def test_parses_proc_mounts(self):
+        content = (
+            "/dev/sda1 / ext4 rw,relatime 0 0\n"
+            "/dev/sdb1 /srv xfs rw,prjquota 0 0\n"
+        )
+        with patch("builtins.open", mock_open(read_data=content)) as opened:
+            mounts = quotas._read_mounts()
+
+        opened.assert_called_once_with("/proc/mounts")
+        assert mounts == [
+            ("/", "ext4", "rw,relatime"),
+            ("/srv", "xfs", "rw,prjquota"),
+        ]
+
+    def test_short_lines_are_ignored(self):
+        content = "garbage\n/dev/sdb1 /srv xfs rw 0 0\nalso bad\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert quotas._read_mounts() == [("/srv", "xfs", "rw")]
+
+    def test_four_fields_are_enough(self):
+        # device, mountpoint, fstype, options — the dump/pass columns at the
+        # end are optional as far as this parser is concerned.
+        content = "/dev/sda1 / ext4 rw\n/dev/sdb1 /srv xfs\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert quotas._read_mounts() == [("/", "ext4", "rw")]
+
+    def test_absent_proc_mounts_yields_empty_list(self):
+        # macOS and other non-Linux hosts have no /proc/mounts at all.
+        with patch("builtins.open", side_effect=OSError("no /proc")):
+            assert quotas._read_mounts() == []
+
+
+class TestFindMount:
+    def _mounts(self, monkeypatch, mounts):
+        monkeypatch.setattr(quotas, "_read_mounts", lambda: mounts)
+
+    def test_picks_the_longest_matching_mountpoint(self, monkeypatch):
+        self._mounts(
+            monkeypatch,
+            [
+                ("/", "ext4", "rw"),
+                ("/srv", "ext4", "rw"),
+                ("/srv/oduflow", "xfs", "rw,prjquota"),
+            ],
+        )
+
+        assert quotas._find_mount("/srv/oduflow/team_1") == (
+            "/srv/oduflow",
+            "xfs",
+            "rw,prjquota",
+        )
+
+    def test_longest_match_wins_regardless_of_order(self, monkeypatch):
+        # /proc/mounts is not sorted; the deepest mountpoint must win even when
+        # it is listed first.
+        self._mounts(
+            monkeypatch,
+            [("/srv/oduflow", "xfs", "rw,prjquota"), ("/", "ext4", "rw")],
+        )
+
+        assert quotas._find_mount("/srv/oduflow/team_1")[0] == "/srv/oduflow"
+
+    def test_exact_mountpoint_match(self, monkeypatch):
+        self._mounts(monkeypatch, [("/", "ext4", "rw"), ("/srv", "xfs", "rw")])
+
+        assert quotas._find_mount("/srv") == ("/srv", "xfs", "rw")
+
+    def test_sibling_prefix_is_not_a_match(self, monkeypatch):
+        # /srv-backup must not match the /srv mount just because the string
+        # starts with it — the separator is what makes it a child path.
+        self._mounts(monkeypatch, [("/", "ext4", "rw"), ("/srv", "xfs", "rw")])
+
+        assert quotas._find_mount("/srv-backup/data") == ("/", "ext4", "rw")
+
+    def test_root_mount_matches_everything(self, monkeypatch):
+        self._mounts(monkeypatch, [("/", "ext4", "rw")])
+
+        assert quotas._find_mount("/anywhere/at/all") == ("/", "ext4", "rw")
+
+    def test_no_mounts_yields_none(self, monkeypatch):
+        self._mounts(monkeypatch, [])
+
+        assert quotas._find_mount("/srv") is None
+
+
+class TestXfsQuotaInvocation:
+    def test_builds_the_expected_command(self, monkeypatch):
+        seen = {}
+
+        def _run(argv, **kwargs):
+            seen["argv"] = argv
+            seen["kwargs"] = kwargs
+            return MagicMock(returncode=0, stderr="")
+
+        monkeypatch.setattr(quotas.subprocess, "run", _run)
+
+        quotas._xfs_quota("/srv", "limit -p bhard=10g 1001")
+
+        assert seen["argv"] == [
+            "xfs_quota",
+            "-x",
+            "-c",
+            "limit -p bhard=10g 1001",
+            "/srv",
+        ]
+        assert seen["kwargs"]["capture_output"] is True
+        assert seen["kwargs"]["timeout"] == 60
+
+    def test_nonzero_exit_raises_with_stderr(self, monkeypatch):
+        monkeypatch.setattr(
+            quotas.subprocess,
+            "run",
+            lambda *a, **kw: MagicMock(returncode=1, stderr="  not a mount point \n"),
+        )
+
+        with pytest.raises(RuntimeError, match="not a mount point"):
+            quotas._xfs_quota("/srv", "limit -p bhard=10g 1001")
+
+    def test_success_is_silent(self, monkeypatch):
+        monkeypatch.setattr(
+            quotas.subprocess,
+            "run",
+            lambda *a, **kw: MagicMock(returncode=0, stderr=""),
+        )
+
+        assert quotas._xfs_quota("/srv", "print") is None

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -1,0 +1,449 @@
+"""Idle-environment reaper.
+
+The module had no test file, and its two thresholds decide whether a
+developer's environment is stopped or **permanently deleted**. These tests pin
+the boundaries (strictly-longer-than, not at-or-equal), the exemptions
+(protected, busy, first sighting), and the config switch that turns each
+behaviour off.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow import activity, reaper
+from oduflow.errors import BusyError, FlowError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+
+
+def _iso(seconds_ago: float) -> str:
+    moment = datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+    return moment.isoformat(timespec="seconds")
+
+
+def _env(name="main", running=True, protected=False):
+    return {
+        "env_name": name,
+        "containers": [{"status": "running" if running else "exited"}],
+        "protected": protected,
+    }
+
+
+@pytest.fixture
+def team(tmp_path):
+    data_dir = tmp_path / "team_1"
+    data_dir.mkdir()
+    return TeamSettings(team_id="1", data_dir=str(data_dir))
+
+
+def _settings(tmp_path, team, stop_hours=48, delete_hours=72) -> Settings:
+    # Settings is frozen, so each threshold variation needs its own instance.
+    return Settings(
+        base_data_dir=str(tmp_path),
+        teams={"1": team},
+        auto_stop_hours=stop_hours,
+        auto_delete_hours=delete_hours,
+    )
+
+
+@pytest.fixture
+def settings(team, tmp_path):
+    return _settings(tmp_path, team)
+
+
+@pytest.fixture
+def ops():
+    """Patch the two destructive env operations and env listing."""
+    with (
+        patch("oduflow.docker_ops.env_ops.list_environments") as listing,
+        patch("oduflow.docker_ops.env_ops.stop_environment") as stop,
+        patch("oduflow.docker_ops.env_ops.delete_environment") as delete,
+    ):
+        yield MagicMock(list=listing, stop=stop, delete=delete)
+
+
+class TestIsRunning:
+    def test_any_running_container_counts(self):
+        assert reaper._is_running(
+            {"containers": [{"status": "exited"}, {"status": "running"}]}
+        )
+
+    def test_all_stopped_is_not_running(self):
+        assert not reaper._is_running({"containers": [{"status": "exited"}]})
+
+    def test_no_containers_is_not_running(self):
+        assert not reaper._is_running({})
+
+
+class TestAutoStopThreshold:
+    def test_idle_past_the_threshold_is_stopped(self, settings, team, ops):
+        ops.list.return_value = [_env()]
+        activity.touch(team, "main")
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(48 * 3600 + 60)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_called_once_with(settings, team, "main")
+
+    def test_exactly_at_the_threshold_is_left_alone(self, settings, team, ops):
+        # The check is `now - last > stop_after`, so the environment survives
+        # its own deadline and is reaped on the next sweep.
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(48 * 3600 - 5)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+
+    def test_recent_activity_is_left_alone(self, settings, team, ops):
+        ops.list.return_value = [_env()]
+        activity.touch(team, "main")
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+
+    def test_a_protected_environment_is_never_stopped(self, settings, team, ops):
+        ops.list.return_value = [_env(protected=True)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(1000 * 3600)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+
+    def test_auto_stop_disabled_by_zero_hours(self, settings, team, ops):
+        settings = _settings(settings.base_data_dir, team, stop_hours=0)
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(1000 * 3600)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+
+    def test_one_hour_is_a_real_threshold(self, settings, team, ops):
+        # `stop_after > 0`, not `> 1`: the smallest configurable value works.
+        settings = _settings(settings.base_data_dir, team, stop_hours=1)
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(3600 + 60)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_called_once()
+
+    def test_a_first_sighting_seeds_the_clock_instead_of_reaping(
+        self, settings, team, ops
+    ):
+        ops.list.return_value = [_env()]
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+        assert "last_activity" in activity.get_all(team)["main"]
+
+    def test_a_running_env_with_a_stale_stop_record_is_re_marked(
+        self, settings, team, ops
+    ):
+        # Started outside our hooks (plain `docker start`).
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": _iso(1000 * 3600)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+        rec = activity.get_all(team)["main"]
+        assert "stopped_at" not in rec
+
+
+class TestAutoDeleteThreshold:
+    def test_stopped_past_the_threshold_is_deleted(self, settings, team, ops):
+        ops.list.return_value = [_env(running=False)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": _iso(72 * 3600 + 60)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_called_once_with(settings, team, "main")
+
+    def test_exactly_at_the_threshold_is_left_alone(self, settings, team, ops):
+        ops.list.return_value = [_env(running=False)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": _iso(72 * 3600 - 5)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_not_called()
+
+    def test_a_protected_environment_is_never_deleted(self, settings, team, ops):
+        ops.list.return_value = [_env(running=False, protected=True)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": _iso(1000 * 3600)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_not_called()
+
+    def test_auto_delete_disabled_by_zero_hours(self, settings, team, ops):
+        settings = _settings(settings.base_data_dir, team, delete_hours=0)
+        ops.list.return_value = [_env(running=False)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": _iso(1000 * 3600)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_not_called()
+
+    def test_an_unrecorded_stop_starts_the_clock_instead_of_deleting(
+        self, settings, team, ops
+    ):
+        # Manual `docker stop`, or an environment predating the tracker: the
+        # delete clock starts now rather than from an unknown past.
+        ops.list.return_value = [_env(running=False)]
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_not_called()
+        assert activity.get_all(team)["main"]["stopped_by"] == "observed"
+
+
+class TestConcurrencyAndFailures:
+    def test_a_busy_environment_is_skipped(self, settings, team, ops):
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(1000 * 3600)}},
+        )
+        locks = MagicMock()
+        locks.acquire_env.side_effect = BusyError("in flight")
+
+        reaper.sweep(settings, locks)
+
+        ops.stop.assert_not_called()
+        locks.release_env.assert_not_called()
+
+    def test_the_lock_is_released_after_a_stop(self, settings, team, ops):
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(1000 * 3600)}},
+        )
+        locks = MagicMock()
+
+        reaper.sweep(settings, locks)
+
+        locks.release_env.assert_called_once_with("main")
+
+    def test_the_lock_is_released_when_the_stop_fails(self, settings, team, ops):
+        ops.list.return_value = [_env()]
+        ops.stop.side_effect = FlowError("cannot stop")
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(1000 * 3600)}},
+        )
+        locks = MagicMock()
+
+        reaper.sweep(settings, locks)  # must not raise
+
+        locks.release_env.assert_called_once_with("main")
+
+    def test_an_unlistable_team_does_not_abort_the_sweep(self, settings, tmp_path):
+        other = TeamSettings(
+            team_id="2",
+            data_dir=str(tmp_path / "team_2"),
+            port_range_start=50100,
+            port_range_end=50200,
+        )
+        settings.teams["2"] = other
+        seen = []
+
+        def _list(_settings, team):
+            seen.append(team.team_id)
+            if team.team_id == "1":
+                raise RuntimeError("docker down")
+            return []
+
+        with (
+            patch("oduflow.docker_ops.env_ops.list_environments", side_effect=_list),
+            patch("oduflow.docker_ops.env_ops.stop_environment"),
+        ):
+            reaper.sweep(settings, LockManager())
+
+        assert seen == ["1", "2"]
+
+    def test_stale_records_are_pruned_during_the_sweep(self, settings, team, ops):
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": _iso(10)}, "deleted": {"last_activity": _iso(10)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        assert set(activity.get_all(team)) == {"main"}
+
+
+class TestStartReaper:
+    def _start(self, settings):
+        with patch("threading.Thread") as thread:
+            result = reaper.start_reaper(lambda: settings, LockManager())
+        return result, thread
+
+    def test_both_behaviours_disabled_starts_no_thread(self, settings, team):
+        settings = _settings(settings.base_data_dir, team, 0, 0)
+
+        result, thread = self._start(settings)
+
+        assert result is None
+        thread.assert_not_called()
+
+    def test_auto_stop_alone_starts_the_thread(self, settings, team):
+        settings = _settings(settings.base_data_dir, team, 48, 0)
+
+        result, thread = self._start(settings)
+
+        assert result is not None
+        thread.return_value.start.assert_called_once()
+
+    def test_auto_delete_alone_starts_the_thread(self, settings, team):
+        settings = _settings(settings.base_data_dir, team, 0, 72)
+
+        result, _ = self._start(settings)
+
+        assert result is not None
+
+    def test_enabling_auto_delete_warns_about_permanent_deletion(
+        self, settings, team, caplog
+    ):
+        import logging
+
+        settings = _settings(settings.base_data_dir, team, 48, 72)
+        with caplog.at_level(logging.WARNING, logger="oduflow"), patch(
+            "threading.Thread"
+        ):
+            reaper.start_reaper(lambda: settings, LockManager())
+
+        assert "PERMANENTLY DELETED" in caplog.text
+
+    def test_no_deletion_warning_when_auto_delete_is_off(self, settings, team, caplog):
+        import logging
+
+        settings = _settings(settings.base_data_dir, team, 48, 0)
+        with caplog.at_level(logging.WARNING, logger="oduflow"), patch(
+            "threading.Thread"
+        ):
+            reaper.start_reaper(lambda: settings, LockManager())
+
+        assert "PERMANENTLY DELETED" not in caplog.text
+
+    def test_one_hour_auto_delete_still_warns(self, settings, team, caplog):
+        # `auto_delete_hours > 0`, not `> 1`.
+        import logging
+
+        settings = _settings(settings.base_data_dir, team, 48, 1)
+        with caplog.at_level(logging.WARNING, logger="oduflow"), patch(
+            "threading.Thread"
+        ):
+            reaper.start_reaper(lambda: settings, LockManager())
+
+        assert "PERMANENTLY DELETED" in caplog.text
+
+
+class TestThresholdIsStrict:
+    """Both deadlines use ``>``, not ``>=``.
+
+    Pinning that needs the clock frozen: with a wall-clock ``now`` the exact
+    boundary is unreachable, so an off-by-one in either comparison — or in the
+    hours-to-seconds conversion — goes unnoticed.
+    """
+
+    @pytest.fixture
+    def frozen(self, monkeypatch):
+        monkeypatch.setattr(reaper.time, "time", lambda: 1_000_000.0)
+        return 1_000_000.0
+
+    def _at(self, offset: float, frozen: float) -> str:
+        return (
+            datetime.fromtimestamp(frozen - offset, tz=timezone.utc)
+            .isoformat(timespec="seconds")
+        )
+
+    def test_idle_exactly_the_stop_threshold_survives(
+        self, settings, team, ops, frozen
+    ):
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": self._at(48 * 3600, frozen)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_not_called()
+
+    def test_one_second_past_the_stop_threshold_is_reaped(
+        self, settings, team, ops, frozen
+    ):
+        ops.list.return_value = [_env()]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"last_activity": self._at(48 * 3600 + 1, frozen)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.stop.assert_called_once()
+
+    def test_stopped_exactly_the_delete_threshold_survives(
+        self, settings, team, ops, frozen
+    ):
+        ops.list.return_value = [_env(running=False)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": self._at(72 * 3600, frozen)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_not_called()
+
+    def test_one_second_past_the_delete_threshold_is_reaped(
+        self, settings, team, ops, frozen
+    ):
+        ops.list.return_value = [_env(running=False)]
+        activity._save(
+            activity.activity_path(team),
+            {"main": {"stopped_at": self._at(72 * 3600 + 1, frozen)}},
+        )
+
+        reaper.sweep(settings, LockManager())
+
+        ops.delete.assert_called_once()

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -1,0 +1,366 @@
+"""boto3 wrapper for the backup subsystem.
+
+The module had no tests at all. The parts worth pinning are the ones whose
+bugs are expensive rather than loud: key prefixing (a wrong prefix silently
+splits a backup across two namespaces), the 403/404-vs-raise split in
+``exists`` (swallowing a real error makes the chunkstore re-upload every
+chunk), and multipart abort-on-failure (orphaned parts accrue storage cost
+forever).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from oduflow import s3_client
+from oduflow.settings import BackupSettings
+
+
+def _backup(**kwargs) -> BackupSettings:
+    defaults = {
+        "bucket": "backups",
+        "access_key": "AK",
+        "secret_key": "SK",
+    }
+    defaults.update(kwargs)
+    return BackupSettings(**defaults)
+
+
+def _client_error(status: int) -> type[Exception]:
+    """A stand-in for botocore's ClientError carrying an HTTP status."""
+
+    class ClientError(Exception):
+        def __init__(self):
+            super().__init__(f"HTTP {status}")
+            self.response = {"ResponseMetadata": {"HTTPStatusCode": status}}
+
+    return ClientError
+
+
+class TestMakeClient:
+    def test_credentials_and_retries_are_passed_through(self, monkeypatch):
+        seen = {}
+
+        def _boto_client(service, **kwargs):
+            seen["service"] = service
+            seen["kwargs"] = kwargs
+            return "client"
+
+        boto3 = MagicMock()
+        boto3.client.side_effect = _boto_client
+        monkeypatch.setitem(__import__("sys").modules, "boto3", boto3)
+
+        assert s3_client.make_client(_backup()) == "client"
+        assert seen["service"] == "s3"
+        assert seen["kwargs"]["aws_access_key_id"] == "AK"
+        assert seen["kwargs"]["aws_secret_access_key"] == "SK"
+        assert seen["kwargs"]["config"].retries == {
+            "max_attempts": 3,
+            "mode": "standard",
+        }
+
+    def test_region_and_endpoint_are_only_sent_when_configured(self, monkeypatch):
+        calls = []
+        boto3 = MagicMock()
+        boto3.client.side_effect = lambda service, **kw: calls.append(kw)
+        monkeypatch.setitem(__import__("sys").modules, "boto3", boto3)
+
+        s3_client.make_client(_backup())
+        assert "region_name" not in calls[0]
+        assert "endpoint_url" not in calls[0]
+
+        s3_client.make_client(
+            _backup(region="eu-central-1", endpoint="https://minio.example")
+        )
+        assert calls[1]["region_name"] == "eu-central-1"
+        assert calls[1]["endpoint_url"] == "https://minio.example"
+
+    def test_a_custom_endpoint_switches_to_path_addressing(self, monkeypatch):
+        # Virtual-host addressing does not work against most S3-compatible
+        # servers (MinIO, Ceph), so a configured endpoint must force paths.
+        calls = []
+        boto3 = MagicMock()
+        boto3.client.side_effect = lambda service, **kw: calls.append(kw)
+        monkeypatch.setitem(__import__("sys").modules, "boto3", boto3)
+
+        s3_client.make_client(_backup())
+        s3_client.make_client(_backup(endpoint="https://minio.example"))
+
+        assert calls[0]["config"].s3 == {}
+        assert calls[1]["config"].s3 == {"addressing_style": "path"}
+
+
+class TestCheckS3:
+    def test_reachable_bucket_is_ok(self, monkeypatch):
+        client = MagicMock()
+        monkeypatch.setattr(s3_client, "make_client", lambda backup: client)
+
+        assert s3_client.check_s3(_backup()) == {"ok": True, "error": ""}
+        client.head_bucket.assert_called_once_with(Bucket="backups")
+
+    def test_failure_is_reported_not_raised(self, monkeypatch):
+        client = MagicMock()
+        client.head_bucket.side_effect = RuntimeError("no such bucket")
+        monkeypatch.setattr(s3_client, "make_client", lambda backup: client)
+
+        result = s3_client.check_s3(_backup())
+
+        assert result["ok"] is False
+        assert "no such bucket" in result["error"]
+
+
+class TestS3StorageKeys:
+    def _storage(self, prefix: str, client: MagicMock | None = None):
+        return s3_client.S3Storage(_backup(), prefix, client=client or MagicMock())
+
+    def test_the_prefix_is_prepended_to_every_key(self):
+        client = MagicMock()
+        storage = self._storage("team_1/prod", client)
+
+        storage.put("chunks/ab/cd", b"x")
+
+        assert client.put_object.call_args.kwargs["Key"] == "team_1/prod/chunks/ab/cd"
+
+    def test_surrounding_slashes_in_the_prefix_are_stripped(self):
+        client = MagicMock()
+        storage = self._storage("/team_1/prod/", client)
+
+        storage.put("k", b"x")
+
+        assert client.put_object.call_args.kwargs["Key"] == "team_1/prod/k"
+
+    def test_an_empty_prefix_leaves_keys_untouched(self):
+        client = MagicMock()
+        storage = self._storage("", client)
+
+        storage.put("k", b"x")
+
+        assert client.put_object.call_args.kwargs["Key"] == "k"
+
+    def test_the_bucket_comes_from_the_backup_settings(self):
+        storage = s3_client.S3Storage(_backup(bucket="other"), "p", client=MagicMock())
+        assert storage.bucket == "other"
+
+    def test_a_client_is_built_when_none_is_supplied(self, monkeypatch):
+        monkeypatch.setattr(s3_client, "make_client", lambda backup: "made")
+        assert s3_client.S3Storage(_backup(), "p").client == "made"
+
+
+class TestS3StorageOperations:
+    def _storage(self, client, prefix="p"):
+        return s3_client.S3Storage(_backup(), prefix, client=client)
+
+    def test_get_returns_the_body_bytes(self):
+        client = MagicMock()
+        client.get_object.return_value = {"Body": MagicMock(read=lambda: b"payload")}
+
+        assert self._storage(client).get("k") == b"payload"
+        assert client.get_object.call_args.kwargs["Key"] == "p/k"
+
+    def test_put_sends_the_body(self):
+        client = MagicMock()
+        self._storage(client).put("k", b"payload")
+
+        assert client.put_object.call_args.kwargs["Body"] == b"payload"
+
+    def test_delete_targets_the_prefixed_key(self):
+        client = MagicMock()
+        self._storage(client).delete("k")
+
+        assert client.delete_object.call_args.kwargs == {
+            "Bucket": "backups",
+            "Key": "p/k",
+        }
+
+    def test_exists_is_true_when_head_succeeds(self):
+        client = MagicMock()
+        assert self._storage(client).exists("k") is True
+        assert client.head_object.call_args.kwargs["Key"] == "p/k"
+
+    @pytest.mark.parametrize("status", [403, 404])
+    def test_missing_or_forbidden_means_absent(self, status):
+        # Buckets without ListBucket answer 403 for a missing key, so both
+        # statuses have to read as "not there".
+        client = MagicMock()
+        error = _client_error(status)
+        client.exceptions.ClientError = error
+        client.head_object.side_effect = error()
+
+        assert self._storage(client).exists("k") is False
+
+    @pytest.mark.parametrize("status", [500, 503])
+    def test_other_client_errors_propagate(self, status):
+        # Swallowing a server error would make the chunkstore believe every
+        # chunk is missing and re-upload the whole backup.
+        client = MagicMock()
+        error = _client_error(status)
+        client.exceptions.ClientError = error
+        client.head_object.side_effect = error()
+
+        with pytest.raises(error):
+            self._storage(client).exists("k")
+
+    def test_list_strips_the_prefix_and_sorts(self):
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.return_value = [
+            {"Contents": [{"Key": "p/b"}, {"Key": "p/a"}]},
+            {"Contents": [{"Key": "p/c"}]},
+        ]
+
+        assert self._storage(client).list("") == ["a", "b", "c"]
+
+    def test_list_paginates_under_the_full_prefix(self):
+        client = MagicMock()
+        paginator = client.get_paginator.return_value
+        paginator.paginate.return_value = []
+
+        self._storage(client).list("chunks/")
+
+        client.get_paginator.assert_called_once_with("list_objects_v2")
+        assert paginator.paginate.call_args.kwargs == {
+            "Bucket": "backups",
+            "Prefix": "p/chunks/",
+        }
+
+    def test_list_without_a_prefix_returns_whole_keys(self):
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.return_value = [
+            {"Contents": [{"Key": "a/b"}]}
+        ]
+
+        assert s3_client.S3Storage(_backup(), "", client=client).list("") == ["a/b"]
+
+    def test_an_empty_page_yields_nothing(self):
+        client = MagicMock()
+        client.get_paginator.return_value.paginate.return_value = [{}]
+
+        assert self._storage(client).list("") == []
+
+    def test_rename_copies_then_deletes_the_source(self):
+        client = MagicMock()
+        self._storage(client).rename("old", "new")
+
+        assert client.copy_object.call_args.kwargs == {
+            "Bucket": "backups",
+            "Key": "p/new",
+            "CopySource": {"Bucket": "backups", "Key": "p/old"},
+        }
+        assert client.delete_object.call_args.kwargs["Key"] == "p/old"
+
+    def test_rename_does_not_delete_when_the_copy_fails(self):
+        # Deleting after a failed copy would lose the object outright.
+        client = MagicMock()
+        client.copy_object.side_effect = RuntimeError("copy failed")
+
+        with pytest.raises(RuntimeError):
+            self._storage(client).rename("old", "new")
+
+        client.delete_object.assert_not_called()
+
+
+class TestMultipartUploadStream:
+    def _client(self):
+        client = MagicMock()
+        client.create_multipart_upload.return_value = {"UploadId": "UP1"}
+        client.upload_part.side_effect = lambda **kw: {
+            "ETag": f"etag-{kw['PartNumber']}"
+        }
+        return client
+
+    def test_a_small_stream_becomes_one_part(self):
+        client = self._client()
+
+        total = s3_client.multipart_upload_stream(
+            client, "backups", "dump.sql", iter([b"abc", b"de"])
+        )
+
+        assert total == 5
+        assert client.upload_part.call_count == 1
+        assert client.upload_part.call_args.kwargs["Body"] == b"abcde"
+        assert client.upload_part.call_args.kwargs["PartNumber"] == 1
+
+    def test_parts_are_flushed_at_the_part_size_and_numbered_from_one(self):
+        client = self._client()
+        frames = [b"x" * s3_client._PART_SIZE, b"y" * 10]
+
+        total = s3_client.multipart_upload_stream(
+            client, "backups", "dump.sql", iter(frames)
+        )
+
+        assert total == s3_client._PART_SIZE + 10
+        numbers = [c.kwargs["PartNumber"] for c in client.upload_part.call_args_list]
+        assert numbers == [1, 2]
+        completed = client.complete_multipart_upload.call_args.kwargs
+        assert completed["MultipartUpload"]["Parts"] == [
+            {"ETag": "etag-1", "PartNumber": 1},
+            {"ETag": "etag-2", "PartNumber": 2},
+        ]
+        assert completed["UploadId"] == "UP1"
+
+    def test_empty_frames_are_skipped(self):
+        client = self._client()
+
+        total = s3_client.multipart_upload_stream(
+            client, "backups", "dump.sql", iter([b"", b"ab", b"", b"c"])
+        )
+
+        assert total == 3
+        assert client.upload_part.call_args.kwargs["Body"] == b"abc"
+
+    def test_a_zero_byte_stream_falls_back_to_put_object(self):
+        # complete_multipart_upload rejects an upload with no parts.
+        client = self._client()
+
+        total = s3_client.multipart_upload_stream(
+            client, "backups", "dump.sql", iter([])
+        )
+
+        assert total == 0
+        client.complete_multipart_upload.assert_not_called()
+        client.abort_multipart_upload.assert_called_once()
+        assert client.put_object.call_args.kwargs == {
+            "Bucket": "backups",
+            "Key": "dump.sql",
+            "Body": b"",
+        }
+
+    def test_a_failure_mid_stream_aborts_the_upload(self):
+        # Orphaned parts are billed until a lifecycle rule reaps them.
+        client = self._client()
+
+        def _frames():
+            yield b"ab"
+            raise RuntimeError("pg_dump died")
+
+        with pytest.raises(RuntimeError, match="pg_dump died"):
+            s3_client.multipart_upload_stream(
+                client, "backups", "dump.sql", _frames()
+            )
+
+        client.abort_multipart_upload.assert_called_once_with(
+            Bucket="backups", Key="dump.sql", UploadId="UP1"
+        )
+        client.complete_multipart_upload.assert_not_called()
+
+    def test_a_failing_upload_part_aborts_the_upload(self):
+        client = self._client()
+        client.upload_part.side_effect = RuntimeError("network")
+
+        with pytest.raises(RuntimeError):
+            s3_client.multipart_upload_stream(
+                client, "backups", "dump.sql", iter([b"ab"])
+            )
+
+        client.abort_multipart_upload.assert_called_once()
+
+    def test_a_failing_abort_does_not_mask_the_original_error(self):
+        client = self._client()
+        client.upload_part.side_effect = RuntimeError("original")
+        client.abort_multipart_upload.side_effect = RuntimeError("abort failed")
+
+        with pytest.raises(RuntimeError, match="original"):
+            s3_client.multipart_upload_stream(
+                client, "backups", "dump.sql", iter([b"ab"])
+            )

--- a/tests/test_sanitizer_scripts.py
+++ b/tests/test_sanitizer_scripts.py
@@ -1,0 +1,289 @@
+"""Execution semantics of the sanitize script runner.
+
+``_run_scripts_from_dir`` executes operator-supplied ``.sql`` (against the env
+database) and ``.py`` (inside the serving container) scripts. Every other
+sanitizer test patches it out to assert *which* directories are visited; this
+module covers what the runner itself does — ordering, the SQL/DB it hands to
+``_exec_sql``, the environment handed to the container, and the rule that a
+failing script degrades to a warning instead of aborting provisioning.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import docker as _docker
+from oduflow import sanitizer
+
+
+def _settings() -> MagicMock:
+    settings = MagicMock()
+    settings.prefix = "oduflow"
+    settings.shared_db_container = "oduflow-db"
+    settings.db_user = "odoo"
+    settings.db_password = "pw"
+    return settings
+
+
+def _team(tmp_path) -> MagicMock:
+    team = MagicMock()
+    team.team_id = "1"
+    team.data_dir = str(tmp_path / "team")
+    team.workspaces_dir = str(tmp_path / "workspaces")
+    return team
+
+
+def _client(container: MagicMock | None = None) -> MagicMock:
+    client = MagicMock()
+    if container is None:
+        client.containers.get.side_effect = _docker.errors.NotFound("nope")
+    else:
+        client.containers.get.return_value = container
+    return client
+
+
+def _run(tmp_path, scripts_dir, *, container=None, label="system"):
+    return sanitizer._run_scripts_from_dir(
+        str(scripts_dir),
+        label,
+        _client(container),
+        _settings(),
+        _team(tmp_path),
+        "oduflow_1_main",
+        "main",
+    )
+
+
+class TestMissingDirectory:
+    def test_absent_directory_is_a_no_op(self, tmp_path):
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, tmp_path / "nope")
+
+        assert logs == []
+        exec_sql.assert_not_called()
+
+    def test_empty_directory_is_a_no_op(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, scripts)
+
+        assert logs == []
+        exec_sql.assert_not_called()
+
+
+class TestSqlScripts:
+    def test_runs_sql_against_the_environment_database(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "10_wipe.sql").write_text("DELETE FROM res_partner;\n")
+
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, scripts)
+
+        assert exec_sql.call_count == 1
+        assert exec_sql.call_args.args[2] == "DELETE FROM res_partner;"
+        assert exec_sql.call_args.kwargs["db"] == "oduflow_1_main"
+        assert logs == ["[SANITIZE:system] Executed 10_wipe.sql"]
+
+    def test_scripts_run_in_alphabetical_order(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        for name in ("30_c.sql", "10_a.sql", "20_b.sql"):
+            (scripts / name).write_text(f"SELECT '{name}';")
+
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, scripts)
+
+        executed = [call.args[2] for call in exec_sql.call_args_list]
+        assert executed == ["SELECT '10_a.sql';", "SELECT '20_b.sql';", "SELECT '30_c.sql';"]
+        assert logs == [
+            "[SANITIZE:system] Executed 10_a.sql",
+            "[SANITIZE:system] Executed 20_b.sql",
+            "[SANITIZE:system] Executed 30_c.sql",
+        ]
+
+    def test_blank_script_is_skipped_without_a_log_line(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "empty.sql").write_text("   \n\n")
+
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, scripts)
+
+        exec_sql.assert_not_called()
+        assert logs == []
+
+    def test_failing_sql_warns_and_the_run_continues(self, tmp_path, caplog):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "10_bad.sql").write_text("BOOM;")
+        (scripts / "20_good.sql").write_text("SELECT 1;")
+
+        def _exec(client, settings, sql, db=None):
+            if "BOOM" in sql:
+                raise RuntimeError("syntax error")
+
+        with (
+            caplog.at_level(logging.WARNING, logger="oduflow"),
+            patch.object(sanitizer, "_exec_sql", side_effect=_exec),
+        ):
+            logs = _run(tmp_path, scripts)
+
+        assert logs == [
+            "[SANITIZE:system] WARNING: 10_bad.sql failed: syntax error",
+            "[SANITIZE:system] Executed 20_good.sql",
+        ]
+        assert "10_bad.sql" in caplog.text
+
+    def test_non_sql_non_py_files_are_ignored(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "README.md").write_text("not a script")
+        (scripts / "notes.txt").write_text("also not a script")
+
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, scripts)
+
+        exec_sql.assert_not_called()
+        assert logs == []
+
+
+class TestPyScripts:
+    def test_runs_python_in_the_container_with_db_credentials(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "anonymize.py").write_text("print('hi')")
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"done")
+
+        with patch.object(
+            sanitizer,
+            "load_credentials",
+            return_value={"pg_user": "u1", "pg_password": "s3cret"},
+        ):
+            logs = _run(tmp_path, scripts, container=container)
+
+        cmd, kwargs = container.exec_run.call_args.args[0], container.exec_run.call_args.kwargs
+        assert cmd == ["python3", "-c", "print('hi')"]
+        assert kwargs["environment"] == {
+            "ODOO_DB": "oduflow_1_main",
+            "DB_HOST": "oduflow-db",
+            "DB_USER": "u1",
+            "DB_PASSWORD": "s3cret",
+        }
+        assert logs == ["[SANITIZE:system] Executed anonymize.py"]
+
+    def test_nonzero_exit_warns_and_the_run_continues(self, tmp_path, caplog):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "10_bad.py").write_text("raise SystemExit(3)")
+        (scripts / "20_good.py").write_text("pass")
+        container = MagicMock()
+        container.exec_run.side_effect = [(3, b"traceback"), (0, b"")]
+
+        with (
+            caplog.at_level(logging.WARNING, logger="oduflow"),
+            patch.object(
+                sanitizer, "load_credentials", return_value={"pg_user": "u", "pg_password": "p"}
+            ),
+        ):
+            logs = _run(tmp_path, scripts, container=container)
+
+        assert logs == [
+            "[SANITIZE:system] WARNING: 10_bad.py failed (exit 3)",
+            "[SANITIZE:system] Executed 20_good.py",
+        ]
+        assert "10_bad.py" in caplog.text
+
+    def test_exec_exception_is_contained(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "boom.py").write_text("pass")
+        container = MagicMock()
+        container.exec_run.side_effect = RuntimeError("docker exploded")
+
+        with patch.object(
+            sanitizer, "load_credentials", return_value={"pg_user": "u", "pg_password": "p"}
+        ):
+            logs = _run(tmp_path, scripts, container=container)
+
+        assert logs == [
+            "[SANITIZE:system] WARNING: boom.py failed: docker exploded"
+        ]
+
+    def test_missing_container_skips_py_but_keeps_sql_results(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "10_first.sql").write_text("SELECT 1;")
+        (scripts / "20_second.py").write_text("pass")
+
+        with patch.object(sanitizer, "_exec_sql") as exec_sql:
+            logs = _run(tmp_path, scripts, container=None)
+
+        assert exec_sql.call_count == 1
+        assert logs == [
+            "[SANITIZE:system] Executed 10_first.sql",
+            "[SANITIZE:system] WARNING: container not found, skipping .py scripts",
+        ]
+
+    def test_sql_runs_before_py(self, tmp_path):
+        # Ordering matters: .sql wipes rows, .py scripts then work on what is
+        # left. The name below sorts before the .sql file to prove the tiers,
+        # not the filenames, decide the order.
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "00_first.py").write_text("pass")
+        (scripts / "99_last.sql").write_text("SELECT 1;")
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"")
+
+        with (
+            patch.object(sanitizer, "_exec_sql"),
+            patch.object(
+                sanitizer, "load_credentials", return_value={"pg_user": "u", "pg_password": "p"}
+            ),
+        ):
+            logs = _run(tmp_path, scripts, container=container)
+
+        assert logs == [
+            "[SANITIZE:system] Executed 99_last.sql",
+            "[SANITIZE:system] Executed 00_first.py",
+        ]
+
+    def test_label_appears_in_every_log_line(self, tmp_path):
+        scripts = tmp_path / "sanitize"
+        scripts.mkdir()
+        (scripts / "a.sql").write_text("SELECT 1;")
+
+        with patch.object(sanitizer, "_exec_sql"):
+            logs = _run(tmp_path, scripts, label="repo-legacy")
+
+        assert logs == ["[SANITIZE:repo-legacy] Executed a.sql"]
+
+
+class TestDetectOdooMajor:
+    def test_reads_major_from_the_image_label(self):
+        container = MagicMock()
+        container.labels = {"oduflow.image": "odoo:18.0"}
+        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") == 18
+
+    def test_handles_registry_style_image_references(self):
+        container = MagicMock()
+        container.labels = {"oduflow.image": "ghcr.io/acme/odoo/17.0-custom"}
+        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") == 17
+
+    def test_unknown_or_missing_label_yields_none(self):
+        container = MagicMock()
+        container.labels = {"other": "odoo:18.0"}
+        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") is None
+
+        container.labels = {"oduflow.image": "postgres:16"}
+        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") is None
+
+    def test_non_dict_labels_yield_none(self):
+        container = MagicMock()
+        container.labels = ["not", "a", "dict"]
+        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") is None

--- a/tests/test_scoped_access.py
+++ b/tests/test_scoped_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+from types import SimpleNamespace
 
 import pytest
 from fastmcp.exceptions import ToolError
@@ -414,3 +415,145 @@ def test_mcp_access_endpoint_unknown_env(monkeypatch):
     resp = _ui_client(settings).get("/api/environments/ghost/mcp-access")
     data = resp.json()
     assert data["ok"] is False
+
+
+# --- request/token env extraction ------------------------------------------
+
+
+class TestScopedEnvFromRequest:
+    """Reads the env out of the ASGI scope set by ``ScopedEnvASGI``."""
+
+    def test_returns_the_scoped_env(self, monkeypatch):
+        request = SimpleNamespace(scope={scoped_access.SCOPE_KEY: "feature/x"})
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_request", lambda: request
+        )
+
+        assert scoped_access.scoped_env_from_request() == "feature/x"
+
+    def test_returns_none_for_an_unscoped_request(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_http_request",
+            lambda: SimpleNamespace(scope={}),
+        )
+
+        assert scoped_access.scoped_env_from_request() is None
+
+    def test_outside_a_request_context_is_not_an_error(self, monkeypatch):
+        # Called from the CLI or a background thread there is no request.
+        def _boom():
+            raise RuntimeError("no active request")
+
+        monkeypatch.setattr("fastmcp.server.dependencies.get_http_request", _boom)
+
+        assert scoped_access.scoped_env_from_request() is None
+
+
+class TestEnvFromAccessToken:
+    """Reads the bound env out of a per-env token's scopes."""
+
+    def _token(self, scopes):
+        return SimpleNamespace(scopes=scopes)
+
+    def test_returns_the_env_the_token_is_bound_to(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_access_token",
+            lambda: self._token(["oduflow_env:feature/x"]),
+        )
+
+        assert scoped_access.env_from_access_token() == "feature/x"
+
+    def test_the_env_scope_is_found_among_others(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_access_token",
+            lambda: self._token(["openid", "oduflow_env:main", "profile"]),
+        )
+
+        assert scoped_access.env_from_access_token() == "main"
+
+    def test_a_team_token_carries_no_env(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_access_token",
+            lambda: self._token(["openid"]),
+        )
+
+        assert scoped_access.env_from_access_token() is None
+
+    def test_no_scopes_at_all(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_access_token",
+            lambda: self._token(None),
+        )
+
+        assert scoped_access.env_from_access_token() is None
+
+    def test_no_token(self, monkeypatch):
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_access_token", lambda: None
+        )
+
+        assert scoped_access.env_from_access_token() is None
+
+    def test_outside_an_authenticated_context_is_not_an_error(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("no auth context")
+
+        monkeypatch.setattr("fastmcp.server.dependencies.get_access_token", _boom)
+
+        assert scoped_access.env_from_access_token() is None
+
+    def test_an_empty_env_scope_yields_an_empty_string(self, monkeypatch):
+        # decide() treats "" as falsy, so this stays a full-access token
+        # rather than silently binding to an env named "".
+        monkeypatch.setattr(
+            "fastmcp.server.dependencies.get_access_token",
+            lambda: self._token(["oduflow_env:"]),
+        )
+
+        assert scoped_access.env_from_access_token() == ""
+
+
+# --- ASGI path rewriting boundaries ----------------------------------------
+
+
+class TestScopedEnvPath:
+    _asgi = scoped_access.ScopedEnvASGI
+
+    def test_the_env_is_everything_after_the_prefix(self):
+        assert self._asgi._scoped_env("/mcp/feature/x") == "feature/x"
+
+    def test_the_bare_prefix_is_not_a_scoped_path(self):
+        # "/mcp/" carries no env name; treating it as one would scope the
+        # request to an environment called "".
+        assert self._asgi._scoped_env("/mcp/") is None
+
+    def test_the_root_endpoint_is_not_scoped(self):
+        assert self._asgi._scoped_env("/mcp") is None
+
+    def test_an_unrelated_path_is_not_scoped(self):
+        assert self._asgi._scoped_env("/api/environments") is None
+        assert self._asgi._scoped_env("/mcpx/main") is None
+
+    def test_a_single_character_env_is_scoped(self):
+        assert self._asgi._scoped_env("/mcp/a") == "a"
+
+
+class TestWellKnownPath:
+    _asgi = scoped_access.ScopedEnvASGI
+
+    def _prefix(self) -> str:
+        return self._asgi._WELL_KNOWN_PREFIX
+
+    def test_a_scoped_resource_path_maps_back_to_mcp(self):
+        assert self._asgi._well_known(f"{self._prefix()}/mcp/main") == (
+            f"{self._prefix()}/mcp"
+        )
+
+    def test_the_bare_scoped_prefix_is_not_rewritten(self):
+        assert self._asgi._well_known(f"{self._prefix()}/mcp/") is None
+
+    def test_the_unscoped_resource_path_is_not_rewritten(self):
+        assert self._asgi._well_known(f"{self._prefix()}/mcp") is None
+
+    def test_an_unrelated_well_known_path_is_not_rewritten(self):
+        assert self._asgi._well_known("/.well-known/openid-configuration") is None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -544,6 +544,25 @@ class TestBackupSettings:
         with pytest.raises(ValueError, match="requires all of"):
             Settings.from_toml(self._toml(tmp_path, '[backup]\nbucket = "b"\n'))
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            '[backup]\nbucket = "b"\naccess_key = "ak"\n',
+            '[backup]\nbucket = "b"\nsecret_key = "sk"\n',
+            '[backup]\naccess_key = "ak"\nsecret_key = "sk"\n',
+            '[backup]\naccess_key = "ak"\n',
+            '[backup]\nsecret_key = "sk"\n',
+            '[backup]\nbucket = "b"\naccess_key = "ak"\nsecret_key = "  "\n',
+            '[backup]\nbucket = "  "\naccess_key = "ak"\nsecret_key = "sk"\n',
+        ],
+    )
+    def test_every_missing_credential_is_rejected(self, tmp_path, body):
+        # All three of bucket/access_key/secret_key are required together; any
+        # one of them missing (or blank) must fail loudly rather than silently
+        # disable backups.
+        with pytest.raises(ValueError, match="requires all of"):
+            Settings.from_toml(self._toml(tmp_path, body))
+
     def test_bad_snapshot_time_rejected_by_validate(self, tmp_path):
         s = Settings.from_toml(
             self._toml(
@@ -575,3 +594,139 @@ class TestBackupSettings:
             )
         )
         assert s.backup.prefix == "my/prefix"
+
+
+class TestDirectoryResolution:
+    """Where Oduflow puts its data and config when the TOML says nothing.
+
+    Both resolvers memoize into a module global. The probing (``os.access``)
+    must happen exactly once, and the cached value must be the one returned on
+    every later call — an inverted cache check re-probes forever or, worse,
+    returns the unset global.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_caches(self):
+        from oduflow import settings as settings_mod
+
+        settings_mod._cached_data_dir = None
+        settings_mod._cached_etc_dir = None
+        yield
+        settings_mod._cached_data_dir = None
+        settings_mod._cached_etc_dir = None
+
+    def test_explicit_data_dir_wins_and_is_not_cached(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(settings_mod.os, "access", lambda *a: False)
+
+        assert settings_mod._resolve_data_dir("/explicit") == "/explicit"
+        # An explicit value must not poison the cache for later default lookups.
+        assert settings_mod._cached_data_dir is None
+
+    def test_data_dir_uses_srv_when_parent_is_writable(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(settings_mod.os, "access", lambda path, mode: path == "/srv")
+
+        assert settings_mod._resolve_data_dir("") == "/srv/oduflow"
+
+    def test_data_dir_uses_existing_writable_srv_oduflow(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.os, "access", lambda path, mode: path == "/srv/oduflow"
+        )
+        monkeypatch.setattr(
+            settings_mod.os.path, "isdir", lambda path: path == "/srv/oduflow"
+        )
+
+        assert settings_mod._resolve_data_dir("") == "/srv/oduflow"
+
+    def test_data_dir_needs_both_isdir_and_write_access_for_the_fallback_probe(
+        self, monkeypatch
+    ):
+        # /srv is not writable and /srv/oduflow exists but is read-only ->
+        # neither branch qualifies, so the home directory is used.
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(settings_mod.os, "access", lambda path, mode: False)
+        monkeypatch.setattr(settings_mod.os.path, "isdir", lambda path: True)
+        monkeypatch.setattr(settings_mod.os.path, "expanduser", lambda p: "/home/me")
+
+        assert settings_mod._resolve_data_dir("") == "/home/me/.oduflow/data"
+
+    def test_data_dir_falls_back_to_home(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(settings_mod.os, "access", lambda *a: False)
+        monkeypatch.setattr(settings_mod.os.path, "isdir", lambda path: False)
+        monkeypatch.setattr(settings_mod.os.path, "expanduser", lambda p: "/home/me")
+
+        assert settings_mod._resolve_data_dir("") == "/home/me/.oduflow/data"
+
+    def test_data_dir_is_probed_once_and_then_served_from_cache(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        calls = []
+
+        def _access(path, mode):
+            calls.append(path)
+            return path == "/srv"
+
+        monkeypatch.setattr(settings_mod.os, "access", _access)
+
+        first = settings_mod._resolve_data_dir("")
+        probes_after_first = len(calls)
+        second = settings_mod._resolve_data_dir("")
+
+        assert first == second == "/srv/oduflow"
+        assert probes_after_first > 0
+        assert len(calls) == probes_after_first  # no re-probing
+
+    def test_etc_dir_uses_etc_oduflow_when_writable(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.os, "access", lambda path, mode: path == "/etc/oduflow"
+        )
+
+        assert settings_mod._resolve_etc_dir() == "/etc/oduflow"
+
+    def test_etc_dir_accepts_a_writable_parent(self, monkeypatch):
+        # /etc/oduflow does not exist yet, but /etc is writable, so it can be
+        # created there.
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod.os, "access", lambda path, mode: path == "/etc"
+        )
+
+        assert settings_mod._resolve_etc_dir() == "/etc/oduflow"
+
+    def test_etc_dir_falls_back_to_home(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        monkeypatch.setattr(settings_mod.os, "access", lambda *a: False)
+        monkeypatch.setattr(settings_mod.os.path, "expanduser", lambda p: "/home/me")
+
+        assert settings_mod._resolve_etc_dir() == "/home/me/.oduflow/conf"
+
+    def test_etc_dir_is_probed_once_and_then_served_from_cache(self, monkeypatch):
+        from oduflow import settings as settings_mod
+
+        calls = []
+
+        def _access(path, mode):
+            calls.append(path)
+            return path == "/etc/oduflow"
+
+        monkeypatch.setattr(settings_mod.os, "access", _access)
+
+        first = settings_mod._resolve_etc_dir()
+        probes_after_first = len(calls)
+        second = settings_mod._resolve_etc_dir()
+
+        assert first == second == "/etc/oduflow"
+        assert probes_after_first > 0
+        assert len(calls) == probes_after_first  # no re-probing

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,7 +1,8 @@
 import hashlib
 import hmac
 import json
-from unittest.mock import patch
+import logging
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -227,3 +228,204 @@ class TestHandleGithubEvent:
         )
         assert status == 200
         assert body["ignored"] == "issues"
+
+
+class TestDeployInBackground:
+    """The worker every other webhook test patches out.
+
+    It owns three invariants that only show up under failure: the production
+    lock is always released, the coalescing slot is always freed, and a failed
+    deploy never propagates out of the thread.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_pending(self):
+        webhooks._pending.clear()
+        yield
+        webhooks._pending.clear()
+
+    def _run(self, settings, team, locks, name="erp"):
+        webhooks._pending.add(f"{team.team_id}/{name}")
+        webhooks._deploy_in_background(settings, team, locks, name)
+
+    def test_deploys_under_the_production_lock_and_releases_it(
+        self, settings, team
+    ):
+        locks = LockManager()
+        from oduflow.server import prod_lock_key
+
+        key = prod_lock_key(team.team_id, "erp")
+
+        with patch("oduflow.docker_ops.production_ops.update_production") as update:
+            update.return_value = {"action": "upgrade"}
+            self._run(settings, team, locks)
+
+        update.assert_called_once_with(settings, team, "erp", trigger="webhook")
+        # Released: a fresh acquire must succeed immediately.
+        assert locks.acquire_env_blocking(key, 0.1) is True
+        locks.release_env(key)
+
+    def test_the_coalescing_slot_is_freed_before_the_deploy_runs(
+        self, settings, team
+    ):
+        # A push arriving while the deploy is already running must be able to
+        # queue the next one, so the slot is dropped once the lock is held.
+        locks = LockManager()
+        seen = {}
+
+        def _update(*args, **kwargs):
+            seen["pending"] = set(webhooks._pending)
+            return {"action": "none"}
+
+        with patch(
+            "oduflow.docker_ops.production_ops.update_production", side_effect=_update
+        ):
+            self._run(settings, team, locks)
+
+        assert seen["pending"] == set()
+        assert webhooks._pending == set()
+
+    def test_a_failing_deploy_does_not_escape_the_thread(self, settings, team):
+        locks = LockManager()
+        from oduflow.server import prod_lock_key
+
+        with patch(
+            "oduflow.docker_ops.production_ops.update_production",
+            side_effect=RuntimeError("deploy exploded"),
+        ):
+            self._run(settings, team, locks)  # must not raise
+
+        assert webhooks._pending == set()
+        key = prod_lock_key(team.team_id, "erp")
+        assert locks.acquire_env_blocking(key, 0.1) is True
+        locks.release_env(key)
+
+    def test_lock_timeout_skips_the_deploy_and_frees_the_slot(
+        self, settings, team, caplog
+    ):
+        # A stuck slot would make dispatch_push drop every later push for this
+        # production until the server restarts.
+        locks = MagicMock()
+        locks.acquire_env_blocking.return_value = False
+
+        with (
+            caplog.at_level(logging.WARNING, logger="oduflow"),
+            patch("oduflow.docker_ops.production_ops.update_production") as update,
+        ):
+            self._run(settings, team, locks)
+
+        update.assert_not_called()
+        locks.release_env.assert_not_called()
+        assert webhooks._pending == set()
+        assert "gave up waiting" in caplog.text
+
+    def test_the_lock_key_is_team_scoped(self, settings, team):
+        locks = MagicMock()
+        locks.acquire_env_blocking.return_value = False
+
+        self._run(settings, team, locks)
+
+        assert locks.acquire_env_blocking.call_args.args[0] == "prod:1:erp"
+
+    def test_the_lock_wait_is_bounded(self, settings, team):
+        locks = MagicMock()
+        locks.acquire_env_blocking.return_value = False
+
+        self._run(settings, team, locks)
+
+        assert (
+            locks.acquire_env_blocking.call_args.args[1]
+            == webhooks._LOCK_TIMEOUT_SECONDS
+        )
+
+
+class TestDispatchPush:
+    @pytest.fixture(autouse=True)
+    def _clean_pending(self):
+        webhooks._pending.clear()
+        yield
+        webhooks._pending.clear()
+
+    def test_nothing_matching_queues_nothing(self, settings, team):
+        with patch.object(webhooks, "_deploy_in_background") as worker:
+            queued = webhooks.dispatch_push(
+                settings, team, LockManager(), {"ref": "refs/tags/v1"}
+            )
+
+        assert queued == []
+        worker.assert_not_called()
+        assert webhooks._pending == set()
+
+
+class TestSignatureScheme:
+    def test_a_correct_digest_under_the_wrong_scheme_is_rejected(self):
+        # The scheme is not decoration: accepting any prefix would let a
+        # caller present a valid sha256 digest labelled as something else.
+        body = b'{"ref":"refs/heads/main"}'
+        digest = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+
+        assert webhooks.verify_signature("s3cret", body, f"md5={digest}") is False
+        assert webhooks.verify_signature("s3cret", body, f"sha1={digest}") is False
+        assert webhooks.verify_signature("s3cret", body, digest) is False
+
+    def test_the_scheme_is_matched_case_insensitively(self):
+        body = b"x"
+        digest = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+
+        assert webhooks.verify_signature("s3cret", body, f"SHA256={digest}") is True
+
+    def test_an_empty_digest_is_rejected(self):
+        assert webhooks.verify_signature("s3cret", b"x", "sha256=") is False
+
+    def test_an_uppercase_digest_still_matches(self):
+        body = b"x"
+        digest = hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+
+        assert (
+            webhooks.verify_signature("s3cret", body, f"sha256={digest.upper()}")
+            is True
+        )
+
+    def test_a_different_body_does_not_match(self):
+        digest = hmac.new(b"s3cret", b"one", hashlib.sha256).hexdigest()
+
+        assert webhooks.verify_signature("s3cret", b"two", f"sha256={digest}") is False
+
+
+class TestMalformedPayload:
+    @pytest.fixture
+    def secret(self, team):
+        # The team's webhook secret is generated with its first production.
+        production_registry.create_production(
+            team, "erp", {"repo_url": "https://github.com/org/erp.git"}
+        )
+        return production_registry.get_webhook_secret(team)
+
+    def test_unparsable_json_is_a_400_not_a_401(self, settings, team, secret):
+        # 401 would tell the caller their signature was wrong when it was
+        # actually fine — the request is authenticated, the body is not JSON.
+        body = b"{not json"
+
+        status, payload = webhooks.handle_github_event(
+            settings,
+            LockManager(),
+            event="push",
+            body=body,
+            signature_header=_sign(secret, body),
+        )
+
+        assert status == 400
+        assert payload["error"] == "malformed payload"
+
+    def test_undecodable_bytes_are_also_a_400(self, settings, team, secret):
+        body = b"\xff\xfe not utf-8"
+
+        status, _payload = webhooks.handle_github_event(
+            settings,
+            LockManager(),
+            event="push",
+            body=body,
+            signature_header=_sign(secret, body),
+        )
+
+        assert status == 400


### PR DESCRIPTION
Adds a scoped `[tool.mutmut]` configuration covering 39 pure-logic modules and the tests needed to kill the mutants it surfaced. Across that scope 6409 mutants are now killed against 1553 at the start, uncovered mutants drop from 585 to 10, and the unit suite grows from 1249 to 1723 tests while still running in ~8s.

Almost every finding was a missing assertion rather than a bug, but one was real: `activity._load` and `port_registry._load_registry` both call `.items()` on whatever `json.load` returns and catch only JSONDecodeError/ValueError/OSError, so a file holding valid JSON of the wrong shape (a truncated write leaving `null`) raised AttributeError straight through the handler — for activity, aborting `stop_environment` on a corrupt best-effort tracking file. Both loaders now check the shape first; that is the only production change.

The largest gaps were modules with no test file at all: `git_ops` (402 uncovered mutants — the credential store's masking and exact-match deletion, and the valid/invalid/unknown split where reporting "invalid" on a GitHub outage would tell the user to re-enter a working token), `s3_client` (230), `sanitizer._run_scripts_from_dir` (149), `licensing._verify_license_text` (71, patched out everywhere so the signature check itself was untested), plus new files for `reaper`, `activity`, `oauth_token_store`, `output_cache` and `locking`.

Behind those sat assertions that permitted real defects: `port_registry.allocate_port` could hand out an already-bound port, `settings._parse_backup_section` accepted an S3 config with no `secret_key`, `webhooks.verify_signature` would have accepted a valid digest under the wrong scheme, and the reaper's two thresholds — which decide whether an environment is stopped or permanently deleted — were never pinned. `systemd.py` is deliberately excluded: no tests to measure, and its code shells out to `systemctl stop/disable`. Reproduce with `mutmut run --max-children 8` (~5 min).
