### PR TITLE
Add template metadata editor

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2618,6 +2618,8 @@ contain `/` are accepted and URL-decoded as one environment name.
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/templates` | List template profiles |
+| `GET` | `/api/templates/{name:path}/metadata` | Read the complete `metadata.json` content and its optimistic revision |
+| `PUT` | `/api/templates/{name:path}/metadata` | Validate and atomically replace `metadata.json`; body: `content`, `revision` |
 | `POST` | `/api/templates/{name}/delete` | Delete a template |
 | `POST` | `/api/templates/{name}/rename` | Rename it; body: `new_name` |
 | `POST` | `/api/templates/import-token` | UI-authenticated: mint a 15-minute Odoo.sh import token |

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -72,6 +72,8 @@ contain `/` are accepted and URL-decoded as one environment name.
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/templates` | List template profiles |
+| `GET` | `/api/templates/{name:path}/metadata` | Read the complete `metadata.json` content and its optimistic revision |
+| `PUT` | `/api/templates/{name:path}/metadata` | Validate and atomically replace `metadata.json`; body: `content`, `revision` |
 | `POST` | `/api/templates/{name}/delete` | Delete a template |
 | `POST` | `/api/templates/{name}/rename` | Rename it; body: `new_name` |
 | `POST` | `/api/templates/import-token` | UI-authenticated: mint a 15-minute Odoo.sh import token |

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import gzip
+import hashlib
 import json
 import logging
 import os
@@ -3477,6 +3478,92 @@ def rename_template(
     }
 
 
+def get_template_metadata(team: TeamSettings, template_name: str) -> dict[str, str]:
+    """Return a template's raw metadata file and its optimistic revision.
+
+    Invalid JSON is deliberately returned unchanged so the dashboard editor can
+    be used to repair a file that was broken by an earlier filesystem edit.
+    """
+    validate_template_name(template_name)
+    template_dir = team.get_template_dir(template_name)
+    if not os.path.isdir(template_dir):
+        raise NotFoundError(f"Template '{template_name}' not found.")
+
+    metadata_path = team.get_template_metadata_path(template_name)
+    try:
+        with open(metadata_path, "rb") as f:
+            raw = f.read()
+    except FileNotFoundError:
+        raw = b""
+
+    return {
+        "content": raw.decode("utf-8") if raw else "{}\n",
+        "revision": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def update_template_metadata(
+    team: TeamSettings,
+    template_name: str,
+    content: str,
+    expected_revision: str,
+) -> dict[str, str]:
+    """Validate and atomically replace a template's ``metadata.json`` file."""
+    validate_template_name(template_name)
+    template_dir = team.get_template_dir(template_name)
+    if not os.path.isdir(template_dir):
+        raise NotFoundError(f"Template '{template_name}' not found.")
+
+    metadata_path = team.get_template_metadata_path(template_name)
+    try:
+        with open(metadata_path, "rb") as f:
+            current_raw = f.read()
+    except FileNotFoundError:
+        current_raw = b""
+
+    current_revision = hashlib.sha256(current_raw).hexdigest()
+    if expected_revision != current_revision:
+        raise ConflictError(
+            f"Template '{template_name}' metadata changed after it was opened. "
+            "Reload the settings and apply your changes again."
+        )
+
+    try:
+        metadata = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"
+        ) from exc
+    if not isinstance(metadata, dict):
+        raise TypeError("Template metadata must be a JSON object.")
+
+    normalized = (json.dumps(metadata, indent=2, ensure_ascii=False) + "\n").encode(
+        "utf-8"
+    )
+    tmp_path = f"{metadata_path}.tmp-{uuid.uuid4().hex}"
+    try:
+        mode = stat.S_IMODE(os.stat(metadata_path).st_mode)
+    except FileNotFoundError:
+        mode = 0o644
+
+    try:
+        with open(tmp_path, "wb") as f:
+            f.write(normalized)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, metadata_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    logger.info("Updated metadata for template %s", template_name)
+    return {
+        "content": normalized.decode("utf-8"),
+        "revision": hashlib.sha256(normalized).hexdigest(),
+    }
+
+
 def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any]]:
     client = get_client()
     templates = team.list_templates()
@@ -3486,12 +3573,26 @@ def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any
         has_sql = os.path.isfile(team.get_template_sql_path(template_name))
         has_filestore = os.path.isdir(team.get_template_filestore_path(template_name))
         db_loaded = _db_exists(client, settings, tpl_db)
-        metadata = {}
+        metadata: dict[str, Any] = {}
+        metadata_valid = True
         metadata_path = team.get_template_metadata_path(template_name)
         if os.path.isfile(metadata_path):
-            with open(metadata_path) as f:
-                metadata = json.load(f)
-        if "filestore_size_mb" not in metadata or "dump_size_mb" not in metadata:
+            try:
+                with open(metadata_path) as f:
+                    loaded_metadata = json.load(f)
+                if not isinstance(loaded_metadata, dict):
+                    raise TypeError("metadata must be a JSON object")
+                metadata = loaded_metadata
+            except (OSError, TypeError, UnicodeError, ValueError) as exc:
+                metadata_valid = False
+                logger.warning(
+                    "Could not read metadata for template %s: %s",
+                    template_name,
+                    exc,
+                )
+        if metadata_valid and (
+            "filestore_size_mb" not in metadata or "dump_size_mb" not in metadata
+        ):
             metadata = _update_template_sizes(team, settings, template_name, metadata)
         result.append(
             {
@@ -3500,6 +3601,7 @@ def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any
                 "has_sql": has_sql,
                 "has_filestore": has_filestore,
                 "db_loaded": db_loaded,
+                "metadata_valid": metadata_valid,
                 "odoo_image": metadata.get("odoo_image", ""),
                 "repo_url": metadata.get("repo_url", ""),
                 "git_user": metadata.get("git_user", ""),

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -803,6 +803,7 @@ def save_as_template(
 
 @mcp.tool()
 @handle_errors
+@with_team_lock
 def list_templates(ctx: Context | None = None) -> str:
     """List available template profiles (database + filestore snapshots)."""
     settings = _get_settings()

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3374,8 +3374,12 @@ async function submitTemplateSettings() {
   var editor = document.getElementById('template-metadata-editor');
   var errEl = document.getElementById('template-settings-error');
   var btn = document.getElementById('template-settings-submit');
+  var name = _templateSettingsName;
+  var revision = _templateSettingsRevision;
+  var token = _templateSettingsLoadToken;
+  var content = editor.value;
   try {
-    var parsed = JSON.parse(editor.value);
+    var parsed = JSON.parse(content);
     if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
       throw new Error('Template metadata must be a JSON object.');
     }
@@ -3390,31 +3394,35 @@ async function submitTemplateSettings() {
   btn.disabled = true;
   btn.textContent = 'Saving...';
   try {
-    var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(_templateSettingsName) + '/metadata', {
+    var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(name) + '/metadata', {
       method: 'PUT',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({
-        content: editor.value,
-        revision: _templateSettingsRevision
+        content: content,
+        revision: revision
       })
     });
     var data = await r.json();
+    if (token !== _templateSettingsLoadToken || name !== _templateSettingsName) return;
     if (data.ok) {
       editor.value = data.content;
       _templateSettingsRevision = data.revision;
-      showToast('Template "' + _templateSettingsName + '" settings saved');
-      hideModal('template-settings-modal');
+      showToast('Template "' + name + '" settings saved');
+      closeTemplateSettingsModal();
       await loadTemplates();
     } else {
       errEl.textContent = data.error || 'Failed to save template settings';
       errEl.style.display = 'block';
     }
   } catch (e) {
+    if (token !== _templateSettingsLoadToken || name !== _templateSettingsName) return;
     errEl.textContent = 'Connection error: ' + e.message;
     errEl.style.display = 'block';
   } finally {
-    btn.disabled = false;
-    btn.textContent = 'Save settings';
+    if (token === _templateSettingsLoadToken && name === _templateSettingsName) {
+      btn.disabled = false;
+      btn.textContent = 'Save settings';
+    }
   }
 }
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -573,6 +573,15 @@
   .modal-sm { max-width: 460px; }
   .modal-md { max-width: 520px; }
   .modal-routes { max-width: 680px; max-height: 90vh; }
+  #template-settings-modal .modal { width: min(760px, calc(100vw - 32px)); max-height: 90vh; }
+  #template-metadata-editor {
+    min-height: 48vh;
+    resize: vertical;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: 1.5;
+    tab-size: 2;
+  }
   /* Unified large modal size (chat / terminals) — almost fullscreen, with margins */
   .modal-terminal, .modal-chat { width: 92vw; max-width: 92vw; height: 90vh; max-height: 90vh; }
   /* --- ACP chat (chat.js) — Engineer's Console tokens only (DESIGN.md) --- */
@@ -1707,6 +1716,27 @@
           <button class="btn" onclick="closeImportOdooModal()">Close</button>
           <button class="btn-create" onclick="copyImportOdooCommand()">Copy command</button>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal-overlay" id="template-settings-modal" onclick="closeTemplateSettingsModal(event)">
+  <div class="modal">
+    <div class="modal-header">
+      <h2 id="template-settings-title">Template settings</h2>
+      <button class="modal-close" aria-label="Close template settings" onclick="closeTemplateSettingsModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-error" id="template-settings-error"></div>
+      <div class="form-group">
+        <label for="template-metadata-editor">metadata.json</label>
+        <textarea id="template-metadata-editor" rows="18" spellcheck="false" autocomplete="off" aria-describedby="template-metadata-hint" disabled></textarea>
+        <div class="hint" id="template-metadata-hint">This is the complete template metadata file. Changes affect environments created from this template.</div>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeTemplateSettingsModal()">Cancel</button>
+        <button class="btn-create" id="template-settings-submit" onclick="submitTemplateSettings()" disabled>Save settings</button>
       </div>
     </div>
   </div>
@@ -3291,6 +3321,103 @@ async function submitImportOdoo() {
 
 var _renameTplName = '';
 
+var _templateSettingsName = '';
+var _templateSettingsRevision = '';
+var _templateSettingsLoadToken = 0;
+
+async function openTemplateSettingsModal(name) {
+  _templateSettingsName = name;
+  _templateSettingsRevision = '';
+  var token = ++_templateSettingsLoadToken;
+  var editor = document.getElementById('template-metadata-editor');
+  var errEl = document.getElementById('template-settings-error');
+  var btn = document.getElementById('template-settings-submit');
+  document.getElementById('template-settings-title').textContent = 'Template settings — ' + name;
+  editor.value = 'Loading metadata.json...';
+  editor.disabled = true;
+  btn.disabled = true;
+  btn.textContent = 'Save settings';
+  errEl.style.display = 'none';
+  errEl.textContent = '';
+  showModal('template-settings-modal');
+
+  try {
+    var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(name) + '/metadata');
+    var data = await r.json();
+    if (token !== _templateSettingsLoadToken) return;
+    if (data.ok) {
+      editor.value = data.content;
+      _templateSettingsRevision = data.revision;
+      editor.disabled = false;
+      btn.disabled = false;
+      editor.focus();
+    } else {
+      editor.value = '';
+      errEl.textContent = data.error || 'Failed to load template settings';
+      errEl.style.display = 'block';
+    }
+  } catch (e) {
+    if (token !== _templateSettingsLoadToken) return;
+    editor.value = '';
+    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.style.display = 'block';
+  }
+}
+
+function closeTemplateSettingsModal(event) {
+  if (event && event.target !== event.currentTarget) return;
+  _templateSettingsLoadToken += 1;
+  hideModal('template-settings-modal');
+}
+
+async function submitTemplateSettings() {
+  var editor = document.getElementById('template-metadata-editor');
+  var errEl = document.getElementById('template-settings-error');
+  var btn = document.getElementById('template-settings-submit');
+  try {
+    var parsed = JSON.parse(editor.value);
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+      throw new Error('Template metadata must be a JSON object.');
+    }
+  } catch (e) {
+    errEl.textContent = 'Invalid JSON: ' + e.message;
+    errEl.style.display = 'block';
+    editor.focus();
+    return;
+  }
+
+  errEl.style.display = 'none';
+  btn.disabled = true;
+  btn.textContent = 'Saving...';
+  try {
+    var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(_templateSettingsName) + '/metadata', {
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        content: editor.value,
+        revision: _templateSettingsRevision
+      })
+    });
+    var data = await r.json();
+    if (data.ok) {
+      editor.value = data.content;
+      _templateSettingsRevision = data.revision;
+      showToast('Template "' + _templateSettingsName + '" settings saved');
+      hideModal('template-settings-modal');
+      await loadTemplates();
+    } else {
+      errEl.textContent = data.error || 'Failed to save template settings';
+      errEl.style.display = 'block';
+    }
+  } catch (e) {
+    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Save settings';
+  }
+}
+
 function openRenameTemplateModal(name) {
   _renameTplName = name;
   var errEl = document.getElementById('rename-tpl-error');
@@ -3423,9 +3550,14 @@ function renderTemplates(templates) {
     var fsTag = t.has_filestore
       ? '<span class="tag tag-ok" title="Filestore snapshot (attachments) is present">Filestore</span>'
       : '<span class="tag tag-missing" title="No filestore snapshot">No Filestore</span>';
-    var modeTag = t.use_overlay
-      ? '<span class="tag tag-neutral" title="Filestore cloning mode: copy-on-write via fuse-overlayfs">Overlay</span>'
-      : '<span class="tag tag-neutral" title="Filestore cloning mode: plain copy">Copy</span>';
+    var modeTag = t.metadata_valid === false
+      ? ''
+      : (t.use_overlay
+        ? '<span class="tag tag-neutral" title="Filestore cloning mode: copy-on-write via fuse-overlayfs">Overlay</span>'
+        : '<span class="tag tag-neutral" title="Filestore cloning mode: plain copy">Copy</span>');
+    var metadataTag = t.metadata_valid === false
+      ? '<span class="tag tag-missing" title="metadata.json is invalid; open Settings to repair it">Invalid metadata</span>'
+      : '';
     var sizeHtml = '';
     if (t.filestore_size_mb != null || t.dump_size_mb != null) {
       var fmtSize = function(mb) {
@@ -3448,8 +3580,9 @@ function renderTemplates(templates) {
       '<div class="tpl-head">' +
         '<span class="tpl-name">' + esc(t.template_name) + '</span>' +
         '<div class="tpl-head-right">' +
-          '<div class="tpl-meta">' + dbTag + sqlTag + fsTag + modeTag + sizeHtml + '</div>' +
+          '<div class="tpl-meta">' + dbTag + sqlTag + fsTag + modeTag + metadataTag + sizeHtml + '</div>' +
           '<button class="btn-create btn-sm" onclick="openCreateFromTemplate(\'' + escAttr(t.template_name) + '\')">+ New Env</button>' +
+          '<button class="btn btn-sm" onclick="openTemplateSettingsModal(\'' + escAttr(t.template_name) + '\')">Settings</button>' +
           '<button class="btn btn-sm" onclick="openRenameTemplateModal(\'' + escAttr(t.template_name) + '\')">Rename</button>' +
           '<button class="btn btn-delete btn-sm" onclick="doDeleteTemplate(\'' + escAttr(t.template_name) + '\')">Remove</button>' +
         '</div>' +
@@ -5219,6 +5352,7 @@ var MODAL_CLOSERS = {
   'license-modal': closeLicenseModal,
   'add-extra-repo-modal': closeAddExtraRepoModal,
   'add-credential-modal': closeAddCredentialModal,
+  'template-settings-modal': closeTemplateSettingsModal,
   'confirm-modal': cancelConfirm,
   'note-modal': closeNoteModal
 };

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1250,8 +1250,13 @@ def _build_routes(
             )
 
     def api_templates(request: Request) -> JSONResponse:
+        team = _get_ui_team(request)
         try:
-            templates = system_ops.list_templates(get_settings(), _get_ui_team(request))
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            templates = system_ops.list_templates(get_settings(), team)
             return JSONResponse({"ok": True, "templates": templates})
         except FlowError as e:
             return _error_response(e)
@@ -1260,6 +1265,8 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
+        finally:
+            locks.release_team(team.team_id)
 
     def api_template_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -61,7 +61,7 @@ from oduflow.docker_ops.stats import (
     refresh_env_storage,
     refresh_team_storage,
 )
-from oduflow.errors import BusyError, FlowError, NotFoundError
+from oduflow.errors import BusyError, ConflictError, FlowError, NotFoundError
 from oduflow.licensing import get_license_info, install_license_from_text
 from oduflow.locking import LockManager
 from oduflow.naming import validate_template_name
@@ -1308,6 +1308,78 @@ def _build_routes(
             return _error_response(e)
         except Exception:
             logger.exception("Unexpected error in api_template_rename")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+        finally:
+            locks.release_team(team.team_id)
+
+    def api_template_metadata(request: Request) -> JSONResponse:
+        name = request.path_params["name"]
+        team = _get_ui_team(request)
+        try:
+            result = system_ops.get_template_metadata(team, name)
+            return JSONResponse({"ok": True, **result})
+        except ValueError as e:  # invalid template name
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except FlowError as e:
+            return _error_response(e)
+        except UnicodeDecodeError:
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": "Template metadata is not valid UTF-8.",
+                },
+                status_code=400,
+            )
+        except Exception:
+            logger.exception("Unexpected error in api_template_metadata")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+
+    async def api_template_metadata_update(request: Request) -> JSONResponse:
+        name = request.path_params["name"]
+        team = _get_ui_team(request)
+        try:
+            validate_template_name(name)
+            body = await request.json()
+        except (TypeError, ValueError) as e:
+            message = str(e) or "Invalid JSON body"
+            return JSONResponse({"ok": False, "error": message}, status_code=400)
+
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"ok": False, "error": "JSON body must be an object"},
+                status_code=400,
+            )
+
+        content = body.get("content")
+        revision = body.get("revision")
+        if not isinstance(content, str):
+            return JSONResponse(
+                {"ok": False, "error": "content must be a string"}, status_code=400
+            )
+        if not isinstance(revision, str):
+            return JSONResponse(
+                {"ok": False, "error": "revision must be a string"}, status_code=400
+            )
+
+        try:
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            result = system_ops.update_template_metadata(team, name, content, revision)
+            return JSONResponse({"ok": True, **result})
+        except ConflictError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=409)
+        except (TypeError, ValueError) as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in api_template_metadata_update")
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
@@ -4260,6 +4332,16 @@ def _build_routes(
             methods=["POST"],
         ),
         Route("/api/templates/import/finalize", api_import_finalize, methods=["POST"]),
+        Route(
+            "/api/templates/{name:path}/metadata",
+            api_template_metadata,
+            methods=["GET"],
+        ),
+        Route(
+            "/api/templates/{name:path}/metadata",
+            api_template_metadata_update,
+            methods=["PUT"],
+        ),
         Route("/api/templates/{name}/delete", api_template_delete, methods=["POST"]),
         Route("/api/templates/{name}/rename", api_template_rename, methods=["POST"]),
         Route("/api/environments", api_list, methods=["GET"]),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -971,6 +971,21 @@ class TestEnvLock:
             _locks.release_env("main")
 
 
+class TestTemplateListLock:
+    @patch("oduflow.docker_ops.system_ops.list_templates")
+    def test_busy_raises_tool_error_without_listing(self, mock_list):
+        import oduflow.server
+
+        locks = oduflow.server._locks
+        locks.acquire_team("1")
+        try:
+            with pytest.raises(ToolError, match="Another team-level operation"):
+                _call_tool("list_templates")
+        finally:
+            locks.release_team("1")
+        mock_list.assert_not_called()
+
+
 class TestListServicePresetsTool:
     @patch("oduflow.docker_ops.service_presets.list_presets")
     def test_list_shows_all_fields(self, mock_list):

--- a/tests/test_template_metadata.py
+++ b/tests/test_template_metadata.py
@@ -1,0 +1,117 @@
+import hashlib
+import json
+from unittest.mock import patch
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ConflictError, NotFoundError
+from oduflow.settings import Settings, TeamSettings
+
+
+def _template(tmp_path, name="default", content='{"odoo_image":"odoo:18.0"}'):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path))
+    template_dir = tmp_path / "templates" / name
+    template_dir.mkdir(parents=True)
+    metadata_path = template_dir / "metadata.json"
+    if content is not None:
+        metadata_path.write_text(content, encoding="utf-8")
+    return team, metadata_path
+
+
+def test_get_template_metadata_returns_raw_content_and_revision(tmp_path):
+    raw = '{"custom": true, "odoo_image": "odoo:18.0"}\n'
+    team, _ = _template(tmp_path, content=raw)
+
+    result = system_ops.get_template_metadata(team, "default")
+
+    assert result["content"] == raw
+    assert result["revision"] == hashlib.sha256(raw.encode()).hexdigest()
+
+
+def test_get_template_metadata_allows_creating_missing_file(tmp_path):
+    team, metadata_path = _template(tmp_path, content=None)
+
+    opened = system_ops.get_template_metadata(team, "default")
+    updated = system_ops.update_template_metadata(
+        team,
+        "default",
+        '{"custom": "value"}',
+        opened["revision"],
+    )
+
+    assert opened["content"] == "{}\n"
+    assert json.loads(updated["content"]) == {"custom": "value"}
+    assert json.loads(metadata_path.read_text()) == {"custom": "value"}
+
+
+def test_update_template_metadata_preserves_custom_fields_and_formats_json(tmp_path):
+    team, metadata_path = _template(tmp_path)
+    opened = system_ops.get_template_metadata(team, "default")
+
+    result = system_ops.update_template_metadata(
+        team,
+        "default",
+        '{"odoo_image":"odoo:19.0","custom":{"enabled":true}}',
+        opened["revision"],
+    )
+
+    assert result["content"].endswith("\n")
+    assert json.loads(metadata_path.read_text()) == {
+        "odoo_image": "odoo:19.0",
+        "custom": {"enabled": True},
+    }
+    assert result["revision"] == hashlib.sha256(metadata_path.read_bytes()).hexdigest()
+
+
+@pytest.mark.parametrize("content", ["{broken", "[]", "null"])
+def test_update_template_metadata_rejects_invalid_content_without_modifying_file(
+    tmp_path, content
+):
+    team, metadata_path = _template(tmp_path)
+    original = metadata_path.read_bytes()
+    revision = system_ops.get_template_metadata(team, "default")["revision"]
+
+    with pytest.raises((TypeError, ValueError)):
+        system_ops.update_template_metadata(team, "default", content, revision)
+
+    assert metadata_path.read_bytes() == original
+
+
+def test_update_template_metadata_rejects_stale_revision(tmp_path):
+    team, metadata_path = _template(tmp_path)
+    opened = system_ops.get_template_metadata(team, "default")
+    metadata_path.write_text('{"changed": true}', encoding="utf-8")
+
+    with pytest.raises(ConflictError, match="changed after it was opened"):
+        system_ops.update_template_metadata(
+            team,
+            "default",
+            '{"replacement": true}',
+            opened["revision"],
+        )
+
+    assert json.loads(metadata_path.read_text()) == {"changed": True}
+
+
+def test_template_metadata_validates_name_and_template_existence(tmp_path):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+    with pytest.raises(ValueError):
+        system_ops.get_template_metadata(team, "../escape")
+    with pytest.raises(NotFoundError, match="not found"):
+        system_ops.get_template_metadata(team, "missing")
+
+
+def test_list_templates_keeps_invalid_metadata_available_for_repair(tmp_path):
+    team, metadata_path = _template(tmp_path, content="{broken")
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+
+    with (
+        patch("oduflow.docker_ops.system_ops.get_client"),
+        patch("oduflow.docker_ops.system_ops._db_exists", return_value=False),
+    ):
+        result = system_ops.list_templates(settings, team)
+
+    assert result[0]["metadata_valid"] is False
+    assert metadata_path.read_text() == "{broken"

--- a/tests/test_template_metadata_web.py
+++ b/tests/test_template_metadata_web.py
@@ -127,6 +127,18 @@ def test_template_metadata_update_busy_keeps_foreign_lock(tmp_path):
         locks.release_team("1")
 
 
+def test_template_list_busy_keeps_foreign_lock(tmp_path):
+    client, locks = _client(tmp_path)
+    locks.acquire_team("1")
+    try:
+        response = client.get("/api/templates")
+        assert response.status_code == 409
+        with pytest.raises(BusyError):
+            locks.acquire_team("1")
+    finally:
+        locks.release_team("1")
+
+
 def test_template_metadata_get_rejects_invalid_or_missing_template(tmp_path):
     client, _ = _client(tmp_path)
 

--- a/tests/test_template_metadata_web.py
+++ b/tests/test_template_metadata_web.py
@@ -1,0 +1,137 @@
+import json
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.errors import BusyError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path):
+    team = TeamSettings(team_id="1", hostname="example.com", data_dir=str(tmp_path))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    locks = LockManager()
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, locks)
+    return TestClient(app), locks
+
+
+def _metadata(tmp_path, content='{"odoo_image": "odoo:18.0"}', name="default"):
+    path = tmp_path / "templates" / name / "metadata.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_template_metadata_get_and_update(tmp_path):
+    metadata_path = _metadata(tmp_path)
+    client, _ = _client(tmp_path)
+
+    opened = client.get("/api/templates/default/metadata")
+    assert opened.status_code == 200
+    revision = opened.json()["revision"]
+
+    saved = client.put(
+        "/api/templates/default/metadata",
+        json={
+            "content": '{"odoo_image":"odoo:19.0","custom":true}',
+            "revision": revision,
+        },
+    )
+
+    assert saved.status_code == 200
+    assert saved.json()["ok"] is True
+    assert json.loads(metadata_path.read_text()) == {
+        "odoo_image": "odoo:19.0",
+        "custom": True,
+    }
+
+
+def test_template_metadata_supports_nested_template_names(tmp_path):
+    _metadata(tmp_path, name="customer/base")
+    client, _ = _client(tmp_path)
+
+    response = client.get("/api/templates/customer%2Fbase/metadata")
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_template_metadata_update_rejects_invalid_json(tmp_path):
+    metadata_path = _metadata(tmp_path)
+    original = metadata_path.read_text()
+    client, _ = _client(tmp_path)
+    revision = client.get("/api/templates/default/metadata").json()["revision"]
+
+    response = client.put(
+        "/api/templates/default/metadata",
+        json={"content": "{broken", "revision": revision},
+    )
+
+    assert response.status_code == 400
+    assert "line 1" in response.json()["error"]
+    assert metadata_path.read_text() == original
+
+
+def test_template_metadata_update_rejects_stale_revision(tmp_path):
+    metadata_path = _metadata(tmp_path)
+    client, _ = _client(tmp_path)
+    revision = client.get("/api/templates/default/metadata").json()["revision"]
+    metadata_path.write_text('{"filesystem": "edit"}', encoding="utf-8")
+
+    response = client.put(
+        "/api/templates/default/metadata",
+        json={"content": '{"dashboard": "edit"}', "revision": revision},
+    )
+
+    assert response.status_code == 409
+    assert "changed after it was opened" in response.json()["error"]
+    assert json.loads(metadata_path.read_text()) == {"filesystem": "edit"}
+
+
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        ([], "JSON body must be an object"),
+        ({"content": "{}"}, "revision must be a string"),
+        ({"revision": "x"}, "content must be a string"),
+    ],
+)
+def test_template_metadata_update_validates_request_body(tmp_path, body, error):
+    _metadata(tmp_path)
+    client, _ = _client(tmp_path)
+
+    response = client.put("/api/templates/default/metadata", json=body)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == error
+
+
+def test_template_metadata_update_busy_keeps_foreign_lock(tmp_path):
+    _metadata(tmp_path)
+    client, locks = _client(tmp_path)
+    revision = client.get("/api/templates/default/metadata").json()["revision"]
+    locks.acquire_team("1")
+    try:
+        response = client.put(
+            "/api/templates/default/metadata",
+            json={"content": "{}", "revision": revision},
+        )
+        assert response.status_code == 409
+        with pytest.raises(BusyError):
+            locks.acquire_team("1")
+    finally:
+        locks.release_team("1")
+
+
+def test_template_metadata_get_rejects_invalid_or_missing_template(tmp_path):
+    client, _ = _client(tmp_path)
+
+    invalid = client.get("/api/templates/%2E%2E/metadata")
+    missing = client.get("/api/templates/missing/metadata")
+
+    assert invalid.status_code in (400, 404)
+    assert missing.status_code == 404


### PR DESCRIPTION
## Summary

Adds a Template Settings modal that lets operators inspect and edit each template's complete `metadata.json` without filesystem access.

- Adds authenticated metadata endpoints with JSON-object validation, atomic writes, nested-template support, and optimistic revisions.
- Keeps invalid metadata visible and repairable from the dashboard.
- Serializes REST and MCP template listing with metadata updates so derived size refreshes cannot overwrite an edit.
- Ignores stale save responses after the editor is closed or reopened for another template.

## Root cause of follow-up fixes

Template listing can persist derived size fields but was not using the team lock taken by metadata updates. The modal also protected stale load responses but not stale save responses.

## Validation

- `pytest -q -m "not integration and not heavyweight"` — 1,468 passed, 15 deselected
- Targeted template metadata and lock tests — 22 passed
- Ruff
- mypy
- `git diff --check`
