### PR TITLE
Improve agent diagnostics and template/code lineage

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -163,10 +163,10 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `upgrade_odoo_modules` — upgrade Odoo modules
 - `export_module_translations` — export a module's .pot/.po translation catalogue
 - `translation_status` — check what translations actually loaded, and lint the .po files
-- `run_odoo_tests` — run Odoo tests for specific modules
+- `run_odoo_tests` — run Odoo tests for specific modules (`test_tags` narrows to one class/method; `upgrade=False` skips the `-u`, collects `post_install` tests only, and requires module-scoped positive tags)
 - `pull_and_apply` — pull latest code and auto-install/upgrade/restart as needed
 - `get_environment_logs` — retrieve container logs
-- `run_odoo_command` — execute shell commands inside the Odoo container
+- `run_odoo_command` — execute shell commands inside the Odoo container (through `sh -c`, so pipes and redirections work; `shell=False` for exact argv)
 - `run_odoo_shell` — execute Python code in the Odoo shell with full ORM access
 - `odoo_search_read` / `odoo_create` / `odoo_write` / `odoo_unlink` / `odoo_call` / `odoo_schema` — XML-RPC `execute_kw`-equivalent ORM tools. Structured JSON in and out, no Python to write; every one takes `as_user` (login or id, empty = the environment's admin) and runs in a real session for that user, so `ir.model.access` and `ir.rule` apply as they do in the web client. `odoo_call` handles other public methods (`read_group`, `name_search`, `action_*`, custom methods), while policy-visible `create`/`write`/`unlink` must use their dedicated tools; `odoo_schema` pages through models or returns `fields_get`. They hit the **running** server: edited Python is invisible until the environment restarts, and each call is its own committed transaction — use `run_odoo_shell` for a fresh registry, `sudo()`, private methods, a dry run, or multi-step atomicity
 - `read_file_in_odoo` — read a text file or list a directory inside the container (supports line ranges)
@@ -2755,11 +2755,11 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
 | `upgrade_odoo_modules` | ✓ | Upgrade Odoo modules (`-u`) |
-| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules |
 | `export_module_translations` | ✓ | Export a module's `.pot`/`.po` with Odoo's own exporter, write it into the module's `i18n/`, and return a summary plus an HTTP download URL or local temporary path |
 | `translation_status` | ✓ | Compare a module's terms, database translations and committed `.po` files, including the sibling-POT metadata merge Odoo performs before import |
+| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `test_tags` narrows the run to one class or method, `upgrade=False` skips the `-u` for a fast re-run (collects `post_install` tests only and requires module-scoped positive tags) |
 | `get_environment_logs` | | Retrieve recent container logs |
-| `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container |
+| `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |
 | `run_odoo_shell` | ✓ | Execute Python code in the Odoo shell context with full ORM access; `auto_commit=True` commits successful writes, while `False` leaves the shell transaction uncommitted |
 | `odoo_search_read` | ✓ | Search and read records (XML-RPC `search_read`/`search_count`) as any user, with ACLs and record rules applied |
 | `odoo_create` | ✓ | Create one or many records (XML-RPC `create`). Committed immediately |
@@ -2778,7 +2778,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `read_output` | | Read from a cached tool output by ID (paginate, grep, errors, tail) |
 | **Template Management** | | |
 | `save_as_template` | ✓ | ⚠️ Save a branch DB + filestore as a new template |
-| `list_templates` | | List available template profiles |
+| `list_templates` | | List available template profiles, including the branch/commit each database snapshot was taken from |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `rename_template` | ✓ | Rename a template (directory + PostgreSQL template DB); refused if any environment uses it |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only PostgreSQL custom dump |
@@ -2792,7 +2792,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
-| `run_service_command` | | Execute a shell command inside a service container |
+| `run_service_command` | | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
 | **Volumes** | | |
 | `create_volume` | ✓ | Create a named Docker volume for use with services |
 | `list_volumes` | | List all managed Docker volumes and their usage by services |
@@ -2838,7 +2838,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `get_odoo_development_guide` | | Get Odoo development standards guide for a specific version (15–19) |
 
 !!! info "Locking"
-    Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`.
+    Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.
 
 The exact current signature and defaults for every tool are also available from
 `oduflow list` (`oduflow list --verbose` adds descriptions). The production
@@ -4174,6 +4174,88 @@ This is intentional. A template's filestore is the overlay **lower layer** for
 every environment built from it; deleting the template would pull the base out
 from under those live overlays and break them. Delete the listed environments
 first (or keep the template). The same guard applies to renaming a template.
+
+---
+
+## A brand-new environment fails its first upgrade
+
+An environment is a *new* database cloned from a template plus *your* branch's
+code. The template database is a snapshot of some branch at some commit, so the
+two can drift in either direction — and the failure only surfaces on the first
+`-u`.
+
+```bash
+# What the template was snapshotted from:
+oduflow call list_templates
+# → - prod: DB=loaded, ..., Source=prod @ c0ffee12 @ snapshot 2026-08-01
+```
+
+`create_environment` compares that commit with the branch checkout and reports
+the drift in its response:
+
+* **"Code is behind the template database"** — your branch does not contain the
+  snapshot commit. The database already holds views and records written by newer
+  code, so upgrading the older branch fails validation (typically a `ParseError`
+  on a view referencing a method your branch does not have). **Merge the
+  template's source branch** into yours, push, then `pull_and_apply`.
+* **"Code is ahead of the template database"** — the database predates your
+  code. Apply the drift explicitly with the arguments reported by Oduflow, for
+  example `pull_and_apply(install="new_module", upgrade="a,b,c")`, listing
+  dependencies before dependents. Brand-new modules need `install=`; existing
+  modules with schema/data drift need `upgrade=`. Modules whose manifest version
+  was not bumped are never upgraded automatically, so a `column ... does not
+  exist` or a missing external ID means "find the module that owns it and add it
+  to `upgrade=`".
+
+Templates created before Oduflow recorded provenance — and templates imported
+from a running Odoo — have no commit to compare against, so no drift is
+reported. That is not an error; the rule above still applies, you just have to
+apply it by hand.
+
+!!! warning "Recreating the environment does not fix it"
+    The template is unchanged, so the same drift comes straight back — and the
+    environment's data is gone. Reconcile with a merge or an explicit
+    install/upgrade action.
+
+---
+
+## `BusyError`: "Another operation ... is in progress"
+
+The message names the holder and its age:
+
+```
+Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress.
+```
+
+Locks are held for exactly as long as the operation runs and are released when
+it finishes. A long-running install, upgrade or test run legitimately holds one
+for minutes — including when the *client* gave up waiting and timed out, because
+the work continues server-side. Wait for it to finish and retry; restarting or
+recreating the environment interrupts real work instead of clearing anything.
+
+Background operations take the same locks and are named too: `auto-stop`,
+`auto-delete`, `scheduled backup`, `webhook deploy`.
+
+---
+
+## The Odoo web client loads blank
+
+The page is served, the JS bundles arrive, the browser console is clean — and
+nothing renders. This is an Odoo-side asset/registry problem (commonly a custom
+systray or a legacy widget that never resolves during `startWebClient`), not an
+environment provisioning problem: restarting the container or rebuilding assets
+does not help, and headless browser tooling tends to hang on such a page.
+
+Verify server-side instead — it works normally while the web client does not:
+
+```bash
+oduflow call run_odoo_shell '{"env_name": "my-branch", "python_code":
+  "print(env[\"res.partner\"].fields_get([\"name\"]).keys())", "auto_commit": false}'
+oduflow call run_odoo_tests '{"env_name": "my-branch", "modules": "my_module"}'
+```
+
+Then narrow the failing asset with `get_environment_logs` and by disabling the
+suspect module's assets.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -163,10 +163,10 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `upgrade_odoo_modules` — upgrade Odoo modules
 - `export_module_translations` — export a module's .pot/.po translation catalogue
 - `translation_status` — check what translations actually loaded, and lint the .po files
-- `run_odoo_tests` — run Odoo tests for specific modules
+- `run_odoo_tests` — run Odoo tests for specific modules (`test_tags` narrows to one class/method; `upgrade=False` skips the `-u`, collects `post_install` tests only, and requires module-scoped positive tags)
 - `pull_and_apply` — pull latest code and auto-install/upgrade/restart as needed
 - `get_environment_logs` — retrieve container logs
-- `run_odoo_command` — execute shell commands inside the Odoo container
+- `run_odoo_command` — execute shell commands inside the Odoo container (through `sh -c`, so pipes and redirections work; `shell=False` for exact argv)
 - `run_odoo_shell` — execute Python code in the Odoo shell with full ORM access
 - `odoo_search_read` / `odoo_create` / `odoo_write` / `odoo_unlink` / `odoo_call` / `odoo_schema` — XML-RPC `execute_kw`-equivalent ORM tools. Structured JSON in and out, no Python to write; every one takes `as_user` (login or id, empty = the environment's admin) and runs in a real session for that user, so `ir.model.access` and `ir.rule` apply as they do in the web client. `odoo_call` handles other public methods (`read_group`, `name_search`, `action_*`, custom methods), while policy-visible `create`/`write`/`unlink` must use their dedicated tools; `odoo_schema` pages through models or returns `fields_get`. They hit the **running** server: edited Python is invisible until the environment restarts, and each call is its own committed transaction — use `run_odoo_shell` for a fresh registry, `sudo()`, private methods, a dry run, or multi-step atomicity
 - `read_file_in_odoo` — read a text file or list a directory inside the container (supports line ranges)

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -19,11 +19,11 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
 | `upgrade_odoo_modules` | ✓ | Upgrade Odoo modules (`-u`) |
-| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules |
 | `export_module_translations` | ✓ | Export a module's `.pot`/`.po` with Odoo's own exporter, write it into the module's `i18n/`, and return a summary plus an HTTP download URL or local temporary path |
 | `translation_status` | ✓ | Compare a module's terms, database translations and committed `.po` files, including the sibling-POT metadata merge Odoo performs before import |
+| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `test_tags` narrows the run to one class or method, `upgrade=False` skips the `-u` for a fast re-run (collects `post_install` tests only and requires module-scoped positive tags) |
 | `get_environment_logs` | | Retrieve recent container logs |
-| `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container |
+| `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |
 | `run_odoo_shell` | ✓ | Execute Python code in the Odoo shell context with full ORM access; `auto_commit=True` commits successful writes, while `False` leaves the shell transaction uncommitted |
 | `odoo_search_read` | ✓ | Search and read records (XML-RPC `search_read`/`search_count`) as any user, with ACLs and record rules applied |
 | `odoo_create` | ✓ | Create one or many records (XML-RPC `create`). Committed immediately |
@@ -42,7 +42,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `read_output` | | Read from a cached tool output by ID (paginate, grep, errors, tail) |
 | **Template Management** | | |
 | `save_as_template` | ✓ | ⚠️ Save a branch DB + filestore as a new template |
-| `list_templates` | | List available template profiles |
+| `list_templates` | | List available template profiles, including the branch/commit each database snapshot was taken from |
 | `delete_template` | ✓ | ⚠️ Delete a template profile (DB + files) |
 | `rename_template` | ✓ | Rename a template (directory + PostgreSQL template DB); refused if any environment uses it |
 | `import_template_from_odoo` | ✓ | Import a template from a running Odoo instance via database manager API; optional `without_filestore` requests a database-only PostgreSQL custom dump |
@@ -56,7 +56,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
-| `run_service_command` | | Execute a shell command inside a service container |
+| `run_service_command` | | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
 | **Volumes** | | |
 | `create_volume` | ✓ | Create a named Docker volume for use with services |
 | `list_volumes` | | List all managed Docker volumes and their usage by services |
@@ -102,7 +102,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `get_odoo_development_guide` | | Get Odoo development standards guide for a specific version (15–19) |
 
 !!! info "Locking"
-    Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`.
+    Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.
 
 The exact current signature and defaults for every tool are also available from
 `oduflow list` (`oduflow list --verbose` adds descriptions). The production

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -233,3 +233,85 @@ This is intentional. A template's filestore is the overlay **lower layer** for
 every environment built from it; deleting the template would pull the base out
 from under those live overlays and break them. Delete the listed environments
 first (or keep the template). The same guard applies to renaming a template.
+
+---
+
+## A brand-new environment fails its first upgrade
+
+An environment is a *new* database cloned from a template plus *your* branch's
+code. The template database is a snapshot of some branch at some commit, so the
+two can drift in either direction — and the failure only surfaces on the first
+`-u`.
+
+```bash
+# What the template was snapshotted from:
+oduflow call list_templates
+# → - prod: DB=loaded, ..., Source=prod @ c0ffee12 @ snapshot 2026-08-01
+```
+
+`create_environment` compares that commit with the branch checkout and reports
+the drift in its response:
+
+* **"Code is behind the template database"** — your branch does not contain the
+  snapshot commit. The database already holds views and records written by newer
+  code, so upgrading the older branch fails validation (typically a `ParseError`
+  on a view referencing a method your branch does not have). **Merge the
+  template's source branch** into yours, push, then `pull_and_apply`.
+* **"Code is ahead of the template database"** — the database predates your
+  code. Apply the drift explicitly with the arguments reported by Oduflow, for
+  example `pull_and_apply(install="new_module", upgrade="a,b,c")`, listing
+  dependencies before dependents. Brand-new modules need `install=`; existing
+  modules with schema/data drift need `upgrade=`. Modules whose manifest version
+  was not bumped are never upgraded automatically, so a `column ... does not
+  exist` or a missing external ID means "find the module that owns it and add it
+  to `upgrade=`".
+
+Templates created before Oduflow recorded provenance — and templates imported
+from a running Odoo — have no commit to compare against, so no drift is
+reported. That is not an error; the rule above still applies, you just have to
+apply it by hand.
+
+!!! warning "Recreating the environment does not fix it"
+    The template is unchanged, so the same drift comes straight back — and the
+    environment's data is gone. Reconcile with a merge or an explicit
+    install/upgrade action.
+
+---
+
+## `BusyError`: "Another operation ... is in progress"
+
+The message names the holder and its age:
+
+```
+Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress.
+```
+
+Locks are held for exactly as long as the operation runs and are released when
+it finishes. A long-running install, upgrade or test run legitimately holds one
+for minutes — including when the *client* gave up waiting and timed out, because
+the work continues server-side. Wait for it to finish and retry; restarting or
+recreating the environment interrupts real work instead of clearing anything.
+
+Background operations take the same locks and are named too: `auto-stop`,
+`auto-delete`, `scheduled backup`, `webhook deploy`.
+
+---
+
+## The Odoo web client loads blank
+
+The page is served, the JS bundles arrive, the browser console is clean — and
+nothing renders. This is an Odoo-side asset/registry problem (commonly a custom
+systray or a legacy widget that never resolves during `startWebClient`), not an
+environment provisioning problem: restarting the container or rebuilding assets
+does not help, and headless browser tooling tends to hang on such a page.
+
+Verify server-side instead — it works normally while the web client does not:
+
+```bash
+oduflow call run_odoo_shell '{"env_name": "my-branch", "python_code":
+  "print(env[\"res.partner\"].fields_get([\"name\"]).keys())", "auto_commit": false}'
+oduflow call run_odoo_tests '{"env_name": "my-branch", "modules": "my_module"}'
+```
+
+Then narrow the failing asset with `get_environment_logs` and by disabling the
+suspect module's assets.

--- a/specs/0043-template-code-provenance-and-lineage.md
+++ b/specs/0043-template-code-provenance-and-lineage.md
@@ -1,0 +1,103 @@
+# 0043 — Template code provenance and the environment lineage check
+
+**Status:** Adopted (current)
+**Type:** Architecture
+**First introduced:** 2026-08-08, from a field report of repeated "the branch was cut before the template snapshot" upgrade failures
+**Key code today:** `docker_ops/system_ops.py` (`_code_provenance`, template metadata, `list_templates`), `git_analysis.py` (`template_lineage`), `git_ops.py` (`commit_exists`, `is_ancestor`, `diff_names`), `docker_ops/env_ops.py` (`_template_code_lineage`, `create_environment`)
+
+## Context
+
+An environment is a **new database cloned from a template** plus **the branch's
+own code** ([[0003-database-templates-and-filestore-isolation]],
+[[0001-mcp-orchestrated-ephemeral-per-branch-environments]]). Those are two
+snapshots of the same lineage, taken at different times — and nothing tied them
+together. The template recorded *where the code came from* (`repo_url`,
+`odoo_image`, extra addons) but never *which commit its data was snapshotted
+at*.
+
+In practice that gap produced two failures that look unrelated but are the same
+problem mirrored:
+
+- **The branch is behind the snapshot.** A branch cut from an older commit gets a
+  database already carrying views and records written by newer code. The first
+  `-u` validates old code against new data and dies — typically a `ParseError` on
+  a view referring to a method the branch does not have. The remedy is to merge
+  the template's source branch first.
+- **The branch is ahead of the snapshot.** The database predates the code, so
+  fields and XML IDs the code assumes are missing: `column ... does not exist`,
+  `External ID not found`. The remedy is an explicit `-u` naming every affected
+  module — including dependency modules whose manifest version was never bumped,
+  which nothing upgrades automatically.
+
+Agents were rediscovering both by trial and error, and reaching for the one
+"fix" that cannot work: deleting and recreating the environment. The template is
+unchanged, so the drift returns — minus the environment's data.
+[[0006-git-driven-change-classification]] already knew how to turn a commit range
+into the right module list; it simply had no range to look at, because the
+template's end of the comparison did not exist.
+
+## Decision
+
+Record **code provenance** on every template whose data comes from one of our own
+environments — the source branch, the commit its database was snapshotted at, and
+when — and **compare it against the checkout at environment creation**, reporting
+the drift and its remedy while the agent is still deciding what its first
+`pull_and_apply` should do.
+
+The comparison is **advisory, never a gate**. Creation proceeds regardless; a
+template with no recorded commit (imported from a foreign Odoo, or created before
+this record) simply produces no verdict.
+
+## How it works (macro)
+
+- **Provenance at snapshot time.** `save_as_template` reads the source
+  environment's branch label and resolves its checkout's `HEAD`, storing
+  `source_branch` / `source_commit` / `snapshot_at` in the template metadata
+  alongside the existing code-source fields. Live-mounted environments use their
+  mounted checkout. Imports from a running Odoo record only `snapshot_at`: there
+  is no commit of ours behind that data, and inventing one would be worse than
+  saying nothing.
+- **A three-way verdict at creation.** After the clone (or live-mount),
+  `template_lineage` compares the recorded commit with the checkout's `HEAD`:
+  *aligned*, *ahead* (the snapshot is an ancestor of `HEAD`), *diverged* (it is
+  not), or *unknown* (no commit recorded, or the commit is absent from this
+  repository — a deleted branch, a different remote, or an unavailable fetch).
+  Managed depth-one development clones fetch the current and template-source
+  branch histories before this comparison; live-mounted checkouts are never
+  fetched or otherwise mutated by the check.
+- **The remedy comes with the verdict.** For *diverged* the message names the
+  branch to merge. For *ahead*, the snapshot commit is fed as the base ref into
+  the existing change classifier, so the environment reports the concrete
+  `install="new_module"` and `upgrade="a,b,c"` sets rather than a generic
+  warning — reusing [[0006-git-driven-change-classification]] instead of
+  duplicating its rules.
+- **Visible before creation too.** `list_templates` shows each template's
+  `Source=<branch> @ <commit> @ snapshot <date>`, so the drift can be anticipated
+  when choosing a template.
+- **Failure is silence.** Any error inside the check (git missing, unreadable
+  metadata, an odd repository state) degrades to *unknown*. An advisory check
+  must never be able to fail a provisioning that otherwise succeeded.
+
+## Consequences
+
+- The rule an experienced operator carried in their head — *"merge `prod` before
+  the first apply"* — is now stated by the system, in both directions, at the
+  moment it matters, and is written down as a general invariant rather than a
+  project-specific ritual.
+- The `-i` / `-u` sets for an ahead branch are computed, not guessed, and the
+  upgrade set includes dependency modules that no version bump would have
+  caught.
+- Templates predating provenance keep working and stay quiet; provenance accrues
+  as they are re-baselined. There is no migration and no new configuration.
+- The check is one more consumer of the classifier's commit-range contract,
+  which further entrenches `base_ref`-style comparison as the way Oduflow reasons
+  about "what changed".
+- Because it only reports, a wrong verdict costs an ignorable line of text — the
+  deliberate trade for running it on every creation without review.
+
+## History
+
+- 2026-08-08 — provenance recorded at `save_as_template` / import, surfaced in
+  `list_templates`, and compared at `create_environment`; shipped together with
+  the lock-holder diagnostics and `run_odoo_tests(test_tags=…)` from the same
+  field report.

--- a/specs/README.md
+++ b/specs/README.md
@@ -61,6 +61,7 @@ precursors).
 | [0040](0040-versioned-coder-image-contract.md) | 2026-07-22 | Immutable, release-coupled coder image tags replace the rolling runtime |
 | [0041](0041-structured-odoo-orm-tools.md) | 2026-08-02 | Structured Odoo ORM tools (`execute_kw` semantics) over the web JSON-RPC endpoint |
 | [0042](0042-translation-tooling.md) | 2026-07-27 | Translation tooling on Odoo's own exporter, plus one-time artifact download links |
+| [0043](0043-template-code-provenance-and-lineage.md) | 2026-08-08 | Templates record the commit their data was snapshotted at; environments report code/database drift at creation |
 
 ## Design docs
 

--- a/src/oduflow/backup_scheduler.py
+++ b/src/oduflow/backup_scheduler.py
@@ -173,7 +173,7 @@ def _run_snapshot_job(
 
     key = prod_lock_key(team.team_id, name)
     try:
-        locks.acquire_env(key)
+        locks.acquire_env(key, operation="scheduled backup")
     except BusyError:
         return  # deploy/restore in flight; still due next tick
     started = time.time()
@@ -255,7 +255,7 @@ def _run_basebackup_job(
     base["slot_attempts"] = attempts + 1
     _save_cluster_state(settings, state)
     try:
-        locks.acquire_env("prod:__cluster__")
+        locks.acquire_env("prod:__cluster__", operation="scheduled base backup")
     except BusyError:
         return
     try:
@@ -297,7 +297,7 @@ def _run_prune_job(
     ok = True
     for team in settings.teams.values():
         try:
-            locks.acquire_team(team.team_id)
+            locks.acquire_team(team.team_id, operation="scheduled backup prune")
         except BusyError:
             ok = False
             continue

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -248,6 +248,64 @@ def _dir_size_mb(path: str) -> float:
     return total / (1024 * 1024)
 
 
+def _read_template_metadata(team: TeamSettings, template_name: str) -> dict[str, Any]:
+    """Template metadata.json, or an empty dict when it is absent/unreadable."""
+    metadata_path = team.get_template_metadata_path(template_name)
+    if not os.path.isfile(metadata_path):
+        return {}
+    try:
+        with open(metadata_path) as f:
+            loaded: dict[str, Any] = json.load(f)
+            return loaded
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _template_code_lineage(
+    team: TeamSettings,
+    template_name: str | None,
+    repo_path: str,
+    *,
+    current_branch: str = "",
+    fetch_missing_history: bool = False,
+) -> dict[str, Any]:
+    """Drift between this checkout and the commit the template DB came from.
+
+    Advisory only: templates predating provenance (and imported ones, which have
+    no commit of ours behind them) yield status ``unknown`` and say nothing.
+    """
+    empty: dict[str, Any] = {
+        "status": "unknown",
+        "message": "",
+        "modules_to_install": [],
+        "modules_to_upgrade": [],
+    }
+    if template_name is None:
+        return empty
+    from oduflow import git_analysis, git_ops
+
+    metadata = _read_template_metadata(team, template_name)
+    try:
+        template_commit = str(metadata.get("source_commit", ""))
+        source_branch = str(metadata.get("source_branch", ""))
+        if template_commit and fetch_missing_history:
+            git_ops.ensure_lineage_history(
+                repo_path,
+                template_commit,
+                current_branch,
+                source_branch,
+                team.git_credentials_file(),
+            )
+        return git_analysis.template_lineage(
+            repo_path,
+            template_commit,
+            source_branch,
+        )
+    except Exception:  # noqa: BLE001 - never fail creation over an advisory check
+        logger.warning("Template lineage check failed", exc_info=True)
+        return empty
+
+
 def _mount_filestore(
     client: DockerClient,
     settings: Settings,
@@ -1049,6 +1107,17 @@ def create_environment(
             git_user=git_user,
         )
 
+    # The template database is a snapshot of some commit; this checkout may sit
+    # before or after it. Report the drift now, while the agent is still deciding
+    # what its first pull_and_apply should do.
+    lineage = _template_code_lineage(
+        team,
+        template_name,
+        repo_path,
+        current_branch=branch,
+        fetch_missing_history=not local_mount,
+    )
+
     # --- Shared immutable extra-addons checkouts ---
     extra_mount_paths: list[tuple[str, str]] = []
     extra_revisions: dict[str, str] = {}
@@ -1344,6 +1413,7 @@ def create_environment(
     result["extra_addons"] = extra_addons or {}
     result["extra_addons_revisions"] = extra_revisions
     result["local_path"] = repo_path if local_mount else ""
+    result["template_lineage"] = lineage
     result["elapsed_seconds"] = round(time.time() - start_time, 1)
     activity.touch(team, env_name)
     # Let the new env's MCP token resolve without waiting for the scan interval.

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -78,8 +78,68 @@ def _longpoll_port_flag(container: Any, image_label: str) -> str:
     return "--gevent-port"
 
 
+def _validate_test_tags(test_tags: str) -> None:
+    """Reject anything that is not an Odoo ``--test-tags`` expression.
+
+    Same argument-injection concern as module names: the value lands in a
+    command string that ``exec_run`` tokenizes with ``shlex.split``, so a token
+    containing whitespace would become a separate argv entry and smuggle extra
+    Odoo CLI flags into the run. Odoo's own grammar
+    (``[-][tag][/module][:Class][.method]``, comma-separated) needs no spaces.
+    """
+    if not re.match(r"^[A-Za-z0-9_,:./+*-]+$", test_tags):
+        raise ValueError(
+            f"Invalid test_tags '{test_tags}': expected a comma-separated Odoo "
+            "test-tags expression such as '/my_module:TestClass.test_method' "
+            "(no spaces)."
+        )
+
+
+def _scope_test_tags_without_upgrade(test_tags: str, module_list: list[str]) -> str:
+    """Keep an upgrade-free test run inside the requested modules.
+
+    Without ``-u`` Odoo considers post-install tests from every initialized
+    module, so ``modules`` does not scope collection by itself. Positive tag
+    selectors must therefore name one of the requested modules. An
+    exclusion-only expression (for example ``-slow``) is prefixed with module
+    selectors so it subtracts from the requested modules rather than from the
+    entire registry.
+    """
+    if not test_tags:
+        return ",".join(f"/{module}" for module in module_list)
+
+    selectors = test_tags.split(",")
+    positive_modules: list[str] = []
+    for selector in selectors:
+        if selector.startswith("-"):
+            continue
+        body = selector[1:] if selector.startswith("+") else selector
+        if "/" not in body:
+            raise ValueError(
+                "With upgrade=False, positive test_tags must include a module "
+                "scope, for example 'slow/sale' or '/sale:TestClass'."
+            )
+        module = body.split("/", 1)[1].split(":", 1)[0]
+        if not module or module not in module_list:
+            raise ValueError(
+                f"test_tags selector '{selector}' is outside the requested "
+                f"modules: {','.join(module_list)}."
+            )
+        positive_modules.append(module)
+
+    if positive_modules:
+        return test_tags
+    module_scope = [f"/{module}" for module in module_list]
+    return ",".join([*module_scope, *selectors])
+
+
 def run_environment_tests(
-    settings: Settings, team: TeamSettings, env_name: str, modules: str
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    modules: str,
+    test_tags: str = "",
+    upgrade: bool = True,
 ) -> str:
     client = get_client()
     odoo_container_name = get_resource_name(
@@ -94,7 +154,20 @@ def run_environment_tests(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
 
-    _validate_module_names([m.strip() for m in modules.split(",") if m.strip()])
+    module_list = [m.strip() for m in modules.split(",") if m.strip()]
+    if not module_list:
+        # An empty list would produce a bare `-u` (no value), or with
+        # upgrade=False an unscoped run over every installed module's tests.
+        raise ValueError("modules is required: name the modules to test.")
+    _validate_module_names(module_list)
+    if test_tags:
+        _validate_test_tags(test_tags)
+    if not upgrade:
+        # Without an upgrade nothing narrows the run to the requested modules —
+        # Odoo would sweep the post-install tests of every installed module.
+        # Preserve an explicit module-qualified selector, or combine an
+        # exclusion-only expression with derived module filters.
+        test_tags = _scope_test_tags_without_upgrade(test_tags, module_list)
     # allow_fallback=False: tests run tenant-controlled code inside the odoo
     # container, so the shared superuser password must never be exposed there
     # (cross-tenant DB access on legacy environments predating per-env
@@ -112,22 +185,37 @@ def run_environment_tests(
     # template, and -i on an installed module is a no-op that never enters the test
     # phase (→ "0 of 0 tests"). -u re-runs the module's tests on the existing DB.
     #
+    # upgrade=False drops -u for a fast re-run. Odoo then takes the test set from
+    # `registry._init_modules` instead of `registry.updated_modules` and builds a
+    # 'post_install' suite only (odoo/service/server.py, identical on 15–19), so
+    # at_install tests — the default position for TestCase/TransactionCase — are
+    # NOT collected. Keep the default (-u) unless the target class is post_install.
+    #
     # --no-http has no effect under --test-enable (tests need a live HTTP server),
     # so instead of disabling HTTP we move the test server's HTTP and gevent ports
     # off the defaults (8069/8072) already held by the running Odoo container.
     # Odoo 16.0 renamed --longpolling-port to --gevent-port, so pick the flag the
     # environment's Odoo version actually understands.
     port_flag = _longpoll_port_flag(container, settings.image_label)
+    upgrade_flag = f"-u {modules} " if upgrade else ""
+    # --test-tags=VALUE (not a separate argv token): a leading '-' in an
+    # exclusion expression like '-slow' would otherwise parse as a CLI flag.
+    tags_flag = f"--test-tags={test_tags} " if test_tags else ""
     cmd = (
         f"odoo --test-enable --stop-after-init --workers 0 "
-        f"--http-port 8089 {port_flag} 8090 -u {modules} "
+        f"--http-port 8089 {port_flag} 8090 {upgrade_flag}{tags_flag}"
         f"--db_host={settings.shared_db_container} "
         f"-r {creds['pg_user']} "
         f"--database={env_db}"
     )
     logger.info(
         "Running tests",
-        extra={"env_name": env_name, "modules": modules},
+        extra={
+            "env_name": env_name,
+            "modules": modules,
+            "test_tags": test_tags,
+            "upgrade": upgrade,
+        },
     )
     exit_code, output = container.exec_run(
         cmd, environment={"PGPASSWORD": creds["pg_password"]}
@@ -361,7 +449,17 @@ def run_command_in_environment(
     env_name: str,
     command: str,
     user: str = "odoo",
+    shell: bool = True,
 ) -> dict[str, Any]:
+    """Run *command* inside the environment's Odoo container.
+
+    By default the command goes through ``sh -c``, so pipes, redirections,
+    ``&&``, ``cd x && y`` and variable expansion behave as written. Docker's
+    bare exec has no shell: it splits the string with ``shlex.split`` and runs
+    argv[0] directly, which silently passes ``|``/``>``/``&&`` to the program as
+    literal arguments. Pass ``shell=False`` for exact argv semantics (no
+    globbing, no expansion, metacharacters stay literal).
+    """
     client = get_client()
     odoo_container_name = get_resource_name(
         env_name, "odoo", settings.prefix, team.team_id
@@ -376,9 +474,16 @@ def run_command_in_environment(
 
     logger.info(
         "Executing command in environment",
-        extra={"env_name": env_name, "command": command, "user": user},
+        extra={
+            "env_name": env_name,
+            "command": command,
+            "user": user,
+            "shell": shell,
+        },
     )
-    exit_code, output = container.exec_run(command, user=user)
+    exit_code, output = container.exec_run(
+        ["sh", "-c", command] if shell else command, user=user
+    )
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
     return {

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -944,8 +944,21 @@ def get_service_logs(
 
 
 def run_command_in_service(
-    settings: Settings, team: TeamSettings, name: str, command: str, user: str = "root"
+    settings: Settings,
+    team: TeamSettings,
+    name: str,
+    command: str,
+    user: str = "root",
+    shell: bool = True,
 ) -> dict[str, object]:
+    """Run *command* inside a managed service container.
+
+    Same shell semantics as :func:`odoo_ops.run_command_in_environment`: by
+    default the command runs through ``sh -c`` so pipes and redirections work;
+    ``shell=False`` execs the argv directly. Service images are minimal but all
+    ship a POSIX ``sh``; on one that genuinely has none (scratch/distroless),
+    use ``shell=False``.
+    """
     client = get_client()
     container_name = get_service_container_name(name, settings.prefix, team.team_id)
 
@@ -956,9 +969,11 @@ def run_command_in_service(
 
     logger.info(
         "Executing command in service",
-        extra={"service": name, "command": command, "user": user},
+        extra={"service": name, "command": command, "user": user, "shell": shell},
     )
-    exit_code, output = container.exec_run(command, user=user)
+    exit_code, output = container.exec_run(
+        ["sh", "-c", command] if shell else command, user=user
+    )
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
     return {

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -2043,7 +2043,10 @@ def init_template(
     logger.info("Template generation complete, loading into template DB")
     result = reload_template(settings, team, template_name=template_name)
 
-    metadata: dict[str, Any] = {"odoo_image": odoo_image}
+    metadata: dict[str, Any] = {
+        "odoo_image": odoo_image,
+        "snapshot_at": _utc_now_iso(),
+    }
     from oduflow.docker_ops.env_ops import _dir_size_mb
 
     fs_size = _dir_size_mb(template_filestore_path)
@@ -2061,6 +2064,42 @@ def init_template(
         1 for _ in pathlib.Path(template_filestore_path).rglob("*") if _.is_file()
     )
     return result
+
+
+def _utc_now_iso() -> str:
+    import datetime
+
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def _code_provenance(
+    team: TeamSettings, env_name: str, labels: dict[str, Any]
+) -> dict[str, str]:
+    """Which code the template's database was snapshotted from.
+
+    A template DB is a snapshot of a branch at a moment in time; without that
+    anchor nothing can tell a later environment whether its checkout predates
+    the data it was handed. Recorded best-effort — a missing checkout only means
+    the lineage check is skipped later (see git_analysis.template_lineage).
+    """
+    from oduflow.git_ops import is_git_repository, rev_parse
+    from oduflow.naming import get_repo_path
+
+    provenance: dict[str, str] = {"snapshot_at": _utc_now_iso()}
+    branch = labels.get("oduflow.git_branch", "")
+    if branch:
+        provenance["source_branch"] = branch
+    repo_path = labels.get("oduflow.local_path", "") or get_repo_path(
+        env_name, team.workspaces_dir
+    )
+    if is_git_repository(repo_path):
+        try:
+            provenance["source_commit"] = rev_parse(repo_path)
+        except (ExternalCommandError, OSError) as exc:
+            logger.debug(
+                "No snapshot commit for template source %s: %s", repo_path, exc
+            )
+    return provenance
 
 
 def _source_env_metadata(settings: Settings, labels: dict[str, Any]) -> dict[str, Any]:
@@ -2255,12 +2294,13 @@ def publish_env_as_template(
 
     # Save template metadata from source environment
     promoted_container_name = f"{settings.prefix}{env_name.replace('/', '-')}-odoo"
-    metadata = {}
+    metadata: dict[str, Any] = {}
     try:
         pc = client.containers.get(promoted_container_name)
         metadata = _source_env_metadata(settings, pc.labels)
+        metadata.update(_code_provenance(team, env_name, pc.labels))
     except docker.errors.NotFound:
-        pass
+        metadata = {"snapshot_at": _utc_now_iso()}
     fs_size = (
         env_ops._dir_size_mb(template_filestore_path)
         if os.path.isdir(template_filestore_path)
@@ -2784,6 +2824,9 @@ def import_from_odoo(
         "pg_version": manifest.get("pg_version", ""),
         "modules": manifest.get("modules", {}),
         "includes_filestore": not without_filestore,
+        # No source_commit: an imported database has no branch of ours behind
+        # it, so the lineage check has nothing to compare against and is skipped.
+        "snapshot_at": _utc_now_iso(),
     }
     _update_template_sizes(team, settings, template_name, metadata)
     logger.info("Metadata saved for template %s", template_name)
@@ -3467,6 +3510,11 @@ def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any
                 "filestore_size_mb": metadata.get("filestore_size_mb"),
                 "dump_size_mb": metadata.get("dump_size_mb"),
                 "auto_install_modules": metadata.get("auto_install_modules", ""),
+                # Code the snapshot was taken from — the anchor for the lineage
+                # check run at environment creation.
+                "source_branch": metadata.get("source_branch", ""),
+                "source_commit": metadata.get("source_commit", ""),
+                "snapshot_at": metadata.get("snapshot_at", ""),
             }
         )
     return result

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -574,6 +574,117 @@ def merge_recommendations(recs: Iterable[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def template_lineage(
+    repo_path: str,
+    template_commit: str,
+    template_branch: str = "",
+) -> dict[str, Any]:
+    """Compare a checkout against the commit its template database came from.
+
+    A template database and a branch checkout are two snapshots of one lineage,
+    and they diverge in both directions:
+
+    * the checkout is **ahead** — the database predates the code, so existing
+      modules whose schema/data changed need an explicit ``-u`` and newly added
+      modules need ``-i``. The classic symptom is ``column ... does not exist``
+      for a field that exists in the code but not yet in the template's database.
+    * the checkout is **behind or diverged** — the database already holds views
+      and records written by newer code, and upgrading against the older branch
+      fails validation. The fix is to merge the template's source branch first,
+      never to recreate the environment (the template would be the same).
+
+    Returns ``{status, message, modules_to_install, modules_to_upgrade}`` where
+    status is one of ``unknown`` (no usable provenance — always safe to ignore),
+    ``aligned``, ``ahead`` or ``diverged``.
+    """
+    from oduflow import git_ops
+
+    unknown: dict[str, Any] = {
+        "status": "unknown",
+        "message": "",
+        "modules_to_install": [],
+        "modules_to_upgrade": [],
+    }
+    if not template_commit or not git_ops.is_git_repository(repo_path):
+        return unknown
+    if not git_ops.commit_exists(repo_path, template_commit):
+        # Deleted source branch, different repository, or unavailable fetch —
+        # the comparison is simply unavailable, which is not a problem to report.
+        return unknown
+
+    short = template_commit[:8]
+    branch_hint = f" (branch '{template_branch}')" if template_branch else ""
+
+    try:
+        head = git_ops.rev_parse(repo_path)
+    except Exception:  # noqa: BLE001 - lineage info is advisory, never fatal
+        return unknown
+
+    if head == template_commit:
+        return {
+            "status": "aligned",
+            "message": "",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+
+    if not git_ops.is_ancestor(repo_path, template_commit, head):
+        merge_hint = template_branch or "the template's source branch"
+        return {
+            "status": "diverged",
+            "message": (
+                f"This branch does not contain the template's snapshot commit "
+                f"{short}{branch_hint}. The database is newer than the code, so "
+                f"upgrades can fail against data written by code this branch does "
+                f"not have. Merge {merge_hint} into this branch before the first "
+                f"pull_and_apply."
+            ),
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+
+    try:
+        changed = git_ops.diff_names(repo_path, template_commit, head)
+    except Exception:  # noqa: BLE001 - advisory only
+        return unknown
+    if not changed:
+        return {
+            "status": "aligned",
+            "message": "",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+
+    rec = recommend(changed, repo_path, template_commit)
+    to_install = sorted(set(rec.get("modules_to_install", [])))
+    to_upgrade = sorted(set(rec.get("modules_to_upgrade", [])))
+    modules = sorted(set(to_install) | set(to_upgrade))
+    if not modules:
+        return {
+            "status": "ahead",
+            "message": "",
+            "modules_to_install": [],
+            "modules_to_upgrade": [],
+        }
+    action_args = []
+    if to_install:
+        action_args.append(f'install="{",".join(to_install)}"')
+    if to_upgrade:
+        action_args.append(f'upgrade="{",".join(to_upgrade)}"')
+    return {
+        "status": "ahead",
+        "message": (
+            f"This branch is ahead of the template snapshot {short}{branch_hint}: "
+            f"schema/data changed in {', '.join(modules)}. Apply them explicitly "
+            f"with pull_and_apply({', '.join(action_args)}) — list "
+            "dependencies before dependents; modules whose version was not bumped "
+            "are not upgraded automatically."
+        ),
+        "modules_to_install": to_install,
+        "modules_to_upgrade": to_upgrade,
+    }
+
+
 def guardrail_warnings(
     recommended: dict[str, Any],
     to_install: list[str],

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -409,6 +409,164 @@ def rev_parse(repo_path: str, ref: str = "HEAD") -> str:
         raise ExternalCommandError("git rev-parse", e.returncode, e.stderr or "")
 
 
+def is_git_repository(repo_path: str) -> bool:
+    """Whether *repo_path* is a Git working tree.
+
+    Ask Git instead of inspecting ``.git``: linked worktrees store ``.git`` as
+    a file that points at the common repository, while ordinary clones use a
+    directory.
+    """
+    if not os.path.isdir(repo_path):
+        return False
+    result = subprocess.run(
+        ["git", "-C", repo_path, "rev-parse", "--is-inside-work-tree"],
+        capture_output=True,
+        text=True,
+        env=_GIT_BASE_ENV,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def commit_exists(repo_path: str, commit: str) -> bool:
+    """True when *commit* is present in *repo_path*'s object database.
+
+    A template's snapshot commit can be absent for perfectly ordinary reasons —
+    the branch it was taken from was deleted, the clone is shallow, the template
+    came from a different repository. Callers treat "absent" as "no lineage
+    information", never as an error.
+    """
+    if not commit:
+        return False
+    return (
+        subprocess.run(
+            ["git", "-C", repo_path, "cat-file", "-e", f"{commit}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            env=_GIT_BASE_ENV,
+        ).returncode
+        == 0
+    )
+
+
+def ensure_lineage_history(
+    repo_path: str,
+    commit: str,
+    current_branch: str,
+    source_branch: str = "",
+    cred_file: str = "",
+) -> bool:
+    """Best-effort fetch of history needed to compare *commit* with ``HEAD``.
+
+    Development environments are cloned with ``--depth 1``. Deepen the current
+    branch first so ancestry is reliable, then fetch the template's source
+    branch when it differs. Returns whether *commit* is available afterwards;
+    callers keep lineage advisory when a branch was deleted or a fetch fails.
+    """
+    if not commit or not is_git_repository(repo_path):
+        return False
+    if commit_exists(repo_path, commit):
+        return True
+
+    env = git_env_for_team(cred_file) if cred_file else _GIT_BASE_ENV
+    try:
+        shallow = (
+            subprocess.run(
+                ["git", "-C", repo_path, "rev-parse", "--is-shallow-repository"],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            ).stdout.strip()
+            == "true"
+        )
+
+        if current_branch:
+            cmd = [
+                "git",
+                "-C",
+                repo_path,
+                "fetch",
+                "--recurse-submodules=no",
+            ]
+            if shallow:
+                cmd.append("--unshallow")
+            cmd.extend(
+                [
+                    "origin",
+                    f"+refs/heads/{current_branch}:refs/remotes/origin/{current_branch}",
+                ]
+            )
+            subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env=env,
+            )
+
+        if source_branch and source_branch != current_branch:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    repo_path,
+                    "fetch",
+                    "--recurse-submodules=no",
+                    "origin",
+                    f"+refs/heads/{source_branch}:refs/remotes/origin/{source_branch}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env=env,
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.info("Could not fetch template lineage history: %s", type(exc).__name__)
+
+    return commit_exists(repo_path, commit)
+
+
+def is_ancestor(repo_path: str, ancestor: str, descendant: str = "HEAD") -> bool:
+    """True when *ancestor* is reachable from *descendant*.
+
+    Thin wrapper over ``git merge-base --is-ancestor``.
+    """
+    return (
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "merge-base",
+                "--is-ancestor",
+                ancestor,
+                descendant,
+            ],
+            capture_output=True,
+            text=True,
+            env=_GIT_BASE_ENV,
+        ).returncode
+        == 0
+    )
+
+
+def diff_names(repo_path: str, base: str, head: str = "HEAD") -> list[str]:
+    """Files changed between *base* and *head* (``git diff --name-only base..head``)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_path, "diff", "--name-only", f"{base}..{head}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_GIT_BASE_ENV,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        raise ExternalCommandError("git diff", e.returncode, e.stderr or "")
+    return [f for f in out.strip().splitlines() if f]
+
+
 def reset_hard(repo_path: str, ref: str) -> None:
     """``git reset --hard <ref>`` — the code-rollback primitive."""
     try:

--- a/src/oduflow/locking.py
+++ b/src/oduflow/locking.py
@@ -8,8 +8,36 @@ resource are serialised.
 from __future__ import annotations
 
 import threading
+import time
 
 from oduflow.errors import BusyError
+
+
+def _format_age(seconds: float) -> str:
+    """Human-readable duration for a lock that is still held ('4m12s')."""
+    total = int(seconds)
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m{total % 60:02d}s"
+    return f"{total // 3600}h{(total % 3600) // 60:02d}m"
+
+
+class _Holder:
+    """Which operation took a lock, and when."""
+
+    __slots__ = ("operation", "acquired_at")
+
+    def __init__(self, operation: str) -> None:
+        self.operation = operation
+        self.acquired_at = time.monotonic()
+
+    def describe(self) -> str:
+        """' (pull_and_apply, running for 4m12s)' — empty when unknown."""
+        age = _format_age(time.monotonic() - self.acquired_at)
+        if self.operation:
+            return f" ({self.operation}, running for {age})"
+        return f" (running for {age})"
 
 
 class LockManager:
@@ -21,6 +49,12 @@ class LockManager:
         self._active_team_locks: set[str] = set()
         self._env_lock_teams: dict[str, str] = {}
         self._active_env_counts_by_team: dict[str, int] = {}
+        # A rejected caller cannot tell "still running" from "stuck". Record who
+        # holds each lock and since when, so BusyError can say it (issue: agents
+        # read a bare "in progress" as a stale lock and reach for restarts).
+        self._env_holders: dict[str, _Holder] = {}
+        self._team_holders: dict[str, _Holder] = {}
+        self._system_holder: _Holder | None = None
         self._system_lock = threading.Lock()
         self._map_lock = threading.Lock()  # protects dict access
 
@@ -32,11 +66,22 @@ class LockManager:
                 self._env_locks[env_name] = threading.Lock()
             return self._env_locks[env_name]
 
-    def acquire_env(self, env_name: str, team_id: str | None = None) -> None:
+    def _env_holder_hint(self, env_name: str) -> str:
+        holder = self._env_holders.get(env_name)
+        return holder.describe() if holder else ""
+
+    def _team_holder_hint(self, team_id: str) -> str:
+        holder = self._team_holders.get(team_id)
+        return holder.describe() if holder else ""
+
+    def acquire_env(
+        self, env_name: str, team_id: str | None = None, operation: str = ""
+    ) -> None:
         with self._map_lock:
             if team_id is not None and team_id in self._active_team_locks:
                 raise BusyError(
-                    f"Another team-level operation (team '{team_id}') is in progress. "
+                    f"Another team-level operation (team '{team_id}')"
+                    f"{self._team_holder_hint(team_id)} is in progress. "
                     "Try again later."
                 )
             if env_name not in self._env_locks:
@@ -44,21 +89,35 @@ class LockManager:
             lock = self._env_locks[env_name]
             if not lock.acquire(blocking=False):
                 raise BusyError(
-                    f"Another operation on environment '{env_name}' is in progress. "
-                    "Try again later."
+                    f"Another operation on environment '{env_name}'"
+                    f"{self._env_holder_hint(env_name)} is in progress. "
+                    "It is still running server-side — wait for it to finish "
+                    "rather than restarting the environment."
                 )
+            self._env_holders[env_name] = _Holder(operation)
             if team_id is not None:
                 self._env_lock_teams[env_name] = team_id
                 self._active_env_counts_by_team[team_id] = (
                     self._active_env_counts_by_team.get(team_id, 0) + 1
                 )
 
-    def acquire_env_blocking(self, env_name: str, timeout: float) -> bool:
+    def acquire_env_blocking(
+        self, env_name: str, timeout: float, operation: str = ""
+    ) -> bool:
         """Blocking acquire with a timeout — webhook-triggered production
         deploys queue behind a running one instead of dropping the push.
         Returns False when the timeout expires (caller skips the run)."""
         lock = self._get_env_lock(env_name)
-        return lock.acquire(blocking=True, timeout=timeout)
+        acquired = lock.acquire(blocking=True, timeout=timeout)
+        if acquired:
+            with self._map_lock:
+                self._env_holders[env_name] = _Holder(operation)
+        return acquired
+
+    def describe_env_holder(self, env_name: str) -> str:
+        """Holder hint for callers that report contention without raising."""
+        with self._map_lock:
+            return self._env_holder_hint(env_name)
 
     def release_env(self, env_name: str) -> None:
         with self._map_lock:
@@ -69,6 +128,7 @@ class LockManager:
                 lock.release()
             except RuntimeError:
                 return
+            self._env_holders.pop(env_name, None)
             team_id = self._env_lock_teams.pop(env_name, None)
             if team_id is not None:
                 count = self._active_env_counts_by_team.get(team_id, 0) - 1
@@ -85,21 +145,32 @@ class LockManager:
                 self._team_locks[team_id] = threading.Lock()
             return self._team_locks[team_id]
 
-    def acquire_team(self, team_id: str) -> None:
+    def acquire_team(self, team_id: str, operation: str = "") -> None:
         with self._map_lock:
             if team_id not in self._team_locks:
                 self._team_locks[team_id] = threading.Lock()
             lock = self._team_locks[team_id]
-            if (
-                team_id in self._active_team_locks
-                or self._active_env_counts_by_team.get(team_id, 0) > 0
-                or not lock.acquire(blocking=False)
-            ):
+            if team_id in self._active_team_locks or not lock.acquire(blocking=False):
                 raise BusyError(
-                    f"Another team-level operation (team '{team_id}') is in progress. "
+                    f"Another team-level operation (team '{team_id}')"
+                    f"{self._team_holder_hint(team_id)} is in progress. "
                     "Try again later."
                 )
+            if self._active_env_counts_by_team.get(team_id, 0) > 0:
+                # An environment-level operation is running under this team: a
+                # team-wide operation would race it. Give the lock back.
+                lock.release()
+                busy = ", ".join(
+                    f"'{env}'{self._env_holder_hint(env)}"
+                    for env, tid in sorted(self._env_lock_teams.items())
+                    if tid == team_id
+                )
+                raise BusyError(
+                    f"An environment operation in team '{team_id}' is in "
+                    f"progress: {busy}. Try again later."
+                )
             self._active_team_locks.add(team_id)
+            self._team_holders[team_id] = _Holder(operation)
 
     def release_team(self, team_id: str) -> None:
         with self._map_lock:
@@ -107,6 +178,7 @@ class LockManager:
             if lock is None:
                 return
             self._active_team_locks.discard(team_id)
+            self._team_holders.pop(team_id, None)
             try:
                 lock.release()
             except RuntimeError:
@@ -114,11 +186,17 @@ class LockManager:
 
     # -- system lock --
 
-    def acquire_system(self) -> None:
+    def acquire_system(self, operation: str = "") -> None:
         if not self._system_lock.acquire(blocking=False):
-            raise BusyError("A system-level operation is in progress. Try again later.")
+            holder = self._system_holder
+            hint = holder.describe() if holder else ""
+            raise BusyError(
+                f"A system-level operation{hint} is in progress. Try again later."
+            )
+        self._system_holder = _Holder(operation)
 
     def release_system(self) -> None:
+        self._system_holder = None
         try:
             self._system_lock.release()
         except RuntimeError:

--- a/src/oduflow/reaper.py
+++ b/src/oduflow/reaper.py
@@ -47,7 +47,7 @@ def _auto_stop(
     settings: Settings, team: TeamSettings, locks: LockManager, env_name: str
 ) -> None:
     try:
-        locks.acquire_env(env_name, team.team_id)
+        locks.acquire_env(env_name, team.team_id, operation="auto-stop")
     except BusyError:
         return  # an operation is in flight; it counts as activity anyway
     try:
@@ -70,7 +70,7 @@ def _auto_delete(
     settings: Settings, team: TeamSettings, locks: LockManager, env_name: str
 ) -> None:
     try:
-        locks.acquire_env(env_name, team.team_id)
+        locks.acquire_env(env_name, team.team_id, operation="auto-delete")
     except BusyError:
         return
     try:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -281,7 +281,7 @@ def with_env_lock(fn: Callable[P, R]) -> Callable[P, R]:
                 f"'{env_name}' is a production environment. Use the "
                 "*_production tools instead of the dev environment tools."
             )
-        _locks.acquire_env(env_name, team.team_id)
+        _locks.acquire_env(env_name, team.team_id, operation=fn.__name__)
         try:
             try:
                 activity.touch(team, env_name)
@@ -316,7 +316,7 @@ def with_team_lock(fn: Callable[P, R]) -> Callable[P, R]:
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         ctx = cast("Context | None", kwargs.get("ctx"))
         team = _resolve_team(ctx)
-        _locks.acquire_team(team.team_id)
+        _locks.acquire_team(team.team_id, operation=fn.__name__)
         try:
             return fn(*args, **kwargs)
         finally:
@@ -361,7 +361,7 @@ def with_prod_lock(fn: Callable[P, R]) -> Callable[P, R]:
         ctx = cast("Context | None", kwargs.get("ctx"))
         team = _resolve_team(ctx)
         key = prod_lock_key(team.team_id, name)
-        _locks.acquire_env(key)
+        _locks.acquire_env(key, operation=fn.__name__)
         try:
             return fn(*args, **kwargs)
         finally:
@@ -558,7 +558,7 @@ def create_environment(
     resolved_env_name = validate_env_name(env_name or branch)
     settings = _get_settings()
     team = _resolve_team(ctx)
-    _locks.acquire_env(resolved_env_name, team.team_id)
+    _locks.acquire_env(resolved_env_name, team.team_id, operation="create_environment")
     try:
         resolved_template: str | None
         if not template_name or template_name.lower() == "none":
@@ -709,6 +709,14 @@ def create_environment(
             lines.append(
                 "Env vars: " + ", ".join(f"{k}={v}" for k, v in parsed_env.items())
             )
+        lineage = result.get("template_lineage") or {}
+        if lineage.get("message"):
+            label = (
+                "Code is behind the template database"
+                if lineage.get("status") == "diverged"
+                else "Code is ahead of the template database"
+            )
+            lines.append(f"\n⚠️ {label} — {lineage['message']}")
         setup_logs: list[str] = result.get("setup_logs", [])
         if setup_logs:
             lines.append("\n--- Setup Log ---")
@@ -815,7 +823,17 @@ def list_templates(ctx: Context | None = None) -> str:
             size_info = f", Filestore size={fs_str}, Dump size={dump_str}"
         auto_install = r.get("auto_install_modules", "")
         auto_info = f", Auto-install={auto_install}" if auto_install else ""
-        output += f"- {r['template_name']}: DB={db_status}, SQL={r['has_sql']}, Filestore={r['has_filestore']}, Mode={overlay_status}{size_info}{auto_info}\n"
+        # Provenance: which code this database snapshot came from. A branch that
+        # does not contain that commit will hit upgrade failures against newer data.
+        origin_parts = []
+        if r.get("source_branch"):
+            origin_parts.append(str(r["source_branch"]))
+        if r.get("source_commit"):
+            origin_parts.append(str(r["source_commit"])[:8])
+        if r.get("snapshot_at"):
+            origin_parts.append(f"snapshot {str(r['snapshot_at'])[:10]}")
+        origin_info = f", Source={' @ '.join(origin_parts)}" if origin_parts else ""
+        output += f"- {r['template_name']}: DB={db_status}, SQL={r['has_sql']}, Filestore={r['has_filestore']}, Mode={overlay_status}{size_info}{auto_info}{origin_info}\n"
     return output
 
 
@@ -1195,25 +1213,53 @@ def list_environments(ctx: Context | None = None) -> str:
 @mcp.tool()
 @handle_errors
 @with_env_lock
-def run_odoo_tests(env_name: str, modules: str, ctx: Context | None = None) -> str:
+def run_odoo_tests(
+    env_name: str,
+    modules: str,
+    test_tags: str = "",
+    upgrade: bool = True,
+    ctx: Context | None = None,
+) -> str:
     """
     Run Odoo tests for specific modules in an environment.
 
-    The module must already be installed in the environment (it runs the tests via
-    an upgrade, `-u`). Install it first with install_odoo_modules or pull_and_apply
-    if it is not present; testing an uninstalled module yields "0 of 0 tests".
+    The module must already be installed in the environment (by default it runs the
+    tests via an upgrade, `-u`). Install it first with install_odoo_modules or
+    pull_and_apply if it is not present; testing an uninstalled module yields
+    "0 of 0 tests".
+
+    Narrow a run to a single class or method with test_tags — a full module upgrade
+    to re-run one test is usually wasted minutes.
 
     Args:
         env_name: The name of the environment.
         modules: Comma-separated list of already-installed modules to test.
+        test_tags: Odoo `--test-tags` expression narrowing which tests run, e.g.
+            "/my_module:TestInvoice" (one class), "/my_module:TestInvoice.test_total"
+            (one method), or "-slow" (exclude a tag). Comma-separated, no spaces.
+            Empty (default) runs every test of the listed modules. With
+            upgrade=False, positive selectors must include one of the requested
+            modules (for example "slow/my_module"); exclusion-only selectors such
+            as "-slow" are automatically scoped to the requested modules.
+        upgrade: Upgrade the modules before testing (default True, `odoo -u`). Set
+            False to skip the upgrade for a much faster re-run when the code under
+            test is already loaded in the database — but note that without an
+            upgrade Odoo only collects **post_install** tests, so classes at the
+            default at_install position (plain TransactionCase/TestCase) will report
+            "0 tests". If a class you expect does not run, re-run with upgrade=True.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
     woke = _wake_for_work(settings, team, env_name)
-    output = odoo_ops.run_environment_tests(settings, team, env_name, modules)
+    output = odoo_ops.run_environment_tests(
+        settings, team, env_name, modules, test_tags=test_tags, upgrade=upgrade
+    )
     header = woke + f"Test Results for {env_name}:"
     return _maybe_cache(
-        output, header, "run_odoo_tests", f"env={env_name}, modules={modules}"
+        output,
+        header,
+        "run_odoo_tests",
+        f"env={env_name}, modules={modules}, test_tags={test_tags}, upgrade={upgrade}",
     )
 
 
@@ -2232,21 +2278,32 @@ def list_installed_modules(
 @handle_errors
 @with_env_lock
 def run_odoo_command(
-    env_name: str, command: str, user: str = "odoo", ctx: Context | None = None
+    env_name: str,
+    command: str,
+    user: str = "odoo",
+    shell: bool = True,
+    ctx: Context | None = None,
 ) -> str:
     """
     Execute an arbitrary shell command inside the Odoo container for a specific environment.
 
+    The command runs through `sh -c`, so pipes, redirections, `&&`, `cd x && y`,
+    `$VAR` and quoting all behave as written — one call, one shell line.
+
     Args:
         env_name: The name of the environment.
-        command: The shell command to execute (e.g. "ls /mnt/extra-addons", "python3 -c 'print(1)'").
+        command: The shell command to execute (e.g. "ls /mnt/extra-addons | head", "python3 -c 'print(1)'").
         user: The OS user to run the command as (default "odoo"). Use "root" for privileged operations.
+        shell: Run via `sh -c` (default True). Pass False for exact argv semantics —
+            the string is then split on whitespace and executed directly, so `|`, `>`,
+            `&&`, `*` and `$VAR` reach the program as literal arguments instead of
+            being interpreted.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
     woke = _wake_for_work(settings, team, env_name)
     result = odoo_ops.run_command_in_environment(
-        settings, team, env_name, command, user
+        settings, team, env_name, command, user, shell=shell
     )
     exit_code = result["exit_code"]
     output = result.get("output", "")
@@ -3364,18 +3421,26 @@ def get_service_logs(name: str, n_lines: int = 100, ctx: Context | None = None) 
 @mcp.tool()
 @handle_errors
 def run_service_command(
-    name: str, command: str, user: str = "root", ctx: Context | None = None
+    name: str,
+    command: str,
+    user: str = "root",
+    shell: bool = True,
+    ctx: Context | None = None,
 ) -> str:
     """
     Execute an arbitrary shell command inside a managed auxiliary service container.
 
+    The command runs through `sh -c`, so pipes, redirections and `&&` work as written.
+
     Args:
         name: The name of the service (e.g. "redis", "meilisearch").
-        command: The shell command to execute (e.g. "redis-cli ping", "ls /data").
+        command: The shell command to execute (e.g. "redis-cli ping", "ls /data | wc -l").
         user: The OS user to run the command as (default "root").
+        shell: Run via `sh -c` (default True). Pass False for exact argv semantics, or
+            when the image ships no shell at all (scratch/distroless).
     """
     result = service_ops.run_command_in_service(
-        _get_settings(), _resolve_team(ctx), name, command, user
+        _get_settings(), _resolve_team(ctx), name, command, user, shell=shell
     )
     exit_code = result["exit_code"]
     output = cast(str, result.get("output", ""))
@@ -4089,7 +4154,7 @@ def prune_production_backups(ctx: Context | None = None) -> str:
 
     settings = _get_settings()
     team = _resolve_team(ctx)
-    _locks.acquire_team(team.team_id)
+    _locks.acquire_team(team.team_id, operation="prune_backups")
     try:
         result = backup_ops.prune_backups(settings, team)
     finally:
@@ -4130,7 +4195,7 @@ def restore_cluster_pitr(
 
     settings = _get_settings()
     _resolve_team(ctx)  # authenticate the caller; PITR spans all teams
-    _locks.acquire_env("prod:__cluster__")
+    _locks.acquire_env("prod:__cluster__", operation="restore_cluster_pitr")
     try:
         from oduflow.docker_ops.client import get_client
 

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 3
+Version: 4
 
 ## What is Oduflow
 
@@ -76,7 +76,7 @@ In live-mount mode, you as the agent must track the intent of your own edits. If
 |---|---|
 | `install_odoo_modules(env_name, modules)` | Install modules for the first time (`odoo -i`). Comma-separated list, e.g. `"sale,crm"`. **Returns full output including any errors directly in the response.** |
 | `upgrade_odoo_modules(env_name, modules)` | Force-upgrade modules (`odoo -u`). Usually handled by `pull_and_apply`. **Returns full output including any errors directly in the response.** |
-| `run_odoo_tests(env_name, modules)` | Run Odoo tests (`--test-enable`) for specific modules. **Returns full test output directly in the response.** |
+| `run_odoo_tests(env_name, modules, test_tags?, upgrade?)` | Run Odoo tests (`--test-enable`) for specific modules. **Returns full test output directly in the response.** Narrow a run with `test_tags="/my_module:TestClass.test_method"` instead of re-running a whole module. `upgrade=False` skips the `-u` for a fast re-run — but Odoo then collects **only `post_install` tests**, so a plain `TransactionCase` (at_install by default) reports "0 tests"; re-run with the default `upgrade=True` if a class you expect does not appear. With `upgrade=False`, positive tags must name a requested module (`slow/my_module`); exclusion-only tags such as `-slow` are scoped automatically. |
 | `list_installed_modules(env_name, name_filter?, state_filter?)` | List Odoo modules with name/state filtering. Default: installed modules only. |
 
 ### Translations (i18n)
@@ -142,7 +142,7 @@ first when reading or changing data. `run_odoo_shell` stays the escape hatch.
 |---|---|
 | `get_environment_logs(env_name, n_lines?, grep?, level?)` | Logs from the **running Odoo server** (main container process). Use `grep` for substring filtering, `level` for "ERROR"/"WARNING"/"CRITICAL". Does **NOT** contain output from install/upgrade/test operations. |
 | `read_file_in_odoo(env_name, path, read_range?)` | Read a text file or list a directory inside the container. Use to inspect Odoo source code, addon structure, config files. Supports `read_range="START:END"` for large files. **Prefer this over `run_odoo_command` with `cat`/`ls`.** |
-| `run_odoo_command(env_name, command, user?)` | Run shell commands inside the container. Use `user="root"` for privileged ops (pip install, apt). Useful for debugging, running Odoo shell commands. For reading files, prefer `read_file_in_odoo` instead |
+| `run_odoo_command(env_name, command, user?, shell?)` | Run shell commands inside the container. Runs through `sh -c`, so pipes, redirections, `&&`, `cd x && y` and `$VAR` behave as written. Pass `shell=False` for exact argv semantics (metacharacters stay literal). Use `user="root"` for privileged ops (pip install, apt). For reading files, prefer `read_file_in_odoo` instead |
 
 **When to use which:**
 - After `pull_and_apply` / `install_odoo_modules` / `upgrade_odoo_modules` / `run_odoo_tests` → **read the tool response** for errors
@@ -176,7 +176,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 | `restore_service(name)` | Recreate a service from its saved preset after deletion (volumes, host_mode, cap_add, env are all preserved) |
 | `list_service_presets` | List saved service presets (configurations that can be restored after a service is deleted) |
 | `delete_service_preset(name)` | Remove a saved service preset |
-| `run_service_command(name, command, user?)` | Execute a shell command inside a service container. Default user is `root`. Output is cached if large — use `read_output` for drill-down |
+| `run_service_command(name, command, user?, shell?)` | Execute a shell command inside a service container. Default user is `root`. Runs through `sh -c` like `run_odoo_command`; `shell=False` for exact argv (or for an image that ships no shell). Output is cached if large — use `read_output` for drill-down |
 
 > **Connecting to a service from Odoo:** use the container name reported as `Container:` / `Internal hostname:` by `create_service` and `get_service_info` — that is the exact DNS name (`oduflow-{team}-svc-{name}`) resolvable from Odoo and every other container on the team network. There is no shorter alias, and the `URL:` line is the *external* Traefik/host address, not the internal one. Host-mode services are not on the team network — reach them via `host.docker.internal`.
 
@@ -201,7 +201,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 
 | Tool | When to use |
 |---|---|
-| `list_templates` | List available database template profiles |
+| `list_templates` | List available database template profiles, including `Source=<branch> @ <commit> @ snapshot <date>` — the code each database snapshot was taken from (see "Template ↔ Code Lineage") |
 | `import_template_from_odoo(odoo_url, master_pwd, db_name?, template_name?, without_filestore=False)` | Import a template from a running Odoo instance via its database manager API. Set `without_filestore=True` for a database-only PostgreSQL custom dump. Requires explicit user permission |
 | `save_as_template(env_name, reset_env_changes=False)` | Make a branch the new template baseline. Other overlay environments on this template are remounted against the new baseline, **keeping their filestore changes by default** (non-destructive); `reset_env_changes=True` discards them. The source env is always reset. Requires explicit user permission |
 | `refresh_template(template_name, reset_env_changes=False)` | Re-apply a template's current filestore to live overlay environments, keeping their changes (non-destructive); `reset_env_changes=True` resets them to the template baseline. Use after the template filestore changed on disk or to re-sync a skipped env. Requires explicit user permission |
@@ -309,7 +309,7 @@ The environment container runs **remotely** and has access only to the git repos
 
 ### General
 - **One task = one branch = one environment.**
-- Mutexed tools (create, delete, install, upgrade, pull, test, exec) reject concurrent calls with `BusyError` — retry after a short delay.
+- Mutexed tools (create, delete, install, upgrade, pull, test, exec) reject concurrent calls with `BusyError` — retry after a short delay. The message names the operation holding the lock and how long it has held it (`pull_and_apply, running for 4m12s`), so read it before reacting: the lock is held by work that is **still running server-side**, including when your own earlier call timed out client-side. Wait for it; do not restart or recreate the environment to "clear" it.
 - `run_odoo_command` runs as `odoo` by default. Use `user="root"` for package installation or system operations.
 - Database is accessible from inside the container: `psql -h oduflow-db -U odoo -d oduflow_{env_name}`.
 
@@ -366,6 +366,26 @@ Notes:
 - In live-mount mode, you as the agent must track the intent of your own edits. If you add/change fields, models, `_inherit`/`_name`, manifest `data`/`depends`, security/data XML, `ir.cron`, mail templates, `i18n/*.po` translations, or anything loaded into the database, call `pull_and_apply(..., upgrade="module")`. If you add a new module, call `install="module"`. Use `restart=True` only for Python logic changes that do not require registry/schema/data updates.
 - Git is optional in live-mount mode. Commit whenever you want for your own workflow; Oduflow does not require commits, create commits, or read Git state to apply local changes.
 - With `repo_url` mode, use the normal remote workflow: edit locally, commit, push, then call `pull_and_apply` so the managed clone can pull the pushed commits.
+
+---
+
+## Template ↔ Code Lineage
+
+> ⚠️ **A template database is a snapshot of a branch at a moment in time. Your checkout can sit on either side of it.**
+
+The environment you get is a *new* database cloned from the template plus *your* branch's code. Those two are snapshots of the same lineage taken at different times, and they drift in both directions. Check which case you are in **before the first `pull_and_apply`** — `create_environment` reports it, and `list_templates` shows each template's `Source=<branch> @ <commit>`.
+
+| Where your branch sits | What that means | What to do |
+|---|---|---|
+| **Behind / diverged** — your branch does not contain the template's snapshot commit (branched off an older commit) | The database already holds views, records and constraints written by newer code your branch lacks. Any upgrade validates *old* code against *new* data and fails | **Merge the template's source branch** (typically `prod`/`main`) into your branch, push, then `pull_and_apply` |
+| **Ahead** — your branch contains the snapshot commit plus later commits | The database predates your code. Schema/data changes since the snapshot are not in it | Apply the exact arguments reported by Oduflow, e.g. `pull_and_apply(install="new_module", upgrade="a,b,c")`, dependencies before dependents. New modules require `install=`; existing modules with schema/data drift require `upgrade=`. Modules whose manifest version was **not** bumped are never picked up automatically — name them yourself |
+| **Aligned** | Nothing to reconcile | Proceed normally |
+
+**Symptoms and their meaning:**
+- `column ... does not exist` / `External ID not found` during an upgrade → you are **ahead**; find the module that owns the missing column or xmlid and add it to `upgrade=`.
+- A `ParseError` or validation error on a view/method the branch does not define → you are **behind**; merge the source branch.
+
+**Never recreate the environment to fix either case.** The template is the same, so the drift comes straight back — and you lose the environment's data. This is the same rule as the migrations section below: reconcile with the reported install/upgrade action, not with a fresh environment.
 
 ---
 

--- a/src/oduflow/webhooks.py
+++ b/src/oduflow/webhooks.py
@@ -130,7 +130,9 @@ def _deploy_in_background(
     key = prod_lock_key(team.team_id, name)
     pending_key = f"{team.team_id}/{name}"
     try:
-        if not locks.acquire_env_blocking(key, _LOCK_TIMEOUT_SECONDS):
+        if not locks.acquire_env_blocking(
+            key, _LOCK_TIMEOUT_SECONDS, operation="webhook deploy"
+        ):
             logger.warning(
                 "Webhook deploy of production '%s' gave up waiting for its "
                 "lock (%.0f min)",

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -1,6 +1,8 @@
 import os
 import textwrap
 
+import pytest
+
 from oduflow.git_analysis import (
     _extract_field_lines,
     _extract_view_tag_attrs,
@@ -768,3 +770,143 @@ class TestMergeRecommendations:
         extra = {"action": "none", "modules_to_install": [], "modules_to_upgrade": []}
         merged = merge_recommendations([main, extra])
         assert merged["action"] == "restart"
+
+
+class TestTemplateLineage:
+    """A template DB and a branch checkout drift in both directions; the check
+    must name the right remedy for each and stay silent when it cannot tell."""
+
+    def _repo(self, tmp_path):
+        os.makedirs(tmp_path / ".git", exist_ok=True)
+        return str(tmp_path)
+
+    @pytest.fixture(autouse=True)
+    def _recognize_test_repo(self, monkeypatch):
+        from oduflow import git_ops
+
+        monkeypatch.setattr(git_ops, "is_git_repository", lambda path: True)
+
+    def test_no_commit_recorded_is_unknown(self, tmp_path):
+        from oduflow.git_analysis import template_lineage
+
+        result = template_lineage(self._repo(tmp_path), "")
+        assert result["status"] == "unknown"
+        assert result["message"] == ""
+
+    def test_commit_absent_from_repo_is_unknown(self, tmp_path, monkeypatch):
+        # Deleted source branch / different repo / shallow clone: no lineage
+        # information is not an error and must not produce a warning.
+        from oduflow import git_ops
+        from oduflow.git_analysis import template_lineage
+
+        monkeypatch.setattr(git_ops, "commit_exists", lambda p, c: False)
+        result = template_lineage(self._repo(tmp_path), "deadbeef", "prod")
+        assert result["status"] == "unknown"
+
+    def test_same_commit_is_aligned(self, tmp_path, monkeypatch):
+        from oduflow import git_ops
+        from oduflow.git_analysis import template_lineage
+
+        monkeypatch.setattr(git_ops, "commit_exists", lambda p, c: True)
+        monkeypatch.setattr(git_ops, "rev_parse", lambda p, ref="HEAD": "abc123")
+        result = template_lineage(self._repo(tmp_path), "abc123", "prod")
+        assert result["status"] == "aligned"
+        assert result["message"] == ""
+
+    def test_branch_missing_snapshot_commit_asks_for_a_merge(
+        self, tmp_path, monkeypatch
+    ):
+        # The database is newer than the code — upgrading would validate the old
+        # code against data written by newer code. Merge first.
+        from oduflow import git_ops
+        from oduflow.git_analysis import template_lineage
+
+        monkeypatch.setattr(git_ops, "commit_exists", lambda p, c: True)
+        monkeypatch.setattr(git_ops, "rev_parse", lambda p, ref="HEAD": "feature1")
+        monkeypatch.setattr(git_ops, "is_ancestor", lambda p, a, d="HEAD": False)
+        result = template_lineage(self._repo(tmp_path), "snapshot1", "prod")
+        assert result["status"] == "diverged"
+        assert "Merge prod" in result["message"]
+        assert result["modules_to_upgrade"] == []
+
+    def test_branch_ahead_names_the_modules_to_upgrade(self, tmp_path, monkeypatch):
+        # The code is newer than the database: the changed modules need an
+        # explicit -u, including ones whose version was never bumped.
+        from oduflow import git_ops
+        from oduflow.git_analysis import template_lineage
+
+        module_dir = tmp_path / "supply" / "models"
+        module_dir.mkdir(parents=True)
+        (tmp_path / "supply" / "__manifest__.py").write_text(
+            "{'name': 'Supply', 'version': '15.0.1.0.0', 'data': []}"
+        )
+        (module_dir / "supply.py").write_text(
+            textwrap.dedent(
+                """
+                class Supply(models.Model):
+                    _name = "supply"
+                    new_field = fields.Char()
+                """
+            )
+        )
+        monkeypatch.setattr(git_ops, "commit_exists", lambda p, c: True)
+        monkeypatch.setattr(git_ops, "rev_parse", lambda p, ref="HEAD": "head1")
+        monkeypatch.setattr(git_ops, "is_ancestor", lambda p, a, d="HEAD": True)
+        monkeypatch.setattr(
+            git_ops, "diff_names", lambda p, b, h="HEAD": ["supply/models/supply.py"]
+        )
+
+        from unittest.mock import patch
+
+        with patch("subprocess.run") as mock_run:
+            # The old revision of the file had no field definition at all.
+            mock_run.return_value = type("Result", (), {"stdout": "class Supply:\n"})()
+            result = template_lineage(self._repo(tmp_path), "snapshot1", "prod")
+
+        assert result["status"] == "ahead"
+        assert result["modules_to_upgrade"] == ["supply"]
+        assert 'upgrade="supply"' in result["message"]
+
+    def test_new_modules_are_installed_not_upgraded(self, tmp_path, monkeypatch):
+        from oduflow import git_analysis, git_ops
+        from oduflow.git_analysis import template_lineage
+
+        monkeypatch.setattr(git_ops, "commit_exists", lambda p, c: True)
+        monkeypatch.setattr(git_ops, "rev_parse", lambda p, ref="HEAD": "head1")
+        monkeypatch.setattr(git_ops, "is_ancestor", lambda p, a, d="HEAD": True)
+        monkeypatch.setattr(
+            git_ops,
+            "diff_names",
+            lambda p, b, h="HEAD": [
+                "new_module/__manifest__.py",
+                "sale/models/order.py",
+            ],
+        )
+        monkeypatch.setattr(
+            git_analysis,
+            "recommend",
+            lambda files, path, base: {
+                "modules_to_install": ["new_module"],
+                "modules_to_upgrade": ["sale"],
+            },
+        )
+
+        result = template_lineage(self._repo(tmp_path), "snapshot1", "prod")
+
+        assert result["modules_to_install"] == ["new_module"]
+        assert result["modules_to_upgrade"] == ["sale"]
+        assert 'install="new_module"' in result["message"]
+        assert 'upgrade="sale"' in result["message"]
+
+    def test_ahead_without_db_relevant_changes_stays_quiet(self, tmp_path, monkeypatch):
+        # Ahead by a README only: nothing to upgrade, so say nothing.
+        from oduflow import git_ops
+        from oduflow.git_analysis import template_lineage
+
+        monkeypatch.setattr(git_ops, "commit_exists", lambda p, c: True)
+        monkeypatch.setattr(git_ops, "rev_parse", lambda p, ref="HEAD": "head1")
+        monkeypatch.setattr(git_ops, "is_ancestor", lambda p, a, d="HEAD": True)
+        monkeypatch.setattr(git_ops, "diff_names", lambda p, b, h="HEAD": ["README.md"])
+        result = template_lineage(self._repo(tmp_path), "snapshot1", "prod")
+        assert result["status"] == "ahead"
+        assert result["message"] == ""

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -1,0 +1,96 @@
+"""A rejected caller must be able to tell "still running" from "stuck".
+
+An agent that reads a bare "another operation is in progress" as a stale lock
+reaches for restarts and recreations; the message therefore names the operation
+that holds the lock and how long it has held it.
+"""
+
+import pytest
+
+from oduflow.errors import BusyError
+from oduflow.locking import LockManager, _format_age
+
+
+class TestFormatAge:
+    def test_seconds(self):
+        assert _format_age(42) == "42s"
+
+    def test_minutes(self):
+        assert _format_age(252) == "4m12s"
+
+    def test_hours(self):
+        assert _format_age(3900) == "1h05m"
+
+
+class TestEnvLockDiagnostics:
+    def test_busy_error_names_the_holder(self):
+        locks = LockManager()
+        locks.acquire_env("main", "1", operation="pull_and_apply")
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_env("main", "1", operation="run_odoo_tests")
+        message = str(exc.value)
+        assert "pull_and_apply" in message
+        assert "running for" in message
+        # The lock is held by a live operation, not leaked — say so, because the
+        # tempting "fix" (restart the environment) would interrupt real work.
+        assert "restarting" in message
+
+    def test_holder_is_forgotten_after_release(self):
+        locks = LockManager()
+        locks.acquire_env("main", "1", operation="pull_and_apply")
+        locks.release_env("main")
+        assert locks.describe_env_holder("main") == ""
+        # Reacquiring is possible and reports the new holder.
+        locks.acquire_env("main", "1", operation="run_odoo_tests")
+        assert "run_odoo_tests" in locks.describe_env_holder("main")
+
+    def test_unknown_operation_still_reports_age(self):
+        locks = LockManager()
+        locks.acquire_env("main")
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_env("main")
+        assert "running for" in str(exc.value)
+
+    def test_blocking_acquire_records_holder(self):
+        locks = LockManager()
+        assert locks.acquire_env_blocking("prod:1:erp", 0.1, operation="webhook deploy")
+        assert "webhook deploy" in locks.describe_env_holder("prod:1:erp")
+
+
+class TestTeamLockDiagnostics:
+    def test_team_operation_blocks_env_and_is_named(self):
+        locks = LockManager()
+        locks.acquire_team("1", operation="save_as_template")
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_env("feature-x", "1", operation="pull_and_apply")
+        assert "save_as_template" in str(exc.value)
+
+    def test_env_operation_blocks_team_and_is_named(self):
+        locks = LockManager()
+        locks.acquire_env("feature-x", "1", operation="run_odoo_tests")
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_team("1", operation="save_as_template")
+        message = str(exc.value)
+        assert "feature-x" in message
+        assert "run_odoo_tests" in message
+
+    def test_team_lock_is_reusable_after_a_rejected_acquire(self):
+        # The rejected team acquire must not leave the underlying lock taken.
+        locks = LockManager()
+        locks.acquire_env("feature-x", "1")
+        with pytest.raises(BusyError):
+            locks.acquire_team("1")
+        locks.release_env("feature-x")
+        locks.acquire_team("1")  # would raise if the lock had leaked
+        locks.release_team("1")
+
+
+class TestSystemLockDiagnostics:
+    def test_system_busy_names_the_holder(self):
+        locks = LockManager()
+        locks.acquire_system(operation="init_system")
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_system(operation="destroy")
+        assert "init_system" in str(exc.value)
+        locks.release_system()
+        locks.acquire_system()  # released cleanly

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1702,6 +1702,188 @@ class TestRunEnvironmentTests:
         assert "--longpolling-port 8090" in test_cmd
         assert "--gevent-port" not in test_cmd
 
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_test_tags_narrow_the_run(self, mock_load_creds, mock_docker_client):
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        container.exec_run.return_value = (0, b"1 test")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_environment_tests(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "main",
+            "sale",
+            test_tags="/sale:TestInvoice.test_total",
+        )
+
+        args = container.exec_run.call_args[0][0]
+        # --test-tags=VALUE, not a separate token: an exclusion expression like
+        # '-slow' would otherwise be parsed as a CLI flag.
+        assert "--test-tags=/sale:TestInvoice.test_total" in args
+        assert "-u sale" in args  # upgrade still on by default
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_upgrade_false_drops_u_and_scopes_by_module(
+        self, mock_load_creds, mock_docker_client
+    ):
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        container.exec_run.return_value = (0, b"ok")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_environment_tests(
+            TEST_SETTINGS, TEST_TEAM, "main", "sale,crm", upgrade=False
+        )
+
+        args = container.exec_run.call_args[0][0]
+        assert "-u " not in args
+        # Without -u, Odoo would otherwise sweep every installed module's
+        # post-install tests; the module filter keeps the run scoped.
+        assert "--test-tags=/sale,/crm" in args
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_explicit_tags_win_over_derived_ones(
+        self, mock_load_creds, mock_docker_client
+    ):
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        container.exec_run.return_value = (0, b"ok")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_environment_tests(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "main",
+            "sale",
+            test_tags="/sale:TestX",
+            upgrade=False,
+        )
+
+        args = container.exec_run.call_args[0][0]
+        assert "--test-tags=/sale:TestX" in args
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "test-pw"},
+    )
+    def test_upgrade_false_scopes_exclusion_to_requested_modules(
+        self, mock_load_creds, mock_docker_client
+    ):
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        container.exec_run.return_value = (0, b"ok")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_environment_tests(
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "main",
+            "sale,crm",
+            test_tags="-slow",
+            upgrade=False,
+        )
+
+        args = container.exec_run.call_args[0][0]
+        assert "--test-tags=/sale,/crm,-slow" in args
+
+    def test_upgrade_false_rejects_unscoped_positive_tag(self, mock_docker_client):
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(ValueError, match="must include a module scope"):
+            odoo_ops.run_environment_tests(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "main",
+                "sale",
+                test_tags="slow",
+                upgrade=False,
+            )
+
+    def test_upgrade_false_rejects_tag_for_another_module(self, mock_docker_client):
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(ValueError, match="outside the requested modules"):
+            odoo_ops.run_environment_tests(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "main",
+                "sale",
+                test_tags="/stock:TestMove",
+                upgrade=False,
+            )
+
+    def test_empty_modules_rejected(self, mock_docker_client):
+        # A bare `-u` (no value) with upgrade=True, and an unscoped sweep over
+        # every installed module's post-install tests with upgrade=False.
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(ValueError, match="modules is required"):
+            odoo_ops.run_environment_tests(TEST_SETTINGS, TEST_TEAM, "main", "")
+
+    def test_test_tags_with_whitespace_rejected(self, mock_docker_client):
+        # Same argument-injection guard as module names: exec_run splits the
+        # command with shlex, so a space would smuggle a second CLI flag.
+        container = MagicMock()
+        container.labels = {TEST_SETTINGS.image_label: "odoo:17.0"}
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(ValueError, match="Invalid test_tags"):
+            odoo_ops.run_environment_tests(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "main",
+                "sale",
+                test_tags="/sale --load=web,base",
+            )
+
+
+class TestRunCommandInEnvironment:
+    """Docker exec has no shell — pipes and redirections would reach the program
+    as literal argv entries. Commands go through `sh -c` unless asked otherwise."""
+
+    def test_shell_by_default(self, mock_docker_client):
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"2\n")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_command_in_environment(
+            TEST_SETTINGS, TEST_TEAM, "main", "ls /mnt/extra-addons | wc -l"
+        )
+
+        assert container.exec_run.call_args[0][0] == [
+            "sh",
+            "-c",
+            "ls /mnt/extra-addons | wc -l",
+        ]
+        assert container.exec_run.call_args.kwargs["user"] == "odoo"
+
+    def test_shell_false_passes_the_raw_command(self, mock_docker_client):
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"")
+        mock_docker_client.containers.get.return_value = container
+
+        odoo_ops.run_command_in_environment(
+            TEST_SETTINGS, TEST_TEAM, "main", "odoo --version", shell=False
+        )
+
+        assert container.exec_run.call_args[0][0] == "odoo --version"
+
 
 class TestRunOdooShell:
     @patch(

--- a/tests/test_template_provenance.py
+++ b/tests/test_template_provenance.py
@@ -14,11 +14,10 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
+from tool_helpers import call_tool as _call_tool  # noqa: E402
 
 from oduflow.docker_ops import env_ops, system_ops
 from oduflow.settings import Settings, TeamSettings
-
-from tool_helpers import call_tool as _call_tool  # noqa: E402
 
 
 def _make_env(tmp_path):

--- a/tests/test_template_provenance.py
+++ b/tests/test_template_provenance.py
@@ -1,0 +1,381 @@
+"""Tests for template code provenance and the lineage check at creation.
+
+A template database is a snapshot of a branch at a moment in time. Without that
+anchor an agent cannot tell whether a fresh checkout predates the data it was
+handed — the failure then surfaces much later, as an upgrade that dies on
+validation against records written by code the branch does not have.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from oduflow.docker_ops import env_ops, system_ops
+from oduflow.settings import Settings, TeamSettings
+
+from tool_helpers import call_tool as _call_tool  # noqa: E402
+
+
+def _make_env(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path / "team"),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        disable_telemetry=True,
+        teams={"1": team},
+    )
+    return settings, team
+
+
+def _write_template(team: TeamSettings, name: str, metadata: dict) -> None:
+    path = team.get_template_metadata_path(name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(metadata, f)
+
+
+def _git(repo, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _init_repo(path) -> None:
+    path.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main", str(path)],
+        check=True,
+        capture_output=True,
+    )
+    _git(path, "config", "user.email", "tests@example.com")
+    _git(path, "config", "user.name", "Oduflow Tests")
+
+
+@pytest.fixture
+def tool_env(tmp_path):
+    import oduflow.server as server
+
+    settings, team = _make_env(tmp_path)
+    old = server._settings
+    server._settings = settings
+    with patch("oduflow.server._resolve_team", return_value=team):
+        yield settings, team
+    server._settings = old
+
+
+# --- recording the snapshot's origin ---------------------------------------
+
+
+class TestCodeProvenance:
+    def test_records_branch_and_commit_of_the_source_checkout(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        repo = os.path.join(team.workspaces_dir, "feature-x", "repo")
+        os.makedirs(os.path.join(repo, ".git"))
+
+        with (
+            patch("oduflow.git_ops.is_git_repository", return_value=True),
+            patch("oduflow.git_ops.rev_parse", return_value="c0ffee1234"),
+        ):
+            provenance = system_ops._code_provenance(
+                team, "feature-x", {"oduflow.git_branch": "prod"}
+            )
+
+        assert provenance["source_branch"] == "prod"
+        assert provenance["source_commit"] == "c0ffee1234"
+        assert provenance["snapshot_at"]
+
+    def test_live_mount_checkout_is_used_when_present(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        checkout = tmp_path / "local-addons"
+        (checkout / ".git").mkdir(parents=True)
+
+        with (
+            patch("oduflow.git_ops.is_git_repository", return_value=True),
+            patch("oduflow.git_ops.rev_parse", return_value="abc123") as rev,
+        ):
+            provenance = system_ops._code_provenance(
+                team,
+                "feature-x",
+                {"oduflow.git_branch": "main", "oduflow.local_path": str(checkout)},
+            )
+
+        assert rev.call_args[0][0] == str(checkout)
+        assert provenance["source_commit"] == "abc123"
+
+    def test_git_worktree_checkout_is_recorded(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        source = tmp_path / "source"
+        checkout = tmp_path / "feature-worktree"
+        _init_repo(source)
+        (source / "README.md").write_text("base\n")
+        _git(source, "add", "README.md")
+        _git(source, "commit", "-m", "base")
+        _git(source, "worktree", "add", "-b", "feature", str(checkout))
+
+        assert (checkout / ".git").is_file()
+        provenance = system_ops._code_provenance(
+            team,
+            "feature-x",
+            {"oduflow.git_branch": "feature", "oduflow.local_path": str(checkout)},
+        )
+
+        assert provenance["source_commit"] == _git(checkout, "rev-parse", "HEAD")
+
+    def test_missing_checkout_yields_timestamp_only(self, tmp_path):
+        # No repo on disk (deleted workspace, imported template): record the
+        # snapshot time and leave the lineage check with nothing to compare.
+        settings, team = _make_env(tmp_path)
+        provenance = system_ops._code_provenance(team, "gone", {})
+        assert "source_commit" not in provenance
+        assert provenance["snapshot_at"]
+
+
+# --- surfacing it to agents -------------------------------------------------
+
+
+class TestListTemplatesShowsOrigin:
+    @patch("oduflow.docker_ops.system_ops._db_exists", return_value=True)
+    def test_source_line_includes_branch_and_short_commit(
+        self, _db_exists, tool_env, tmp_path
+    ):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "prod",
+            {
+                "odoo_image": "odoo:19.0",
+                "source_branch": "prod",
+                "source_commit": "c0ffee1234567890",
+                "snapshot_at": "2026-08-01T10:00:00+00:00",
+                "filestore_size_mb": 1.0,
+                "dump_size_mb": 1.0,
+            },
+        )
+        output = _call_tool("list_templates")
+
+        assert "Source=prod @ c0ffee12 @ snapshot 2026-08-01" in output
+
+
+# --- the lineage check ------------------------------------------------------
+
+
+class TestTemplateCodeLineage:
+    def test_no_template_means_no_check(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        result = env_ops._template_code_lineage(team, None, str(tmp_path))
+        assert result["status"] == "unknown"
+
+    def test_template_without_provenance_is_silent(self, tmp_path):
+        # Templates created before provenance existed must not start warning.
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "old", {"odoo_image": "odoo:19.0"})
+        result = env_ops._template_code_lineage(team, "old", str(tmp_path))
+        assert result["status"] == "unknown"
+        assert result["message"] == ""
+
+    def test_passes_recorded_commit_to_the_comparison(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(
+            team, "prod", {"source_commit": "snapshot1", "source_branch": "prod"}
+        )
+        with patch(
+            "oduflow.git_analysis.template_lineage",
+            return_value={
+                "status": "diverged",
+                "message": "Merge prod",
+                "modules_to_upgrade": [],
+            },
+        ) as lineage:
+            result = env_ops._template_code_lineage(team, "prod", "/repo")
+
+        assert lineage.call_args[0] == ("/repo", "snapshot1", "prod")
+        assert result["status"] == "diverged"
+
+    def test_fetches_missing_history_for_managed_clone(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(
+            team, "prod", {"source_commit": "snapshot1", "source_branch": "prod"}
+        )
+        with (
+            patch(
+                "oduflow.git_ops.ensure_lineage_history", return_value=True
+            ) as ensure,
+            patch(
+                "oduflow.git_analysis.template_lineage",
+                return_value={
+                    "status": "aligned",
+                    "message": "",
+                    "modules_to_install": [],
+                    "modules_to_upgrade": [],
+                },
+            ),
+        ):
+            env_ops._template_code_lineage(
+                team,
+                "prod",
+                "/repo",
+                current_branch="feature",
+                fetch_missing_history=True,
+            )
+
+        ensure.assert_called_once_with(
+            "/repo",
+            "snapshot1",
+            "feature",
+            "prod",
+            team.git_credentials_file(),
+        )
+
+    def test_depth_one_clone_fetches_both_sides_of_lineage(self, tmp_path):
+        from oduflow import git_ops
+
+        source = tmp_path / "source"
+        _init_repo(source)
+        (source / "module.py").write_text("base = True\n")
+        _git(source, "add", "module.py")
+        _git(source, "commit", "-m", "base")
+        base_commit = _git(source, "rev-parse", "HEAD")
+        _git(source, "branch", "feature")
+        (source / "module.py").write_text("base = True\nnew = True\n")
+        _git(source, "commit", "-am", "template snapshot")
+        template_commit = _git(source, "rev-parse", "HEAD")
+
+        ahead = tmp_path / "ahead"
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                "main",
+                f"file://{source}",
+                str(ahead),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        assert not git_ops.commit_exists(str(ahead), base_commit)
+        assert git_ops.ensure_lineage_history(str(ahead), base_commit, "main", "main")
+        assert git_ops.is_ancestor(str(ahead), base_commit)
+
+        behind = tmp_path / "behind"
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                "feature",
+                f"file://{source}",
+                str(behind),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        assert not git_ops.commit_exists(str(behind), template_commit)
+        assert git_ops.ensure_lineage_history(
+            str(behind), template_commit, "feature", "main"
+        )
+        assert not git_ops.is_ancestor(str(behind), template_commit)
+
+    def test_a_failing_check_never_breaks_creation(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "prod", {"source_commit": "snapshot1"})
+        with patch(
+            "oduflow.git_analysis.template_lineage",
+            side_effect=RuntimeError("git gone"),
+        ):
+            result = env_ops._template_code_lineage(team, "prod", "/repo")
+        assert result["status"] == "unknown"
+
+
+class TestCreateEnvironmentReportsLineage:
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_diverged_branch_is_reported_with_the_remedy(
+        self, mock_create, tool_env, tmp_path
+    ):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "prod",
+            {"odoo_image": "odoo:19.0", "repo_url": "https://github.com/x/y.git"},
+        )
+        mock_create.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-t-odoo",
+            "database": "oduflow_1_t",
+            "workspace": "/tmp/ws",
+            "template_lineage": {
+                "status": "diverged",
+                "message": "Merge prod into this branch before the first pull_and_apply.",
+                "modules_to_upgrade": [],
+            },
+        }
+
+        result = _call_tool("create_environment", branch="t", template_name="prod")
+
+        assert "Code is behind the template database" in result
+        assert "Merge prod into this branch" in result
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_aligned_branch_says_nothing(self, mock_create, tool_env, tmp_path):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "prod",
+            {"odoo_image": "odoo:19.0", "repo_url": "https://github.com/x/y.git"},
+        )
+        mock_create.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-t-odoo",
+            "database": "oduflow_1_t",
+            "workspace": "/tmp/ws",
+            "template_lineage": {
+                "status": "aligned",
+                "message": "",
+                "modules_to_upgrade": [],
+            },
+        }
+
+        result = _call_tool("create_environment", branch="t", template_name="prod")
+
+        assert "template database" not in result
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_ahead_branch_gets_the_upgrade_list(self, mock_create, tool_env, tmp_path):
+        settings, team = tool_env
+        _write_template(
+            team,
+            "prod",
+            {"odoo_image": "odoo:19.0", "repo_url": "https://github.com/x/y.git"},
+        )
+        mock_create.return_value = {
+            "url": "http://localhost:50000",
+            "odoo_container": "oduflow-t-odoo",
+            "database": "oduflow_1_t",
+            "workspace": "/tmp/ws",
+            "template_lineage": {
+                "status": "ahead",
+                "message": "schema/data changed in supply, supply_stock. Apply "
+                'them explicitly with pull_and_apply(upgrade="supply,supply_stock")',
+                "modules_to_upgrade": ["supply", "supply_stock"],
+            },
+        }
+
+        result = _call_tool("create_environment", branch="t", template_name="prod")
+
+        assert "Code is ahead of the template database" in result
+        assert 'upgrade="supply,supply_stock"' in result


### PR DESCRIPTION
## Summary

- record template source branch, commit, and snapshot time, then report template/code drift when creating environments
- make lineage checks work with depth-one managed clones and linked Git worktrees, with separate install and upgrade remediation
- identify lock holders and elapsed time in BusyError messages
- add targeted Odoo test tags and optional upgrade-free reruns while preserving module scope
- run Odoo and service commands through a shell by default, with an exact-argv opt-out
- document common agent failure modes and update the bundled agent guide

## Why

Agents could not distinguish active work from stale locks, and newly created environments could combine code with a template database from a different point in history without any warning. This led to unnecessary restarts/recreates and hard-to-diagnose first-upgrade failures. Command and test helpers also lacked the semantics needed for efficient debugging.

## Impact

Environment creation remains advisory and non-blocking. Managed shallow clones fetch the history needed for lineage comparison; live-mounted repositories are never fetched or mutated. Ahead branches receive explicit `install=` and `upgrade=` guidance, while behind/diverged branches are told which source branch to merge.

## Validation

- `pytest -m "not integration and not heavyweight"`: 1291 passed, 15 deselected
- focused regression suite: 207 passed
- `mypy src/oduflow`: passed
- Ruff F/E9 and format checks for touched files: passed
- `git diff --check`: passed