### PR TITLE
Tell agents to delete test environments when done

### DIFF
--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 3
+Version: 4
 
 ## What is Oduflow
 
@@ -30,7 +30,7 @@ In live-mount mode, you as the agent must track the intent of your own edits. If
 5. pull_and_apply — Pull changes; errors/tracebacks are returned directly in the response
 6. If errors in response → fix code → go to step 4
 7. run_odoo_tests            — Run Odoo tests for the changed modules
-8. delete_environment          — Tear down when done
+8. delete_environment          — Tear down when done; environments are disposable and cheap to recreate
 ```
 
 ---
@@ -44,7 +44,7 @@ In live-mount mode, you as the agent must track the intent of your own edits. If
 4. pull_and_apply             — Pass install/upgrade/restart explicitly when your edits require it
 5. If errors in response → fix code → repeat from step 4
 6. run_odoo_tests             — Run Odoo tests for the changed modules
-7. delete_environment         — Tear down when done
+7. delete_environment         — Tear down when done; environments are disposable and cheap to recreate
 ```
 
 ---
@@ -273,8 +273,24 @@ push → pull_and_apply → read the response for errors → fix if errors → r
 Do NOT call `get_environment_logs` after `pull_and_apply` — the errors are already in the response. Use `get_environment_logs` only to check the **running server** (e.g., runtime errors during request handling).
 
 ### Teardown
-- Only call `delete_environment` when the task is **Done** or **Cancelled**.
-- Do **not** recreate an environment to fix errors without user consent.
+
+Environments are **disposable test sandboxes**, not long-lived installations.
+They exist so you can verify your code, and they are cheap to recreate — a new
+one is provisioned from a template in seconds.
+
+- When the task is **Done** or **Cancelled** and you are confident the
+  environment will not be needed again, call `delete_environment` as the final
+  step of your work. Deleting is the normal, expected end of a task — not an
+  exception.
+- Do not hesitate to delete. Nothing is lost that matters: if the environment
+  turns out to be needed later, call `create_environment` again and continue.
+- Keep it only for a concrete reason — the user still needs the URL for manual
+  testing, the work continues in a later session, or the environment holds test
+  data that cannot be reproduced. If it must survive idle timeouts, call
+  `protect_environment`.
+- Never delete mid-task. Do **not** delete and recreate an environment to fix
+  errors or to apply migrations without user consent (see "Database Migrations
+  Workflow") — that is a different situation, and it is still forbidden.
 
 ### Container Is Read-Only for Code
 


### PR DESCRIPTION
## What

Rewrites the **Teardown** section of the agent instruction document (`agent_instructions.md`, served by the `get_agent_instructions` MCP tool).

The old wording was two lines that read as "delete only in the narrow case":

```
- Only call `delete_environment` when the task is **Done** or **Cancelled**.
- Do **not** recreate an environment to fix errors without user consent.
```

Agents took that as a reason to leave finished environments running, so they piled up until the idle reaper collected them.

## Why

Environments are ephemeral by design — a new one is provisioned from a template in seconds. Deleting one after the work is finished should be the expected end of a task, not an exception, and agents need to be told that losing an environment costs nothing.

## Changes

- **Teardown** rewritten: environments framed as disposable test sandboxes; delete as the final step once the agent is confident it will not be needed again; concrete reasons to keep one (user still needs the URL for manual testing, work continues in a later session, irreproducible test data → `protect_environment`).
- Both existing prohibitions kept explicit: no delete/recreate to work around errors, and no recreate to apply migrations (cross-referenced to "Database Migrations Workflow").
- Both Core Workflow blocks: final step now notes environments are disposable and cheap to recreate.
- Document `Version: 3` → `4` so agents holding a cached copy pick up the change.

## Testing

`pytest -m "not integration and not heavyweight"` — 1406 passed, 15 deselected.