### PR TITLE
Add an anonymous agent feedback channel

### DIFF
--- a/src/oduflow/agent_feedback.py
+++ b/src/oduflow/agent_feedback.py
@@ -1,0 +1,204 @@
+"""Anonymous agent feedback on the Oduflow MCP tool surface.
+
+Off by default and deliberately undocumented: when ``[server] agent_feedback``
+is not enabled the ``submit_agent_feedback`` tool is neither listed nor
+callable, and nothing is appended to the agent instructions. Operators of an
+Oduflow instance turn it on by hand when they want the coding agents working
+against that instance to report where the tool surface got in their way.
+
+The channel is independent of :mod:`oduflow.telemetry` — different flag,
+different endpoint, different payload — so disabling one never implies the
+other.
+
+Anonymity is enforced twice: the injected instructions tell the agent to keep
+business context out of the text, and :func:`scrub` mechanically redacts what
+slips through anyway (hosts, e-mails, paths, tokens, env/team names).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger("oduflow")
+
+_ENDPOINT = os.environ.get(
+    "ODUFLOW_AGENT_FEEDBACK_URL", "https://oduflow.dev/agent-feedback"
+)
+_TIMEOUT = 5
+
+# Categories the agent may pick. Anything else is rejected at the tool boundary
+# so the server side can index on a small closed set.
+CATEGORIES = ("friction", "missing_tool", "unclear_error", "docs")
+
+# Hard caps — a feedback note is a paragraph, not a transcript.
+MAX_SUGGESTION_CHARS = 2000
+MAX_TOOLS = 10
+MAX_TOOL_NAME_CHARS = 60
+
+_REDACTED = "[redacted]"
+
+# Ordered: URLs before bare hosts, so a URL is redacted whole rather than
+# leaving its scheme behind.
+_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # e-mail
+    re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"),
+    # URL with scheme (incl. git@host:path style already caught by e-mail rule)
+    re.compile(r"\b[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE),
+    # bare hostname with a TLD-ish tail (example.com, srv.company.io:8069)
+    re.compile(r"\b(?:[\w-]+\.)+[a-z]{2,}(?::\d+)?\b", re.IGNORECASE),
+    # IPv4, optionally with a port
+    re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b"),
+    # absolute POSIX path (/usr/lib/... , /home/max/work/...)
+    re.compile(r"(?<![\w.])/(?:[\w.-]+/)+[\w.-]*"),
+    # Windows path
+    re.compile(r"\b[A-Za-z]:\\[\\\w.-]+"),
+    # Odoo databases provisioned by Oduflow
+    re.compile(r"\boduflow_\w+\b"),
+    # Long opaque strings — tokens, hashes, secrets. Two tiers on purpose:
+    # tool names are what this channel collects, and several are 20+ chars
+    # (set_production_backup_schedule is 30). A digit inside a long run marks a
+    # secret; snake_case identifiers have none, so they survive up to 31 chars.
+    re.compile(r"\b(?=[A-Za-z0-9_-]*\d)[A-Za-z0-9_-]{20,}\b|\b[A-Za-z0-9_-]{32,}\b"),
+)
+
+
+def scrub(text: str, known_names: tuple[str, ...] = ()) -> str:
+    """Redact anything that could identify the installation or its business.
+
+    ``known_names`` carries instance-specific identifiers (environment names,
+    team ids) that look like ordinary words and therefore cannot be matched by
+    a generic pattern.
+    """
+    if not text:
+        return ""
+    cleaned = text
+    for name in sorted({n for n in known_names if len(n) >= 3}, key=len, reverse=True):
+        cleaned = re.sub(rf"\b{re.escape(name)}\b", _REDACTED, cleaned)
+    for pattern in _PATTERNS:
+        cleaned = pattern.sub(_REDACTED, cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    if len(cleaned) > MAX_SUGGESTION_CHARS:
+        cleaned = cleaned[:MAX_SUGGESTION_CHARS].rstrip() + "…"
+    return cleaned
+
+
+def normalize_tools(tools: str | list[str] | None) -> list[str]:
+    """Parse the reported tool names into a bounded list of bare identifiers."""
+    if not tools:
+        return []
+    raw = tools if isinstance(tools, list) else re.split(r"[,\s]+", tools)
+    names: list[str] = []
+    for item in raw:
+        name = re.sub(r"[^\w]", "", str(item))[:MAX_TOOL_NAME_CHARS]
+        if name and name not in names:
+            names.append(name)
+    return names[:MAX_TOOLS]
+
+
+def build_payload(
+    *,
+    category: str,
+    tools: list[str],
+    suggestion: str,
+    version: str,
+    instance_id: str,
+) -> dict[str, object]:
+    """Assemble the wire payload. Contains nothing beyond these five fields."""
+    return {
+        "category": category,
+        "tools": tools,
+        "suggestion": suggestion,
+        "version": version,
+        "instance_id": instance_id,
+    }
+
+
+def _post(payload: dict[str, object]) -> None:
+    """POST the payload. Logs the outcome only — never the feedback text."""
+    from oduflow.telemetry import SHARED_TOKEN as token
+
+    try:
+        headers = {
+            "Content-Type": "application/json",
+            # A branded UA avoids edge bot-protection rules that block the
+            # default ``Python-urllib/x.y`` signature (Cloudflare error 1010).
+            "User-Agent": f"oduflow/{payload.get('version') or ''}".rstrip("/"),
+        }
+        if token:
+            headers["X-Oduflow-Telemetry"] = token
+        req = Request(
+            _ENDPOINT,
+            data=json.dumps(payload).encode(),
+            headers=headers,
+            method="POST",
+        )
+        with urlopen(req, timeout=_TIMEOUT) as resp:
+            logger.info(
+                "Agent feedback sent (category=%s, status=%s)",
+                payload.get("category"),
+                resp.status,
+            )
+    except Exception as exc:
+        logger.info(
+            "Agent feedback delivery failed (category=%s): %s",
+            payload.get("category"),
+            type(exc).__name__,
+        )
+
+
+def send(payload: dict[str, object]) -> None:
+    """Deliver the payload in a daemon thread; never blocks the tool call."""
+    threading.Thread(target=_post, args=(payload,), daemon=True).start()
+
+
+# --- Instruction text injected only while the feature is enabled -------------
+
+# One line appended to the MCP server instructions, which every client sees in
+# the initialize handshake — agents that never re-read the guide still learn
+# about the tool.
+MCP_HINT = (
+    "When a task is finished, call submit_agent_feedback once if the Oduflow "
+    "tools got in your way or something was missing. Keep it anonymous: no "
+    "names, paths, hosts, repos or business details."
+)
+
+INSTRUCTIONS_SECTION = """
+---
+
+## Session Feedback (after the task is done)
+
+When a task reaches its end, call `submit_agent_feedback` **once** — but only
+if you actually have something to report about the Oduflow MCP tools
+themselves: friction you hit, an error message that did not tell you what went
+wrong, a workflow that took more calls than it should, or a tool you wished
+existed. Skip the call when the session was uneventful; silence is a valid
+result.
+
+Arguments:
+
+- `category` — one of `friction`, `missing_tool`, `unclear_error`, `docs`.
+- `tools` — the Oduflow tool names involved, comma-separated (e.g.
+  `pull_and_apply, get_environment_logs`).
+- `suggestion` — one short English paragraph: what happened and what would
+  have helped.
+
+**This report leaves the machine, so it must be anonymous.** Write about the
+tools, never about the work. Do not include branch, environment, database,
+module, company or people names, repository URLs, hostnames, IP addresses,
+file paths, credentials, or excerpts of the user's code and data. Describe the
+shape of the problem instead.
+
+- ❌ "pull_and_apply failed for branch feature-invoice-pdf in
+  github.com/acme/addons — the invoice_pdf module of ACME broke"
+- ✅ "pull_and_apply reported a failed upgrade without naming the module that
+  failed; I had to reconstruct it from the traceback"
+
+- ❌ "run_db_query returned 812 rows of customer orders and truncated them"
+- ✅ "run_db_query truncates large result sets with no way to page through
+  them; a limit/offset argument would remove the guesswork"
+""".lstrip()

--- a/src/oduflow/agent_feedback.py
+++ b/src/oduflow/agent_feedback.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import threading
+from collections.abc import Collection
 from urllib.request import Request, urlopen
 
 logger = logging.getLogger("oduflow")
@@ -49,12 +50,22 @@ _PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b"),
     # URL with scheme (incl. git@host:path style already caught by e-mail rule)
     re.compile(r"\b[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE),
+    # absolute POSIX path (/usr/lib/... , /home/max/work/...)
+    re.compile(r"(?<![\w.])/(?:[\w.-]+/)+[\w.-]*"),
+    # relative POSIX path. Require either an explicit ./ or ../ prefix, at
+    # least two separators, or a filename extension so ordinary phrases such
+    # as "limit/offset" keep their meaning.
+    re.compile(
+        r"(?<![\w./-])(?:"
+        r"(?:\.{1,2}/)+(?:[\w.-]+/)*[\w.-]+"
+        r"|(?:[\w.-]+/){2,}[\w.-]+"
+        r"|[\w.-]+/[\w.-]+\.[A-Za-z0-9]{1,10}"
+        r")(?![\w./-])"
+    ),
     # bare hostname with a TLD-ish tail (example.com, srv.company.io:8069)
     re.compile(r"\b(?:[\w-]+\.)+[a-z]{2,}(?::\d+)?\b", re.IGNORECASE),
     # IPv4, optionally with a port
     re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b"),
-    # absolute POSIX path (/usr/lib/... , /home/max/work/...)
-    re.compile(r"(?<![\w.])/(?:[\w.-]+/)+[\w.-]*"),
     # Windows path
     re.compile(r"\b[A-Za-z]:\\[\\\w.-]+"),
     # Odoo databases provisioned by Oduflow
@@ -78,7 +89,12 @@ def scrub(text: str, known_names: tuple[str, ...] = ()) -> str:
         return ""
     cleaned = text
     for name in sorted({n for n in known_names if len(n) >= 3}, key=len, reverse=True):
-        cleaned = re.sub(rf"\b{re.escape(name)}\b", _REDACTED, cleaned)
+        cleaned = re.sub(
+            rf"(?<!\w){re.escape(name)}(?!\w)",
+            _REDACTED,
+            cleaned,
+            flags=re.IGNORECASE,
+        )
     for pattern in _PATTERNS:
         cleaned = pattern.sub(_REDACTED, cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
@@ -87,15 +103,22 @@ def scrub(text: str, known_names: tuple[str, ...] = ()) -> str:
     return cleaned
 
 
-def normalize_tools(tools: str | list[str] | None) -> list[str]:
-    """Parse the reported tool names into a bounded list of bare identifiers."""
+def normalize_tools(
+    tools: str | list[str] | None,
+    allowed_names: Collection[str] | None = None,
+) -> list[str]:
+    """Parse reported tool names into a bounded, optionally closed-set list."""
     if not tools:
         return []
     raw = tools if isinstance(tools, list) else re.split(r"[,\s]+", tools)
     names: list[str] = []
     for item in raw:
         name = re.sub(r"[^\w]", "", str(item))[:MAX_TOOL_NAME_CHARS]
-        if name and name not in names:
+        if (
+            name
+            and (allowed_names is None or name in allowed_names)
+            and name not in names
+        ):
             names.append(name)
     return names[:MAX_TOOLS]
 

--- a/src/oduflow/scoped_access.py
+++ b/src/oduflow/scoped_access.py
@@ -51,6 +51,9 @@ SCOPED_ALLOWLIST = frozenset(
     {
         "get_agent_instructions",
         "get_odoo_development_guide",
+        # Present only while the hidden [server] agent_feedback option is on;
+        # otherwise the tool is disabled and never reaches this allowlist.
+        "submit_agent_feedback",
         "read_output",
         "get_environment_info",
         "get_environment_logs",

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1131,9 +1131,15 @@ def submit_agent_feedback(
     except Exception:
         pass
 
+    # This field is structurally separate from the scrubbed suggestion, so
+    # restrict it to registered MCP names rather than letting arbitrary
+    # identifiers leave the instance under the guise of tool names.
+    registered_tools = set(
+        getattr(getattr(mcp, "_tool_manager", None), "_tools", {}) or {}
+    )
     payload = feedback_mod.build_payload(
         category=normalized,
-        tools=feedback_mod.normalize_tools(tools),
+        tools=feedback_mod.normalize_tools(tools, registered_tools),
         suggestion=feedback_mod.scrub(suggestion, tuple(n for n in known if n)),
         version=_get_version(),
         instance_id=_instance_id,

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1021,22 +1021,32 @@ def get_agent_instructions(ctx: Context | None = None) -> str:
             "---\n\n"
         )
 
+    def _guide_body() -> str:
+        for name in ("agent_instructions.md", "agent_skill.md", "agent_guide.md"):
+            skill_path = os.path.join(team.data_dir, "agent_guides", name)
+            if os.path.isfile(skill_path):
+                with open(skill_path, "r", encoding="utf-8") as f:
+                    return _mode_preface() + f.read()
+        for name in ("agent_instructions.md", "agent_skill.md", "agent_guide.md"):
+            bundled = (
+                pathlib.Path(__file__).resolve().parent
+                / "templates"
+                / "agent_guides"
+                / name
+            )
+            if bundled.is_file():
+                return _mode_preface() + bundled.read_text(encoding="utf-8")
+        return "Agent skill not found."
+
     team = _resolve_team(ctx)
-    for name in ("agent_instructions.md", "agent_skill.md", "agent_guide.md"):
-        skill_path = os.path.join(team.data_dir, "agent_guides", name)
-        if os.path.isfile(skill_path):
-            with open(skill_path, "r", encoding="utf-8") as f:
-                return _mode_preface() + f.read()
-    for name in ("agent_instructions.md", "agent_skill.md", "agent_guide.md"):
-        bundled = (
-            pathlib.Path(__file__).resolve().parent
-            / "templates"
-            / "agent_guides"
-            / name
-        )
-        if bundled.is_file():
-            return _mode_preface() + bundled.read_text(encoding="utf-8")
-    return "Agent skill not found."
+    guide = _guide_body()
+    # The feedback section ships nowhere on disk — it exists only while the
+    # (undocumented) [server] agent_feedback option is on.
+    if _get_settings().agent_feedback:
+        from oduflow import agent_feedback as feedback_mod
+
+        guide = guide.rstrip() + "\n\n" + feedback_mod.INSTRUCTIONS_SECTION
+    return guide
 
 
 @mcp.tool()
@@ -1076,6 +1086,63 @@ def get_odoo_development_guide(version: str, ctx: Context | None = None) -> str:
     if available:
         return f"No development guide found for Odoo {version}. Available versions: {', '.join(sorted(available))}"
     return f"No development guide found for Odoo {version}."
+
+
+@mcp.tool(enabled=False)
+@handle_errors
+def submit_agent_feedback(
+    category: str,
+    tools: str,
+    suggestion: str,
+    ctx: Context | None = None,
+) -> str:
+    """
+    Report anonymous feedback about the Oduflow MCP tools once a task is finished.
+
+    Call this at most once per task, and only when the tools themselves caused
+    friction or something was missing. Never include names, paths, hostnames,
+    repositories, credentials or any of the user's business data — the report
+    leaves the machine.
+
+    Args:
+        category: One of "friction", "missing_tool", "unclear_error", "docs".
+        tools: Oduflow tool names involved, comma-separated.
+        suggestion: One short English paragraph — what happened and what would have helped.
+    """
+    from oduflow import agent_feedback as feedback_mod
+
+    normalized = category.strip().lower()
+    if normalized not in feedback_mod.CATEGORIES:
+        raise ToolError(
+            f"category must be one of: {', '.join(feedback_mod.CATEGORIES)}"
+        )
+
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+
+    # Identifiers that look like ordinary words and so cannot be caught by a
+    # generic pattern — redact them by name.
+    known: set[str] = {team.team_id, team.hostname}
+    try:
+        known.update(
+            str(env.get("env_name", ""))
+            for env in env_ops.list_environments(settings, team)
+        )
+    except Exception:
+        pass
+
+    payload = feedback_mod.build_payload(
+        category=normalized,
+        tools=feedback_mod.normalize_tools(tools),
+        suggestion=feedback_mod.scrub(suggestion, tuple(n for n in known if n)),
+        version=_get_version(),
+        instance_id=_instance_id,
+    )
+    if not payload["suggestion"]:
+        raise ToolError("suggestion is required")
+
+    feedback_mod.send(payload)
+    return "Feedback submitted anonymously. Thanks."
 
 
 # =============================================================================
@@ -4208,10 +4275,28 @@ def delete_production(
 # =============================================================================
 
 
+def _apply_agent_feedback(settings: Settings) -> None:
+    """Expose ``submit_agent_feedback`` only while the hidden option is on.
+
+    Registered disabled, so by default the tool is absent from ``list_tools``
+    and calling it answers "Unknown tool". Enabling also appends a one-liner to
+    the MCP instructions every client receives in the initialize handshake.
+    """
+    if not settings.agent_feedback:
+        return
+    from oduflow import agent_feedback as feedback_mod
+
+    submit_agent_feedback.enable()
+    if feedback_mod.MCP_HINT not in (mcp.instructions or ""):
+        mcp.instructions = f"{mcp.instructions}\n\n{feedback_mod.MCP_HINT}".strip()
+    logger.info("Agent feedback enabled (submit_agent_feedback exposed)")
+
+
 def _ensure_initialized(settings: Settings) -> None:
     """Ensure shared infrastructure and per-team directories exist (idempotent)."""
     from oduflow import prereqs
 
+    _apply_agent_feedback(settings)
     _copy_bundled_configs()
     prereqs.ensure_fuse_overlayfs()
     system_ops.init_system(settings)

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -185,6 +185,11 @@ class Settings:
     port: int = 8000
     trace: bool = False
     disable_telemetry: bool = False
+    # Undocumented, off by default: lets the coding agents working against this
+    # instance report friction with the Oduflow MCP tools themselves. While
+    # off, the submit_agent_feedback tool is not even listed. See
+    # oduflow.agent_feedback.
+    agent_feedback: bool = False
     allow_local_path: bool = True
     # Allow starting the HTTP transport with no MCP authentication. Off by
     # default so /mcp is never served unauthenticated by accident (#37); set
@@ -577,6 +582,7 @@ class Settings:
             port=int(server.get("port", 8000)),
             trace=trace,
             disable_telemetry=bool(server.get("disable_telemetry", False)),
+            agent_feedback=bool(server.get("agent_feedback", False)),
             allow_local_path=bool(server.get("allow_local_path", True)),
             allow_insecure_http=bool(server.get("allow_insecure_http", False)),
             routing_mode=routing_mode,

--- a/src/oduflow/telemetry.py
+++ b/src/oduflow/telemetry.py
@@ -12,7 +12,10 @@ _ENDPOINT = "https://oduflow.dev/usage"
 _TIMEOUT = 5
 # Optional shared marker. Must match the server's USAGE_TELEMETRY_TOKEN. Only a
 # speed bump against random scanners — this code is open source. Empty = disabled.
-_TELEMETRY_TOKEN = "5ae286c3f9a162c178577659db75f78259b01942f12ec357929f73e0a222c707"
+# Shared with oduflow.agent_feedback, which posts to the same origin behind the
+# same header.
+SHARED_TOKEN = "5ae286c3f9a162c178577659db75f78259b01942f12ec357929f73e0a222c707"
+_TELEMETRY_TOKEN = SHARED_TOKEN
 
 
 def _get_instance_id(etc_dir: str) -> tuple[str, bool]:

--- a/tests/test_agent_feedback.py
+++ b/tests/test_agent_feedback.py
@@ -1,0 +1,223 @@
+"""Unit tests for the hidden agent-feedback channel."""
+
+import asyncio
+
+import pytest
+from fastmcp import Client
+
+from tool_helpers import call_tool
+
+from oduflow import agent_feedback, server
+from oduflow.settings import Settings, TeamSettings
+
+
+class TestScrub:
+    def test_email(self):
+        assert "@" not in agent_feedback.scrub("ping max@acme.example for details")
+
+    def test_url(self):
+        out = agent_feedback.scrub("cloned https://github.com/acme/addons.git")
+        assert "github" not in out and "acme" not in out
+
+    def test_bare_host(self):
+        out = agent_feedback.scrub("failed against odoo.acme.example:8069")
+        assert "acme" not in out
+
+    def test_ipv4(self):
+        assert "10.0.0.7" not in agent_feedback.scrub("connect 10.0.0.7:5432 refused")
+
+    def test_absolute_path(self):
+        out = agent_feedback.scrub("wrote /home/max/work/addons/sale_ext/models.py")
+        assert "/home" not in out and "sale_ext" not in out
+
+    def test_windows_path(self):
+        assert "Users" not in agent_feedback.scrub(r"read C:\Users\max\addons")
+
+    def test_database_name(self):
+        assert "oduflow_feature" not in agent_feedback.scrub("psql oduflow_feature_x")
+
+    def test_long_token(self):
+        secret = "a" * 40
+        assert secret not in agent_feedback.scrub(f"token {secret} rejected")
+
+    def test_hex_token(self):
+        secret = "5ae286c3f9a162c178577659db75f782"
+        assert secret not in agent_feedback.scrub(f"header {secret} was ignored")
+
+    def test_long_tool_names_survive(self):
+        # The whole point of the channel: long snake_case tool names are not
+        # secrets and must reach the report intact.
+        text = (
+            "get_environment_logs and set_production_backup_schedule return "
+            "output that install_odoo_modules does not"
+        )
+        assert agent_feedback.scrub(text) == text
+
+    def test_known_names(self):
+        out = agent_feedback.scrub(
+            "environment payments broke", known_names=("payments",)
+        )
+        assert "payments" not in out
+
+    def test_short_known_names_ignored(self):
+        # A two-letter name would shred ordinary prose; leave it alone.
+        out = agent_feedback.scrub("it is an ok result", known_names=("ok",))
+        assert "ok" in out
+
+    def test_keeps_the_actual_point(self):
+        out = agent_feedback.scrub(
+            "pull_and_apply did not name the module that failed to upgrade"
+        )
+        assert out == "pull_and_apply did not name the module that failed to upgrade"
+
+    def test_length_cap(self):
+        out = agent_feedback.scrub("word " * 2000)
+        assert len(out) <= agent_feedback.MAX_SUGGESTION_CHARS + 1
+
+    def test_empty(self):
+        assert agent_feedback.scrub("") == ""
+
+
+class TestNormalizeTools:
+    def test_comma_separated(self):
+        assert agent_feedback.normalize_tools("pull_and_apply, run_odoo_tests") == [
+            "pull_and_apply",
+            "run_odoo_tests",
+        ]
+
+    def test_list_input(self):
+        assert agent_feedback.normalize_tools(["read_output"]) == ["read_output"]
+
+    def test_dedupes_and_caps(self):
+        assert agent_feedback.normalize_tools("a_tool, a_tool") == ["a_tool"]
+        many = ", ".join(f"tool_{i}" for i in range(50))
+        assert len(agent_feedback.normalize_tools(many)) == agent_feedback.MAX_TOOLS
+
+    def test_strips_punctuation(self):
+        assert agent_feedback.normalize_tools("`pull_and_apply()`") == [
+            "pull_and_apply"
+        ]
+
+    def test_empty(self):
+        assert agent_feedback.normalize_tools("") == []
+
+
+class TestPayload:
+    def test_contains_only_expected_fields(self):
+        payload = agent_feedback.build_payload(
+            category="friction",
+            tools=["pull_and_apply"],
+            suggestion="error text is vague",
+            version="1.68.0",
+            instance_id="abc",
+        )
+        assert set(payload) == {
+            "category",
+            "tools",
+            "suggestion",
+            "version",
+            "instance_id",
+        }
+
+
+class TestSettings:
+    def test_off_by_default(self):
+        assert Settings().agent_feedback is False
+
+    def test_read_from_toml(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text("[server]\nagent_feedback = true\n\n[team.1]\nname = 'Team'\n")
+        assert Settings.from_toml(str(toml)).agent_feedback is True
+
+
+@pytest.fixture
+def feedback_enabled(monkeypatch):
+    """Enable the tool for one test and always put it back."""
+    original_instructions = server.mcp.instructions
+    server._apply_agent_feedback(Settings(agent_feedback=True))
+    yield
+    server.submit_agent_feedback.disable()
+    server.mcp.instructions = original_instructions
+
+
+def _tool_names() -> list[str]:
+    async def go():
+        async with Client(server.mcp) as client:
+            return [t.name for t in await client.list_tools()]
+
+    return asyncio.run(go())
+
+
+class TestExposure:
+    def test_hidden_by_default(self):
+        assert "submit_agent_feedback" not in _tool_names()
+
+    def test_disabled_toggle_is_a_noop(self):
+        server._apply_agent_feedback(Settings(agent_feedback=False))
+        assert "submit_agent_feedback" not in _tool_names()
+        assert agent_feedback.MCP_HINT not in (server.mcp.instructions or "")
+
+    def test_exposed_when_enabled(self, feedback_enabled):
+        assert "submit_agent_feedback" in _tool_names()
+        assert agent_feedback.MCP_HINT in server.mcp.instructions
+
+    def test_enabling_twice_does_not_duplicate_the_hint(self, feedback_enabled):
+        server._apply_agent_feedback(Settings(agent_feedback=True))
+        assert server.mcp.instructions.count(agent_feedback.MCP_HINT) == 1
+
+
+def _patch_instance(monkeypatch, settings: Settings, envs: list[dict] | None = None):
+    team = TeamSettings(team_id="1", hostname="odoo.acme.example")
+    monkeypatch.setattr(server, "_get_settings", lambda: settings)
+    monkeypatch.setattr(server, "_resolve_team", lambda ctx: team)
+    monkeypatch.setattr(server.env_ops, "list_environments", lambda *a, **k: envs or [])
+
+
+class TestGuideSection:
+    def test_absent_by_default(self, monkeypatch):
+        _patch_instance(monkeypatch, Settings())
+        assert "Session Feedback" not in call_tool("get_agent_instructions", ctx=None)
+
+    def test_appended_when_enabled(self, monkeypatch):
+        _patch_instance(monkeypatch, Settings(agent_feedback=True))
+        guide = call_tool("get_agent_instructions", ctx=None)
+        assert "Session Feedback" in guide
+        assert "submit_agent_feedback" in guide
+
+
+class TestSubmitTool:
+    def _call(self, monkeypatch, **kwargs):
+        sent: list[dict] = []
+        _patch_instance(
+            monkeypatch, Settings(agent_feedback=True), [{"env_name": "acme-crm"}]
+        )
+        monkeypatch.setattr(
+            agent_feedback, "send", lambda payload: sent.append(payload)
+        )
+        result = call_tool("submit_agent_feedback", **kwargs)
+        return result, sent
+
+    def test_scrubs_before_sending(self, monkeypatch):
+        _, sent = self._call(
+            monkeypatch,
+            category="friction",
+            tools="pull_and_apply",
+            suggestion=(
+                "env acme-crm on https://git.acme.example failed and the error "
+                "did not name the module"
+            ),
+        )
+        assert len(sent) == 1
+        text = sent[0]["suggestion"]
+        assert "acme" not in text
+        assert "did not name the module" in text
+        assert sent[0]["tools"] == ["pull_and_apply"]
+        assert sent[0]["category"] == "friction"
+
+    def test_rejects_unknown_category(self, monkeypatch):
+        with pytest.raises(Exception, match="category must be one of"):
+            self._call(monkeypatch, category="praise", tools="", suggestion="all good")
+
+    def test_rejects_empty_suggestion(self, monkeypatch):
+        with pytest.raises(Exception, match="suggestion is required"):
+            self._call(monkeypatch, category="docs", tools="", suggestion="   ")

--- a/tests/test_agent_feedback.py
+++ b/tests/test_agent_feedback.py
@@ -4,7 +4,6 @@ import asyncio
 
 import pytest
 from fastmcp import Client
-
 from tool_helpers import call_tool
 
 from oduflow import agent_feedback, server
@@ -29,6 +28,15 @@ class TestScrub:
     def test_absolute_path(self):
         out = agent_feedback.scrub("wrote /home/max/work/addons/sale_ext/models.py")
         assert "/home" not in out and "sale_ext" not in out
+
+    def test_relative_path(self):
+        out = agent_feedback.scrub("read addons/acme_secret/models/invoice.py")
+        assert "addons" not in out and "acme_secret" not in out
+
+    def test_slash_separated_terms_are_not_paths(self):
+        assert agent_feedback.scrub("add limit/offset arguments") == (
+            "add limit/offset arguments"
+        )
 
     def test_windows_path(self):
         assert "Users" not in agent_feedback.scrub(r"read C:\Users\max\addons")
@@ -58,6 +66,12 @@ class TestScrub:
             "environment payments broke", known_names=("payments",)
         )
         assert "payments" not in out
+
+    def test_known_names_are_case_insensitive(self):
+        out = agent_feedback.scrub(
+            "environment Payments broke", known_names=("payments",)
+        )
+        assert "payments" not in out.lower()
 
     def test_short_known_names_ignored(self):
         # A two-letter name would shred ordinary prose; leave it alone.
@@ -97,6 +111,12 @@ class TestNormalizeTools:
         assert agent_feedback.normalize_tools("`pull_and_apply()`") == [
             "pull_and_apply"
         ]
+
+    def test_filters_names_outside_the_allowed_set(self):
+        assert agent_feedback.normalize_tools(
+            "pull_and_apply, acme_customer_database",
+            {"pull_and_apply", "run_odoo_tests"},
+        ) == ["pull_and_apply"]
 
     def test_empty(self):
         assert agent_feedback.normalize_tools("") == []
@@ -213,6 +233,15 @@ class TestSubmitTool:
         assert "did not name the module" in text
         assert sent[0]["tools"] == ["pull_and_apply"]
         assert sent[0]["category"] == "friction"
+
+    def test_drops_unregistered_tool_identifiers(self, monkeypatch):
+        _, sent = self._call(
+            monkeypatch,
+            category="friction",
+            tools="pull_and_apply, acme_customer_database",
+            suggestion="the workflow took too many calls",
+        )
+        assert sent[0]["tools"] == ["pull_and_apply"]
 
     def test_rejects_unknown_category(self, monkeypatch):
         with pytest.raises(Exception, match="category must be one of"):

--- a/tests/test_documentation_sync.py
+++ b/tests/test_documentation_sync.py
@@ -13,6 +13,12 @@ from scripts.build_llms_full import SOURCES
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
 
+# This opt-in feedback channel is intentionally absent from public docs. Keep
+# the exceptions exact so every other MCP tool and setting remains covered by
+# the central references.
+HIDDEN_MCP_TOOLS = {"submit_agent_feedback"}
+HIDDEN_SETTINGS = {"[server].agent_feedback"}
+
 
 def _tree(relative_path: str) -> ast.Module:
     return ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
@@ -35,7 +41,9 @@ def test_every_mcp_tool_is_in_the_central_reference():
     }
     reference = (DOCS / "mcp-tools.md").read_text(encoding="utf-8")
 
-    missing = sorted(tool for tool in tools if f"`{tool}`" not in reference)
+    missing = sorted(
+        tool for tool in tools - HIDDEN_MCP_TOOLS if f"`{tool}`" not in reference
+    )
     assert not missing, f"MCP tools missing from docs/mcp-tools.md: {missing}"
 
 
@@ -129,8 +137,9 @@ def test_every_toml_setting_is_in_the_installation_reference():
     for section, receivers in sections.items():
         function = parse_backup if section == "backup" else from_toml
         for key in _get_keys(function, receivers):
-            if f"`[{section}].{key}`" not in reference:
-                missing.append(f"[{section}].{key}")
+            qualified = f"[{section}].{key}"
+            if qualified not in HIDDEN_SETTINGS and f"`{qualified}`" not in reference:
+                missing.append(qualified)
 
     team_keys = _get_keys(from_toml, {"team_cfg"})
     for key in team_keys:


### PR DESCRIPTION
## Summary

- add an opt-in, hidden MCP tool for anonymous agent feedback
- inject feedback guidance only when the feature is enabled
- scrub hosts, addresses, absolute and relative paths, tokens, and instance-specific names
- restrict the tool-name field to registered Oduflow MCP tools
- keep the deliberately hidden tool and setting out of public documentation while preserving documentation-sync coverage for every other interface

## Why

Coding agents encounter Oduflow's MCP surface directly and can identify friction, missing capabilities, and unclear errors. This provides an operator-controlled channel for that feedback without exposing business context or changing the default tool surface.

The review follow-up closes privacy gaps in relative-path, capitalization, and arbitrary tool-name handling, and restores all repository lint and documentation-contract checks.

## Validation

- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow tests`
- `mypy src/oduflow`
- `pytest -q -m "not integration and not heavyweight"` — 1485 passed, 15 deselected