### PR TITLE
Keep dashboard responsive during long requests

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1774,6 +1774,10 @@
         <label for="new-tpl-name">Template name</label>
         <input type="text" id="new-tpl-name" placeholder="new template name">
         <div class="hint">Saves this environment's database and filestore as a new template. Refused if a template with this name already exists.</div>
+        <div class="hint" id="new-tpl-progress" role="status" aria-live="polite" style="display:none">
+          <span>Saving database and filestore…</span>
+          <span id="new-tpl-elapsed" aria-hidden="true"></span>
+        </div>
       </div>
       <div class="form-actions">
         <button class="btn" onclick="closeNewTemplateModal()">Cancel</button>
@@ -2349,7 +2353,7 @@ async function refreshStorage(branch) {
   applyStats();
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/storage/refresh', { method: 'POST' });
-    const data = await r.json();
+    const data = await readResult(r);
     if (data.ok) {
       envStorageMap[branch] = data.storage;
     } else {
@@ -2587,7 +2591,7 @@ async function _runBulk(branches, action, opLabel, doneLabel) {
   var results = await Promise.all(branches.map(async function(b) {
     try {
       var r = await fetch(API + '/' + encodeURIComponent(b) + '/' + action, { method: 'POST' });
-      var data = await r.json();
+      var data = await readResult(r);
       return { branch: b, ok: !!data.ok, error: data.error };
     } catch (e) {
       return { branch: b, ok: false, error: e.message };
@@ -2670,6 +2674,10 @@ function escAttr(s) {
     .replace(/>/g, '&gt;');
 }
 
+function isAmbiguousGatewayStatus(status) {
+  return [408, 502, 503, 504, 524].indexOf(status) !== -1;
+}
+
 // Reads a fetch Response without throwing on an empty / non-JSON body.
 // Always returns a {ok, error, ...} object. A non-2xx response whose body
 // isn't JSON (e.g. a reverse-proxy timeout page on a long request) yields a
@@ -2681,6 +2689,13 @@ async function readResult(r) {
   try { text = await r.text(); } catch (e) { text = ''; }
   try { return JSON.parse(text); }
   catch (e) {
+    if (isAmbiguousGatewayStatus(r.status)) {
+      return {
+        ok: false,
+        error: 'The request timed out at the proxy (HTTP ' + r.status +
+          '). The operation may still be running on the server; refresh in a moment.'
+      };
+    }
     return {
       ok: false,
       error: (text && text.trim())
@@ -2757,7 +2772,7 @@ async function _putNote(branch, note, okMsg) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({note: note})
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) { showToast(okMsg); closeNoteModal(); }
     else { showToast(data.error || 'Failed to update note', true); }
   } catch(e) { showToast('Connection error: ' + e.message, true); }
@@ -2787,7 +2802,7 @@ async function openMcpAccess(branch) {
   showModal('mcp-access-modal');
   try {
     var r = await fetch(API + '/' + encodeURIComponent(branch) + '/mcp-access');
-    var data = await r.json();
+    var data = await readResult(r);
     if (!data.ok) { showToast(data.error || 'Failed to load MCP access', true); return; }
     document.getElementById('mcp-access-url').value = data.result.url || '';
     if (data.result.token) {
@@ -2873,7 +2888,7 @@ async function openConnect(branch) {
   showModal('connect-modal');
   try {
     var r = await fetch(API + '/' + encodeURIComponent(branch) + '/users');
-    var data = await r.json();
+    var data = await readResult(r);
     if (!data.ok) {
       fillConnectSelects([], data.error || 'Failed to load users');
     } else {
@@ -2908,7 +2923,7 @@ function submitConnect() {
 async function loadEnvironments(force) {
   try {
     const r = await fetch(API);
-    const data = await r.json();
+    const data = await readResult(r);
     if (data.ok) {
       cachedEnvs = data.environments || [];
       renderEnvironments(cachedEnvs, force);
@@ -2923,7 +2938,7 @@ async function loadEnvironments(force) {
 async function loadStats() {
   try {
     const r = await fetch('/api/stats');
-    const data = await r.json();
+    const data = await readResult(r);
     if (!data.ok) return;
 
     containerStatsMap = {};
@@ -2953,7 +2968,7 @@ async function doUpdate(branch) {
   setBusy(branch, 'Updating');
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/update', { method: 'POST' });
-    const data = await r.json();
+    const data = await readResult(r);
     if (data.ok) {
       showToast(branch + ': updated');
     } else {
@@ -2976,7 +2991,7 @@ async function doRecreate(branch) {
   setBusy(branch, 'Recreating');
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/recreate', { method: 'POST' });
-    const data = await r.json();
+    const data = await readResult(r);
     if (data.ok) {
       showToast(branch + ': recreated');
     } else {
@@ -2999,7 +3014,7 @@ async function doDelete(branch) {
   setBusy(branch, 'Deleting');
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/delete', { method: 'POST' });
-    const data = await r.json();
+    const data = await readResult(r);
     if (data.ok) {
       showToast(branch + ': deleted');
     } else {
@@ -3021,7 +3036,7 @@ async function doProtect(branch, isProtected) {
   }))) return;
   try {
     var r = await fetch(API + '/' + encodeURIComponent(branch) + '/' + action, { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast(branch + ': ' + (isProtected ? 'unprotected' : 'protected'));
     } else {
@@ -3075,7 +3090,7 @@ async function fetchLogs() {
       if (cont) url += '&container=' + encodeURIComponent(cont);
     }
     var r = await fetch(url);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       _logsState.lines = (data.logs || '').split('\n');
       renderLogs();
@@ -3205,7 +3220,7 @@ function switchTab(name) {
 async function loadTemplates() {
   try {
     var r = await fetch(API_TEMPLATES);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       cachedTemplates = data.templates || [];
       renderTemplates(cachedTemplates);
@@ -3226,7 +3241,7 @@ async function doDeleteTemplate(name) {
   }))) return;
   try {
     var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(name) + '/delete', { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Template "' + name + '" removed');
       await loadTemplates();
@@ -3301,7 +3316,7 @@ async function submitImportOdoo() {
         with_extra_addons: document.getElementById('import-with-extra').checked
       })
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       document.getElementById('import-odoo-command').textContent = data.command;
       document.getElementById('import-odoo-form').style.display = 'none';
@@ -3343,7 +3358,7 @@ async function openTemplateSettingsModal(name) {
 
   try {
     var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(name) + '/metadata');
-    var data = await r.json();
+    var data = await readResult(r);
     if (token !== _templateSettingsLoadToken) return;
     if (data.ok) {
       editor.value = data.content;
@@ -3402,7 +3417,7 @@ async function submitTemplateSettings() {
         revision: revision
       })
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (token !== _templateSettingsLoadToken || name !== _templateSettingsName) return;
     if (data.ok) {
       editor.value = data.content;
@@ -3467,7 +3482,7 @@ async function submitRenameTemplate() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ new_name: newName })
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Template renamed to "' + newName + '"');
       hideModal('rename-tpl-modal');
@@ -3496,6 +3511,8 @@ function doNewTemplate(branch) {
   input.value = '';
   document.getElementById('new-tpl-submit').disabled = false;
   document.getElementById('new-tpl-submit').textContent = 'Create';
+  document.getElementById('new-tpl-progress').style.display = 'none';
+  document.getElementById('new-tpl-elapsed').textContent = '';
   showModal('new-tpl-modal');
   input.focus();
 }
@@ -3506,6 +3523,7 @@ function closeNewTemplateModal(event) {
 }
 
 async function submitNewTemplate() {
+  var branch = _newTplBranch;
   var name = document.getElementById('new-tpl-name').value.trim();
   var errEl = document.getElementById('new-tpl-error');
   if (!name) {
@@ -3515,18 +3533,34 @@ async function submitNewTemplate() {
   }
   errEl.style.display = 'none';
   var btn = document.getElementById('new-tpl-submit');
+  var progress = document.getElementById('new-tpl-progress');
+  var elapsed = document.getElementById('new-tpl-elapsed');
+  var started = Date.now();
   btn.disabled = true;
-  btn.textContent = 'Creating...';
+  btn.textContent = 'Creating…';
+  progress.style.display = 'block';
+  var updateProgress = function() {
+    elapsed.textContent = _fmtElapsed(Date.now() - started);
+  };
+  updateProgress();
+  var progressTimer = setInterval(updateProgress, 1000);
+  setBusy(branch, 'Saving template');
   try {
-    var r = await fetch(API + '/' + encodeURIComponent(_newTplBranch) + '/save-as-template', {
+    var r = await fetch(API + '/' + encodeURIComponent(branch) + '/save-as-template', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ template_name: name })
     });
-    var data = await r.json();
-    if (data.ok) {
-      showToast('Saved "' + _newTplBranch + '" as template "' + name + '"');
+    var data = await readResult(r);
+    if (r.ok && data.ok) {
+      showToast('Saved "' + branch + '" as template "' + name + '"');
       hideModal('new-tpl-modal');
+      await loadTemplates();
+      await loadEnvironments(true);
+    } else if (isAmbiguousGatewayStatus(r.status)) {
+      hideModal('new-tpl-modal');
+      showToast('The proxy stopped waiting, but saving template "' + name +
+        '" may still be running. Refresh in a moment.');
       await loadTemplates();
       await loadEnvironments(true);
     } else {
@@ -3537,6 +3571,9 @@ async function submitNewTemplate() {
     errEl.textContent = 'Connection error: ' + e.message;
     errEl.style.display = 'block';
   } finally {
+    clearInterval(progressTimer);
+    clearBusy(branch);
+    progress.style.display = 'none';
     btn.disabled = false;
     btn.textContent = 'Create';
   }
@@ -3798,7 +3835,7 @@ async function doAction(branch, action) {
 
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/' + action, { method: 'POST' });
-    const data = await r.json();
+    const data = await readResult(r);
     if (data.ok) {
       if (action === 'sync' && data.result) {
         showSyncResult(branch, data.result);
@@ -3841,7 +3878,7 @@ const API_SERVICES = '/api/services';
 async function loadServices() {
   try {
     var r = await fetch(API_SERVICES);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       renderServices(data.services || []);
     } else {
@@ -3995,7 +4032,7 @@ async function doUpdateService(name) {
   if (card) card.querySelectorAll('button').forEach(function(b) { b.disabled = true; });
   try {
     var r = await fetch(API_SERVICES + '/' + encodeURIComponent(name) + '/update', { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       var res = data.result || {};
       var digest = (res.new_digest || '').substring(0, 19);
@@ -4023,7 +4060,7 @@ async function doRestartService(name) {
   if (card) card.querySelectorAll('button').forEach(function(b) { b.disabled = true; });
   try {
     var r = await fetch(API_SERVICES + '/' + encodeURIComponent(name) + '/restart', { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Service "' + name + '" restarted');
     } else {
@@ -4046,7 +4083,7 @@ async function doDeleteService(name) {
   if (card) card.querySelectorAll('button').forEach(function(b) { b.disabled = true; });
   try {
     var r = await fetch(API_SERVICES + '/' + encodeURIComponent(name) + '/delete', { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Service "' + name + '" deleted');
     } else {
@@ -4136,7 +4173,7 @@ async function submitCreateService() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       closeCreateServiceModal();
       showToast('Service "' + name + '" created');
@@ -4161,7 +4198,7 @@ var _cachedPresets = [];
 async function loadServicePresets() {
   try {
     var r = await fetch(API_PRESETS);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       _cachedPresets = data.presets || [];
       renderPresetsList(_cachedPresets);
@@ -4219,7 +4256,7 @@ async function doDeletePreset(name) {
   }))) return;
   try {
     var r = await fetch(API_PRESETS + '/' + encodeURIComponent(name) + '/delete', { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Preset "' + name + '" deleted');
       await loadServicePresets();
@@ -4275,7 +4312,7 @@ function openRestoreServiceModal(preselect) {
   sel.innerHTML = '<option value="">Loading...</option>';
   showModal('restore-svc-modal');
 
-  fetch(API_PRESETS).then(function(r) { return r.json(); }).then(function(data) {
+  fetch(API_PRESETS).then(function(r) { return readResult(r); }).then(function(data) {
     if (data.ok && data.presets && data.presets.length > 0) {
       sel.innerHTML = '<option value="">— select a preset —</option>' +
         data.presets.map(function(p) {
@@ -4340,7 +4377,7 @@ async function submitRestoreService() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       closeRestoreServiceModal();
       showToast('Service "' + name + '" restored');
@@ -4372,7 +4409,7 @@ const API_VOLUMES = '/api/volumes';
 async function loadVolumes() {
   try {
     var r = await fetch(API_VOLUMES);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       renderVolumes(data.volumes || []);
     } else {
@@ -4460,7 +4497,7 @@ async function submitCreateVolume() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       closeCreateVolumeModal();
       showToast('Volume "' + name + '" created');
@@ -4487,7 +4524,7 @@ async function doDeleteVolume(name) {
   }))) return;
   try {
     var r = await fetch(API_VOLUMES + '/' + encodeURIComponent(name) + '/delete', { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Volume "' + name + '" deleted');
       await loadVolumes();
@@ -4505,7 +4542,7 @@ const API_GUIDES = '/api/agent-guides';
 async function loadAgentGuides() {
   try {
     var r = await fetch(API_GUIDES);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       renderAgentGuides(data.guides || []);
     } else {
@@ -4537,7 +4574,7 @@ async function openGuide(filename, title) {
   document.getElementById('guide-editor').value = 'Loading...';
   try {
     var r = await fetch(API_GUIDES + '/' + encodeURIComponent(filename));
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       document.getElementById('guide-editor').value = data.content || '';
     } else {
@@ -4559,7 +4596,7 @@ const API_LICENSE = '/api/license';
 async function loadLicense() {
   try {
     var r = await fetch(API_LICENSE);
-    var data = await r.json();
+    var data = await readResult(r);
     if (!data.ok) return;
     var lic = data.license;
     var badge = document.getElementById('license-badge');
@@ -4646,7 +4683,7 @@ async function activateLicense() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({ key: key })
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       closeLicenseModal();
       showToast('License activated: ' + data.license.label);
@@ -4670,7 +4707,7 @@ let cachedExtraRepos = [];
 async function loadExtraRepos() {
   try {
     var r = await fetch(API_EXTRA_REPOS);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       cachedExtraRepos = data.repos || [];
       renderExtraRepos(cachedExtraRepos);
@@ -4756,7 +4793,7 @@ async function submitAddExtraRepo() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({name: name, repo_url: url, git_user: gitUser})
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       closeAddExtraRepoModal();
       showToast('Extra repo "' + name + '" cloned');
@@ -4779,7 +4816,7 @@ async function doPullExtraRepo(name, btn) {
   btn.textContent = 'Updating...';
   try {
     var r = await fetch(API_EXTRA_REPOS + '/' + encodeURIComponent(name) + '/pull', {method:'POST'});
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showExtraRepoUpdateResult(name, data.result);
       await loadExtraRepos();
@@ -4835,7 +4872,7 @@ async function doProtectExtraRepo(name, isProtected) {
   }))) return;
   try {
     var r = await fetch(API_EXTRA_REPOS + '/' + encodeURIComponent(name) + '/' + action, { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast(name + ': ' + (isProtected ? 'unprotected' : 'protected'));
     } else {
@@ -4856,7 +4893,7 @@ async function doDeleteExtraRepo(name) {
   }))) return;
   try {
     var r = await fetch(API_EXTRA_REPOS + '/' + encodeURIComponent(name) + '/delete', {method:'POST'});
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Extra repo "' + name + '" deleted');
       await loadExtraRepos();
@@ -4879,7 +4916,7 @@ window.ODU_AGENT_DEFAULT = 'claude';
 async function refreshAgentInfo() {
   try {
     var r = await fetch('/api/agent');
-    var data = await r.json();
+    var data = await readResult(r);
     if (!data.ok) return;
     var enabled = !!data.enabled;
     var changed = enabled !== window.ODU_AGENT_ENABLED;
@@ -4899,7 +4936,7 @@ let cachedCredentials = [];
 async function loadCredentials() {
   try {
     var r = await fetch(API_CREDENTIALS);
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       cachedCredentials = data.credentials || [];
       renderCredentials(data.credentials || []);
@@ -4970,7 +5007,7 @@ async function submitAddCredential() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({repo_url: url})
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       closeAddCredentialModal();
       showToast('Credential saved and verified');
@@ -5001,7 +5038,7 @@ async function doDeleteCredential(host, username) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({host: host, username: username})
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) {
       showToast('Credential deleted');
       await loadCredentials();
@@ -5026,7 +5063,7 @@ async function doValidateCredential(host, username) {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({host: host, username: username})
     });
-    var data = await r.json();
+    var data = await readResult(r);
     if (badge) {
       if (data.ok && data.status === 'valid') {
         badge.textContent = '✓ Valid';
@@ -5507,7 +5544,7 @@ function prodBadgeClass(status) {
 async function loadProductions() {
   try {
     var r = await fetch(API_PRODUCTIONS);
-    var data = await r.json();
+    var data = await readResult(r);
     if (!data.ok) { showToast(data.error || 'Failed to load productions', true); return; }
     cachedProds = data.productions || [];
     window._prodBackupConfigured = !!data.backup_configured;
@@ -5608,13 +5645,13 @@ async function _loadProdSection(name, section) {
   try {
     if (section === 'logs') {
       var r = await fetch(API_PRODUCTIONS + '/' + encodeURIComponent(name) + '/logs?lines=200');
-      var data = await r.json();
+      var data = await readResult(r);
       el.innerHTML = data.ok
         ? '<div class="prod-logs-pre">' + esc(data.logs || '(no output)') + '</div>'
         : esc(data.error || 'Failed to load logs');
     } else if (section === 'deploys') {
       var r2 = await fetch(API_PRODUCTIONS + '/' + encodeURIComponent(name) + '/deploys');
-      var d2 = await r2.json();
+      var d2 = await readResult(r2);
       if (!d2.ok) { el.textContent = d2.error || 'Failed to load deploys'; return; }
       var rows = (d2.deploys || []).slice().reverse().map(function(d) {
         return '<tr><td class="prod-mono">' + esc((d.ts_end || d.ts_start || '').slice(0, 19)) + '</td>' +
@@ -5628,7 +5665,7 @@ async function _loadProdSection(name, section) {
         : 'No deploys recorded yet.';
     } else if (section === 'snapshots') {
       var r3 = await fetch(API_PRODUCTIONS + '/' + encodeURIComponent(name) + '/snapshots');
-      var d3 = await r3.json();
+      var d3 = await readResult(r3);
       if (!d3.ok) { el.textContent = d3.error || 'Failed to load snapshots'; return; }
       var rows3 = (d3.snapshots || []).slice().reverse().map(function(s) {
         return '<tr><td class="prod-mono">' + esc(s.id) + '</td>' +
@@ -5660,7 +5697,7 @@ async function _prodPost(url, body, okMsg) {
     var r = await fetch(url, body !== undefined
       ? { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
       : { method: 'POST' });
-    var data = await r.json();
+    var data = await readResult(r);
     if (data.ok) { if (okMsg) showToast(okMsg); await loadProductions(); return data; }
     showToast(data.error || 'Request failed', true);
   } catch (e) {
@@ -5819,7 +5856,7 @@ async function submitCreateProduction() {
 async function loadHealth() {
   try {
     var r = await fetch('/healthz');
-    var data = await r.json();
+    var data = await readResult(r);
     var el = document.getElementById('health-chips');
     if (!el || !data.checks) return;
     var labels = {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -21,6 +21,7 @@ from urllib.parse import quote, urlsplit
 
 from itsdangerous import BadData, URLSafeTimedSerializer
 from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import Headers
 from starlette.exceptions import HTTPException
 from starlette.requests import ClientDisconnect, HTTPConnection, Request
@@ -355,6 +356,11 @@ def _error_response(e: FlowError) -> JSONResponse:
     return JSONResponse({"ok": False, "error": str(e)}, status_code=status)
 
 
+async def _offload(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """Run blocking dashboard work without stalling the ASGI event loop."""
+    return await run_in_threadpool(func, *args, **kwargs)
+
+
 def _normalize_extra_addons(raw_addons: object) -> dict[str, str]:
     if isinstance(raw_addons, dict):
         return raw_addons
@@ -596,12 +602,27 @@ class _LoginRateLimiter:
             self._failures.pop(key, None)
 
 
+class _ImportStagingLocks:
+    """Serialize finalizers that mutate one template import staging tree."""
+
+    def __init__(self) -> None:
+        self._locks: dict[str, threading.Lock] = {}
+        self._map_lock = threading.Lock()
+
+    def for_path(self, staging: str) -> threading.Lock:
+        with self._map_lock:
+            if staging not in self._locks:
+                self._locks[staging] = threading.Lock()
+            return self._locks[staging]
+
+
 def _build_routes(
     get_settings: Callable[[], Settings],
     locks: LockManager,
 ) -> list[BaseRoute]:
     # Per-app so test apps and real deployments don't share failure counters.
     login_limiter = _LoginRateLimiter()
+    import_staging_locks = _ImportStagingLocks()
 
     def _set_session_cookie(
         response: Response, team: TeamSettings, request: Request
@@ -858,7 +879,8 @@ def _build_routes(
         try:
             settings = get_settings()
             activity.touch(team, branch)
-            result = env_ops.update_environment(
+            result = await _offload(
+                env_ops.update_environment,
                 settings,
                 team,
                 branch,
@@ -967,8 +989,12 @@ def _build_routes(
             # No overwrite from the UI: publishing over an existing template is a
             # deliberate re-baseline reserved for the MCP tool, so a duplicate name
             # here raises ConflictError (surfaced to the client by _error_response).
-            result = system_ops.publish_env_as_template(
-                get_settings(), team, branch, template_name=template_name
+            result = await _offload(
+                system_ops.publish_env_as_template,
+                get_settings(),
+                team,
+                branch,
+                template_name=template_name,
             )
             return JSONResponse(
                 {
@@ -1112,7 +1138,8 @@ def _build_routes(
                 if auto_install_raw
                 else []
             )
-            result = env_ops.create_environment(
+            result = await _offload(
+                env_ops.create_environment,
                 settings,
                 team,
                 env_name,
@@ -1307,7 +1334,9 @@ def _build_routes(
         except BusyError as e:
             return _error_response(e)
         try:
-            result = system_ops.rename_template(get_settings(), team, name, new_name)
+            result = await _offload(
+                system_ops.rename_template, get_settings(), team, name, new_name
+            )
             return JSONResponse({"ok": True, "result": result})
         except ValueError as e:  # invalid template name
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
@@ -1713,15 +1742,24 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         fs_dir = os.path.join(staging, "filestore")
         os.makedirs(staging, exist_ok=True)
-        tmp_tar = os.path.join(staging, f".chunk_{chunk}.tar")
+        fd, tmp_tar = tempfile.mkstemp(
+            dir=staging, prefix=f".chunk_{chunk}_", suffix=".tar"
+        )
         try:
-            with open(tmp_tar, "wb") as f:
+            with os.fdopen(fd, "wb") as f:
                 async for data in request.stream():
                     f.write(data)
+
             # Atomic: the chunk dir appears in staging only after the whole tar
             # extracted, so a truncated upload is never mistaken for a complete
             # chunk on resume.
-            system_ops.extract_filestore_chunk(tmp_tar, fs_dir, chunk)
+            def _finish_filestore_chunk() -> None:
+                with import_staging_locks.for_path(staging):
+                    if os.path.isdir(os.path.join(fs_dir, chunk)):
+                        return
+                    system_ops.extract_filestore_chunk(tmp_tar, fs_dir, chunk)
+
+            await _offload(_finish_filestore_chunk)
         except Exception:
             logger.exception(
                 "Failed to receive filestore chunk %s for %s", chunk, template_name
@@ -1760,8 +1798,16 @@ def _build_routes(
             except (OSError, ValueError):
                 entries = []
         entries.append(entry)
-        with open(path, "w") as f:
-            json.dump(entries, f, indent=2)
+        fd, staged_path = tempfile.mkstemp(
+            dir=staging, prefix=".addons_", suffix=".json"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(entries, f, indent=2)
+            os.replace(staged_path, path)
+        finally:
+            if os.path.exists(staged_path):
+                os.remove(staged_path)
 
     async def api_import_addon(request: Request) -> JSONResponse:
         """Receive one addon directory (tar stream) that becomes a local
@@ -1786,24 +1832,25 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         addons_dir = os.path.join(staging, "addons")
         os.makedirs(staging, exist_ok=True)
-        final_tar = os.path.join(staging, f".addon_{name}.tar")
-        part = f"{final_tar}.part"
+        part = os.path.join(staging, f".addon_{name}.tar.part")
 
-        def _finish() -> None:
+        def _finish(final_tar: str) -> None:
             """Extract the assembled tar and record the addon; clean up."""
             try:
-                system_ops.extract_addon_dir(final_tar, addons_dir, name)
-                _record_import_addon(
-                    team,
-                    template_name,
-                    {
-                        "name": name,
-                        "kind": "local",
-                        "branch": branch,
-                        "origin_url": "",
-                        "category": category,
-                    },
-                )
+                with import_staging_locks.for_path(staging):
+                    if not os.path.isdir(os.path.join(addons_dir, name)):
+                        system_ops.extract_addon_dir(final_tar, addons_dir, name)
+                    _record_import_addon(
+                        team,
+                        template_name,
+                        {
+                            "name": name,
+                            "kind": "local",
+                            "branch": branch,
+                            "origin_url": "",
+                            "category": category,
+                        },
+                    )
             finally:
                 if os.path.exists(final_tar):
                     os.remove(final_tar)
@@ -1811,12 +1858,14 @@ def _build_routes(
         offset_raw = request.query_params.get("offset")
         if offset_raw is None:
             # Legacy single-shot upload (no chunking).
+            fd, final_tar = tempfile.mkstemp(
+                dir=staging, prefix=f".addon_{name}_", suffix=".tar"
+            )
             try:
-                with open(part, "wb") as f:
+                with os.fdopen(fd, "wb") as f:
                     async for data in request.stream():
                         f.write(data)
-                os.replace(part, final_tar)
-                _finish()
+                await _offload(_finish, final_tar)
             except Exception:
                 logger.exception(
                     "Failed to receive addon %s for %s", name, template_name
@@ -1825,8 +1874,8 @@ def _build_routes(
                     {"ok": False, "error": "Internal server error."}, status_code=500
                 )
             finally:
-                if os.path.exists(part):
-                    os.remove(part)
+                if os.path.exists(final_tar):
+                    os.remove(final_tar)
             return JSONResponse({"ok": True})
 
         # Chunked upload: append at `offset`, extract when the part hits `total`.
@@ -1860,9 +1909,13 @@ def _build_routes(
             )
         complete = total > 0 and size >= total
         if complete:
+            fd, final_tar = tempfile.mkstemp(
+                dir=staging, prefix=f".addon_{name}_", suffix=".tar"
+            )
+            os.close(fd)
             try:
                 os.replace(part, final_tar)
-                _finish()
+                await _offload(_finish, final_tar)
             except Exception:
                 logger.exception(
                     "Failed to finalize addon %s for %s", name, template_name
@@ -1870,6 +1923,9 @@ def _build_routes(
                 return JSONResponse(
                     {"ok": False, "error": "Internal server error."}, status_code=500
                 )
+            finally:
+                if os.path.exists(final_tar):
+                    os.remove(final_tar)
         return JSONResponse({"ok": True, "received": size, "complete": complete})
 
     async def api_import_addon_remote(request: Request) -> JSONResponse:
@@ -1899,17 +1955,23 @@ def _build_routes(
         branch = str((body or {}).get("branch") or "").strip()
         template_name = str(record["template_name"])
         try:
-            _record_import_addon(
-                team,
-                template_name,
-                {
-                    "name": name,
-                    "kind": "remote",
-                    "branch": branch,
-                    "origin_url": origin_url,
-                    "category": "extra",
-                },
-            )
+            staging = team.get_import_staging_dir(template_name)
+
+            def _record_remote_addon() -> None:
+                with import_staging_locks.for_path(staging):
+                    _record_import_addon(
+                        team,
+                        template_name,
+                        {
+                            "name": name,
+                            "kind": "remote",
+                            "branch": branch,
+                            "origin_url": origin_url,
+                            "category": "extra",
+                        },
+                    )
+
+            await _offload(_record_remote_addon)
         except ValueError as e:  # invalid template name
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         return JSONResponse({"ok": True})
@@ -2006,7 +2068,8 @@ def _build_routes(
             privileged = bool(body.get("privileged", False))
             net_admin = bool(body.get("net_admin", False))
             cap_add = ["NET_ADMIN"] if net_admin else None
-            result = service_ops.create_service(
+            result = await _offload(
+                service_ops.create_service,
                 get_settings(),
                 team,
                 name,
@@ -2084,7 +2147,8 @@ def _build_routes(
             if body and "net_admin" in body and body["net_admin"] is not None:
                 cap_add_override = ["NET_ADMIN"] if bool(body["net_admin"]) else []
 
-            result = service_ops.update_service(
+            result = await _offload(
+                service_ops.update_service,
                 get_settings(),
                 team,
                 name,
@@ -2218,7 +2282,8 @@ def _build_routes(
             privileged = bool(body.get("privileged", False))
             net_admin = bool(body.get("net_admin", False))
             cap_add = ["NET_ADMIN"] if net_admin else None
-            result = service_ops.create_service(
+            result = await _offload(
+                service_ops.create_service,
                 get_settings(),
                 team,
                 name,
@@ -2285,8 +2350,12 @@ def _build_routes(
                     {"ok": False, "error": "Volume name is required."},
                     status_code=400,
                 )
-            result = volume_ops.create_volume(
-                get_settings(), team, name, description=description
+            result = await _offload(
+                volume_ops.create_volume,
+                get_settings(),
+                team,
+                name,
+                description=description,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -2644,7 +2713,9 @@ def _build_routes(
                 )
             from oduflow.extra_addons import clone_extra_repo
 
-            result = clone_extra_repo(team, name, repo_url, git_user=git_user)
+            result = await _offload(
+                clone_extra_repo, team, name, repo_url, git_user=git_user
+            )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -2666,7 +2737,7 @@ def _build_routes(
         try:
             from oduflow.extra_addons import fetch_extra_repo
 
-            summary = fetch_extra_repo(team, name)
+            summary = await _offload(fetch_extra_repo, team, name)
             return JSONResponse({"ok": True, "result": summary})
         except FlowError as e:
             return _error_response(e)
@@ -2757,8 +2828,8 @@ def _build_routes(
             from oduflow import git_ops
 
             team = _get_ui_team(request)
-            result = git_ops.setup_repo_auth(
-                repo_url, cred_file=team.git_credentials_file()
+            result = await _offload(
+                git_ops.setup_repo_auth, repo_url, cred_file=team.git_credentials_file()
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -2815,8 +2886,11 @@ def _build_routes(
             from oduflow.git_ops import validate_credential
 
             team = _get_ui_team(request)
-            status = validate_credential(
-                host, username, cred_file=team.git_credentials_file()
+            status = await _offload(
+                validate_credential,
+                host,
+                username,
+                cred_file=team.git_credentials_file(),
             )
             return JSONResponse({"ok": True, "status": status})
         except Exception:
@@ -2916,7 +2990,9 @@ def _build_routes(
             body = await request.json()
             user = (body.get("user") or "admin").strip() or "admin"
             activity.touch(team, branch)
-            result = odoo_ops.connect_as_user(settings, team, branch, user)
+            result = await _offload(
+                odoo_ops.connect_as_user, settings, team, branch, user
+            )
             return JSONResponse(
                 {
                     "ok": True,
@@ -2968,7 +3044,9 @@ def _build_routes(
             team = _get_ui_team(request)
             user = (request.query_params.get("user") or "admin").strip() or "admin"
             activity.touch(team, branch)
-            result = odoo_ops.connect_as_user(settings, team, branch, user)
+            result = await _offload(
+                odoo_ops.connect_as_user, settings, team, branch, user
+            )
             if settings.routing_mode == "traefik":
                 env_host = result["cookie_domain"]
                 token = connect_tokens.issue(env_host, result["sid"])
@@ -3888,7 +3966,8 @@ def _build_routes(
         except FlowError as e:
             return _error_response(e)
         try:
-            result = production_ops.create_production(
+            result = await _offload(
+                production_ops.create_production,
                 settings,
                 team,
                 name,
@@ -4089,8 +4168,12 @@ def _build_routes(
         except FlowError as e:
             return _error_response(e)
         try:
-            result = production_ops.delete_production(
-                settings, team, name, drop_database=bool(data.get("drop_database"))
+            result = await _offload(
+                production_ops.delete_production,
+                settings,
+                team,
+                name,
+                drop_database=bool(data.get("drop_database")),
             )
             return JSONResponse({"ok": True, **result})
         except FlowError as e:
@@ -4159,7 +4242,9 @@ def _build_routes(
         except FlowError as e:
             return _error_response(e)
         try:
-            result = backup_ops.restore_production(settings, team, name, snapshot_id)
+            result = await _offload(
+                backup_ops.restore_production, settings, team, name, snapshot_id
+            )
             return JSONResponse({"ok": True, **result})
         except FlowError as e:
             return _error_response(e)

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -4,6 +4,9 @@ import io
 import json
 import os
 import tarfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
 from unittest.mock import patch
 
 from starlette.applications import Starlette
@@ -350,6 +353,79 @@ def test_addon_upload_and_status(tmp_path):
     assert st["progress"]["addons"] == ["enterprise"]
 
 
+def test_concurrent_addon_finalizers_are_serialized(tmp_path):
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    first_started = Event()
+    release_first = Event()
+    second_started = Event()
+    state_lock = Lock()
+    active = 0
+    real_extract = system_ops.extract_addon_dir
+
+    def extract(tar_path, addons_dir, name):
+        nonlocal active
+        with state_lock:
+            active += 1
+            if active == 2:
+                second_started.set()
+        try:
+            if not first_started.is_set():
+                first_started.set()
+                assert release_first.wait(timeout=5)
+            return real_extract(tar_path, addons_dir, name)
+        finally:
+            with state_lock:
+                active -= 1
+
+    staging = team.get_import_staging_dir("zipfit")
+    uploads = {
+        "enterprise": _tar_bytes({"enterprise_src/mod_a/__manifest__.py": b"{}"}),
+        "themes": _tar_bytes({"themes_src/mod_b/__manifest__.py": b"{}"}),
+    }
+    with (
+        client,
+        patch.object(system_ops, "extract_addon_dir", side_effect=extract),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        first = executor.submit(
+            client.post,
+            "/api/templates/import/addon?name=enterprise&branch=18.0",
+            headers=hdr,
+            content=uploads["enterprise"],
+        )
+        assert first_started.wait(timeout=2)
+        second = executor.submit(
+            client.post,
+            "/api/templates/import/addon?name=themes&branch=18.0",
+            headers=hdr,
+            content=uploads["themes"],
+        )
+        deadline = time.monotonic() + 2
+        staged_tars: list[str] = []
+        while time.monotonic() < deadline:
+            staged_tars = [
+                name
+                for name in os.listdir(staging)
+                if name.startswith(".addon_") and name.endswith(".tar")
+            ]
+            if len(staged_tars) == 2:
+                break
+            time.sleep(0.01)
+        try:
+            assert len(staged_tars) == 2
+            assert not second_started.wait(timeout=0.2)
+        finally:
+            release_first.set()
+
+        assert first.result(timeout=2).status_code == 200
+        assert second.result(timeout=2).status_code == 200
+
+    entries = json.loads(open(os.path.join(staging, "addons.json")).read())
+    assert {entry["name"] for entry in entries} == {"enterprise", "themes"}
+
+
 def test_addon_remote_announce(tmp_path):
     client, _s, _t = _client(tmp_path)
     token, _ = _mint(client, "zipfit")
@@ -507,6 +583,66 @@ def test_corrupt_chunk_is_not_marked_complete(tmp_path):
     assert r.status_code == 200
     st = client.get("/api/templates/import/status", headers=hdr).json()
     assert st["progress"]["filestore_chunks"] == ["ab"]
+
+
+def test_concurrent_filestore_retry_uses_unique_staging_tar(tmp_path):
+    client, _s, team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    hdr = {"Authorization": f"Bearer {token}"}
+    tar = _tar_bytes({"ab/f": b"data"})
+    first_started = Event()
+    release_first = Event()
+    real_extract = system_ops.extract_filestore_chunk
+
+    def extract(tar_path, filestore_dir, chunk):
+        first_started.set()
+        assert release_first.wait(timeout=5)
+        return real_extract(tar_path, filestore_dir, chunk)
+
+    staging = team.get_import_staging_dir("zipfit")
+    with (
+        client,
+        patch.object(
+            system_ops, "extract_filestore_chunk", side_effect=extract
+        ) as mocked,
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        first = executor.submit(
+            client.post,
+            "/api/templates/import/filestore?chunk=ab",
+            headers=hdr,
+            content=tar,
+        )
+        assert first_started.wait(timeout=2)
+        retry = executor.submit(
+            client.post,
+            "/api/templates/import/filestore?chunk=ab",
+            headers=hdr,
+            content=tar,
+        )
+        deadline = time.monotonic() + 2
+        staged_tars: list[str] = []
+        while time.monotonic() < deadline:
+            staged_tars = [
+                name
+                for name in os.listdir(staging)
+                if name.startswith(".chunk_ab_") and name.endswith(".tar")
+            ]
+            if len(staged_tars) == 2:
+                break
+            time.sleep(0.01)
+        try:
+            assert len(staged_tars) == 2
+        finally:
+            release_first.set()
+
+        assert first.result(timeout=2).status_code == 200
+        assert retry.result(timeout=2).status_code == 200
+        assert mocked.call_count == 1
+
+    extracted = os.path.join(staging, "filestore", "ab", "f")
+    assert open(extracted, "rb").read() == b"data"
+    assert not any(name.startswith(".chunk_ab_") for name in os.listdir(staging))
 
 
 def test_extract_filestore_chunk_missing_dir_fails_cleanly(tmp_path):

--- a/tests/test_save_as_template_web.py
+++ b/tests/test_save_as_template_web.py
@@ -6,6 +6,8 @@ only create fresh templates), an empty name is rejected before any Docker call,
 and a duplicate name surfaces the backend ConflictError as a failed response.
 """
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from unittest.mock import patch
 
 import pytest
@@ -60,6 +62,43 @@ def test_save_as_template_creates_new(tmp_path):
     assert publish.call_args.kwargs["template_name"] == "prod"
     # The UI never overwrites: no overwrite flag is passed (defaults to False).
     assert publish.call_args.kwargs.get("overwrite") in (None, False)
+
+
+def test_save_as_template_does_not_block_dashboard(tmp_path):
+    client = _client(tmp_path)
+    operation_started = Event()
+    release_operation = Event()
+
+    def publish(*args, **kwargs):
+        operation_started.set()
+        assert release_operation.wait(timeout=5)
+        return {
+            "status": "promoted",
+            "env_name": "feature-x",
+            "template_db": "oduflow_1_t_prod",
+        }
+
+    with (
+        client,
+        patch(
+            "oduflow.web_ui.system_ops.publish_env_as_template",
+            side_effect=publish,
+        ),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        save = executor.submit(
+            client.post,
+            "/api/environments/feature-x/save-as-template",
+            json={"template_name": "prod"},
+        )
+        try:
+            assert operation_started.wait(timeout=2)
+            dashboard = executor.submit(client.get, "/").result(timeout=2)
+            assert dashboard.status_code == 200
+        finally:
+            release_operation.set()
+
+        assert save.result(timeout=2).status_code == 200
 
 
 def test_save_as_template_requires_name(tmp_path):

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -55,3 +55,25 @@ def test_environment_metadata_shows_live_mount_path(tmp_path):
 
     assert dashboard.status_code == 200
     assert "env.local_path ? '<span>Live-mount:" in dashboard.text
+
+
+def test_dashboard_uses_safe_json_response_reader(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert re.search(r"await\s+\w+\.json\(\)", dashboard.text) is None
+    assert "return r.json()" not in dashboard.text
+    assert "[408, 502, 503, 504, 524]" in dashboard.text
+    assert "The operation may still be running on the server" in dashboard.text
+
+
+def test_save_as_template_shows_elapsed_progress(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert 'id="new-tpl-progress" role="status" aria-live="polite"' in dashboard.text
+    assert "Saving database and filestore…" in dashboard.text
+    assert 'id="new-tpl-elapsed" aria-hidden="true"' in dashboard.text
+    assert "elapsed.textContent = _fmtElapsed" in dashboard.text
+    assert "progress.textContent = 'Saving database and filestore" not in dashboard.text
+    assert "setBusy(branch, 'Saving template')" in dashboard.text


### PR DESCRIPTION
## Summary

- offload blocking dashboard operations so long-running requests do not stall the ASGI event loop
- parse empty and non-JSON gateway responses safely and show elapsed save-as-template progress
- make Odoo.sh import retries safe through unique staging files, serialized finalization, and atomic addon metadata updates
- add real shared-event-loop and overlapping-import regression coverage

## Root cause

Several blocking Docker, Git, backup, and filesystem operations ran directly inside async dashboard handlers. While one was running, the event loop could not serve unrelated dashboard requests, and reverse proxies could return HTML timeout pages that the UI attempted to parse as JSON. Moving the work into the thread pool also required explicit serialization for import staging data that had previously been protected only by the blocked event loop.

## Impact

The dashboard remains responsive during long operations, proxy timeout responses are actionable, save-as-template reports progress accessibly, and retried Odoo.sh imports no longer race over shared tar or addon manifest files.

## Validation

- `ruff check src/oduflow tests`
- `mypy src/oduflow`
- `pytest -q -m "not integration and not heavyweight"` — 1,525 passed, 15 deselected
- `git diff --check origin/main...HEAD`
