### PR TITLE
Add a user-attributed GitHub feedback flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,38 @@
+name: Bug report
+description: Something in Oduflow does not work as documented
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. If you opened this from the Oduflow dashboard or
+        from a coding agent, the fields below are already filled in — review
+        them (and remove anything you would rather not publish) before
+        submitting.
+  - type: textarea
+    id: details
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what happened instead.
+      placeholder: |
+        Steps:
+        1. ...
+
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or errors
+      description: Command output, tool responses, or `oduflow` / container logs.
+      render: text
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Oduflow version and deployment details.
+      render: text
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://docs.oduflow.dev
+    about: Installation, configuration, MCP tools, and troubleshooting guides.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,22 @@
+name: Feature request
+description: Suggest a capability or an improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you are trying to solve — that is more useful than
+        a proposed solution, and usually leads to a better one.
+  - type: textarea
+    id: details
+    attributes:
+      label: What you would like to do
+      description: The workflow you are after, and what stops you today.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Oduflow version and deployment details.
+      render: text

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,21 @@
+name: Feedback
+description: Share how Oduflow works for you — rough edges, confusing docs, anything
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        No format required. Half-formed impressions are welcome; they are how
+        rough edges get found.
+  - type: textarea
+    id: details
+    attributes:
+      label: Your feedback
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Oduflow version and deployment details.
+      render: text

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -192,6 +192,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
 - `get_agent_instructions` — get AI agent instructions for using Oduflow
 - `get_odoo_development_guide` — get Odoo development standards guide for a specific version (15–19)
+- `report_issue` — build a prefilled GitHub issue link so the user can report an Oduflow bug, request a feature, or send feedback from their own account
 
 ## Production Hosting
 
@@ -2875,6 +2876,8 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Agent Instructions** | | |
 | `get_agent_instructions` | | Get AI agent instructions for using Oduflow MCP tools |
 | `get_odoo_development_guide` | | Get Odoo development standards guide for a specific version (15–19) |
+| **Feedback** | | |
+| `report_issue` | | Build a prefilled link for the user to file a bug, feature request, or feedback about Oduflow on GitHub |
 
 !!! info "Locking"
     Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2594,6 +2594,12 @@ enabled—coding agents and productions. Environment cards also expose logs,
 Odoo/SQL terminals, Connect As, notes, protection, scoped MCP access, and
 save-as-template actions.
 
+The header's **Feedback** action opens a prefilled issue form on
+`github.com/oduist/oduflow`. Oduflow holds no GitHub credentials and files
+nothing itself: it builds the link with the description and a short
+version/platform/transport block, then the user reviews and submits it from
+their own GitHub account.
+
 ## Authentication and responses
 
 Dashboard API routes use the authenticated UI session (user `admin`, password
@@ -2716,6 +2722,7 @@ workflow.
 | `GET` | `/healthz` | Public health report; returns `200` when healthy, `503` when degraded |
 | `GET` | `/api/license` | License information |
 | `POST` | `/api/license/activate` | Activate body `key` |
+| `POST` | `/api/feedback/link` | Build a prefilled `github.com/oduist/oduflow` issue URL. Body: required `details`; optional `kind` (`bug`, `feature`, or `feedback`) and `title` |
 | `GET` | `/api/agent-guides` | List available agent guides |
 | `GET` | `/api/agent-guides/{filename}` | Read a guide |
 
@@ -4318,6 +4325,31 @@ oduflow call run_odoo_tests '{"env_name": "my-branch", "modules": "my_module"}'
 
 Then narrow the failing asset with `get_environment_logs` and by disabling the
 suspect module's assets.
+
+---
+
+## Reporting a bug or sending feedback
+
+If none of the above helps — or Oduflow itself is at fault — file an issue on
+[github.com/oduist/oduflow](https://github.com/oduist/oduflow/issues).
+
+Three ways to get there, all producing a prefilled issue form:
+
+- **Dashboard** — the **Feedback** action in the header. Pick the kind (bug,
+  feature request, feedback), describe it, and press *Open on GitHub*.
+- **Coding agent** — ask your agent to report it; the `report_issue` MCP tool
+  returns the same prefilled link for you to open.
+- **CLI** — `oduflow call report_issue '{"kind": "bug", "details": "..."}'`.
+
+In every case Oduflow only *builds the link*: it holds no GitHub credentials
+and never files anything on your behalf. You submit it from your own GitHub
+account and can edit it first — which matters, because the report reaches
+maintainers under your name and stays public.
+
+Attached automatically: Oduflow version, Python version, platform, transport
+and routing mode. Never attached: hostnames, team names, repository URLs,
+branch or database names. Add logs yourself where they help, and check them for
+secrets before submitting.
 
 ---
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -192,6 +192,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `add_extra_repo` / `list_extra_repos` / `update_extra_repo` / `delete_extra_repo` — manage extra addons repositories
 - `get_agent_instructions` — get AI agent instructions for using Oduflow
 - `get_odoo_development_guide` — get Odoo development standards guide for a specific version (15–19)
+- `report_issue` — build a prefilled GitHub issue link so the user can report an Oduflow bug, request a feature, or send feedback from their own account
 
 ## Production Hosting
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -100,6 +100,8 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Agent Instructions** | | |
 | `get_agent_instructions` | | Get AI agent instructions for using Oduflow MCP tools |
 | `get_odoo_development_guide` | | Get Odoo development standards guide for a specific version (15–19) |
+| **Feedback** | | |
+| `report_issue` | | Build a prefilled link for the user to file a bug, feature request, or feedback about Oduflow on GitHub |
 
 !!! info "Locking"
     Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -315,3 +315,28 @@ oduflow call run_odoo_tests '{"env_name": "my-branch", "modules": "my_module"}'
 
 Then narrow the failing asset with `get_environment_logs` and by disabling the
 suspect module's assets.
+
+---
+
+## Reporting a bug or sending feedback
+
+If none of the above helps — or Oduflow itself is at fault — file an issue on
+[github.com/oduist/oduflow](https://github.com/oduist/oduflow/issues).
+
+Three ways to get there, all producing a prefilled issue form:
+
+- **Dashboard** — the **Feedback** action in the header. Pick the kind (bug,
+  feature request, feedback), describe it, and press *Open on GitHub*.
+- **Coding agent** — ask your agent to report it; the `report_issue` MCP tool
+  returns the same prefilled link for you to open.
+- **CLI** — `oduflow call report_issue '{"kind": "bug", "details": "..."}'`.
+
+In every case Oduflow only *builds the link*: it holds no GitHub credentials
+and never files anything on your behalf. You submit it from your own GitHub
+account and can edit it first — which matters, because the report reaches
+maintainers under your name and stays public.
+
+Attached automatically: Oduflow version, Python version, platform, transport
+and routing mode. Never attached: hostnames, team names, repository URLs,
+branch or database names. Add logs yourself where they help, and check them for
+secrets before submitting.

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -10,6 +10,12 @@ enabled—coding agents and productions. Environment cards also expose logs,
 Odoo/SQL terminals, Connect As, notes, protection, scoped MCP access, and
 save-as-template actions.
 
+The header's **Feedback** action opens a prefilled issue form on
+`github.com/oduist/oduflow`. Oduflow holds no GitHub credentials and files
+nothing itself: it builds the link with the description and a short
+version/platform/transport block, then the user reviews and submits it from
+their own GitHub account.
+
 ## Authentication and responses
 
 Dashboard API routes use the authenticated UI session (user `admin`, password
@@ -132,6 +138,7 @@ workflow.
 | `GET` | `/healthz` | Public health report; returns `200` when healthy, `503` when degraded |
 | `GET` | `/api/license` | License information |
 | `POST` | `/api/license/activate` | Activate body `key` |
+| `POST` | `/api/feedback/link` | Build a prefilled `github.com/oduist/oduflow` issue URL. Body: required `details`; optional `kind` (`bug`, `feature`, or `feedback`) and `title` |
 | `GET` | `/api/agent-guides` | List available agent guides |
 | `GET` | `/api/agent-guides/{filename}` | Read a guide |
 

--- a/specs/0045-user-attributed-github-feedback.md
+++ b/specs/0045-user-attributed-github-feedback.md
@@ -1,0 +1,65 @@
+# 0045 — User-attributed GitHub feedback
+
+**Status:** Adopted
+**Type:** Product capability / MCP + dashboard
+**First introduced:** `litnimax/github-issue-feedback` branch (2026-08-11)
+**Key code today:** `feedback.py`, `server.py` (`report_issue`), `web_ui.py`, dashboard feedback dialog, `.github/ISSUE_TEMPLATE/`
+
+## Context
+
+Users and coding agents need a low-friction way to report bugs, request
+features, and send product feedback while they are working in Oduflow. Filing
+issues automatically would require Oduflow to hold GitHub credentials, decide
+whose identity owns the report, and publish user-entered content without a
+final human review. A private relay would solve attribution differently but
+would add another operated service and obscure where the report goes.
+
+Diagnostic context is useful, but Oduflow installations contain identifying
+and sensitive values such as hostnames, team names, repository URLs, branches,
+and database names. A feedback convenience must not silently disclose them.
+
+## Decision
+
+Oduflow builds a prefilled GitHub Issue Form URL but never submits the issue.
+The user opens the form, reviews or edits every field, and creates the issue
+from their own GitHub account. The dashboard and the `report_issue` MCP tool
+share one URL builder and diagnostics policy.
+
+Only non-identifying runtime facts are added automatically: Oduflow and Python
+versions, platform family and architecture, transport, routing mode, and
+whether production support is enabled. Deployment identifiers and customer
+data are excluded. Free-form title and details are bounded so the encoded URL
+remains usable, and issue-form YAML owns labels because ordinary GitHub users
+cannot reliably set labels through the new-issue URL.
+
+## How it works (macro)
+
+- Separate issue forms define bug, feature, and general-feedback fields and
+  labels. Their stable field IDs are the prefill contract.
+- `feedback.py` selects the form, collects safe diagnostics, percent-encodes
+  the fields, and truncates free-form content to a conservative URL budget.
+- The authenticated dashboard endpoint validates the request and returns the
+  URL. The browser opens it in a new tab so the user remains in control of
+  publication.
+- The MCP `report_issue` tool returns the same URL and makes explicit that
+  nothing is sent until the user presses GitHub's create button.
+
+## Consequences
+
+- Reports are attributable without storing a GitHub token in Oduflow, and the
+  reporter gets a final privacy and accuracy review before publication.
+- The feature has no automatic delivery, retry, or telemetry semantics. It is
+  distinct from [[0019-telemetry]]: this channel is deliberate, public, and
+  user-attributed.
+- Users can still paste secrets into free-form fields, so the UI and issue
+  forms warn that reports are public.
+- Long reports may be truncated in the prefilled URL; the user can paste the
+  remainder directly into GitHub.
+- The flow depends on GitHub's issue-form and URL-prefill behavior, while the
+  dashboard exposure follows [[0005-web-dashboard-and-rest-api]] and agent
+  access follows [[0009-agent-guidance-system]].
+
+## History
+
+- `litnimax/github-issue-feedback` / PR #175 (2026-08-11) — shared prefilled
+  issue-link builder, dashboard dialog and endpoint, MCP tool, and issue forms.

--- a/specs/README.md
+++ b/specs/README.md
@@ -63,6 +63,7 @@ precursors).
 | [0042](0042-translation-tooling.md) | 2026-07-27 | Translation tooling on Odoo's own exporter, plus one-time artifact download links |
 | [0043](0043-template-code-provenance-and-lineage.md) | 2026-08-08 | Templates record the commit their data was snapshotted at; environments report code/database drift at creation |
 | [0044](0044-unified-host-resource-planning.md) | 2026-08-02 | One host-wide resource plan for dev PostgreSQL, production PostgreSQL, and production Odoo |
+| [0045](0045-user-attributed-github-feedback.md) | 2026-08-11 | User-attributed GitHub feedback through prefilled, review-before-submit issue forms |
 
 ## Design docs
 

--- a/src/oduflow/feedback.py
+++ b/src/oduflow/feedback.py
@@ -1,0 +1,130 @@
+"""Prefilled GitHub issue links for user feedback.
+
+Oduflow never files issues on the user's behalf: it builds a link to the
+project's "new issue" form with the description and a short diagnostics block
+prefilled, and the user submits it from their own GitHub account. That keeps
+the report attributable to a real person, keeps Oduflow free of any GitHub
+credentials, and lets the user read and edit everything before it becomes
+public.
+
+Two consequences shape this module:
+
+* ``labels=`` is deliberately absent from the query string. GitHub rejects that
+  parameter (404) for users without triage rights on the repository, so labels
+  live in the issue *form* YAML (``.github/ISSUE_TEMPLATE/``) instead and are
+  applied on submission regardless of permissions.
+* The diagnostics block carries only non-identifying deployment facts — the
+  same bar as the anonymous telemetry in ``telemetry.py``. No hostnames, team
+  names, repository URLs, branch or database names ever go into a link.
+"""
+
+from __future__ import annotations
+
+import platform
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING
+from urllib.parse import quote, urlencode
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from oduflow.settings import Settings
+
+REPO = "oduist/oduflow"
+NEW_ISSUE_URL = f"https://github.com/{REPO}/issues/new"
+ISSUES_URL = f"https://github.com/{REPO}/issues"
+
+# Issue form templates shipped in .github/ISSUE_TEMPLATE/. Each form defines the
+# `details` and `environment` field ids this module prefills, and carries its
+# own labels.
+KINDS: dict[str, str] = {
+    "bug": "bug.yml",
+    "feature": "feature.yml",
+    "feedback": "feedback.yml",
+}
+DEFAULT_KIND = "feedback"
+
+# GitHub answers 414 for over-long URLs; browsers and proxies add their own
+# limits. Stay well below any of them and truncate the free-form text instead.
+MAX_URL_LEN = 4000
+_TRUNCATION_NOTE = "\n\n[truncated — please paste the rest here]"
+
+
+def oduflow_version() -> str:
+    """Return the installed package version, or "dev" from a source checkout."""
+    try:
+        return version("oduflow")
+    except PackageNotFoundError:
+        return "dev"
+
+
+def diagnostics(settings: Settings | None = None) -> dict[str, str]:
+    """Collect the non-identifying deployment facts worth having in a report.
+
+    Everything here describes *how Oduflow is running*, never *what it runs*:
+    no hostnames, team names, repo URLs, branch or database names.
+    """
+    from oduflow import settings as settings_module
+
+    info = {
+        "Oduflow": oduflow_version(),
+        "Python": platform.python_version(),
+        "Platform": f"{platform.system()} {platform.machine()}",
+        "Transport": settings_module.TRANSPORT,
+    }
+    if settings is not None:
+        info["Routing"] = settings.routing_mode
+        info["Production"] = "enabled" if settings.prod_enabled else "disabled"
+    return info
+
+
+def format_diagnostics(info: dict[str, str]) -> str:
+    """Render diagnostics as the plain ``key: value`` block the forms expect."""
+    return "\n".join(f"{key}: {value}" for key, value in info.items())
+
+
+def build_issue_url(
+    kind: str = DEFAULT_KIND,
+    title: str = "",
+    details: str = "",
+    settings: Settings | None = None,
+    environment: str = "",
+) -> str:
+    """Build a prefilled "new issue" URL for oduist/oduflow.
+
+    ``kind`` selects the issue form (and with it the labels applied on
+    submission). ``environment`` overrides the auto-collected diagnostics block;
+    pass an empty string to collect it here.
+    """
+    template = KINDS.get(kind, KINDS[DEFAULT_KIND])
+    if not environment:
+        environment = format_diagnostics(diagnostics(settings))
+
+    params = {"template": template, "environment": environment}
+    if title.strip():
+        params["title"] = title.strip()
+    params["details"] = details.strip()
+
+    # Percent-encoding can triple a character, so shrink the free-form text by
+    # measuring the encoded URL instead of trusting the character count.
+    keep = len(params["details"])
+    while len(_encode(params)) > MAX_URL_LEN and keep > 0:
+        keep = int(keep * 0.8)
+        params["details"] = (
+            details.strip()[:keep].rstrip() + _TRUNCATION_NOTE if keep else ""
+        )
+    return _encode(params)
+
+
+def _encode(params: dict[str, str]) -> str:
+    # quote_via=quote keeps spaces as %20 rather than "+", which GitHub renders
+    # literally in a prefilled textarea.
+    return f"{NEW_ISSUE_URL}?{urlencode(params, quote_via=quote)}"
+
+
+def report_issue_message(url: str, kind: str) -> str:
+    """Human-facing instructions returned by the MCP tool / CLI."""
+    return (
+        f"Open this link to file a {kind} report on {REPO} from your own GitHub\n"
+        f"account. The form is prefilled — review and edit it before submitting;\n"
+        f"nothing is sent until you press 'Create'.\n\n"
+        f"{url}\n"
+    )

--- a/src/oduflow/feedback.py
+++ b/src/oduflow/feedback.py
@@ -45,6 +45,7 @@ DEFAULT_KIND = "feedback"
 # GitHub answers 414 for over-long URLs; browsers and proxies add their own
 # limits. Stay well below any of them and truncate the free-form text instead.
 MAX_URL_LEN = 4000
+MAX_TITLE_LEN = 256
 _TRUNCATION_NOTE = "\n\n[truncated — please paste the rest here]"
 
 
@@ -99,8 +100,9 @@ def build_issue_url(
         environment = format_diagnostics(diagnostics(settings))
 
     params = {"template": template, "environment": environment}
-    if title.strip():
-        params["title"] = title.strip()
+    title = title.strip()
+    if title:
+        params["title"] = title[:MAX_TITLE_LEN].rstrip()
     params["details"] = details.strip()
 
     # Percent-encoding can triple a character, so shrink the free-form text by

--- a/src/oduflow/scoped_access.py
+++ b/src/oduflow/scoped_access.py
@@ -51,6 +51,7 @@ SCOPED_ALLOWLIST = frozenset(
     {
         "get_agent_instructions",
         "get_odoo_development_guide",
+        "report_issue",
         # Present only while the hidden [server] agent_feedback option is on;
         # otherwise the tool is disabled and never reaches this allowlist.
         "submit_agent_feedback",

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1171,6 +1171,57 @@ def submit_agent_feedback(
 
 
 # =============================================================================
+# MCP Tools — Feedback
+# =============================================================================
+
+
+@mcp.tool()
+@handle_errors
+def report_issue(
+    details: str,
+    kind: str = "feedback",
+    title: str = "",
+    ctx: Context | None = None,
+) -> str:
+    """
+    Build a link that lets the user file an issue about Oduflow itself on GitHub.
+
+    Use this when the user hits a bug in Oduflow, wants a feature, or wants to
+    send feedback about the tool — not for problems in their own Odoo code.
+    The tool does NOT create the issue: it returns a prefilled link to the
+    oduist/oduflow issue form. Show the link to the user and let them submit it
+    from their own GitHub account, so the report is attributable to them and
+    they can edit it first.
+
+    Oduflow version, Python version, platform, transport and routing mode are
+    attached automatically. Never put hostnames, repository URLs, branch or
+    database names, credentials, or customer data into the text.
+
+    Args:
+        details: The report body — what happened, what was expected, or the feedback.
+        kind: One of "bug", "feature", "feedback" (default). Selects the issue form and its labels.
+        title: Optional one-line summary used as the issue title.
+    """
+    from oduflow import feedback
+
+    normalized = kind.strip().lower()
+    if normalized not in feedback.KINDS:
+        raise ToolError(
+            f"Unknown kind '{kind}'. Use one of: {', '.join(sorted(feedback.KINDS))}."
+        )
+    if not details.strip():
+        raise ToolError("details is required — describe the issue or the feedback.")
+
+    url = feedback.build_issue_url(
+        kind=normalized,
+        title=title,
+        details=details,
+        settings=_get_settings(),
+    )
+    return feedback.report_issue_message(url, normalized)
+
+
+# =============================================================================
 # MCP Tools — Template management
 # =============================================================================
 

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -214,6 +214,7 @@ Extra addons repositories (Odoo Enterprise, OCA, your own shared addons) are clo
 |---|---|
 | `get_odoo_development_guide(version)` | Fetch Odoo development standards and constraints for a specific Odoo version (15–19). Read it before writing or refactoring module code |
 | `get_agent_instructions` | Re-fetch this instruction document (the one you are reading) — e.g. after a context reset |
+| `report_issue(details, kind="feedback", title?)` | Build a prefilled `github.com/oduist/oduflow` issue link when the user hits a bug **in Oduflow itself**, wants a feature, or has feedback about the tool — not for bugs in their own Odoo code. It files nothing: show the returned link and let the user submit it from their own GitHub account. Never put hostnames, repo URLs, branch/database names, credentials, or customer data in the text |
 
 ---
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3871,7 +3871,7 @@ async function submitFeedback() {
         details: details,
       })
     });
-    var d = await r.json();
+    var d = await readResult(r);
     if (!d.ok) throw new Error(d.error || 'Could not build the issue link.');
     if (tab) { tab.location = d.url; } else { window.location.href = d.url; }
     hideModal('feedback-modal');
@@ -5513,6 +5513,7 @@ window.addEventListener('resize', function() {
 var MODAL_CLOSERS = {
   'sync-result-modal': closeSyncResult,
   'create-modal': closeCreateModal,
+  'feedback-modal': closeFeedbackModal,
   'logs-modal': closeLogsModal,
   'svc-info-modal': closeServiceInfo,
   'console-modal': closeConsole,

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -142,6 +142,15 @@
   :root[data-theme="light"] .brand-lockup img { filter: brightness(0); }
   .brand-copy { display: flex; flex-direction: column; gap: 1px; }
   header h1 { font-size: var(--text-xl); font-weight: 600; line-height: 1.05; }
+  /* Machine artifact, so mono per The Console Voice Rule — and small enough to
+     sit inside the headline without competing with it. */
+  .brand-version {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xs);
+    font-weight: 400;
+    color: var(--text-dim);
+    vertical-align: 2px;
+  }
   .brand-byline {
     color: var(--text-dim);
     font-size: var(--text-2xs);
@@ -164,6 +173,10 @@
     font-weight: 500;
     padding: 6px 8px;
     border-radius: var(--radius-sm);
+    background: none;
+    border: none;
+    font-family: inherit;
+    cursor: pointer;
   }
   .docs-link:hover { color: var(--accent); }
   #theme-toggle {
@@ -1141,6 +1154,17 @@
   }
   .tab-toolbar { display: flex; justify-content: flex-end; gap: 8px; margin-bottom: 12px; }
   .hint { font-size: var(--text-xs); color: var(--text-dim); margin-top: 4px; }
+  .fb-diagnostics {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-dim);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
   .label-hint { color: var(--text-dim); font-weight: 400; }
   .check-row { display: flex; align-items: center; gap: 8px; }
   .check-row label { margin-bottom: 0; cursor: pointer; }
@@ -1241,13 +1265,14 @@
   <div class="brand-lockup">
     <img src="/logo.png" alt="Oduflow logo">
     <div class="brand-copy">
-      <h1>Oduflow</h1>
+      <h1>Oduflow <span class="brand-version">v__ODUFLOW_VERSION__</span></h1>
       <div class="brand-byline">a product by <a href="https://oduist.com" target="_blank" rel="noopener">Oduist</a></div>
     </div>
   </div>
   <button id="license-badge" class="license-badge" style="display:none"></button>
   <div class="actions">
     <a class="docs-link" href="https://docs.oduflow.dev" target="_blank" rel="noopener" title="Open the Oduflow documentation">Docs &#8599;</a>
+    <button type="button" class="docs-link" onclick="openFeedbackModal()" title="Report a bug, request a feature, or send feedback on GitHub">Feedback &#8599;</button>
     <button id="theme-toggle" type="button" onclick="cycleTheme()" aria-label="Theme"></button>
     <label class="auto-label" for="refresh-interval">Auto-refresh
       <input type="number" id="refresh-interval" value="60" min="5" step="5"
@@ -1409,6 +1434,46 @@
       <div class="form-actions">
         <button class="btn" onclick="closeCreateModal()">Cancel</button>
         <button class="btn-create" id="cr-submit" onclick="submitCreate()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal-overlay" id="feedback-modal" onclick="closeFeedbackModal(event)">
+  <div class="modal modal-md">
+    <div class="modal-header">
+      <h2>Send feedback</h2>
+      <button class="modal-close" onclick="closeFeedbackModal()" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-error" id="feedback-error"></div>
+      <div class="form-group">
+        <label for="fb-kind">Kind</label>
+        <select id="fb-kind">
+          <option value="bug">Bug report</option>
+          <option value="feature">Feature request</option>
+          <option value="feedback" selected>Feedback</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="fb-title">Summary</label>
+        <input type="text" id="fb-title" placeholder="One line — becomes the issue title">
+      </div>
+      <div class="form-group">
+        <label for="fb-details">Details</label>
+        <textarea id="fb-details" rows="5" placeholder="What you did, what you expected, what happened instead."></textarea>
+      </div>
+      <div class="form-group">
+        <label for="fb-diagnostics">Attached environment</label>
+        <pre id="fb-diagnostics" class="fb-diagnostics">__ODUFLOW_DIAGNOSTICS__</pre>
+        <div class="hint">
+          Opens the issue form on github.com/oduist/oduflow prefilled with the
+          text above. It is filed from your own GitHub account, and nothing is
+          submitted until you review it there and press Create.
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeFeedbackModal()">Cancel</button>
+        <button class="btn-create" id="fb-submit" onclick="submitFeedback()">Open on GitHub</button>
       </div>
     </div>
   </div>
@@ -3755,6 +3820,69 @@ function openCreateModal() {
 function closeCreateModal(event) {
   if (event && event.target !== event.currentTarget) return;
   hideModal('create-modal');
+}
+
+// --- Feedback: prefilled GitHub issue, filed by the user's own account ---
+function openFeedbackModal() {
+  document.getElementById('fb-kind').value = 'feedback';
+  document.getElementById('fb-title').value = '';
+  document.getElementById('fb-details').value = '';
+  var errEl = document.getElementById('feedback-error');
+  errEl.style.display = 'none';
+  errEl.textContent = '';
+  var btn = document.getElementById('fb-submit');
+  btn.disabled = false;
+  btn.textContent = 'Open on GitHub';
+  showModal('feedback-modal');
+  document.getElementById('fb-details').focus();
+}
+
+function closeFeedbackModal(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('feedback-modal');
+}
+
+async function submitFeedback() {
+  var details = document.getElementById('fb-details').value.trim();
+  var errEl = document.getElementById('feedback-error');
+  if (!details) {
+    errEl.textContent = 'Describe what you would like to report.';
+    errEl.style.display = 'block';
+    return;
+  }
+  errEl.style.display = 'none';
+  var btn = document.getElementById('fb-submit');
+  btn.disabled = true;
+  btn.textContent = 'Opening...';
+  // The link is built server-side (single source of truth for the issue forms
+  // and the length budget), so open the tab synchronously here — after the
+  // await, a popup blocker would swallow it. Passing 'noopener' as a window
+  // feature would return null instead of the handle, so drop the opener on the
+  // handle itself; a null tab here means the popup was blocked.
+  var tab = window.open('about:blank', '_blank');
+  if (tab) tab.opener = null;
+  try {
+    var r = await fetch('/api/feedback/link', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        kind: document.getElementById('fb-kind').value,
+        title: document.getElementById('fb-title').value.trim(),
+        details: details,
+      })
+    });
+    var d = await r.json();
+    if (!d.ok) throw new Error(d.error || 'Could not build the issue link.');
+    if (tab) { tab.location = d.url; } else { window.location.href = d.url; }
+    hideModal('feedback-modal');
+  } catch (e) {
+    if (tab) tab.close();
+    errEl.textContent = e.message;
+    errEl.style.display = 'block';
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Open on GitHub';
+  }
 }
 
 async function submitCreate() {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -41,6 +41,7 @@ from oduflow import (
     agent_uploads,
     artifact_tokens,
     connect_tokens,
+    feedback,
     git_ops,
     import_tokens,
     production_registry,
@@ -639,11 +640,22 @@ def _build_routes(
 
     def dashboard(request: Request) -> HTMLResponse:
         html_path = _TEMPLATE_DIR / "dashboard.html"
-        html = html_path.read_text(encoding="utf-8").replace(
-            "__PRODUCTION_TAB_HIDDEN__",
-            "" if get_settings().prod_enabled else "hidden",
+        settings = get_settings()
+        page = (
+            html_path.read_text(encoding="utf-8")
+            .replace(
+                "__PRODUCTION_TAB_HIDDEN__",
+                "" if settings.prod_enabled else "hidden",
+            )
+            .replace("__ODUFLOW_VERSION__", html.escape(feedback.oduflow_version()))
+            .replace(
+                "__ODUFLOW_DIAGNOSTICS__",
+                html.escape(
+                    feedback.format_diagnostics(feedback.diagnostics(settings))
+                ),
+            )
         )
-        response = HTMLResponse(html)
+        response = HTMLResponse(page)
         team = getattr(request.state, "team", None)
         if team is not None and team.ui_password:
             _set_session_cookie(response, team, request)
@@ -2681,6 +2693,33 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
 
+    async def api_feedback_link(request: Request) -> JSONResponse:
+        """Build the prefilled GitHub issue URL the dashboard opens in a tab.
+
+        Built server-side so the issue forms, the diagnostics block, and the URL
+        length budget have one owner (oduflow.feedback) shared with the
+        report_issue MCP tool.
+        """
+        try:
+            body = await request.json()
+            details = (body.get("details") or "").strip()
+            if not details:
+                return JSONResponse(
+                    {"ok": False, "error": "Details are required."}, status_code=400
+                )
+            url = feedback.build_issue_url(
+                kind=(body.get("kind") or feedback.DEFAULT_KIND).strip(),
+                title=(body.get("title") or "").strip(),
+                details=details,
+                settings=get_settings(),
+            )
+            return JSONResponse({"ok": True, "url": url})
+        except Exception:
+            logger.exception("Unexpected error in api_feedback_link")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+
     def api_extra_repos(request: Request) -> JSONResponse:
         from oduflow.extra_addons import list_extra_repos
 
@@ -4408,6 +4447,7 @@ def _build_routes(
         Route("/static/{filename}", static_file, methods=["GET"]),
         Route("/api/license", api_license, methods=["GET"]),
         Route("/api/license/activate", api_license_activate, methods=["POST"]),
+        Route("/api/feedback/link", api_feedback_link, methods=["POST"]),
         Route("/api/templates", api_templates, methods=["GET"]),
         Route("/import-odoo.sh", import_odoo_script, methods=["GET"]),
         Route("/api/templates/import-token", api_import_token, methods=["POST"]),

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2701,15 +2701,35 @@ def _build_routes(
         report_issue MCP tool.
         """
         try:
-            body = await request.json()
-            details = (body.get("details") or "").strip()
+            try:
+                body = await request.json()
+            except (UnicodeDecodeError, ValueError):
+                return JSONResponse(
+                    {"ok": False, "error": "Request body must be valid JSON."},
+                    status_code=400,
+                )
+
+            if not isinstance(body, dict):
+                return JSONResponse(
+                    {"ok": False, "error": "Request body must be a JSON object."},
+                    status_code=400,
+                )
+
+            for field in ("details", "kind", "title"):
+                if field in body and not isinstance(body[field], str):
+                    return JSONResponse(
+                        {"ok": False, "error": f"{field} must be a string."},
+                        status_code=400,
+                    )
+
+            details = body.get("details", "").strip()
             if not details:
                 return JSONResponse(
                     {"ok": False, "error": "Details are required."}, status_code=400
                 )
             url = feedback.build_issue_url(
                 kind=(body.get("kind") or feedback.DEFAULT_KIND).strip(),
-                title=(body.get("title") or "").strip(),
+                title=body.get("title", "").strip(),
                 details=details,
                 settings=get_settings(),
             )

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,136 @@
+import pathlib
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from fastmcp.exceptions import ToolError
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+from tool_helpers import call_tool
+
+from oduflow import feedback
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+_ISSUE_TEMPLATE_DIR = (
+    pathlib.Path(__file__).resolve().parent.parent / ".github" / "ISSUE_TEMPLATE"
+)
+
+
+def _params(url: str) -> dict[str, str]:
+    parts = urlsplit(url)
+    assert f"{parts.scheme}://{parts.netloc}{parts.path}" == feedback.NEW_ISSUE_URL
+    return {k: v[0] for k, v in parse_qs(parts.query, keep_blank_values=True).items()}
+
+
+def _client(tmp_path) -> TestClient:
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def test_url_carries_template_title_and_details():
+    url = feedback.build_issue_url("bug", "Sync fails", "Ran sync, got a traceback")
+
+    params = _params(url)
+    assert params["template"] == "bug.yml"
+    assert params["title"] == "Sync fails"
+    assert params["details"] == "Ran sync, got a traceback"
+    assert "Oduflow:" in params["environment"]
+
+
+def test_unknown_kind_falls_back_to_feedback_form():
+    assert _params(feedback.build_issue_url("nonsense"))["template"] == "feedback.yml"
+
+
+def test_labels_are_never_passed_as_a_query_parameter():
+    # GitHub answers 404 for `labels=` from users without triage rights, so the
+    # labels live in the issue form YAML instead.
+    assert "labels" not in _params(feedback.build_issue_url("bug", "t", "d"))
+
+
+def test_empty_title_is_omitted():
+    assert "title" not in _params(feedback.build_issue_url("feedback", "  ", "d"))
+
+
+def test_long_details_are_truncated_to_keep_the_url_usable():
+    url = feedback.build_issue_url("bug", "t", "x" * 50_000)
+
+    assert len(url) <= feedback.MAX_URL_LEN
+    assert "truncated" in _params(url)["details"]
+
+
+def test_diagnostics_carry_no_identifying_deployment_data(tmp_path):
+    team = TeamSettings(
+        team_id="acme", hostname="odoo.acme.example", data_dir=str(tmp_path)
+    )
+    settings = Settings(base_data_dir=str(tmp_path), teams={"acme": team})
+
+    rendered = feedback.format_diagnostics(feedback.diagnostics(settings))
+
+    assert "acme" not in rendered
+    assert "odoo.acme.example" not in rendered
+    assert str(tmp_path) not in rendered
+    assert "Oduflow:" in rendered
+
+
+def test_dashboard_renders_version_and_diagnostics(tmp_path):
+    html = _client(tmp_path).get("/").text
+
+    assert "__ODUFLOW_VERSION__" not in html
+    assert "__ODUFLOW_DIAGNOSTICS__" not in html
+    assert f'class="brand-version">v{feedback.oduflow_version()}<' in html
+
+
+def test_feedback_link_endpoint_builds_a_prefilled_url(tmp_path):
+    response = _client(tmp_path).post(
+        "/api/feedback/link",
+        json={"kind": "bug", "title": "Sync fails", "details": "traceback here"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    params = _params(body["url"])
+    assert params["template"] == "bug.yml"
+    assert params["details"] == "traceback here"
+
+
+def test_feedback_link_endpoint_requires_details(tmp_path):
+    response = _client(tmp_path).post(
+        "/api/feedback/link", json={"kind": "bug", "details": "   "}
+    )
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+
+
+def test_every_kind_has_a_shipped_issue_form_with_the_prefilled_fields():
+    for kind, filename in feedback.KINDS.items():
+        form = (_ISSUE_TEMPLATE_DIR / filename).read_text(encoding="utf-8")
+        assert "labels:" in form, f"{kind} form must carry its own labels"
+        assert "id: details" in form
+        assert "id: environment" in form
+
+
+def test_report_issue_tool_returns_a_link_without_filing_anything():
+    result = call_tool(
+        "report_issue", details="Sync hangs", kind="bug", title="Sync hangs"
+    )
+
+    assert feedback.NEW_ISSUE_URL in result
+    assert "your own GitHub" in result
+    url = result.split(feedback.NEW_ISSUE_URL)[1]
+    assert "template=bug.yml" in url
+
+
+def test_report_issue_tool_rejects_an_unknown_kind():
+    with pytest.raises(ToolError, match="Unknown kind"):
+        call_tool("report_issue", details="x", kind="rant")
+
+
+def test_report_issue_tool_requires_details():
+    with pytest.raises(ToolError, match="details is required"):
+        call_tool("report_issue", details="   ")

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -114,6 +114,49 @@ def test_feedback_link_endpoint_requires_details(tmp_path):
     assert response.json()["ok"] is False
 
 
+@pytest.mark.parametrize("body", [[], 42, "feedback"])
+def test_feedback_link_endpoint_requires_a_json_object(tmp_path, body):
+    response = _client(tmp_path).post("/api/feedback/link", json=body)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "ok": False,
+        "error": "Request body must be a JSON object.",
+    }
+
+
+@pytest.mark.parametrize(
+    ("body", "field"),
+    [
+        ({"details": ["traceback"]}, "details"),
+        ({"details": "traceback", "kind": 1}, "kind"),
+        ({"details": "traceback", "title": {"text": "Sync fails"}}, "title"),
+    ],
+)
+def test_feedback_link_endpoint_rejects_non_string_fields(tmp_path, body, field):
+    response = _client(tmp_path).post("/api/feedback/link", json=body)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "ok": False,
+        "error": f"{field} must be a string.",
+    }
+
+
+def test_feedback_link_endpoint_rejects_malformed_json(tmp_path):
+    response = _client(tmp_path).post(
+        "/api/feedback/link",
+        content=b"{",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "ok": False,
+        "error": "Request body must be valid JSON.",
+    }
+
+
 def test_every_kind_has_a_shipped_issue_form_with_the_prefilled_fields():
     for kind, filename in feedback.KINDS.items():
         form = (_ISSUE_TEMPLATE_DIR / filename).read_text(encoding="utf-8")
@@ -122,7 +165,14 @@ def test_every_kind_has_a_shipped_issue_form_with_the_prefilled_fields():
         assert "id: environment" in form
 
 
-def test_report_issue_tool_returns_a_link_without_filing_anything():
+def test_report_issue_tool_returns_a_link_without_filing_anything(
+    monkeypatch, tmp_path
+):
+    from oduflow import server
+
+    settings = Settings(base_data_dir=str(tmp_path))
+    monkeypatch.setattr(server, "_get_settings", lambda: settings)
+
     result = call_tool(
         "report_issue", details="Sync hangs", kind="bug", title="Sync hangs"
     )

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -62,6 +62,13 @@ def test_long_details_are_truncated_to_keep_the_url_usable():
     assert "truncated" in _params(url)["details"]
 
 
+def test_long_title_is_bounded_to_keep_the_url_usable():
+    url = feedback.build_issue_url("bug", "😀" * 5_000, "details")
+
+    assert len(url) <= feedback.MAX_URL_LEN
+    assert len(_params(url)["title"]) == feedback.MAX_TITLE_LEN
+
+
 def test_diagnostics_carry_no_identifying_deployment_data(tmp_path):
     team = TeamSettings(
         team_id="acme", hostname="odoo.acme.example", data_dir=str(tmp_path)

--- a/tests/test_scoped_access.py
+++ b/tests/test_scoped_access.py
@@ -212,6 +212,7 @@ def _tools():
             {"properties": {"env_name": {}, "install": {}}, "required": ["env_name"]},
         ),
         _FakeTool("get_agent_instructions", {"properties": {}}),
+        _FakeTool("report_issue", {"properties": {"details": {}}}),
         _FakeTool("delete_environment", {"properties": {"env_name": {}}}),
     ]
 
@@ -245,6 +246,7 @@ def test_list_full_mode_unchanged(monkeypatch):
     assert [t.name for t in result] == [
         "pull_and_apply",
         "get_agent_instructions",
+        "report_issue",
         "delete_environment",
     ]
 
@@ -252,7 +254,11 @@ def test_list_full_mode_unchanged(monkeypatch):
 def test_list_scoped_filters_and_strips(monkeypatch):
     _scope(monkeypatch, "main", None)
     result = _run(_middleware().on_list_tools(object(), _list_next))
-    assert [t.name for t in result] == ["pull_and_apply", "get_agent_instructions"]
+    assert [t.name for t in result] == [
+        "pull_and_apply",
+        "get_agent_instructions",
+        "report_issue",
+    ]
     pa = next(t for t in result if t.name == "pull_and_apply")
     assert "env_name" not in pa.parameters["properties"]
     assert pa.parameters["required"] == []
@@ -272,9 +278,10 @@ def test_call_scoped_injects_env(monkeypatch):
     assert res[0] == "called"
 
 
-def test_call_scoped_no_env_param_not_injected(monkeypatch):
+@pytest.mark.parametrize("tool_name", ["get_agent_instructions", "report_issue"])
+def test_call_scoped_no_env_param_not_injected(monkeypatch, tool_name):
     _scope(monkeypatch, "main", None)
-    ctx = _Ctx("get_agent_instructions", {})
+    ctx = _Ctx(tool_name, {})
     _run(_middleware().on_call_tool(ctx, _call_next))
     assert "env_name" not in ctx.message.arguments
 

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -77,3 +77,10 @@ def test_save_as_template_shows_elapsed_progress(tmp_path):
     assert "elapsed.textContent = _fmtElapsed" in dashboard.text
     assert "progress.textContent = 'Saving database and filestore" not in dashboard.text
     assert "setBusy(branch, 'Saving template')" in dashboard.text
+
+
+def test_feedback_modal_is_registered_for_escape_key(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert re.search(r"'feedback-modal':\s*closeFeedbackModal", dashboard.text)


### PR DESCRIPTION
## What changed

- Add bug, feature-request, and general-feedback issue forms.
- Add a shared feedback-link builder used by a new `report_issue` MCP tool and the dashboard Feedback modal.
- Attach a short non-identifying environment summary while keeping reports user-reviewed and submitted from the user's own GitHub account.
- Expose `report_issue` to hosted agents through the scoped MCP allowlist.
- Bound oversized titles and report bodies so generated GitHub URLs remain usable.
- Document the workflow and add regression coverage for URL generation, scoped access, the REST endpoint, and modal keyboard handling.

## Why

Users and coding agents need a direct way to report Oduflow bugs and ideas without Oduflow holding GitHub credentials or filing reports under an automation identity. Prefilled issue forms keep attribution and final review with the user.

The follow-up fixes address review findings where hosted agents could not access the new tool, oversized titles could bypass the URL budget, and Escape did not close the feedback modal.

## Validation

- `ruff check src/oduflow/feedback.py src/oduflow/scoped_access.py tests/test_feedback.py tests/test_scoped_access.py tests/test_web_ui_static.py`
- `pytest -m "not integration and not heavyweight" -q` — 1,541 passed, 15 deselected