### PR TITLE
Harden startup against Docker daemon stalls

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,23 @@
 
 ### Bug Fixes
 
+- **A wedged Docker call can no longer take the server down silently** — startup
+  runs migrations, `init_system` and quotas before the HTTP listener binds, and
+  docker-py disables the socket timeout while reading exec output, so a Docker
+  daemon restarting underneath Oduflow (typically `unattended-upgrades` letting
+  `needrestart` restart Oduflow in the same batch as `containerd`) could block
+  the start forever: an `active (running)` unit serving nothing, for hours. Four
+  changes close that hole. A startup watchdog aborts the process — after dumping
+  every thread's stack to the journal — when startup emits no log line for 15
+  minutes, so systemd restarts instead of waiting; the PostgreSQL readiness
+  probe now runs detached and polls `exec_inspect`, making its 30-second budget
+  real; startup first waits up to a minute for the daemon to answer; and
+  `oduflow systemd-install` now generates a unit ordered after
+  `containerd.service` with `Restart=always` and no start-rate limit, plus an
+  `/etc/needrestart/conf.d/oduflow.conf` override that keeps Oduflow out of
+  needrestart's automatic restart batches. Existing installs get the unit and
+  override by re-running `oduflow systemd-install`.
+
 - **`http_request_to_odoo` now requests the path you pass it** — the base URL was
   taken from `get_environment_info()["url"]`, which ends in `/web?debug=1`, so
   appending the path buried it in the query string and every request silently hit

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -428,8 +428,28 @@ oduflow systemd-install
 This will:
 
 1. Generate a systemd unit file at `/etc/systemd/system/oduflow.service`
-2. Run `systemctl daemon-reload`
-3. Enable the service for auto-start on boot
+2. Write `/etc/needrestart/conf.d/oduflow.conf` (only if needrestart is installed)
+3. Run `systemctl daemon-reload`
+4. Enable the service for auto-start on boot
+
+The unit is ordered after `docker.service` and `containerd.service`, restarts
+always, and has no start-rate limit, so a host that upgrades Docker underneath
+Oduflow cannot leave the service parked in `failed`.
+
+The needrestart snippet excludes `oduflow.service` from needrestart's automatic
+restarts. Oduflow drives the Docker daemon; when `unattended-upgrades` restarts
+a library, needrestart would otherwise restart Oduflow in the same batch as
+containerd and Docker, and Oduflow's startup would race a daemon that is itself
+going down. With the exclusion in place, needrestart lists Oduflow as needing a
+manual restart instead:
+
+```bash
+systemctl restart oduflow
+```
+
+Already installed the service with an older Oduflow? Re-run
+`oduflow systemd-install` to refresh the unit and add the needrestart override,
+then `systemctl daemon-reload && systemctl restart oduflow`.
 
 ### Manage the service
 
@@ -453,4 +473,5 @@ systemctl restart oduflow
 oduflow systemd-uninstall
 ```
 
-This stops, disables, and removes the unit file.
+This stops, disables, and removes the unit file, along with the needrestart
+override.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -976,8 +976,28 @@ oduflow systemd-install
 This will:
 
 1. Generate a systemd unit file at `/etc/systemd/system/oduflow.service`
-2. Run `systemctl daemon-reload`
-3. Enable the service for auto-start on boot
+2. Write `/etc/needrestart/conf.d/oduflow.conf` (only if needrestart is installed)
+3. Run `systemctl daemon-reload`
+4. Enable the service for auto-start on boot
+
+The unit is ordered after `docker.service` and `containerd.service`, restarts
+always, and has no start-rate limit, so a host that upgrades Docker underneath
+Oduflow cannot leave the service parked in `failed`.
+
+The needrestart snippet excludes `oduflow.service` from needrestart's automatic
+restarts. Oduflow drives the Docker daemon; when `unattended-upgrades` restarts
+a library, needrestart would otherwise restart Oduflow in the same batch as
+containerd and Docker, and Oduflow's startup would race a daemon that is itself
+going down. With the exclusion in place, needrestart lists Oduflow as needing a
+manual restart instead:
+
+```bash
+systemctl restart oduflow
+```
+
+Already installed the service with an older Oduflow? Re-run
+`oduflow systemd-install` to refresh the unit and add the needrestart override,
+then `systemctl daemon-reload && systemctl restart oduflow`.
 
 ### Manage the service
 
@@ -1001,7 +1021,8 @@ systemctl restart oduflow
 oduflow systemd-uninstall
 ```
 
-This stops, disables, and removes the unit file.
+This stops, disables, and removes the unit file, along with the needrestart
+override.
 
 ---
 
@@ -4038,6 +4059,58 @@ See [Disk full](#disk-full) below. Once the DB container is healthy:
 ```bash
 systemctl restart oduflow
 journalctl -u oduflow -f
+```
+
+---
+
+## The server is "active" but nothing responds after a system upgrade
+
+`systemctl status oduflow` says `active (running)`, yet the dashboard, `/mcp`
+and `/healthz` all time out, and `journalctl -u oduflow` stops a few lines into
+startup — typically right after `Initializing system` — with no error.
+
+The cause is a Docker call that never returns. Startup (migrations,
+`init_system`, quotas) runs **before** the HTTP listener binds, and docker-py
+disables the socket timeout while reading exec output, so a daemon that is
+restarting underneath Oduflow can block a readiness probe indefinitely. The
+classic trigger: `unattended-upgrades` upgrades a library, and `needrestart`
+restarts `oduflow.service` in the same batch as `containerd` and `docker`.
+
+Current versions defend on three fronts, all applied by re-running
+`oduflow systemd-install`:
+
+- A **startup watchdog** aborts the process when startup emits no log line for
+  15 minutes, dumping every thread's stack to the journal first, so systemd
+  restarts the service instead of leaving it wedged.
+- The **unit** is ordered after `containerd.service`, uses `Restart=always`, and
+  has no start-rate limit.
+- A **needrestart override** (`/etc/needrestart/conf.d/oduflow.conf`) keeps
+  Oduflow out of automatic restart batches.
+
+Immediate recovery is a plain restart — it completes in seconds once the daemon
+is settled:
+
+```bash
+systemctl restart oduflow
+journalctl -u oduflow -f
+
+# Confirm the defenses are in place on this host:
+systemctl cat oduflow | grep -E 'After=|Restart='
+cat /etc/needrestart/conf.d/oduflow.conf
+```
+
+If the journal contains a `Startup made no progress for …s` line followed by
+thread stacks, that is the watchdog reporting where the start hung — include it
+in any bug report.
+
+If a start is legitimately slower than the window (a very slow link pulling
+images, say) and the watchdog keeps cutting it short, widen it — or set `0` to
+switch it off — via the environment, e.g. in a
+`systemctl edit oduflow` drop-in:
+
+```ini
+[Service]
+Environment=ODUFLOW_STARTUP_STALL_SECONDS=3600
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,6 +42,58 @@ journalctl -u oduflow -f
 
 ---
 
+## The server is "active" but nothing responds after a system upgrade
+
+`systemctl status oduflow` says `active (running)`, yet the dashboard, `/mcp`
+and `/healthz` all time out, and `journalctl -u oduflow` stops a few lines into
+startup — typically right after `Initializing system` — with no error.
+
+The cause is a Docker call that never returns. Startup (migrations,
+`init_system`, quotas) runs **before** the HTTP listener binds, and docker-py
+disables the socket timeout while reading exec output, so a daemon that is
+restarting underneath Oduflow can block a readiness probe indefinitely. The
+classic trigger: `unattended-upgrades` upgrades a library, and `needrestart`
+restarts `oduflow.service` in the same batch as `containerd` and `docker`.
+
+Current versions defend on three fronts, all applied by re-running
+`oduflow systemd-install`:
+
+- A **startup watchdog** aborts the process when startup emits no log line for
+  15 minutes, dumping every thread's stack to the journal first, so systemd
+  restarts the service instead of leaving it wedged.
+- The **unit** is ordered after `containerd.service`, uses `Restart=always`, and
+  has no start-rate limit.
+- A **needrestart override** (`/etc/needrestart/conf.d/oduflow.conf`) keeps
+  Oduflow out of automatic restart batches.
+
+Immediate recovery is a plain restart — it completes in seconds once the daemon
+is settled:
+
+```bash
+systemctl restart oduflow
+journalctl -u oduflow -f
+
+# Confirm the defenses are in place on this host:
+systemctl cat oduflow | grep -E 'After=|Restart='
+cat /etc/needrestart/conf.d/oduflow.conf
+```
+
+If the journal contains a `Startup made no progress for …s` line followed by
+thread stacks, that is the watchdog reporting where the start hung — include it
+in any bug report.
+
+If a start is legitimately slower than the window (a very slow link pulling
+images, say) and the watchdog keeps cutting it short, widen it — or set `0` to
+switch it off — via the environment, e.g. in a
+`systemctl edit oduflow` drop-in:
+
+```ini
+[Service]
+Environment=ODUFLOW_STARTUP_STALL_SECONDS=3600
+```
+
+---
+
 ## Disk full
 
 A full disk cascades: PostgreSQL cannot write and crash-loops, new

--- a/src/oduflow/docker_ops/client.py
+++ b/src/oduflow/docker_ops/client.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import time
 
 import docker
 from docker import DockerClient
@@ -22,6 +23,33 @@ def get_client() -> DockerClient:
             "Cannot connect to Docker. Please make sure Docker is installed "
             "and running. https://docs.docker.com/get-docker/"
         ) from exc
+
+
+def wait_for_docker(timeout: float = 60.0, poll_seconds: float = 2.0) -> None:
+    """Block until the Docker daemon answers, or raise after *timeout*.
+
+    The unit is ordered after ``docker.service``, but a host-wide restart batch
+    (unattended-upgrades restarting containerd, say) can still hand us a socket
+    that exists while the daemon behind it is not answering yet. Retrying for a
+    minute turns that race into a slower start instead of a failed one.
+    """
+    deadline = time.monotonic() + timeout
+    announced = False
+    while True:
+        try:
+            get_client().ping()
+            if announced:
+                logger.info("Docker daemon is answering")
+            return
+        except Exception as exc:
+            if time.monotonic() >= deadline:
+                raise PrerequisiteNotMetError(
+                    f"The Docker daemon did not answer within {timeout:.0f}s: {exc}"
+                ) from exc
+            if not announced:
+                logger.info("Waiting for the Docker daemon to answer (%s)", exc)
+                announced = True
+            time.sleep(poll_seconds)
 
 
 def get_odoo_uid_gid(client: DockerClient, image: str) -> str:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -671,21 +671,67 @@ def _destroy_traefik(
         pass
 
 
+def _exec_exit_code(
+    client: DockerClient,
+    container: Any,
+    cmd: list[str],
+    *,
+    timeout: float = 10.0,
+) -> int:
+    """Run *cmd* in *container* and return its exit code within *timeout*.
+
+    ``container.exec_run`` cannot be used where a hang must not be fatal:
+    docker-py reads the exec output off a socket whose timeout it deliberately
+    disables (``APIClient._disable_socket_timeout``), so an exec that never
+    finishes — a container wedged by a daemon restart, for instance — blocks the
+    caller forever. Starting the exec detached and polling ``exec_inspect``
+    keeps every Docker call under the client's own request timeout and makes the
+    wait genuinely bounded.
+
+    Raises ``TimeoutError`` when the command is still running at the deadline;
+    Docker API failures propagate as ``docker.errors.APIError``.
+    """
+    exec_id = client.api.exec_create(container.id, cmd)["Id"]
+    client.api.exec_start(exec_id, detach=True)
+    deadline = time.monotonic() + timeout
+    while True:
+        info = client.api.exec_inspect(exec_id)
+        if not info.get("Running"):
+            exit_code = info.get("ExitCode")
+            # A finished exec with no reported code is not a success.
+            return 1 if exit_code is None else int(exit_code)
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"'{' '.join(cmd)}' in {container.name} did not finish "
+                f"within {timeout:.0f}s"
+            )
+        time.sleep(0.5)
+
+
 def _wait_pg_ready(
     client: DockerClient,
     settings: Settings,
     timeout: int = 30,
     *,
     container_name: str | None = None,
+    exec_timeout: float = 10.0,
 ) -> None:
     # container_name selects the PostgreSQL instance: the shared dev one by
     # default, or the production cluster (settings.prod_db_container).
     container = client.containers.get(container_name or settings.shared_db_container)
+    deadline = time.monotonic() + timeout
     for _ in range(timeout):
         try:
-            exit_code, _ = container.exec_run(["pg_isready", "-U", settings.db_user])
-            if exit_code == 0:
-                exit_code2, _ = container.exec_run(
+            ready = _exec_exit_code(
+                client,
+                container,
+                ["pg_isready", "-U", settings.db_user],
+                timeout=exec_timeout,
+            )
+            if ready == 0:
+                probe = _exec_exit_code(
+                    client,
+                    container,
                     [
                         "psql",
                         "-U",
@@ -694,9 +740,10 @@ def _wait_pg_ready(
                         "postgres",
                         "-tAc",
                         "SELECT 1;",
-                    ]
+                    ],
+                    timeout=exec_timeout,
                 )
-                if exit_code2 == 0:
+                if probe == 0:
                     return
         except docker.errors.APIError:
             # The DB container isn't running yet — still starting, or restarting
@@ -705,6 +752,12 @@ def _wait_pg_ready(
             # transient state crash the whole server startup (which systemd would
             # turn into a restart loop).
             pass
+        except TimeoutError as exc:
+            # A wedged exec is also just "not ready": retry, and let the loop's
+            # own deadline decide when to give up.
+            logger.warning("PostgreSQL readiness probe timed out: %s", exc)
+        if time.monotonic() >= deadline:
+            break
         time.sleep(1)
     raise PrerequisiteNotMetError(
         f"PostgreSQL ({container.name}) did not become ready within "

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -5727,9 +5727,19 @@ def _run_cli() -> None:
         # No subcommand → start the MCP server. Migrations run before init so
         # each step sees the data dir / Docker resources exactly as the
         # previous version left them.
-        migrations.run_pending(_settings)
-        _ensure_initialized(_settings)
-        quotas.apply_all(_settings)
+        #
+        # Everything here happens before the HTTP listener binds, so a Docker
+        # call that never returns would leave a live process serving nothing
+        # and systemd none the wiser. The watchdog turns that into an exit and
+        # a restart; see startup_watchdog for why silence is the stall signal.
+        from oduflow.docker_ops.client import wait_for_docker
+        from oduflow.startup_watchdog import guard_startup
+
+        with guard_startup():
+            wait_for_docker()
+            migrations.run_pending(_settings)
+            _ensure_initialized(_settings)
+            quotas.apply_all(_settings)
         # Record the active transport for informational purposes.
         # local_path is gated by allow_local_path in Settings.
         settings_module.TRANSPORT = args.transport

--- a/src/oduflow/startup_watchdog.py
+++ b/src/oduflow/startup_watchdog.py
@@ -1,0 +1,181 @@
+"""Fail-fast watchdog for the server's startup phase.
+
+Startup runs migrations, ``init_system`` and quota application *before* the HTTP
+server binds, so anything that blocks in there leaves a process that is alive
+but serves nothing: no ``/healthz``, no ``/mcp``, no dashboard. systemd cannot
+help — a ``Type=simple`` unit counts as started the moment it is exec'd, so
+``TimeoutStartSec`` never applies and ``Restart=`` never fires for a process
+that does not exit.
+
+That failure mode is not hypothetical. An ``unattended-upgrades`` run once
+restarted Oduflow in the same batch as ``containerd``; a Docker call during
+``init_system`` never returned and the deployment was down for four and a half
+hours, until a manual restart brought it up in four seconds. Docker calls are
+the standing hazard here because docker-py's exec/attach paths explicitly
+disable the socket timeout (``APIClient._disable_socket_timeout``), so a wedged
+daemon blocks the caller forever rather than raising.
+
+The watchdog treats *log silence* as the stall signal: every record emitted on
+the ``oduflow`` logger is a heartbeat, so a slow-but-progressing start (a large
+``docker pull``, a template restore) keeps it satisfied, while a wedged call
+does not. On a stall it dumps every thread's stack to the journal — so the next
+occurrence is diagnosable instead of invisible — and exits non-zero so systemd
+restarts the unit.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import faulthandler
+import logging
+import os
+import sys
+import threading
+import time
+from collections.abc import Callable, Iterator
+
+logger = logging.getLogger("oduflow")
+
+# How long startup may go without emitting a single log record before it is
+# considered wedged. Deliberately generous: a first start on a fresh host pulls
+# the PostgreSQL, Traefik and coder images, and those pulls are silent.
+DEFAULT_STALL_SECONDS = 900.0
+
+# How often the watchdog thread re-checks. Small relative to the stall window,
+# so the reported silence is accurate without busy-waiting.
+DEFAULT_POLL_SECONDS = 15.0
+
+# Emergency valve, not a tuning knob: if a future startup step is ever silent
+# for longer than the window, the watchdog would kill every restart the same way
+# and no restart could ever finish. This lets an operator widen the window (or
+# set 0 to switch the watchdog off) to get the host back up without waiting for
+# a release.
+STALL_ENV_VAR = "ODUFLOW_STARTUP_STALL_SECONDS"
+
+
+class _HeartbeatHandler(logging.Handler):
+    """Turns every log record into a heartbeat for its watchdog."""
+
+    def __init__(self, watchdog: StartupWatchdog) -> None:
+        super().__init__(level=logging.NOTSET)
+        self._watchdog = watchdog
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._watchdog.beat()
+
+
+class StartupWatchdog:
+    """Aborts the process when the startup phase stops making visible progress.
+
+    ``on_stall`` is injected so tests can observe the decision without the
+    default's process-level side effects.
+    """
+
+    def __init__(
+        self,
+        *,
+        stall_seconds: float = DEFAULT_STALL_SECONDS,
+        poll_seconds: float = DEFAULT_POLL_SECONDS,
+        on_stall: Callable[[float], None] | None = None,
+    ) -> None:
+        self.stall_seconds = stall_seconds
+        # Never coarser than a quarter of the window, so a narrowed window (the
+        # env valve, or a test) is still noticed promptly.
+        self.poll_seconds = min(poll_seconds, max(1.0, stall_seconds / 4))
+        self._on_stall = on_stall or _abort
+        self._last_beat = time.monotonic()
+        self._lock = threading.Lock()
+        self._done = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._handler: _HeartbeatHandler | None = None
+
+    def beat(self) -> None:
+        with self._lock:
+            self._last_beat = time.monotonic()
+
+    def silence(self) -> float:
+        """Seconds since the last heartbeat."""
+        with self._lock:
+            return time.monotonic() - self._last_beat
+
+    def check(self) -> bool:
+        """Fire ``on_stall`` when the silence exceeds the window. True if fired."""
+        if self.stall_seconds <= 0:
+            return False
+        silence = self.silence()
+        if silence < self.stall_seconds:
+            return False
+        self._on_stall(silence)
+        return True
+
+    def start(self) -> None:
+        if self.stall_seconds <= 0:
+            logger.warning(
+                "Startup watchdog disabled via %s — a wedged Docker call will "
+                "hang the start silently",
+                STALL_ENV_VAR,
+            )
+            return
+        self.beat()
+        self._handler = _HeartbeatHandler(self)
+        logger.addHandler(self._handler)
+        self._thread = threading.Thread(
+            target=self._run, name="oduflow-startup-watchdog", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._done.set()
+        if self._handler is not None:
+            logger.removeHandler(self._handler)
+            self._handler = None
+
+    def _run(self) -> None:
+        while not self._done.wait(self.poll_seconds):
+            if self.check():
+                return
+
+
+def _abort(silence: float) -> None:
+    """Log why, dump every thread's stack, and exit for systemd to restart us."""
+    logger.error(
+        "Startup made no progress for %.0fs — assuming a wedged Docker call and "
+        "exiting so the service is restarted. Thread stacks follow.",
+        silence,
+    )
+    # Written straight to stderr (journal): the logging path itself may be
+    # waiting on the same lock as whatever is stuck.
+    with contextlib.suppress(Exception):
+        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        sys.stderr.flush()
+    # _exit, not sys.exit: a normal exit runs interpreter shutdown, which joins
+    # non-daemon threads — and one of those is exactly what is hung.
+    os._exit(1)
+
+
+def _configured_stall_seconds(default: float) -> float:
+    raw = os.environ.get(STALL_ENV_VAR)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s=%r", STALL_ENV_VAR, raw)
+        return default
+
+
+@contextlib.contextmanager
+def guard_startup(
+    *,
+    stall_seconds: float = DEFAULT_STALL_SECONDS,
+    on_stall: Callable[[float], None] | None = None,
+) -> Iterator[StartupWatchdog]:
+    """Watch the wrapped startup work; stop watching once it completes."""
+    watchdog = StartupWatchdog(
+        stall_seconds=_configured_stall_seconds(stall_seconds), on_stall=on_stall
+    )
+    watchdog.start()
+    try:
+        yield watchdog
+    finally:
+        watchdog.stop()

--- a/src/oduflow/systemd.py
+++ b/src/oduflow/systemd.py
@@ -12,18 +12,42 @@ UNIT_DIR = Path("/etc/systemd/system")
 
 SERVICE_NAME = "oduflow.service"
 
+# needrestart (run by unattended-upgrades after a library upgrade) restarts
+# every affected service in one batch. Oduflow drives the Docker daemon, so
+# being restarted alongside containerd/docker means its startup races a daemon
+# that is itself going down — observed to leave Oduflow blocked in a Docker call
+# with no HTTP listener until someone restarted it by hand.
+NEEDRESTART_DIR = Path("/etc/needrestart")
+NEEDRESTART_CONF = NEEDRESTART_DIR / "conf.d" / "oduflow.conf"
+
+NEEDRESTART_SNIPPET = """\
+# Installed by `oduflow systemd-install`.
+#
+# Oduflow orchestrates Docker. Letting needrestart restart oduflow.service in
+# the same batch as containerd/docker races the daemon restart and can wedge
+# Oduflow's startup. Never restart it automatically: needrestart lists it for a
+# manual `systemctl restart oduflow` instead.
+$nrconf{override_rc}{qr(^oduflow\\.service$)} = 0;
+"""
+
 UNIT_TEMPLATE = """\
 [Unit]
 Description=Oduflow MCP Server
-After=docker.service network-online.target
+After=docker.service containerd.service network-online.target
 Requires=docker.service
 Wants=network-online.target
+# Never give up on restarting: a host that upgrades Docker underneath Oduflow
+# can produce several restarts in a row, and a service left in `failed` is a
+# silent outage.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
 ExecStart={oduflow_bin} --transport http
 WorkingDirectory=/
-Restart=on-failure
+# `always`, not `on-failure`: Oduflow's startup watchdog exits deliberately when
+# a Docker call wedges, and that recovery must survive any exit reason.
+Restart=always
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
@@ -50,6 +74,19 @@ def _systemctl(*args: str) -> None:
     subprocess.run(["systemctl", *args], check=True)
 
 
+def _install_needrestart_override() -> Path | None:
+    """Exclude oduflow.service from needrestart's automatic restarts.
+
+    Returns the written path, or None when needrestart is not installed (there
+    is nothing to configure, and creating its config tree would be misleading).
+    """
+    if not NEEDRESTART_DIR.is_dir():
+        return None
+    NEEDRESTART_CONF.parent.mkdir(parents=True, exist_ok=True)
+    NEEDRESTART_CONF.write_text(NEEDRESTART_SNIPPET)
+    return NEEDRESTART_CONF
+
+
 def install() -> None:
     """Generate, install, and enable the Oduflow systemd service."""
     if os.geteuid() != 0:
@@ -70,6 +107,14 @@ def install() -> None:
     unit_path.write_text(unit_content)
     print(f"Unit file written to {unit_path}")
 
+    needrestart_path = _install_needrestart_override()
+    if needrestart_path:
+        print(
+            f"needrestart override written to {needrestart_path} "
+            "(Oduflow is excluded from automatic restarts, so a Docker upgrade "
+            "cannot restart it in the same batch as containerd)"
+        )
+
     _systemctl("daemon-reload")
     _systemctl("enable", SERVICE_NAME)
 
@@ -86,6 +131,10 @@ def uninstall() -> None:
         sys.exit(1)
 
     unit_path = UNIT_DIR / SERVICE_NAME
+
+    if NEEDRESTART_CONF.exists():
+        NEEDRESTART_CONF.unlink()
+        print(f"Removed needrestart override {NEEDRESTART_CONF}")
 
     if not unit_path.exists():
         print(f"Service file {unit_path} does not exist. Nothing to remove.")

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -74,11 +74,16 @@ class TestInitSystem:
             if name == "oduflow-db":
                 c = MagicMock()
                 c.status = "running"
-                c.exec_run.return_value = (0, b"")
                 return c
             raise docker.errors.NotFound("nf")
 
         mock_docker_client.containers.get.side_effect = get_container
+        # Readiness probes run detached and are polled (see _exec_exit_code).
+        mock_docker_client.api.exec_create.return_value = {"Id": "exec-id"}
+        mock_docker_client.api.exec_inspect.return_value = {
+            "Running": False,
+            "ExitCode": 0,
+        }
 
         result = system_ops.init_system(TEST_SETTINGS)
 

--- a/tests/test_pg_ready.py
+++ b/tests/test_pg_ready.py
@@ -5,6 +5,10 @@ or restarting after a crash — e.g. the disk filled up), Docker's exec_create
 returns 409. _wait_pg_ready must treat that as "not ready yet" and retry, rather
 than letting the raw APIError crash the whole server startup (which systemd then
 turns into a restart loop).
+
+The probe must also survive an exec that never finishes: docker-py disables the
+socket timeout while reading exec output, so the readiness wait is run detached
+and polled instead, and a hung probe is one more "not ready" round.
 """
 
 from unittest.mock import MagicMock, patch
@@ -17,11 +21,24 @@ from oduflow.errors import PrerequisiteNotMetError
 from oduflow.settings import Settings
 
 
-def _client(exec_side_effect):
+def _client(exit_codes):
+    """Docker client whose execs report *exit_codes* (int, or an exception)."""
     client = MagicMock()
     container = MagicMock()
-    container.exec_run.side_effect = exec_side_effect
+    container.id = "cid"
+    container.name = "oduflow-db"
     client.containers.get.return_value = container
+
+    codes = iter(exit_codes) if isinstance(exit_codes, list) else None
+
+    def exec_create(*args, **kwargs):
+        outcome = next(codes) if codes is not None else exit_codes
+        if isinstance(outcome, Exception):
+            raise outcome
+        client.api.exec_inspect.return_value = {"Running": False, "ExitCode": outcome}
+        return {"Id": "exec-id"}
+
+    client.api.exec_create.side_effect = exec_create
     return client
 
 
@@ -30,8 +47,8 @@ def test_tolerates_transient_409_then_ready():
     client = _client(
         [
             docker.errors.APIError("409 Client Error: Conflict"),  # pg_isready
-            (0, b""),  # pg_isready OK
-            (0, b"1"),  # psql SELECT 1 OK
+            0,  # pg_isready OK
+            0,  # psql SELECT 1 OK
         ]
     )
     with patch("oduflow.docker_ops.system_ops.time.sleep"):
@@ -47,13 +64,37 @@ def test_raises_clean_error_when_never_ready():
 
 def test_retries_until_pg_accepts_connections():
     # pg_isready returns non-zero (starting) a couple of times, then ready.
-    client = _client(
-        [
-            (1, b""),  # pg_isready: not ready
-            (1, b""),  # pg_isready: not ready
-            (0, b""),  # pg_isready: ready
-            (0, b"1"),  # psql: ready
-        ]
-    )
+    client = _client([1, 1, 0, 0])
     with patch("oduflow.docker_ops.system_ops.time.sleep"):
         system_ops._wait_pg_ready(client, Settings(), timeout=5)
+
+
+def test_hung_probe_is_bounded_and_retried():
+    # An exec that never reports "finished" must not block forever: it times out
+    # and counts as one failed round.
+    client = MagicMock()
+    container = MagicMock()
+    container.id = "cid"
+    container.name = "oduflow-db"
+    client.containers.get.return_value = container
+    client.api.exec_create.return_value = {"Id": "exec-id"}
+    client.api.exec_inspect.return_value = {"Running": True}  # never finishes
+
+    with patch("oduflow.docker_ops.system_ops.time.sleep"):
+        with pytest.raises(PrerequisiteNotMetError, match="did not become ready"):
+            system_ops._wait_pg_ready(client, Settings(), timeout=2, exec_timeout=0.01)
+
+
+def test_exec_exit_code_reports_the_containers_status():
+    client = MagicMock()
+    container = MagicMock(id="cid")
+    container.name = "oduflow-db"  # `name=` in the constructor is not the attribute
+    client.api.exec_create.return_value = {"Id": "exec-id"}
+    client.api.exec_inspect.side_effect = [
+        {"Running": True},
+        {"Running": False, "ExitCode": 3},
+    ]
+    with patch("oduflow.docker_ops.system_ops.time.sleep"):
+        assert system_ops._exec_exit_code(client, container, ["true"]) == 3
+    # Detached start is what keeps the call bounded by the client's own timeout.
+    assert client.api.exec_start.call_args.kwargs["detach"] is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -62,6 +62,7 @@ class TestCLIInitDestroy:
 
         with (
             patch.object(sys, "argv", ["oduflow", "-t", "http"]),
+            patch("oduflow.docker_ops.client.wait_for_docker") as mock_wait_for_docker,
             patch.object(server.migrations, "run_pending"),
             patch.object(server, "_ensure_initialized"),
             patch.object(server.quotas, "apply_all"),
@@ -72,6 +73,7 @@ class TestCLIInitDestroy:
 
         mock_stdio.assert_not_called()
         mock_http.assert_called_once_with()
+        mock_wait_for_docker.assert_called_once_with()
         assert server.settings_module.TRANSPORT == "http"
 
     @patch("oduflow.docker_ops.system_ops.destroy_system")

--- a/tests/test_startup_watchdog.py
+++ b/tests/test_startup_watchdog.py
@@ -1,0 +1,73 @@
+"""The startup watchdog must fire on silence and stay quiet on progress.
+
+Startup runs before the HTTP listener binds, so a Docker call that never returns
+leaves a live process serving nothing — the failure mode this watchdog exists to
+convert into a restart.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from oduflow.startup_watchdog import StartupWatchdog, guard_startup
+
+
+def _watchdog(stall_seconds: float = 0.0):
+    fired: list[float] = []
+    watchdog = StartupWatchdog(
+        stall_seconds=stall_seconds, on_stall=lambda silence: fired.append(silence)
+    )
+    return watchdog, fired
+
+
+def test_fires_when_startup_goes_silent():
+    watchdog, fired = _watchdog(stall_seconds=60.0)
+    watchdog._last_beat -= 3600  # an hour without a single log record
+    assert watchdog.check() is True
+    assert fired and fired[0] > 60
+
+
+def test_stays_quiet_while_startup_logs_progress():
+    watchdog, fired = _watchdog(stall_seconds=60.0)
+    watchdog.beat()
+    assert watchdog.check() is False
+    assert not fired
+
+
+def test_log_records_are_heartbeats():
+    # Any record on the oduflow logger counts as progress, so a slow but
+    # advancing start (image pulls, template restore) is never killed.
+    watchdog, fired = _watchdog(stall_seconds=60.0)
+    logger = logging.getLogger("oduflow")
+    previous = logger.level
+    logger.setLevel(logging.INFO)  # the level the server runs at
+    watchdog.start()
+    try:
+        watchdog._last_beat -= 3600  # pretend we have been silent for an hour
+        assert watchdog.silence() > 60
+        logger.info("still working")
+        assert watchdog.silence() < 1
+    finally:
+        watchdog.stop()
+        logger.setLevel(previous)
+    assert not fired
+
+
+def test_env_var_widens_the_window_and_can_disable_the_watchdog(monkeypatch):
+    monkeypatch.setenv("ODUFLOW_STARTUP_STALL_SECONDS", "3600")
+    with guard_startup(stall_seconds=1.0, on_stall=lambda silence: None) as watchdog:
+        assert watchdog.stall_seconds == 3600.0
+
+    monkeypatch.setenv("ODUFLOW_STARTUP_STALL_SECONDS", "0")
+    fired: list[float] = []
+    with guard_startup(stall_seconds=0.0, on_stall=fired.append) as watchdog:
+        assert watchdog.check() is False
+    assert not fired
+
+
+def test_guard_removes_its_handler_when_startup_completes():
+    logger = logging.getLogger("oduflow")
+    before = list(logger.handlers)
+    with guard_startup(stall_seconds=60.0, on_stall=lambda silence: None):
+        assert len(logger.handlers) == len(before) + 1
+    assert logger.handlers == before

--- a/tests/test_systemd_unit.py
+++ b/tests/test_systemd_unit.py
@@ -1,0 +1,84 @@
+"""The generated unit and its needrestart override.
+
+An unattended-upgrades run once restarted Oduflow in the same batch as
+containerd and left it wedged before the HTTP listener bound. The unit's
+ordering plus a needrestart exclusion are what keep that from repeating.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from oduflow import systemd
+
+
+def test_unit_is_ordered_after_the_container_runtime():
+    unit = systemd.UNIT_TEMPLATE.format(oduflow_bin="/usr/local/bin/oduflow")
+    assert "After=docker.service containerd.service network-online.target" in unit
+    # Restart=always: the startup watchdog exits on purpose when Docker wedges.
+    assert "Restart=always" in unit
+    # No start-rate limit — a service parked in `failed` is a silent outage.
+    assert "StartLimitIntervalSec=0" in unit
+
+
+def test_install_writes_the_needrestart_override(tmp_path):
+    unit_dir = tmp_path / "systemd"
+    unit_dir.mkdir()
+    needrestart_dir = tmp_path / "needrestart"
+    needrestart_dir.mkdir()  # needrestart is installed on this host
+
+    with (
+        patch.object(systemd, "UNIT_DIR", unit_dir),
+        patch.object(systemd, "NEEDRESTART_DIR", needrestart_dir),
+        patch.object(
+            systemd, "NEEDRESTART_CONF", needrestart_dir / "conf.d" / "oduflow.conf"
+        ),
+        patch.object(systemd, "_find_oduflow_bin", return_value="/usr/bin/oduflow"),
+        patch.object(systemd, "_systemctl"),
+        patch("os.geteuid", return_value=0),
+    ):
+        systemd.install()
+
+        conf = (needrestart_dir / "conf.d" / "oduflow.conf").read_text()
+
+    assert r"$nrconf{override_rc}{qr(^oduflow\.service$)} = 0;" in conf
+    assert (unit_dir / systemd.SERVICE_NAME).exists()
+
+
+def test_install_skips_the_override_when_needrestart_is_absent(tmp_path):
+    unit_dir = tmp_path / "systemd"
+    unit_dir.mkdir()
+    absent = tmp_path / "needrestart"  # not created
+
+    with (
+        patch.object(systemd, "UNIT_DIR", unit_dir),
+        patch.object(systemd, "NEEDRESTART_DIR", absent),
+        patch.object(systemd, "NEEDRESTART_CONF", absent / "conf.d" / "oduflow.conf"),
+        patch.object(systemd, "_find_oduflow_bin", return_value="/usr/bin/oduflow"),
+        patch.object(systemd, "_systemctl"),
+        patch("os.geteuid", return_value=0),
+    ):
+        systemd.install()
+
+    assert not absent.exists()
+
+
+def test_uninstall_removes_the_override(tmp_path):
+    unit_dir = tmp_path / "systemd"
+    unit_dir.mkdir()
+    (unit_dir / systemd.SERVICE_NAME).write_text("unit")
+    conf = tmp_path / "needrestart" / "conf.d" / "oduflow.conf"
+    conf.parent.mkdir(parents=True)
+    conf.write_text(systemd.NEEDRESTART_SNIPPET)
+
+    with (
+        patch.object(systemd, "UNIT_DIR", unit_dir),
+        patch.object(systemd, "NEEDRESTART_CONF", conf),
+        patch.object(systemd, "_systemctl"),
+        patch("subprocess.run"),
+        patch("os.geteuid", return_value=0),
+    ):
+        systemd.uninstall()
+
+    assert not conf.exists()
+    assert not (unit_dir / systemd.SERVICE_NAME).exists()


### PR DESCRIPTION
## Summary

- add a startup watchdog that dumps thread stacks and exits when pre-listener startup stops making progress
- bound PostgreSQL readiness probes by running Docker execs detached and polling their status
- wait for Docker before initialization and harden the generated systemd unit against daemon restart races
- install a needrestart override and document recovery, configuration, and upgrade behavior
- add focused watchdog, systemd, readiness, and CLI startup coverage

## Testing

- `pytest -q -m "not integration and not heavyweight"` — 1536 passed
- `pytest -q tests/test_server.py` — 120 passed
- `ruff check` — passed
- `mypy src/oduflow` — passed
- `git diff --check` — passed