### PR TITLE
Tell agents how to handle an exhausted DB connection pool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3592,10 +3592,12 @@ On startup, an `iptables ACCEPT` rule is automatically added for the `oduflow-ne
 
 The bundled `odoo.conf` template includes these security settings:
 
-- `admin_passwd` set to a random value (prevents database manager access)
 - `list_db = False` (hides database selector)
 - `without_demo = all` (no demo data)
 - `max_cron_threads = 0` (disables cron in dev environments)
+
+A repository that ships its own `.oduflow/odoo.conf` replaces the template
+entirely and is responsible for these settings itself.
 
 ---
 
@@ -4097,6 +4099,55 @@ If step 3 reports `Transport endpoint is not connected` or an empty filestore,
 the overlay mount is broken — see [Overlay filestore](#overlay-filestore).
 Otherwise the failure is usually inside Odoo (a module install/upgrade error);
 read the container logs.
+
+---
+
+## An environment runs out of database connections
+
+Two different limits produce two different errors — read the message before
+changing anything.
+
+**`psycopg2.pool.PoolError: The Connection Pool Is Full`** — the *environment*
+hit its own `db_maxconn` (default `8`). Raise it for that container and
+restart it:
+
+```bash
+# 1. Read the current config
+oduflow call read_file_in_odoo '{"env_name": "feature-login", "path": "/etc/odoo/odoo.conf"}'
+
+# 2. Write it back with a higher db_maxconn (the write replaces the whole file)
+oduflow call write_file_in_odoo '{"env_name": "feature-login", "path": "/etc/odoo/odoo.conf", "content": "[options]\n...\ndb_maxconn = 16\n", "user": "odoo"}'
+
+# 3. Odoo reads the config only at startup
+oduflow call restart_environment feature-login
+```
+
+The edit lives in the container's writable layer: it survives restarts and
+`pull_and_apply`, but is lost when the container is recreated
+(`update_environment`) or when the repository's `.oduflow/odoo.conf` changes
+and is reapplied.
+
+**`FATAL: sorry, too many clients already`** — the *shared PostgreSQL* hit
+`max_connections`. Raising `db_maxconn` makes this worse. Stop idle
+environments, or raise `max_connections` in the cluster config and restart it:
+
+```bash
+docker exec oduflow-db psql -U odoo -c \
+  "SELECT count(*), datname FROM pg_stat_activity GROUP BY datname ORDER BY 1 DESC;"
+$EDITOR /etc/oduflow/postgresql.conf     # or ~/.oduflow/conf/postgresql.conf
+docker restart oduflow-db
+```
+
+To change the default for **all** of a team's environments instead of one
+container, edit the team's `odoo.conf` in its data directory
+(`<data_dir>/team_<id>/odoo.conf`, seeded from the bundled template at init).
+Existing containers keep their current config until they are recreated
+(`update_environment`) or their config is reapplied. A single repository can
+override everything for its own environments with `.oduflow/odoo.conf`.
+
+Budget the two limits together: `max_connections` must cover `db_maxconn` ×
+the number of environments you expect to run at once, plus headroom for
+productions and maintenance connections.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -212,7 +212,9 @@ On startup, an `iptables ACCEPT` rule is automatically added for the `oduflow-ne
 
 The bundled `odoo.conf` template includes these security settings:
 
-- `admin_passwd` set to a random value (prevents database manager access)
 - `list_db = False` (hides database selector)
 - `without_demo = all` (no demo data)
 - `max_cron_threads = 0` (disables cron in dev environments)
+
+A repository that ships its own `.oduflow/odoo.conf` replaces the template
+entirely and is responsible for these settings itself.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -100,6 +100,55 @@ read the container logs.
 
 ---
 
+## An environment runs out of database connections
+
+Two different limits produce two different errors — read the message before
+changing anything.
+
+**`psycopg2.pool.PoolError: The Connection Pool Is Full`** — the *environment*
+hit its own `db_maxconn` (default `8`). Raise it for that container and
+restart it:
+
+```bash
+# 1. Read the current config
+oduflow call read_file_in_odoo '{"env_name": "feature-login", "path": "/etc/odoo/odoo.conf"}'
+
+# 2. Write it back with a higher db_maxconn (the write replaces the whole file)
+oduflow call write_file_in_odoo '{"env_name": "feature-login", "path": "/etc/odoo/odoo.conf", "content": "[options]\n...\ndb_maxconn = 16\n", "user": "odoo"}'
+
+# 3. Odoo reads the config only at startup
+oduflow call restart_environment feature-login
+```
+
+The edit lives in the container's writable layer: it survives restarts and
+`pull_and_apply`, but is lost when the container is recreated
+(`update_environment`) or when the repository's `.oduflow/odoo.conf` changes
+and is reapplied.
+
+**`FATAL: sorry, too many clients already`** — the *shared PostgreSQL* hit
+`max_connections`. Raising `db_maxconn` makes this worse. Stop idle
+environments, or raise `max_connections` in the cluster config and restart it:
+
+```bash
+docker exec oduflow-db psql -U odoo -c \
+  "SELECT count(*), datname FROM pg_stat_activity GROUP BY datname ORDER BY 1 DESC;"
+$EDITOR /etc/oduflow/postgresql.conf     # or ~/.oduflow/conf/postgresql.conf
+docker restart oduflow-db
+```
+
+To change the default for **all** of a team's environments instead of one
+container, edit the team's `odoo.conf` in its data directory
+(`<data_dir>/team_<id>/odoo.conf`, seeded from the bundled template at init).
+Existing containers keep their current config until they are recreated
+(`update_environment`) or their config is reapplied. A single repository can
+override everything for its own environments with `.oduflow/odoo.conf`.
+
+Budget the two limits together: `max_connections` must cover `db_maxconn` ×
+the number of environments you expect to run at once, plus headroom for
+productions and maintenance connections.
+
+---
+
 ## Agent Chat: Claude returns `401 Invalid bearer token`
 
 The ACP session may open successfully and fail only on the first prompt:

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -272,6 +272,44 @@ push → pull_and_apply → read the response for errors → fix if errors → r
 ```
 Do NOT call `get_environment_logs` after `pull_and_apply` — the errors are already in the response. Use `get_environment_logs` only to check the **running server** (e.g., runtime errors during request handling).
 
+### Out of Database Connections
+
+Symptoms — in `get_environment_logs` or in a tool response:
+`psycopg2.pool.PoolError: The Connection Pool Is Full`, connections timing
+out, or requests hanging during a heavy import or a parallel test run.
+
+That means this environment hit its own `db_maxconn` ceiling (default `8`).
+Raise it for this container yourself — no user confirmation needed:
+
+1. `read_file_in_odoo(env_name, "/etc/odoo/odoo.conf")` — read the current config.
+2. Raise `db_maxconn` (8 → 16) and leave every other line untouched.
+3. `write_file_in_odoo(env_name, "/etc/odoo/odoo.conf", <full new content>, user="odoo")`
+   — the write replaces the whole file, so send the complete config back.
+4. `restart_environment(env_name)` — Odoo reads the config only at startup.
+
+Then continue with the work that hit the limit.
+
+Scope and limits:
+
+- **Raise it once.** 16 is enough for any single-user environment; 32 is the
+  hard ceiling. If the pool error comes back after one bump, `db_maxconn` is
+  not the problem — the code is leaking cursors or opening connections in a
+  loop. Investigate that instead of raising the number again.
+- The change is **local to this container** — it does not affect other
+  environments and does not change the shared PostgreSQL instance.
+- The shared PostgreSQL accepts a limited number of connections in total, and
+  every other environment on the host draws from the same pool. If the error
+  is `FATAL: sorry, too many clients already` (PostgreSQL side, not the Odoo
+  pool), raising `db_maxconn` makes it **worse**: report it to the user and
+  suggest stopping idle environments instead.
+- The edit lives in the container's writable layer. It survives
+  `restart_environment` and a normal `pull_and_apply`, but is lost when the
+  container is recreated (`update_environment`) or when the repo's
+  `.oduflow/odoo.conf` changes and gets reapplied. A permanent fix belongs in
+  the repository's `.oduflow/odoo.conf`, or — for the whole team — in the
+  team's own `odoo.conf` on the server, which only the operator can edit. Say
+  so and let the user decide; do not change it yourself.
+
 ### Teardown
 
 Environments are **disposable test sandboxes**, not long-lived installations.
@@ -309,7 +347,7 @@ The environment container runs **remotely** and has access only to the git repos
 
 **If you need to change code** — in **git mode**, do it locally, then `git commit` → `git push` → `pull_and_apply`. In **live-mount mode** (env created with `local_path`), edit the files in that local directory directly and call `pull_and_apply` — no commit/push required (the directory is bind-mounted live into the container). Either way, never edit code *inside* the container.
 
-**Non-standard operations** (e.g., `apt install`, `pip install`, modifying system configs) are possible but **require explicit user confirmation** before proceeding — explain what you want to do and why.
+**Non-standard operations** (e.g., `apt install`, `pip install`, modifying system configs) are possible but **require explicit user confirmation** before proceeding — explain what you want to do and why. The one sanctioned exception is raising `db_maxconn` in `/etc/odoo/odoo.conf` when the connection pool is exhausted — see [Out of Database Connections](#out-of-database-connections).
 
 ### Searching Odoo Source Code
 - If Odoo Community or Enterprise source repositories are available **locally** (cloned to your machine), prefer using your native search tools (Grep, Glob, Read) over `search_in_odoo` — local search is faster and doesn't require a running environment.


### PR DESCRIPTION
Agents that hit `psycopg2.pool.PoolError: The Connection Pool Is Full` had no documented remedy and would stall or escalate; the agent guide now tells them to raise `db_maxconn` in the container's `/etc/odoo/odoo.conf` and restart the environment, and marks that as the one sanctioned exception to "don't touch system configs without asking".

The guidance is deliberately bounded: raise it once (8 → 16, hard ceiling 32), because a pool error that returns after one bump means leaking cursors rather than too small a number, and `FATAL: sorry, too many clients already` is the shared PostgreSQL limit where raising `db_maxconn` only makes things worse. It also spells out that the edit is container-local — it survives restarts and `pull_and_apply` but is lost on recreation — so permanent changes belong in the repository's `.oduflow/odoo.conf` or the team's `odoo.conf`.

The troubleshooting guide documents both errors for operators with the CLI commands and the `max_connections` side of the budget, and a stale claim that the bundled `odoo.conf` sets `admin_passwd` is dropped (it was removed in 135eeca). Docs-only change; `docs/llms-full.txt` is regenerated.