### PR TITLE
Fix the red test and lint jobs on main

### DIFF
--- a/tests/test_chunkstore.py
+++ b/tests/test_chunkstore.py
@@ -572,7 +572,9 @@ class TestChunkerParameters:
         # still respect both bounds and lose no bytes.
         chunks = _chunk_all(Chunker(b"seed", **SMALL), b"\x00" * 100_000)
 
-        assert all(SMALL["min_size"] <= len(c) <= SMALL["max_size"] for c in chunks[:-1])
+        assert all(
+            SMALL["min_size"] <= len(c) <= SMALL["max_size"] for c in chunks[:-1]
+        )
         assert sum(len(c) for c in chunks) == 100_000
         assert b"".join(chunks) == b"\x00" * 100_000
 
@@ -793,9 +795,7 @@ class TestRetentionBoundaries:
         # than thinning it to one per day.
         revs = [self._rev(1, 400), self._rev(2, 401), self._rev(3, 0)]
 
-        kept = select_revisions_to_keep(
-            revs, parse_keep(["1:7", "0:365"]), self._NOW
-        )
+        kept = select_revisions_to_keep(revs, parse_keep(["1:7", "0:365"]), self._NOW)
 
         assert kept == {3}
 
@@ -894,8 +894,15 @@ class TestRestoreDetails:
         self, small_config_storage, tmp_path
     ):
         # A tampered revision must not be able to write outside target_dir.
+        import importlib
+
         from oduflow.chunkstore.backup import load_revision
         from oduflow.chunkstore.format import ensure_config as _ensure
+
+        # The package re-exports the restore() function, so the name
+        # oduflow.chunkstore.restore resolves to that function, not to the
+        # module — patch() by dotted string cannot reach the module's globals.
+        restore_module = importlib.import_module("oduflow.chunkstore.restore")
 
         src = tmp_path / "src"
         _make_tree(str(src), {"a.txt": b"payload"})
@@ -908,8 +915,9 @@ class TestRestoreDetails:
         files[0]["path"] = "../escaped.txt"
 
         with (
-            patch(
-                "oduflow.chunkstore.restore.load_revision",
+            patch.object(
+                restore_module,
+                "load_revision",
                 return_value=(_meta, files, _hashes, _lengths),
             ),
             pytest.raises(ValueError, match="escapes target dir"),
@@ -1040,9 +1048,7 @@ class TestBackupMetadata:
 
         assert result.unchanged_files == 0
 
-    def test_revision_numbers_increment_from_one(
-        self, small_config_storage, tmp_path
-    ):
+    def test_revision_numbers_increment_from_one(self, small_config_storage, tmp_path):
         src = tmp_path / "src"
         _make_tree(str(src), {"a.txt": b"x"})
 
@@ -1068,8 +1074,7 @@ class TestPruneCounters:
         key = f"snapshots/{snapshot_id}/{result.revision}"
         meta = _json.loads(storage.get(key).decode())
         meta["created_at"] = (
-            datetime.datetime.now(datetime.timezone.utc)
-            - datetime.timedelta(days=days)
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
         ).isoformat()
         storage.put(key, _json.dumps(meta).encode())
         return result

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -973,7 +973,7 @@ class TestInstallSupersedesUpgrade:
             "{'name': 'Sale', 'version': '17.0.1.0.0'}"
         )
         (module / "security" / "groups.xml").write_text("<odoo/>")
-        (module / "i18n" / "ru.po").write_text("msgid \"\"\n")
+        (module / "i18n" / "ru.po").write_text('msgid ""\n')
         return module
 
     def test_security_xml_in_a_new_module_stays_install_only(self, tmp_path):
@@ -1121,7 +1121,10 @@ class TestMergeRecommendationPriority:
         merged = merge_recommendations(
             [
                 {"action": "refresh", "details": {"restart_required": []}},
-                {"action": "refresh", "details": {"restart_required": [".oduflow/odoo.conf"]}},
+                {
+                    "action": "refresh",
+                    "details": {"restart_required": [".oduflow/odoo.conf"]},
+                },
             ]
         )
         assert merged["details"]["restart_required"] is True

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -24,8 +24,7 @@ from oduflow.errors import ExternalCommandError
 def cred_file(tmp_path):
     path = tmp_path / "git-credentials"
     path.write_text(
-        "https://ada:ghp_abcdef123456@github.com\n"
-        "https://bob:glpat_secret@gitlab.com\n"
+        "https://ada:ghp_abcdef123456@github.com\nhttps://bob:glpat_secret@gitlab.com\n"
     )
     return str(path)
 
@@ -76,9 +75,7 @@ class TestListCredentials:
     def test_entries_without_a_host_or_user_are_skipped(self, tmp_path):
         path = tmp_path / "creds"
         path.write_text(
-            "not-a-url\n"
-            "https://github.com\n"
-            "https://ada:tok12345@github.com\n"
+            "not-a-url\nhttps://github.com\nhttps://ada:tok12345@github.com\n"
         )
 
         entries = git_ops.list_credentials(str(path))

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -236,7 +236,8 @@ class TestCollectHealth:
 class TestDiskCheck:
     def _disk(self, settings, total, used, free):
         with patch(
-            "shutil.disk_usage", return_value=MagicMock(total=total, used=used, free=free)
+            "shutil.disk_usage",
+            return_value=MagicMock(total=total, used=used, free=free),
         ):
             return health._check_disk(settings)
 

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -109,9 +109,7 @@ class TestVerifyLicenseText:
         return lambda payload: self._sign(private, payload)
 
     def test_valid_license_is_accepted(self, signer):
-        key = signer(
-            {"type": "business", "name": "Acme", "email": "ops@acme.example"}
-        )
+        key = signer({"type": "business", "name": "Acme", "email": "ops@acme.example"})
 
         info = licensing._verify_license_text(key)
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,6 +1,6 @@
 import json
-from unittest.mock import MagicMock
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -276,7 +276,6 @@ class TestTraefikYmlConfigMigration:
 
     def _run(self, monkeypatch, container, routing_mode="traefik"):
         import docker as _docker
-
         from oduflow.migrations import _migrate_traefik_yml_config
 
         client = MagicMock()

--- a/tests/test_oauth_token_store.py
+++ b/tests/test_oauth_token_store.py
@@ -104,7 +104,9 @@ class TestExpiry:
         assert store.get_access(access) is None
         assert store.get_refresh(refresh) is not None
 
-    def test_a_token_expiring_exactly_now_is_still_valid(self, store, path, monkeypatch):
+    def test_a_token_expiring_exactly_now_is_still_valid(
+        self, store, path, monkeypatch
+    ):
         # The check is `expires_at < now`, so the token survives its own
         # expiry second.
         access, _, expires_at = store.mint_pair("1", [])
@@ -250,9 +252,7 @@ class TestPersistenceAndCache:
         store = OAuthTokenStore(path, 3600)
         store.mint_pair("1", [])
         reloads = []
-        monkeypatch.setattr(
-            OAuthTokenStore, "_reload", lambda self: reloads.append(1)
-        )
+        monkeypatch.setattr(OAuthTokenStore, "_reload", lambda self: reloads.append(1))
 
         store.get_access("unknown")
         store.get_access("unknown")

--- a/tests/test_pg_tune.py
+++ b/tests/test_pg_tune.py
@@ -143,9 +143,9 @@ class TestParallelism:
 
     def test_parallel_gather_is_half_the_cpus_up_to_two(self):
         def gather(cpu):
-            return _parse(
-                pg_tune.generate_postgresql_conf(16384, cpu)
-            )["max_parallel_workers_per_gather"]
+            return _parse(pg_tune.generate_postgresql_conf(16384, cpu))[
+                "max_parallel_workers_per_gather"
+            ]
 
         assert gather(1) == "0"
         assert gather(2) == "1"
@@ -154,9 +154,9 @@ class TestParallelism:
 
     def test_parallel_maintenance_workers_track_cpus_with_a_floor(self):
         def maint(cpu):
-            return _parse(
-                pg_tune.generate_postgresql_conf(16384, cpu)
-            )["max_parallel_maintenance_workers"]
+            return _parse(pg_tune.generate_postgresql_conf(16384, cpu))[
+                "max_parallel_maintenance_workers"
+            ]
 
         assert maint(1) == "1"  # floor
         assert maint(2) == "1"
@@ -165,9 +165,9 @@ class TestParallelism:
 
     def test_autovacuum_workers_scale_below_the_cap(self):
         def workers(cpu):
-            return _parse(
-                pg_tune.generate_postgresql_conf(16384, cpu)
-            )["autovacuum_max_workers"]
+            return _parse(pg_tune.generate_postgresql_conf(16384, cpu))[
+                "autovacuum_max_workers"
+            ]
 
         assert workers(1) == "1"
         assert workers(2) == "2"

--- a/tests/test_port_registry_allocate.py
+++ b/tests/test_port_registry_allocate.py
@@ -82,9 +82,7 @@ class TestReuse:
         )
 
         out_of_range_but_free = _seed(tmp_path, {"other": 60_000})
-        assert (
-            allocate_port(out_of_range_but_free, "other", 50_000, 50_100) != 60_000
-        )
+        assert allocate_port(out_of_range_but_free, "other", 50_000, 50_100) != 60_000
 
     def test_assignment_below_the_range_is_reallocated(self, tmp_path):
         path = _seed(tmp_path, {"main": 49_999})

--- a/tests/test_prod_tune.py
+++ b/tests/test_prod_tune.py
@@ -71,12 +71,22 @@ class TestProdPostgresConf:
         assert _mb(settings["wal_buffers"]) == 15
 
     def test_effective_cache_floor_and_cap(self):
-        assert _mb(_parse(prod_tune.generate_prod_postgresql_conf(1024, 2))[
-            "effective_cache_size"
-        ]) == 1024
-        assert _mb(_parse(prod_tune.generate_prod_postgresql_conf(512 * 1024, 32))[
-            "effective_cache_size"
-        ]) == 65536
+        assert (
+            _mb(
+                _parse(prod_tune.generate_prod_postgresql_conf(1024, 2))[
+                    "effective_cache_size"
+                ]
+            )
+            == 1024
+        )
+        assert (
+            _mb(
+                _parse(prod_tune.generate_prod_postgresql_conf(512 * 1024, 32))[
+                    "effective_cache_size"
+                ]
+            )
+            == 65536
+        )
 
     def test_work_mem_floor_and_cap(self):
         # Floor 8 MB with a tiny shared_buffers, cap 64 MB with a large one.
@@ -103,9 +113,9 @@ class TestProdPostgresConf:
         # The unified plan gives production PostgreSQL roughly half the host
         # CPUs, then applies the below-4 / 4-and-up parallelism formula.
         def gather(cpu):
-            return _parse(
-                prod_tune.generate_prod_postgresql_conf(16384, cpu)
-            )["max_parallel_workers_per_gather"]
+            return _parse(prod_tune.generate_prod_postgresql_conf(16384, cpu))[
+                "max_parallel_workers_per_gather"
+            ]
 
         assert gather(1) == "1"
         assert gather(2) == "1"
@@ -117,9 +127,9 @@ class TestProdPostgresConf:
 
     def test_parallel_maintenance_workers_are_capped_at_four(self):
         def maint(cpu):
-            return _parse(
-                prod_tune.generate_prod_postgresql_conf(16384, cpu)
-            )["max_parallel_maintenance_workers"]
+            return _parse(prod_tune.generate_prod_postgresql_conf(16384, cpu))[
+                "max_parallel_maintenance_workers"
+            ]
 
         assert maint(1) == "1"
         assert maint(4) == "1"
@@ -128,9 +138,9 @@ class TestProdPostgresConf:
 
     def test_autovacuum_workers_are_clamped_between_three_and_six(self):
         def workers(cpu):
-            return _parse(
-                prod_tune.generate_prod_postgresql_conf(16384, cpu)
-            )["autovacuum_max_workers"]
+            return _parse(prod_tune.generate_prod_postgresql_conf(16384, cpu))[
+                "autovacuum_max_workers"
+            ]
 
         assert workers(1) == "3"  # floor
         assert workers(8) == "3"

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -158,8 +158,7 @@ class TestApplyAll:
 class TestReadMounts:
     def test_parses_proc_mounts(self):
         content = (
-            "/dev/sda1 / ext4 rw,relatime 0 0\n"
-            "/dev/sdb1 /srv xfs rw,prjquota 0 0\n"
+            "/dev/sda1 / ext4 rw,relatime 0 0\n/dev/sdb1 /srv xfs rw,prjquota 0 0\n"
         )
         with patch("builtins.open", mock_open(read_data=content)) as opened:
             mounts = quotas._read_mounts()

--- a/tests/test_reaper.py
+++ b/tests/test_reaper.py
@@ -303,7 +303,10 @@ class TestConcurrencyAndFailures:
         ops.list.return_value = [_env()]
         activity._save(
             activity.activity_path(team),
-            {"main": {"last_activity": _iso(10)}, "deleted": {"last_activity": _iso(10)}},
+            {
+                "main": {"last_activity": _iso(10)},
+                "deleted": {"last_activity": _iso(10)},
+            },
         )
 
         reaper.sweep(settings, LockManager())
@@ -346,8 +349,9 @@ class TestStartReaper:
         import logging
 
         settings = _settings(settings.base_data_dir, team, 48, 72)
-        with caplog.at_level(logging.WARNING, logger="oduflow"), patch(
-            "threading.Thread"
+        with (
+            caplog.at_level(logging.WARNING, logger="oduflow"),
+            patch("threading.Thread"),
         ):
             reaper.start_reaper(lambda: settings, LockManager())
 
@@ -357,8 +361,9 @@ class TestStartReaper:
         import logging
 
         settings = _settings(settings.base_data_dir, team, 48, 0)
-        with caplog.at_level(logging.WARNING, logger="oduflow"), patch(
-            "threading.Thread"
+        with (
+            caplog.at_level(logging.WARNING, logger="oduflow"),
+            patch("threading.Thread"),
         ):
             reaper.start_reaper(lambda: settings, LockManager())
 
@@ -369,8 +374,9 @@ class TestStartReaper:
         import logging
 
         settings = _settings(settings.base_data_dir, team, 48, 1)
-        with caplog.at_level(logging.WARNING, logger="oduflow"), patch(
-            "threading.Thread"
+        with (
+            caplog.at_level(logging.WARNING, logger="oduflow"),
+            patch("threading.Thread"),
         ):
             reaper.start_reaper(lambda: settings, LockManager())
 
@@ -391,9 +397,8 @@ class TestThresholdIsStrict:
         return 1_000_000.0
 
     def _at(self, offset: float, frozen: float) -> str:
-        return (
-            datetime.fromtimestamp(frozen - offset, tz=timezone.utc)
-            .isoformat(timespec="seconds")
+        return datetime.fromtimestamp(frozen - offset, tz=timezone.utc).isoformat(
+            timespec="seconds"
         )
 
     def test_idle_exactly_the_stop_threshold_survives(

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -335,9 +335,7 @@ class TestMultipartUploadStream:
             raise RuntimeError("pg_dump died")
 
         with pytest.raises(RuntimeError, match="pg_dump died"):
-            s3_client.multipart_upload_stream(
-                client, "backups", "dump.sql", _frames()
-            )
+            s3_client.multipart_upload_stream(client, "backups", "dump.sql", _frames())
 
         client.abort_multipart_upload.assert_called_once_with(
             Bucket="backups", Key="dump.sql", UploadId="UP1"

--- a/tests/test_sanitizer_scripts.py
+++ b/tests/test_sanitizer_scripts.py
@@ -98,7 +98,11 @@ class TestSqlScripts:
             logs = _run(tmp_path, scripts)
 
         executed = [call.args[2] for call in exec_sql.call_args_list]
-        assert executed == ["SELECT '10_a.sql';", "SELECT '20_b.sql';", "SELECT '30_c.sql';"]
+        assert executed == [
+            "SELECT '10_a.sql';",
+            "SELECT '20_b.sql';",
+            "SELECT '30_c.sql';",
+        ]
         assert logs == [
             "[SANITIZE:system] Executed 10_a.sql",
             "[SANITIZE:system] Executed 20_b.sql",
@@ -166,7 +170,10 @@ class TestPyScripts:
         ):
             logs = _run(tmp_path, scripts, container=container)
 
-        cmd, kwargs = container.exec_run.call_args.args[0], container.exec_run.call_args.kwargs
+        cmd, kwargs = (
+            container.exec_run.call_args.args[0],
+            container.exec_run.call_args.kwargs,
+        )
         assert cmd == ["python3", "-c", "print('hi')"]
         assert kwargs["environment"] == {
             "ODOO_DB": "oduflow_1_main",
@@ -187,7 +194,9 @@ class TestPyScripts:
         with (
             caplog.at_level(logging.WARNING, logger="oduflow"),
             patch.object(
-                sanitizer, "load_credentials", return_value={"pg_user": "u", "pg_password": "p"}
+                sanitizer,
+                "load_credentials",
+                return_value={"pg_user": "u", "pg_password": "p"},
             ),
         ):
             logs = _run(tmp_path, scripts, container=container)
@@ -206,13 +215,13 @@ class TestPyScripts:
         container.exec_run.side_effect = RuntimeError("docker exploded")
 
         with patch.object(
-            sanitizer, "load_credentials", return_value={"pg_user": "u", "pg_password": "p"}
+            sanitizer,
+            "load_credentials",
+            return_value={"pg_user": "u", "pg_password": "p"},
         ):
             logs = _run(tmp_path, scripts, container=container)
 
-        assert logs == [
-            "[SANITIZE:system] WARNING: boom.py failed: docker exploded"
-        ]
+        assert logs == ["[SANITIZE:system] WARNING: boom.py failed: docker exploded"]
 
     def test_missing_container_skips_py_but_keeps_sql_results(self, tmp_path):
         scripts = tmp_path / "sanitize"
@@ -243,7 +252,9 @@ class TestPyScripts:
         with (
             patch.object(sanitizer, "_exec_sql"),
             patch.object(
-                sanitizer, "load_credentials", return_value={"pg_user": "u", "pg_password": "p"}
+                sanitizer,
+                "load_credentials",
+                return_value={"pg_user": "u", "pg_password": "p"},
             ),
         ):
             logs = _run(tmp_path, scripts, container=container)
@@ -268,22 +279,37 @@ class TestDetectOdooMajor:
     def test_reads_major_from_the_image_label(self):
         container = MagicMock()
         container.labels = {"oduflow.image": "odoo:18.0"}
-        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") == 18
+        assert (
+            sanitizer._detect_odoo_major_from_container(container, "oduflow.image")
+            == 18
+        )
 
     def test_handles_registry_style_image_references(self):
         container = MagicMock()
         container.labels = {"oduflow.image": "ghcr.io/acme/odoo/17.0-custom"}
-        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") == 17
+        assert (
+            sanitizer._detect_odoo_major_from_container(container, "oduflow.image")
+            == 17
+        )
 
     def test_unknown_or_missing_label_yields_none(self):
         container = MagicMock()
         container.labels = {"other": "odoo:18.0"}
-        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") is None
+        assert (
+            sanitizer._detect_odoo_major_from_container(container, "oduflow.image")
+            is None
+        )
 
         container.labels = {"oduflow.image": "postgres:16"}
-        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") is None
+        assert (
+            sanitizer._detect_odoo_major_from_container(container, "oduflow.image")
+            is None
+        )
 
     def test_non_dict_labels_yield_none(self):
         container = MagicMock()
         container.labels = ["not", "a", "dict"]
-        assert sanitizer._detect_odoo_major_from_container(container, "oduflow.image") is None
+        assert (
+            sanitizer._detect_odoo_major_from_container(container, "oduflow.image")
+            is None
+        )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -627,7 +627,9 @@ class TestDirectoryResolution:
     def test_data_dir_uses_srv_when_parent_is_writable(self, monkeypatch):
         from oduflow import settings as settings_mod
 
-        monkeypatch.setattr(settings_mod.os, "access", lambda path, mode: path == "/srv")
+        monkeypatch.setattr(
+            settings_mod.os, "access", lambda path, mode: path == "/srv"
+        )
 
         assert settings_mod._resolve_data_dir("") == "/srv/oduflow"
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -248,9 +248,7 @@ class TestDeployInBackground:
         webhooks._pending.add(f"{team.team_id}/{name}")
         webhooks._deploy_in_background(settings, team, locks, name)
 
-    def test_deploys_under_the_production_lock_and_releases_it(
-        self, settings, team
-    ):
+    def test_deploys_under_the_production_lock_and_releases_it(self, settings, team):
         locks = LockManager()
         from oduflow.server import prod_lock_key
 
@@ -265,9 +263,7 @@ class TestDeployInBackground:
         assert locks.acquire_env_blocking(key, 0.1) is True
         locks.release_env(key)
 
-    def test_the_coalescing_slot_is_freed_before_the_deploy_runs(
-        self, settings, team
-    ):
+    def test_the_coalescing_slot_is_freed_before_the_deploy_runs(self, settings, team):
         # A push arriving while the deploy is already running must be able to
         # queue the next one, so the slot is dropped once the lock is held.
         locks = LockManager()


### PR DESCRIPTION
#165 landed with three CI failures that only surfaced after it merged, so `main` has been red since.

`tests/test_chunkstore.py::TestRestoreDetails::test_a_path_escaping_the_target_is_refused` patched `"oduflow.chunkstore.restore.load_revision"` by dotted string, but the package re-exports the `restore()` *function*, so that name resolves to the function rather than the module and `patch()` raised `AttributeError` before the test body ran; it now resolves the module via `importlib` and patches its attribute — the same workaround the `small_config_storage` fixture already uses for `backup`. The other two failures are mechanical: unsorted imports in `tests/test_migrations.py` (`ruff check`) and 15 test files that were never run through `ruff format`.

Tests-only change, formatting is whitespace, no test logic touched. Verified with the exact CI commands (ruff 0.16.2 as pinned in `[dev]`): `ruff check`, `ruff format --check`, `mypy`, and `pytest -m "not integration and not heavyweight"` — 2132 passed.