### PR TITLE
Make template snapshots incremental and stream database dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
         fuse-overlayfs \
+        rsync \
         iptables \
         docker.io \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,7 @@
 - **Python 3.10+**
 - **Git**
 - **fuse-overlayfs** (Linux only, for filestore overlay mounting) — auto-installed on first launch; see below
+- **rsync** (all platforms, for incremental filestore copies) — auto-installed on first launch; see below
 
 !!! note "macOS support"
     On macOS, Docker Desktop runs containers inside a Linux VM and projects
@@ -35,6 +36,24 @@ Oduflow mounts each environment's filestore with `fuse-overlayfs`'s `allow_other
 # Only needed when running Oduflow as a non-root user:
 sudo sed -i 's/^#user_allow_other/user_allow_other/' /etc/fuse.conf
 ```
+
+### Install rsync
+
+`rsync` is auto-installed the same way on Linux (`apt-get install -y rsync` when
+running as root on a Debian/Ubuntu host; the Docker image bundles it). Unlike
+fuse-overlayfs it matters on **every** platform, including macOS, where it ships
+with the system:
+
+```bash
+sudo apt install rsync
+```
+
+Oduflow uses it to copy only what changed. Saving an environment as a template
+snapshots its filestore by hardlinking every file that already matches the
+template baseline, so a multi-gigabyte filestore costs only the environment's
+own deltas. Without `rsync`, publishing still works but re-copies the whole
+filestore each time (logged as a warning), and syncing a template from a local
+source fails outright.
 
 ## Install Oduflow
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -555,6 +555,7 @@ When running in HTTP mode, a web dashboard is available at the root URL (`http:/
 - **Python 3.10+**
 - **Git**
 - **fuse-overlayfs** (Linux only, for filestore overlay mounting) — auto-installed on first launch; see below
+- **rsync** (all platforms, for incremental filestore copies) — auto-installed on first launch; see below
 
 !!! note "macOS support"
     On macOS, Docker Desktop runs containers inside a Linux VM and projects
@@ -584,6 +585,24 @@ Oduflow mounts each environment's filestore with `fuse-overlayfs`'s `allow_other
 # Only needed when running Oduflow as a non-root user:
 sudo sed -i 's/^#user_allow_other/user_allow_other/' /etc/fuse.conf
 ```
+
+### Install rsync
+
+`rsync` is auto-installed the same way on Linux (`apt-get install -y rsync` when
+running as root on a Debian/Ubuntu host; the Docker image bundles it). Unlike
+fuse-overlayfs it matters on **every** platform, including macOS, where it ships
+with the system:
+
+```bash
+sudo apt install rsync
+```
+
+Oduflow uses it to copy only what changed. Saving an environment as a template
+snapshots its filestore by hardlinking every file that already matches the
+template baseline, so a multi-gigabyte filestore costs only the environment's
+own deltas. Without `rsync`, publishing still works but re-copies the whole
+filestore each time (logged as a warning), and syncing a template from a local
+source fails outright.
 
 ## Install Oduflow
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3364,6 +3364,20 @@ is physically moved with `ALTER DATABASE ... SET TABLESPACE`. Expect the
 first start after the upgrade to take time proportional to the total
 database size.
 
+A second base-level directory, `{data_dir}/pg_exchange/`, is mounted the same
+way (as `/exchange`). Database dumps are staged in `pg_exchange/team_{id}/`
+so `pg_dump` writes them once, straight to their final filesystem, and a
+restore reads them in place instead of having a full-size copy pushed into
+the PostgreSQL container's writable layer. Give it the **same XFS project ID**
+as the rest of the team: besides keeping the accounting right, XFS refuses to
+rename a file into a project-inheriting directory with a different ID, which
+would break moving a finished dump into the team's templates directory.
+
+Unlike the tablespace change, this one is not migrated. The mount is attached
+when the PostgreSQL container is created, and an existing container is left
+alone; installs without it keep streaming dumps out through the Docker exec
+API and pick up the faster path whenever that container is next recreated.
+
 ## Shared vs. Per-Team Resources
 
 | Resource | Scope |

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -103,6 +103,20 @@ is physically moved with `ALTER DATABASE ... SET TABLESPACE`. Expect the
 first start after the upgrade to take time proportional to the total
 database size.
 
+A second base-level directory, `{data_dir}/pg_exchange/`, is mounted the same
+way (as `/exchange`). Database dumps are staged in `pg_exchange/team_{id}/`
+so `pg_dump` writes them once, straight to their final filesystem, and a
+restore reads them in place instead of having a full-size copy pushed into
+the PostgreSQL container's writable layer. Give it the **same XFS project ID**
+as the rest of the team: besides keeping the accounting right, XFS refuses to
+rename a file into a project-inheriting directory with a different ID, which
+would break moving a finished dump into the team's templates directory.
+
+Unlike the tablespace change, this one is not migrated. The mount is attached
+when the PostgreSQL container is created, and an existing container is left
+alone; installs without it keep streaming dumps out through the Docker exec
+API and pick up the faster path whenever that container is next recreated.
+
 ## Shared vs. Per-Team Resources
 
 | Resource | Scope |

--- a/specs/0026-per-team-pg-tablespaces.md
+++ b/specs/0026-per-team-pg-tablespaces.md
@@ -3,7 +3,7 @@
 **Status:** Adopted
 **Type:** Architecture
 **First introduced:** this change (2026-07-02), branch `litnimax/multi-tenant-hosting-design`
-**Key code today:** `docker_ops/system_ops.py` (`_ensure_pg_container`, `ensure_team_tablespace`), `naming.py` (`get_tablespace_name`), `migrations.py` (`0002-team-pg-tablespaces`), `CREATE DATABASE ... TABLESPACE` call sites in `env_ops.py` / `system_ops.py`
+**Key code today:** `docker_ops/system_ops.py` (`_ensure_pg_container`, `ensure_team_tablespace`, `_pg_exchange_dirs`, `_staged_db_dump`), `naming.py` (`get_tablespace_name`), `migrations.py` (`0002-team-pg-tablespaces`), `quotas.py` (`apply_team_disk_quota`), `CREATE DATABASE ... TABLESPACE` call sites in `env_ops.py` / `system_ops.py`
 
 ## Context
 
@@ -63,6 +63,34 @@ Give every team its **own PostgreSQL tablespace**, with its files under a
   tablespaces exist; the built-in template flow (`pg_dump`) is unaffected.
 - One-time upgrade cost on existing installs: a PG container recreate plus a
   physical copy of every database at first startup.
+
+## Evolution
+
+**A second base-level mount, `pg_exchange/` (2026-08-11).** Dumps used to
+reach the container the only way an unmounted path can: written into its
+writable layer, pulled out through the Docker archive API, and pushed back in
+for the restore. The same two-part rule that produced `/tablespaces` produces
+the answer here — never mount a team dir (workspaces and credentials stay
+invisible), and keep the mount set **static** so adding a team never recreates
+the shared container. So `base_data_dir/pg_exchange/` is mounted once as
+`/exchange`, with per-team subdirectories created inside it, and a finished
+dump is renamed from there into the team's templates dir.
+
+The exposure question is settled differently than for team dirs: a dump is a
+subset of the cluster this container already serves, so staging one there adds
+nothing PostgreSQL cannot already read. What it does add is a constraint
+inherited from the quota model above — `pg_exchange/team_{id}/` must carry the
+**same project ID** as the rest of the team, and not merely for accounting:
+XFS refuses (`-EXDEV`) to rename a file into a project-inheriting directory
+whose project ID differs, so an unstamped exchange dir breaks the move
+outright.
+
+The mount is attached only at container creation, and an existing container is
+never recreated behind the operator's back. Detection is therefore by
+inspection at call time, with the streaming path as the fallback: existing
+installations keep working untouched and pick up the faster route whenever
+their PostgreSQL container is next recreated. No migration entry, no forced
+downtime for a performance change.
 
 ## History
 

--- a/src/oduflow/docker_ops/stats.py
+++ b/src/oduflow/docker_ops/stats.py
@@ -336,16 +336,23 @@ def _write_storage_cache(team: TeamSettings, cache: dict[str, Any]) -> None:
 
 
 def _dir_size_bytes(path: str, skip_dirs: set[str] | None = None) -> int:
-    """Sum file sizes under ``path``, pruning any directory in ``skip_dirs``."""
+    """Sum file sizes under ``path``, counting each hardlinked inode once."""
     skip = skip_dirs or set()
+    seen: set[tuple[int, int]] = set()
     total = 0
     for dirpath, dirnames, filenames in os.walk(path, onerror=lambda e: None):
         dirnames[:] = [d for d in dirnames if os.path.join(dirpath, d) not in skip]
         for name in filenames:
             try:
-                total += os.lstat(os.path.join(dirpath, name)).st_size
+                info = os.lstat(os.path.join(dirpath, name))
             except OSError:
                 continue
+            if info.st_nlink > 1:
+                inode = (info.st_dev, info.st_ino)
+                if inode in seen:
+                    continue
+                seen.add(inode)
+            total += info.st_size
     return total
 
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -2323,6 +2323,93 @@ def _source_env_metadata(settings: Settings, labels: dict[str, Any]) -> dict[str
     return metadata
 
 
+def _snapshot_filestore(
+    source: str, dest: str, *, link_dests: list[str]
+) -> list[str] | None:
+    """Materialise *source* at *dest*, reusing files from *link_dests*.
+
+    *source* is the environment's merged filestore (for an overlay env, the
+    fuse-overlayfs mount: template baseline plus the environment's own upper
+    deltas, whiteouts already applied). Copying it wholesale copies the entire
+    baseline again, which is almost always the bulk of the data and almost
+    always unchanged.
+
+    Each ``--link-dest`` directory lets rsync hardlink instead of copy any file
+    that already matches there, so only the environment's actual deltas hit the
+    disk. Sharing inodes is safe here: Odoo filestore entries are content
+    addressed (the name is the checksum) and never rewritten in place, and the
+    baseline being linked against is replaced by this snapshot moments later —
+    ``rmtree`` only drops one name, the inode survives through the new link.
+
+    Returns the paths rsync transferred, relative to *dest*, or None when the
+    whole tree was copied (in which case every file needs its ownership fixed).
+    """
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+
+    def _full_copy(reason: str) -> None:
+        # Never silent: falling back here costs exactly the full-size copy this
+        # function exists to avoid, so it must be visible in the logs.
+        logger.warning("Filestore snapshot fell back to a full copy: %s", reason)
+        shutil.copytree(source, dest)
+
+    if not shutil.which("rsync"):
+        _full_copy("rsync not found on PATH")
+        return None
+
+    cmd = ["rsync", "-a", "--delete", "--out-format=%n"]
+    for link_dest in link_dests:
+        if os.path.isdir(link_dest):
+            # Relative paths would be resolved against dest, not the cwd.
+            cmd.append(f"--link-dest={os.path.abspath(link_dest)}")
+    cmd += [source.rstrip("/") + "/", dest.rstrip("/") + "/"]
+
+    os.makedirs(dest, exist_ok=True)
+    result = subprocess.run(cmd, capture_output=True)
+    if result.returncode != 0:
+        shutil.rmtree(dest, ignore_errors=True)
+        _full_copy(
+            f"rsync exited {result.returncode}: "
+            f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+        )
+        return None
+
+    return [
+        line
+        for line in result.stdout.decode("utf-8", errors="replace").splitlines()
+        if line and not line.startswith("deleting ")
+    ]
+
+
+def _chown_filestore(
+    root: str,
+    rel_paths: list[str] | None,
+    uid: int,
+    gid: int,
+    client: DockerClient,
+    image: str,
+) -> None:
+    """Give *root* to *uid*:*gid*, touching only *rel_paths* when they are known.
+
+    Files hardlinked from the previous baseline already carry the right
+    ownership — they are the very inodes a previous publish chowned — so only
+    the files rsync actually transferred need fixing. With *rel_paths* None
+    (full copy fallback) the whole tree is walked as before.
+    """
+    if rel_paths is None:
+        chown_recursive(root, uid, gid, client, image)
+        return
+    try:
+        os.chown(root, uid, gid)
+        for rel in rel_paths:
+            target = os.path.join(root, rel)
+            if _is_within_directory(root, target) and os.path.lexists(target):
+                os.chown(target, uid, gid)
+    except PermissionError:
+        # macOS and other non-root hosts: fall back to the container-based chown.
+        chown_recursive(root, uid, gid, client, image)
+
+
 def publish_env_as_template(
     settings: Settings,
     team: TeamSettings,
@@ -2392,26 +2479,36 @@ def publish_env_as_template(
     )
     source_is_overlay = os.path.isdir(branch_merged) and os.path.ismount(branch_merged)
 
+    source_template = ""
+    try:
+        sc = client.containers.get(source_container)
+        source_was_running = sc.status == "running"
+        source_image = sc.image.tags[0] if sc.image.tags else "odoo:19.0"
+        source_template = sc.labels.get("oduflow.template", "") or ""
+    except (docker.errors.NotFound, IndexError):
+        source_was_running = False
+        source_image = "odoo:19.0"
+
     # Snapshot the source env's merged filestore while it is still mounted.
+    # Link against the baseline the env is currently mounted on (where nearly
+    # every file matches) and against the template being published into, which
+    # differ when an env from one template is published under a new name.
+    link_dests = [
+        team.get_template_filestore_path(name)
+        for name in dict.fromkeys(filter(None, (source_template, template_name)))
+    ]
     snapshot_dir: str | None = None
+    transferred: list[str] | None = None
     if os.path.isdir(branch_merged):
         snapshot_dir = branch_merged + "_snapshot"
-        if os.path.exists(snapshot_dir):
-            shutil.rmtree(snapshot_dir)
-        shutil.copytree(branch_merged, snapshot_dir)
+        transferred = _snapshot_filestore(
+            branch_merged, snapshot_dir, link_dests=link_dests
+        )
         logger.info("Snapshot of filestore created for env %s", env_name)
     else:
         logger.warning(
             "Branch filestore %s not found, skipping filestore update", branch_merged
         )
-
-    try:
-        sc = client.containers.get(source_container)
-        source_was_running = sc.status == "running"
-        source_image = sc.image.tags[0] if sc.image.tags else "odoo:19.0"
-    except (docker.errors.NotFound, IndexError):
-        source_was_running = False
-        source_image = "odoo:19.0"
 
     with env_ops.remount_template_overlays(
         client,
@@ -2437,15 +2534,26 @@ def publish_env_as_template(
             os.makedirs(os.path.dirname(template_filestore_path), exist_ok=True)
             try:
                 os.rename(snapshot_dir, template_filestore_path)
-            except OSError:
+            except OSError as exc:
+                # Both paths live under the team data dir, so this should be a
+                # free rename. Anything else (separate mounts, mismatched XFS
+                # project IDs) degrades to a full-size copy — say so loudly
+                # instead of quietly paying for it.
+                logger.warning(
+                    "Could not move the filestore snapshot into place (%s); "
+                    "copying %s instead",
+                    exc,
+                    snapshot_dir,
+                )
                 shutil.copytree(snapshot_dir, template_filestore_path)
                 shutil.rmtree(snapshot_dir)
             logger.info("Template filestore replaced from env %s", env_name)
 
             odoo_uid_gid = get_odoo_uid_gid(client, source_image)
             uid_str, gid_str = odoo_uid_gid.split(":")
-            chown_recursive(
+            _chown_filestore(
                 template_filestore_path,
+                transferred,
                 int(uid_str),
                 int(gid_str),
                 client,

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1295,10 +1295,109 @@ def _pg_restore_jobs() -> int:
 
 
 _PG_TABLESPACES_MOUNT = "/tablespaces"
+_PG_EXCHANGE_MOUNT = "/exchange"
 
 
 def _pg_tablespaces_host_dir(settings: Settings) -> str:
     return os.path.join(settings.base_data_dir, "pg_tablespaces")
+
+
+def _pg_exchange_host_dir(settings: Settings) -> str:
+    return os.path.join(settings.base_data_dir, "pg_exchange")
+
+
+def _pg_exchange_dirs(
+    client: DockerClient, settings: Settings, team: TeamSettings
+) -> tuple[str, str] | None:
+    """Host and in-container paths of the team's dump exchange dir, if mounted.
+
+    Returns None when the shared PostgreSQL container predates the mount (it is
+    only attached at creation time, and an existing container is never recreated
+    behind the operator's back). Callers fall back to streaming the dump out
+    through the exec API, so nothing has to be migrated: an installation picks
+    up the faster path whenever its PostgreSQL container is next recreated.
+    """
+    try:
+        container = client.containers.get(settings.shared_db_container)
+    except (docker.errors.NotFound, docker.errors.APIError):
+        return None
+    attrs = getattr(container, "attrs", None)
+    mounts = attrs.get("Mounts") if isinstance(attrs, dict) else None
+    if not isinstance(mounts, list):
+        return None
+    if not any(
+        isinstance(m, dict) and m.get("Destination") == _PG_EXCHANGE_MOUNT
+        for m in mounts
+    ):
+        return None
+    leaf = f"team_{team.team_id}"
+    return (
+        os.path.join(_pg_exchange_host_dir(settings), leaf),
+        f"{_PG_EXCHANGE_MOUNT}/{leaf}",
+    )
+
+
+@contextlib.contextmanager
+def _staged_db_dump(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    db_name: str,
+    dest_path: str,
+) -> Any:
+    """Dump *db_name* for *dest_path*, as cheaply as this installation allows.
+
+    Yields ``(host_path, container_path)``. ``container_path`` is None unless
+    the dump was staged in the pg_exchange mount, where PostgreSQL can restore
+    it in place instead of having it copied into its writable layer first.
+    Writing through the mount also leaves the archive's TOC offsets intact,
+    which a parallel ``pg_restore`` uses; a dump streamed from stdout cannot
+    carry them.
+
+    On a clean exit the staged dump is moved to *dest_path*; on failure nothing
+    is left behind, and *dest_path* is never half-written.
+    """
+    db_container = client.containers.get(settings.shared_db_container)
+    exchange = _pg_exchange_dirs(client, settings, team)
+    dump_cmd = ["pg_dump", "-U", settings.db_user, "-Fc"]
+    container_path: str | None = None
+
+    if exchange is None:
+        host_path = f"{dest_path}.staged"
+        _stream_exec_to_file(
+            client, db_container, [*dump_cmd, db_name], host_path, tool="pg_dump"
+        )
+    else:
+        host_dir, container_dir = exchange
+        os.makedirs(host_dir, exist_ok=True)
+        name = f"{db_name}-{uuid.uuid4().hex}.pgdump"
+        host_path = os.path.join(host_dir, name)
+        container_path = f"{container_dir}/{name}"
+        exit_code, output = db_container.exec_run(
+            [*dump_cmd, "-f", container_path, db_name]
+        )
+        if exit_code != 0:
+            with contextlib.suppress(OSError):
+                os.remove(host_path)
+            msg = output.decode("utf-8") if isinstance(output, bytes) else str(output)
+            raise ExternalCommandError("pg_dump", exit_code, msg)
+
+    try:
+        yield host_path, container_path
+        try:
+            os.replace(host_path, dest_path)
+        except OSError as exc:
+            # Both paths sit under the base data dir, so this is normally a free
+            # rename. XFS also refuses it (-EXDEV) when the exchange dir was
+            # never stamped with the team's quota project — see quotas.py.
+            logger.warning(
+                "Could not move the staged dump into place (%s); copying instead",
+                exc,
+            )
+            shutil.move(host_path, dest_path)
+    finally:
+        with contextlib.suppress(OSError):
+            os.remove(host_path)
 
 
 def _ensure_pg_container(
@@ -1306,11 +1405,17 @@ def _ensure_pg_container(
 ) -> None:
     """Start (or create) the shared PostgreSQL container.
 
-    Mounts only the dedicated pg_tablespaces directory into the container —
-    never the whole data dir: PostgreSQL has no business seeing team
-    workspaces or credentials. Per-team tablespace directories are created
-    inside this one mount, so adding a team never requires recreating the
-    container (see ensure_team_tablespace).
+    Mounts only dedicated base-level directories into the container — never the
+    whole data dir: PostgreSQL has no business seeing team workspaces or
+    credentials. Per-team subdirectories are created inside these mounts, so
+    adding a team never requires recreating the container (see
+    ensure_team_tablespace).
+
+    pg_tablespaces holds the databases themselves. pg_exchange is where dumps
+    are staged: writing one there costs a single write to its final filesystem
+    instead of a full-size copy through the container's writable layer, and a
+    restore can read it in place. It carries no new exposure — a dump is a
+    subset of the cluster this container already serves.
     """
     try:
         db_container = client.containers.get(settings.shared_db_container)
@@ -1322,6 +1427,8 @@ def _ensure_pg_container(
 
     tablespaces_dir = _pg_tablespaces_host_dir(settings)
     os.makedirs(tablespaces_dir, exist_ok=True)
+    exchange_dir = _pg_exchange_host_dir(settings)
+    os.makedirs(exchange_dir, exist_ok=True)
     client.containers.run(
         settings.postgres_image,
         name=settings.shared_db_container,
@@ -1337,6 +1444,7 @@ def _ensure_pg_container(
                 "mode": "ro",
             },
             tablespaces_dir: {"bind": _PG_TABLESPACES_MOUNT, "mode": "rw"},
+            exchange_dir: {"bind": _PG_EXCHANGE_MOUNT, "mode": "rw"},
         },
         command=["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"],
         environment={
@@ -1804,7 +1912,14 @@ def reload_template(
     team: TeamSettings,
     template_name: str,
     dump_path: str | None = None,
+    container_dump_path: str | None = None,
 ) -> dict[str, Any]:
+    """Rebuild the template database from its dump.
+
+    ``container_dump_path`` names a dump the PostgreSQL container can already
+    read (staged in the pg_exchange mount), skipping the copy into its writable
+    layer. The caller owns that file; only dumps copied in here are cleaned up.
+    """
     client = get_client()
     tpl_db = get_template_db_name(template_name, team.team_id)
     resolved_dump = dump_path or team.get_template_sql_path(template_name)
@@ -1841,15 +1956,16 @@ def reload_template(
         # The DB container is shared across teams, whose locks do not contend.
         # Use an opaque per-restore name so one restore cannot overwrite or
         # clean up another restore's input file.
-        container_dump_name = f"oduflow-restore-{uuid.uuid4().hex}"
-        container_dump_path = f"/tmp/{container_dump_name}"
-        container_tmp_files.add(container_dump_path)
-        _copy_file_to_container(
-            db_container,
-            resolved_dump,
-            "/tmp",
-            archive_name=container_dump_name,
-        )
+        if container_dump_path is None:
+            container_dump_name = f"oduflow-restore-{uuid.uuid4().hex}"
+            container_dump_path = f"/tmp/{container_dump_name}"
+            container_tmp_files.add(container_dump_path)
+            _copy_file_to_container(
+                db_container,
+                resolved_dump,
+                "/tmp",
+                archive_name=container_dump_name,
+            )
 
         # pg_restore runs with --no-owner so restored objects are owned by the
         # restoring superuser, not by whatever role the dump recorded. For
@@ -2448,22 +2564,28 @@ def publish_env_as_template(
         check_db_quota(client, settings, team)
 
     _wait_pg_ready(client, settings)
-    db_container = client.containers.get(settings.shared_db_container)
 
-    # 1. pg_dump branch DB → new template dump. Ownership is stripped at restore
-    # time (pg_restore --no-owner in reload_template), NOT here: --no-owner is
-    # ignored by pg_dump for the -Fc archive format.
+    # 1-2. pg_dump the branch DB, then rebuild the template DB from it, and only
+    # then move the dump into the template dir — a failed restore leaves no
+    # half-published template behind. Ownership is stripped at restore time
+    # (pg_restore --no-owner in reload_template), NOT here: --no-owner is ignored
+    # by pg_dump for the -Fc archive format.
     dump_path = team.get_template_sql_path(template_name)
     os.makedirs(os.path.dirname(dump_path), exist_ok=True)
-    dump_cmd = ["pg_dump", "-U", settings.db_user, "-Fc", env_db]
 
     logger.info("Dumping branch database %s", env_db)
-    _stream_exec_to_file(client, db_container, dump_cmd, dump_path, tool="pg_dump")
-
-    logger.info("Branch dump saved to %s", dump_path)
-
-    # 2. Reload template DB from new dump
-    reload_template(settings, team, template_name=template_name, dump_path=dump_path)
+    with _staged_db_dump(client, settings, team, env_db, dump_path) as (
+        staged_dump,
+        container_dump,
+    ):
+        logger.info("Branch dump saved to %s", staged_dump)
+        reload_template(
+            settings,
+            team,
+            template_name=template_name,
+            dump_path=staged_dump,
+            container_dump_path=container_dump,
+        )
 
     # ------------------------------------------------------------------
     # 3-7. Swap the template's lower filestore non-destructively (issue #2).

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -2497,6 +2497,36 @@ def _snapshot_filestore(
     ]
 
 
+def _baselines_owned_by(link_dests: list[str], uid: int, gid: int) -> bool:
+    """Whether the linkable baselines already carry the target ownership.
+
+    A hardlinked file keeps whatever ownership the publish that created it gave
+    it, so chowning only the transferred files is complete only while that
+    ownership still matches. It stops matching when a team moves to an Odoo
+    image with a different uid — rare, but then the whole tree has to be walked
+    or the old files would keep the previous uid forever.
+
+    Checking each baseline's root is enough: a mismatch forces the full walk,
+    which leaves root and contents consistent again.
+    """
+    for path in link_dests:
+        if not os.path.isdir(path):
+            continue
+        info = os.stat(path)
+        if info.st_uid != uid or info.st_gid != gid:
+            logger.info(
+                "Baseline %s is owned by %d:%d, not %d:%d; chowning the whole "
+                "template filestore",
+                path,
+                info.st_uid,
+                info.st_gid,
+                uid,
+                gid,
+            )
+            return False
+    return True
+
+
 def _chown_filestore(
     root: str,
     rel_paths: list[str] | None,
@@ -2673,11 +2703,12 @@ def publish_env_as_template(
 
             odoo_uid_gid = get_odoo_uid_gid(client, source_image)
             uid_str, gid_str = odoo_uid_gid.split(":")
+            uid, gid = int(uid_str), int(gid_str)
             _chown_filestore(
                 template_filestore_path,
-                transferred,
-                int(uid_str),
-                int(gid_str),
+                transferred if _baselines_owned_by(link_dests, uid, gid) else None,
+                uid,
+                gid,
                 client,
                 source_image,
             )

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -1364,25 +1364,28 @@ def _staged_db_dump(
 
     if exchange is None:
         host_path = f"{dest_path}.staged"
-        _stream_exec_to_file(
-            client, db_container, [*dump_cmd, db_name], host_path, tool="pg_dump"
-        )
     else:
         host_dir, container_dir = exchange
         os.makedirs(host_dir, exist_ok=True)
         name = f"{db_name}-{uuid.uuid4().hex}.pgdump"
         host_path = os.path.join(host_dir, name)
         container_path = f"{container_dir}/{name}"
-        exit_code, output = db_container.exec_run(
-            [*dump_cmd, "-f", container_path, db_name]
-        )
-        if exit_code != 0:
-            with contextlib.suppress(OSError):
-                os.remove(host_path)
-            msg = output.decode("utf-8") if isinstance(output, bytes) else str(output)
-            raise ExternalCommandError("pg_dump", exit_code, msg)
 
     try:
+        if container_path is None:
+            _stream_exec_to_file(
+                client, db_container, [*dump_cmd, db_name], host_path, tool="pg_dump"
+            )
+        else:
+            exit_code, output = db_container.exec_run(
+                [*dump_cmd, "-f", container_path, db_name]
+            )
+            if exit_code != 0:
+                msg = (
+                    output.decode("utf-8") if isinstance(output, bytes) else str(output)
+                )
+                raise ExternalCommandError("pg_dump", exit_code, msg)
+
         yield host_path, container_path
         try:
             os.replace(host_path, dest_path)
@@ -1913,12 +1916,16 @@ def reload_template(
     template_name: str,
     dump_path: str | None = None,
     container_dump_path: str | None = None,
+    *,
+    persist_dump: bool = True,
 ) -> dict[str, Any]:
     """Rebuild the template database from its dump.
 
     ``container_dump_path`` names a dump the PostgreSQL container can already
     read (staged in the pg_exchange mount), skipping the copy into its writable
     layer. The caller owns that file; only dumps copied in here are cleaned up.
+    ``persist_dump=False`` lets a caller install its staged file atomically after
+    this restore succeeds instead of making a second full-size copy here.
     """
     client = get_client()
     tpl_db = get_template_db_name(template_name, team.team_id)
@@ -2129,7 +2136,7 @@ def reload_template(
 
         logger.info("Verified %d tables in restored database %s", num_tables, tpl_db)
 
-        if dump_path:
+        if dump_path and persist_dump:
             tpl_dir = team.get_template_dir(template_name)
             os.makedirs(tpl_dir, exist_ok=True)
             base = "dump.sql" if use_psql else "dump.pgdump"
@@ -2600,8 +2607,9 @@ def publish_env_as_template(
     # half-published template behind. Ownership is stripped at restore time
     # (pg_restore --no-owner in reload_template), NOT here: --no-owner is ignored
     # by pg_dump for the -Fc archive format.
-    dump_path = team.get_template_sql_path(template_name)
-    os.makedirs(os.path.dirname(dump_path), exist_ok=True)
+    template_dir = team.get_template_dir(template_name)
+    dump_path = os.path.join(template_dir, "dump.pgdump")
+    os.makedirs(template_dir, exist_ok=True)
 
     logger.info("Dumping branch database %s", env_db)
     with _staged_db_dump(client, settings, team, env_db, dump_path) as (
@@ -2615,7 +2623,17 @@ def publish_env_as_template(
             template_name=template_name,
             dump_path=staged_dump,
             container_dump_path=container_dump,
+            persist_dump=False,
         )
+
+    # A publish always produces an uncompressed custom-format archive. Keep the
+    # previous dump until the restore and atomic install above have both
+    # succeeded, then remove any obsolete format left by an older template.
+    for old_name in ("dump.sql", "dump.sql.gz", "dump.pgdump.gz"):
+        old_path = os.path.join(template_dir, old_name)
+        if os.path.isfile(old_path):
+            os.remove(old_path)
+            logger.info("Removed old dump %s", old_path)
 
     # ------------------------------------------------------------------
     # 3-7. Swap the template's lower filestore non-destructively (issue #2).

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -2645,9 +2645,15 @@ def publish_env_as_template(
     # Link against the baseline the env is currently mounted on (where nearly
     # every file matches) and against the template being published into, which
     # differ when an env from one template is published under a new name.
+    # An env created without a template carries the literal "none" label
+    # (env_ops._env_labels), which is a sentinel, not a template to link against.
+    candidates = (
+        source_template if source_template != "none" else "",
+        template_name,
+    )
     link_dests = [
         team.get_template_filestore_path(name)
-        for name in dict.fromkeys(filter(None, (source_template, template_name)))
+        for name in dict.fromkeys(filter(None, candidates))
     ]
     snapshot_dir: str | None = None
     transferred: list[str] | None = None

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import gzip
 import hashlib
+import io
 import json
 import logging
 import os
@@ -1123,28 +1124,64 @@ def _is_pg_restore_archive_version_error(output: str) -> bool:
     return "unsupported version" in output and "file header" in output
 
 
+class _ChunkReader(io.RawIOBase):
+    """Read-only file object over an iterator of byte chunks.
+
+    ``container.get_archive`` hands back a generator; wrapping it here lets
+    ``tarfile`` consume the archive as it arrives instead of spooling the whole
+    thing to a temp file first (a full-size extra write + read per dump).
+    """
+
+    def __init__(self, chunks: Any) -> None:
+        self._chunks = iter(chunks)
+        self._buf = b""
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer: Any) -> int:
+        while not self._buf:
+            try:
+                self._buf = next(self._chunks)
+            except StopIteration:
+                return 0
+        size = min(len(buffer), len(self._buf))
+        buffer[:size] = self._buf[:size]
+        self._buf = self._buf[size:]
+        return size
+
+
+@contextlib.contextmanager
+def _container_archive_stream(
+    container: docker.models.containers.Container, container_path: str
+) -> Any:
+    """Open the container's tar stream for sequential reading (``r|``).
+
+    Stream mode has no random access: members must be extracted while the
+    iteration is positioned on them, and ``getmembers()`` is unavailable.
+    """
+    chunks, _ = container.get_archive(container_path)
+    reader = io.BufferedReader(_ChunkReader(chunks))
+    with tarfile.open(fileobj=reader, mode="r|") as tar:
+        yield tar
+
+
 def _copy_file_from_container(
     container: docker.models.containers.Container, container_path: str, dest_path: str
 ) -> None:
-    import tempfile
-
-    chunks, _ = container.get_archive(container_path)
-    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
-        for chunk in chunks:
-            tmp.write(chunk)
-        tmp_path = tmp.name
-    try:
-        with tarfile.open(tmp_path, mode="r") as tar:
-            member = tar.getmembers()[0]
-            f = tar.extractfile(member)
-            if f is None:
-                raise ExternalCommandError(
-                    "get_archive", -1, f"Could not extract {container_path} from tar"
-                )
+    with _container_archive_stream(container, container_path) as tar:
+        for member in tar:
+            if not member.isfile():
+                continue
+            src = tar.extractfile(member)
+            if src is None:
+                break
             with open(dest_path, "wb") as out:
-                shutil.copyfileobj(f, out)
-    finally:
-        os.remove(tmp_path)
+                shutil.copyfileobj(src, out)
+            return
+    raise ExternalCommandError(
+        "get_archive", -1, f"Could not extract {container_path} from tar"
+    )
 
 
 def _extract_archive_from_container(
@@ -1153,44 +1190,108 @@ def _extract_archive_from_container(
     dest_dir: str,
     prefix: str,
 ) -> int:
-    import tempfile
-
-    chunks, _ = container.get_archive(container_path)
-    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp:
-        for chunk in chunks:
-            tmp.write(chunk)
-        tmp_path = tmp.name
-    try:
-        extracted = 0
-        with tarfile.open(tmp_path, mode="r") as tar:
-            for member in tar.getmembers():
-                if not member.name.startswith(prefix) and member.name != prefix.rstrip(
-                    "/"
+    extracted = 0
+    with _container_archive_stream(container, container_path) as tar:
+        for member in tar:
+            if not member.name.startswith(prefix) and member.name != prefix.rstrip("/"):
+                continue
+            rel = member.name[len(prefix) :]
+            if not rel:
+                continue
+            member.name = rel
+            # Reject members that escape dest_dir via traversal or an
+            # absolute/symlink target (defence in depth; source is our own
+            # template-builder container).
+            if not _is_within_directory(dest_dir, os.path.join(dest_dir, rel)):
+                logger.warning("Skipping unsafe archive member: %s", rel)
+                continue
+            if member.issym() or member.islnk():
+                link_target = os.path.join(dest_dir, os.path.dirname(rel))
+                if not _is_within_directory(
+                    dest_dir, os.path.join(link_target, member.linkname)
                 ):
+                    logger.warning("Skipping unsafe link member: %s", rel)
                     continue
-                rel = member.name[len(prefix) :]
-                if not rel:
-                    continue
-                member.name = rel
-                # Reject members that escape dest_dir via traversal or an
-                # absolute/symlink target (defence in depth; source is our own
-                # template-builder container).
-                if not _is_within_directory(dest_dir, os.path.join(dest_dir, rel)):
-                    logger.warning("Skipping unsafe archive member: %s", rel)
-                    continue
-                if member.issym() or member.islnk():
-                    link_target = os.path.join(dest_dir, os.path.dirname(rel))
-                    if not _is_within_directory(
-                        dest_dir, os.path.join(link_target, member.linkname)
-                    ):
-                        logger.warning("Skipping unsafe link member: %s", rel)
-                        continue
-                tar.extract(member, dest_dir)
-                if not member.isdir():
-                    extracted += 1
-        return extracted
-    finally:
-        os.remove(tmp_path)
+            tar.extract(member, dest_dir)
+            if not member.isdir():
+                extracted += 1
+    return extracted
+
+
+_EXEC_EXIT_POLL_SECONDS = 5.0
+
+
+def _wait_exec_exit_code(api: Any, exec_id: str) -> int:
+    """Exit code of a finished exec, tolerating a briefly lagging daemon."""
+    deadline = time.monotonic() + _EXEC_EXIT_POLL_SECONDS
+    while True:
+        code = api.exec_inspect(exec_id).get("ExitCode")
+        if code is not None:
+            return int(code)
+        if time.monotonic() >= deadline:
+            return -1
+        time.sleep(0.05)
+
+
+def _stream_exec_to_file(
+    client: DockerClient,
+    container: docker.models.containers.Container,
+    cmd: list[str],
+    dest_path: str,
+    *,
+    tool: str,
+) -> int:
+    """Run ``cmd`` in ``container``, streaming its stdout straight to ``dest_path``.
+
+    Replaces the exec-to-/tmp + ``get_archive`` route, which wrote every dump
+    three times at full size (container writable layer, host temp tar, final
+    file) and left the container copy behind to grow the writable layer. Here
+    the payload lands only at its destination.
+
+    ``tty=False`` is required: with a TTY the daemon stops multiplexing the
+    streams and mangles binary output. ``demux=True`` then keeps stderr out of
+    the payload bytes. The exit code is checked explicitly — without it a
+    truncated dump looks like success.
+    """
+    api = client.api
+    exec_id = api.exec_create(container.id, cmd, tty=False, stdout=True, stderr=True)[
+        "Id"
+    ]
+    stderr = bytearray()
+    written = 0
+    part_path = dest_path + ".part"
+    try:
+        with open(part_path, "wb") as out:
+            for stdout_chunk, stderr_chunk in api.exec_start(
+                exec_id, stream=True, demux=True
+            ):
+                if stdout_chunk:
+                    out.write(stdout_chunk)
+                    written += len(stdout_chunk)
+                if stderr_chunk:
+                    stderr.extend(stderr_chunk)
+        exit_code = _wait_exec_exit_code(api, exec_id)
+        message = stderr.decode("utf-8", errors="replace")
+        if exit_code != 0:
+            raise ExternalCommandError(tool, exit_code, message)
+        os.replace(part_path, dest_path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(part_path)
+        raise
+    if message.strip():
+        logger.debug("%s stderr: %s", tool, message.strip())
+    return written
+
+
+def _pg_restore_jobs() -> int:
+    """Worker count for parallel ``pg_restore``.
+
+    Derived from the host CPUs rather than configured: the shared PostgreSQL
+    container serves every team, so the cap keeps one restore from taking the
+    whole cluster.
+    """
+    return max(1, min(4, os.cpu_count() or 1))
 
 
 _PG_TABLESPACES_MOUNT = "/tablespaces"
@@ -1781,6 +1882,10 @@ def reload_template(
                     container_dump_path,
                 ]
             else:
+                # Parallel restore only here: -j needs a seekable archive, which
+                # rules out the gzip pipeline above (pg_restore reads a pipe) and
+                # the plain-SQL psql path. Odoo restores are dominated by index
+                # and constraint builds, which is exactly what -j parallelises.
                 restore_cmd = [
                     "pg_restore",
                     "--no-owner",
@@ -1788,8 +1893,11 @@ def reload_template(
                     settings.db_user,
                     "-d",
                     tpl_db,
-                    container_dump_path,
                 ]
+                jobs = _pg_restore_jobs()
+                if jobs > 1:
+                    restore_cmd += ["-j", str(jobs)]
+                restore_cmd.append(container_dump_path)
 
         logger.info(
             "DB restore started, template_db=%s, dump=%s", tpl_db, resolved_dump
@@ -2078,29 +2186,15 @@ def init_template(
     os.makedirs(os.path.dirname(template_sql_path), exist_ok=True)
 
     db_container = client.containers.get(settings.shared_db_container)
-    dump_cmd = [
-        "pg_dump",
-        "-U",
-        settings.db_user,
-        "-Fp",
-        "-f",
-        f"/tmp/{build_db}.dump",
-        build_db,
-    ]
-    exit_code_dump, output_dump = db_container.exec_run(dump_cmd)
-    if exit_code_dump != 0:
-        msg = (
-            output_dump.decode("utf-8")
-            if isinstance(output_dump, bytes)
-            else str(output_dump)
+    dump_cmd = ["pg_dump", "-U", settings.db_user, "-Fp", build_db]
+    try:
+        _stream_exec_to_file(
+            client, db_container, dump_cmd, template_sql_path, tool="pg_dump"
         )
+    except ExternalCommandError:
         temp_container.remove(v=True)
         _exec_sql(client, settings, f"DROP DATABASE IF EXISTS {build_db} WITH (FORCE);")
-        raise ExternalCommandError("pg_dump", exit_code_dump, msg)
-
-    logger.info("pg_dump completed, extracting dump file")
-
-    _copy_file_from_container(db_container, f"/tmp/{build_db}.dump", template_sql_path)
+        raise
 
     logger.info("Dump saved to %s", template_sql_path)
 
@@ -2274,16 +2368,10 @@ def publish_env_as_template(
     # ignored by pg_dump for the -Fc archive format.
     dump_path = team.get_template_sql_path(template_name)
     os.makedirs(os.path.dirname(dump_path), exist_ok=True)
-    dump_file = f"/tmp/{env_db}.dump"
-    dump_cmd = ["pg_dump", "-U", settings.db_user, "-Fc", "-f", dump_file, env_db]
+    dump_cmd = ["pg_dump", "-U", settings.db_user, "-Fc", env_db]
 
     logger.info("Dumping branch database %s", env_db)
-    exit_code, output = db_container.exec_run(dump_cmd)
-    if exit_code != 0:
-        msg = output.decode("utf-8") if isinstance(output, bytes) else str(output)
-        raise ExternalCommandError("pg_dump", exit_code, msg)
-
-    _copy_file_from_container(db_container, dump_file, dump_path)
+    _stream_exec_to_file(client, db_container, dump_cmd, dump_path, tool="pg_dump")
 
     logger.info("Branch dump saved to %s", dump_path)
 

--- a/src/oduflow/prereqs.py
+++ b/src/oduflow/prereqs.py
@@ -1,16 +1,26 @@
 """Best-effort host prerequisite provisioning, run once at server start.
 
-The only prerequisite handled here is ``fuse-overlayfs``, used to clone large
-template filestores copy-on-write instead of duplicating them (see
-``docker_ops/env_ops.py``). It is a Linux/FUSE binary — it does not exist on
-macOS, and the packaged Docker image (``oduist/oduflow``) already bundles it —
-so auto-install only matters for bare-metal Linux installs (``uv tool`` +
-systemd running as root).
+Two host binaries are handled here:
 
-Every check is best-effort and idempotent: nothing here raises. When the binary
+``fuse-overlayfs`` clones large template filestores copy-on-write instead of
+duplicating them (see ``docker_ops/env_ops.py``). It is a Linux/FUSE binary — it
+does not exist on macOS, where filestore overlays are skipped entirely — so its
+absence off Linux is expected and silent.
+
+``rsync`` copies only what changed. Publishing an environment as a template
+snapshots its filestore by hardlinking every unchanged file from the baseline
+(``docker_ops/system_ops.py``), and syncing a template from a local source uses
+it directly (``sync.py``). It is wanted on every platform: without it a publish
+degrades to re-copying the whole filestore, and a local template sync fails.
+
+Both are bundled in the packaged Docker image (``oduist/oduflow``), so
+auto-install only matters for bare-metal installs (``uv tool`` + systemd running
+as root).
+
+Every check is best-effort and idempotent: nothing here raises. When a binary
 cannot be provided (non-Linux, not root, non-Debian, no network), the reason is
-logged and env creation falls back to a plain filestore copy on macOS or surfaces
-a clear ``PrerequisiteNotMetError`` on Linux at mount time.
+logged and the caller degrades — a plain filestore copy, or a clear
+``PrerequisiteNotMetError`` at overlay mount time on Linux.
 
 Called from ``server._ensure_initialized`` on every server start.
 """
@@ -40,37 +50,65 @@ def ensure_fuse_overlayfs() -> None:
     """
     if not sys.platform.startswith("linux"):
         return  # macOS/other: overlay is unsupported, copy mode is used instead
-    if shutil.which("fuse-overlayfs"):
+    _ensure_binary("fuse-overlayfs")
+
+
+def ensure_rsync() -> None:
+    """Install ``rsync`` via apt-get on Linux if it is missing.
+
+    Unlike fuse-overlayfs this is wanted everywhere, so a missing binary is
+    reported off Linux too rather than passed over: publishing a template
+    silently degrades to copying the whole filestore without it, and syncing a
+    template from a local source needs it outright.
+    """
+    if shutil.which("rsync"):
+        return
+    if not sys.platform.startswith("linux"):
+        logger.warning(
+            "rsync is missing; template publishes will copy the whole filestore "
+            "instead of only what changed, and local template syncs will fail"
+        )
+        return
+    _ensure_binary("rsync")
+
+
+def _ensure_binary(binary: str) -> None:
+    """Best-effort ``apt-get install`` of *binary* on a Debian/Ubuntu host."""
+    if shutil.which(binary):
         return  # already present (Docker image ships it, or installed earlier)
     if os.geteuid() != 0:
         logger.warning(
-            "fuse-overlayfs is missing and Oduflow is not running as root; "
-            "install it manually: sudo apt install fuse-overlayfs"
+            "%s is missing and Oduflow is not running as root; "
+            "install it manually: sudo apt install %s",
+            binary,
+            binary,
         )
         return
     if shutil.which("apt-get") is None:
         logger.warning(
-            "fuse-overlayfs is missing and apt-get was not found; install it "
-            "with your distribution's package manager (e.g. dnf install "
-            "fuse-overlayfs)"
+            "%s is missing and apt-get was not found; install it with your "
+            "distribution's package manager (e.g. dnf install %s)",
+            binary,
+            binary,
         )
         return
 
-    logger.info("fuse-overlayfs is missing; installing via apt-get")
-    if _apt_install("fuse-overlayfs"):
-        logger.info("fuse-overlayfs installed successfully")
+    logger.info("%s is missing; installing via apt-get", binary)
+    if _apt_install(binary):
+        logger.info("%s installed successfully", binary)
         return
 
     # Package index may be stale/empty (e.g. fresh minimal image); refresh once
     # and retry a single time.
-    logger.info("fuse-overlayfs install failed; refreshing apt index and retrying")
+    logger.info("%s install failed; refreshing apt index and retrying", binary)
     _run_apt(["apt-get", "update"])
-    if _apt_install("fuse-overlayfs"):
-        logger.info("fuse-overlayfs installed successfully after apt-get update")
+    if _apt_install(binary):
+        logger.info("%s installed successfully after apt-get update", binary)
     else:
         logger.warning(
-            "Could not auto-install fuse-overlayfs; install it manually: "
-            "sudo apt install fuse-overlayfs"
+            "Could not auto-install %s; install it manually: sudo apt install %s",
+            binary,
+            binary,
         )
 
 

--- a/src/oduflow/quotas.py
+++ b/src/oduflow/quotas.py
@@ -123,6 +123,11 @@ def apply_team_disk_quota(
     trees = [
         team.data_dir,
         os.path.join(settings.base_data_dir, "pg_tablespaces", f"team_{team.team_id}"),
+        # Dumps staged for the PostgreSQL container. Stamping this is not just
+        # accounting: XFS refuses to rename a file into a project-inheriting
+        # directory whose project ID differs (-EXDEV), so without it the move of
+        # a finished dump into the team's templates dir would fail outright.
+        os.path.join(settings.base_data_dir, "pg_exchange", f"team_{team.team_id}"),
     ]
     for tree in trees:
         os.makedirs(tree, exist_ok=True)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4422,6 +4422,7 @@ def _ensure_initialized(settings: Settings) -> None:
     _apply_agent_feedback(settings)
     _copy_bundled_configs()
     prereqs.ensure_fuse_overlayfs()
+    prereqs.ensure_rsync()
     system_ops.init_system(settings)
 
     # Snapshot-before-deploy hook (no-op while [backup] is unconfigured).

--- a/tests/test_dump_streaming.py
+++ b/tests/test_dump_streaming.py
@@ -1,0 +1,297 @@
+"""Streaming dump/extract paths in system_ops.
+
+Dumps used to be written three times at full size (pg_dump into the container's
+writable layer, get_archive into a host temp tar, then the final file). These
+tests pin the streaming replacements: the payload must land only at its
+destination, stderr must never reach the payload bytes, and a non-zero exit must
+not leave a truncated dump behind looking like a success.
+"""
+
+import io
+import os
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ExternalCommandError
+from oduflow.settings import Settings, TeamSettings
+
+TEST_SETTINGS = Settings()
+TEST_TEAM = TeamSettings(team_id="1", data_dir="/tmp/oduflow-test-team")
+
+
+def _tar_blob(entries: list[tuple[str, bytes]]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, data in entries:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class _FakeArchiveContainer:
+    """Container whose get_archive hands back many small chunks."""
+
+    def __init__(self, blob: bytes, chunk_size: int = 7) -> None:
+        self._blob = blob
+        self._chunk_size = chunk_size
+        self.archive_calls = 0
+
+    def get_archive(self, path: str):
+        self.archive_calls += 1
+        chunks = (
+            self._blob[i : i + self._chunk_size]
+            for i in range(0, len(self._blob), self._chunk_size)
+        )
+        return chunks, {}
+
+
+class _FakeExecApi:
+    def __init__(self, frames, exit_codes=(0,)) -> None:
+        self.frames = frames
+        self.exit_codes = list(exit_codes)
+        self.cmd = None
+        self.create_kwargs: dict = {}
+        self.start_kwargs: dict = {}
+
+    def exec_create(self, container_id, cmd, **kwargs):
+        self.cmd = cmd
+        self.create_kwargs = kwargs
+        return {"Id": "exec-1"}
+
+    def exec_start(self, exec_id, **kwargs):
+        self.start_kwargs = kwargs
+        return iter(self.frames)
+
+    def exec_inspect(self, exec_id):
+        code = (
+            self.exit_codes.pop(0) if len(self.exit_codes) > 1 else self.exit_codes[0]
+        )
+        return {"ExitCode": code}
+
+
+def _fake_exec_client(frames, exit_codes=(0,)):
+    client = MagicMock()
+    api = _FakeExecApi(frames, exit_codes)
+    client.api = api
+    container = MagicMock()
+    container.id = "db-container"
+    return client, api, container
+
+
+# --------------------------------------------------------------------------
+# _ChunkReader
+# --------------------------------------------------------------------------
+
+
+def test_chunk_reader_reassembles_across_chunk_boundaries():
+    payload = bytes(range(256)) * 4
+    reader = io.BufferedReader(
+        system_ops._ChunkReader(payload[i : i + 5] for i in range(0, len(payload), 5))
+    )
+    assert reader.read() == payload
+
+
+def test_chunk_reader_reports_eof_on_exhausted_iterator():
+    reader = system_ops._ChunkReader(iter([]))
+    assert reader.readinto(bytearray(16)) == 0
+
+
+# --------------------------------------------------------------------------
+# _copy_file_from_container / _extract_archive_from_container
+# --------------------------------------------------------------------------
+
+
+def test_copy_file_from_container_streams_payload(tmp_path):
+    payload = b"PGDMP" + os.urandom(5000)
+    container = _FakeArchiveContainer(_tar_blob([("dump.pgdump", payload)]))
+    dest = tmp_path / "dump.pgdump"
+
+    system_ops._copy_file_from_container(container, "/tmp/dump.pgdump", str(dest))
+
+    assert dest.read_bytes() == payload
+    assert container.archive_calls == 1
+
+
+def test_copy_file_from_container_raises_when_archive_has_no_file(tmp_path):
+    container = _FakeArchiveContainer(_tar_blob([]))
+
+    with pytest.raises(ExternalCommandError):
+        system_ops._copy_file_from_container(
+            container, "/tmp/missing", str(tmp_path / "out")
+        )
+
+
+def test_extract_archive_streams_and_strips_prefix(tmp_path):
+    prefix = "Odoo/filestore/build_db/"
+    blob = _tar_blob(
+        [
+            (prefix + "aa/hash1", b"one"),
+            (prefix + "bb/hash2", b"two"),
+        ]
+    )
+    container = _FakeArchiveContainer(blob)
+
+    extracted = system_ops._extract_archive_from_container(
+        container, "/var/lib/odoo", str(tmp_path), prefix
+    )
+
+    assert extracted == 2
+    assert (tmp_path / "aa/hash1").read_bytes() == b"one"
+    assert (tmp_path / "bb/hash2").read_bytes() == b"two"
+
+
+def test_extract_archive_still_rejects_traversal_members(tmp_path):
+    # The traversal guard must survive the switch to sequential ("r|") reading.
+    prefix = "Odoo/filestore/build_db/"
+    dest = tmp_path / "filestore"
+    dest.mkdir()
+    blob = _tar_blob(
+        [
+            (prefix + "safe", b"ok"),
+            (prefix + "../../../escaped", b"pwned"),
+        ]
+    )
+    container = _FakeArchiveContainer(blob)
+
+    extracted = system_ops._extract_archive_from_container(
+        container, "/var/lib/odoo", str(dest), prefix
+    )
+
+    assert extracted == 1
+    assert (dest / "safe").read_bytes() == b"ok"
+    assert not (tmp_path / "escaped").exists()
+
+
+# --------------------------------------------------------------------------
+# _stream_exec_to_file
+# --------------------------------------------------------------------------
+
+
+def test_stream_exec_writes_stdout_and_drops_stderr(tmp_path):
+    dest = tmp_path / "dump.pgdump"
+    frames = [
+        (b"PGDMP", None),
+        (None, b"pg_dump: warning: something noisy\n"),
+        (b"\x01\x02\x03", None),
+    ]
+    client, api, container = _fake_exec_client(frames)
+
+    written = system_ops._stream_exec_to_file(
+        client, container, ["pg_dump", "db"], str(dest), tool="pg_dump"
+    )
+
+    assert dest.read_bytes() == b"PGDMP\x01\x02\x03"
+    assert written == 8
+    # A TTY would stop the daemon multiplexing and corrupt the binary payload.
+    assert api.create_kwargs["tty"] is False
+    assert api.start_kwargs["demux"] is True
+    assert api.start_kwargs["stream"] is True
+
+
+def test_stream_exec_raises_and_leaves_no_partial_file(tmp_path):
+    dest = tmp_path / "dump.pgdump"
+    frames = [(b"trunc", None), (None, b"pg_dump: error: connection lost\n")]
+    client, api, container = _fake_exec_client(frames, exit_codes=(1,))
+
+    with pytest.raises(ExternalCommandError, match="connection lost"):
+        system_ops._stream_exec_to_file(
+            client, container, ["pg_dump", "db"], str(dest), tool="pg_dump"
+        )
+
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_stream_exec_tolerates_lagging_exit_code(tmp_path):
+    dest = tmp_path / "dump.pgdump"
+    client, api, container = _fake_exec_client([(b"data", None)], exit_codes=(None, 0))
+
+    system_ops._stream_exec_to_file(
+        client, container, ["pg_dump", "db"], str(dest), tool="pg_dump"
+    )
+
+    assert dest.read_bytes() == b"data"
+
+
+def test_stream_exec_fails_when_exit_code_never_arrives(tmp_path):
+    dest = tmp_path / "dump.pgdump"
+    client, api, container = _fake_exec_client([(b"data", None)], exit_codes=(None,))
+
+    with patch.object(system_ops, "_EXEC_EXIT_POLL_SECONDS", 0.0):
+        with pytest.raises(ExternalCommandError):
+            system_ops._stream_exec_to_file(
+                client, container, ["pg_dump", "db"], str(dest), tool="pg_dump"
+            )
+
+    assert not dest.exists()
+
+
+# --------------------------------------------------------------------------
+# parallel restore
+# --------------------------------------------------------------------------
+
+
+def test_pg_restore_jobs_is_bounded():
+    for cpus in (None, 1, 2, 8, 64):
+        with patch.object(system_ops.os, "cpu_count", return_value=cpus):
+            assert 1 <= system_ops._pg_restore_jobs() <= 4
+
+
+def _reload_template_restore_cmds(tmp_path, *, is_text_dump: bool, jobs: int = 4):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path))
+    tpl_dir = team.get_template_dir("mytpl")
+    os.makedirs(tpl_dir, exist_ok=True)
+    dump = os.path.join(tpl_dir, "dump.pgdump")
+    with open(dump, "wb") as fh:
+        fh.write(b"PGDMP" if not is_text_dump else b"-- sql")
+
+    db_container = MagicMock()
+    db_container.exec_run.return_value = (0, b"")
+    client = MagicMock()
+    client.containers.get.return_value = db_container
+
+    with (
+        patch.object(system_ops, "get_client", return_value=client),
+        patch.object(system_ops, "_wait_pg_ready"),
+        patch.object(system_ops, "_exec_sql", return_value="5"),
+        patch.object(system_ops, "_db_exists", return_value=False),
+        patch.object(system_ops, "_is_text_dump", return_value=is_text_dump),
+        patch.object(
+            system_ops, "ensure_team_tablespace", return_value="oduflow_team_1"
+        ),
+        patch.object(system_ops, "_copy_file_to_container"),
+        patch.object(system_ops, "_update_template_sizes"),
+        patch.object(system_ops, "_pg_restore_jobs", return_value=jobs),
+    ):
+        system_ops.reload_template(TEST_SETTINGS, team, "mytpl")
+
+    return [call.args[0] for call in db_container.exec_run.call_args_list]
+
+
+def test_custom_dump_restore_runs_parallel(tmp_path):
+    cmds = _reload_template_restore_cmds(tmp_path, is_text_dump=False)
+    restore = next(cmd for cmd in cmds if cmd[0] == "pg_restore")
+
+    assert "-j" in restore
+    assert restore[restore.index("-j") + 1] == "4"
+    # The archive path must stay last: -j is inserted before it, not after.
+    assert restore[-1].startswith("/tmp/")
+
+
+def test_single_cpu_restore_omits_jobs_flag(tmp_path):
+    cmds = _reload_template_restore_cmds(tmp_path, is_text_dump=False, jobs=1)
+    restore = next(cmd for cmd in cmds if cmd[0] == "pg_restore")
+
+    assert "-j" not in restore
+
+
+def test_plain_sql_restore_never_uses_jobs(tmp_path):
+    # psql has no -j; only seekable custom-format archives can restore in parallel.
+    cmds = _reload_template_restore_cmds(tmp_path, is_text_dump=True)
+    restore = next(cmd for cmd in cmds if cmd[0] == "psql")
+
+    assert "-j" not in restore

--- a/tests/test_filestore_snapshot.py
+++ b/tests/test_filestore_snapshot.py
@@ -171,6 +171,27 @@ def test_chown_walks_everything_after_a_full_copy(tmp_path):
     recursive.assert_called_once()
 
 
+def test_baseline_ownership_check_accepts_a_matching_baseline(tmp_path):
+    baseline = tmp_path / "baseline"
+    _write(str(baseline / "a"), "x")
+    info = os.stat(baseline)
+
+    assert system_ops._baselines_owned_by([str(baseline)], info.st_uid, info.st_gid)
+    assert system_ops._baselines_owned_by([str(tmp_path / "absent")], 0, 0)
+
+
+def test_baseline_ownership_check_rejects_a_foreign_uid(tmp_path):
+    # An env built on an Odoo image with a different uid: files hardlinked from
+    # the old baseline would keep the old owner, so the full walk is required.
+    baseline = tmp_path / "baseline"
+    _write(str(baseline / "a"), "x")
+    info = os.stat(baseline)
+
+    assert not system_ops._baselines_owned_by(
+        [str(baseline)], info.st_uid + 1, info.st_gid
+    )
+
+
 def test_chown_falls_back_to_container_on_permission_error(tmp_path):
     root = tmp_path / "filestore"
     _write(str(root / "a"), "x")

--- a/tests/test_filestore_snapshot.py
+++ b/tests/test_filestore_snapshot.py
@@ -191,6 +191,11 @@ def test_chown_falls_back_to_container_on_permission_error(tmp_path):
 # --------------------------------------------------------------------------
 
 
+def _fake_pg_dump(client, container, cmd, dest_path, *, tool):
+    _write(dest_path, "PGDMP")
+    return 5
+
+
 def _publish(tmp_path, *, env_template: str, target_template: str):
     """Drive publish_env_as_template over a real on-disk filestore layout."""
     import contextlib
@@ -229,7 +234,7 @@ def _publish(tmp_path, *, env_template: str, target_template: str):
         ),
         patch.object(system_ops, "check_db_quota"),
         patch.object(system_ops, "_wait_pg_ready"),
-        patch.object(system_ops, "_stream_exec_to_file"),
+        patch.object(system_ops, "_stream_exec_to_file", side_effect=_fake_pg_dump),
         patch.object(system_ops, "reload_template"),
         patch.object(system_ops, "get_odoo_uid_gid", return_value="101:102"),
         patch.object(system_ops, "chown_recursive"),

--- a/tests/test_filestore_snapshot.py
+++ b/tests/test_filestore_snapshot.py
@@ -1,0 +1,272 @@
+"""Filestore snapshotting when an environment is published as a template.
+
+Publishing used to copy the environment's whole merged filestore — baseline
+included — even though the baseline is almost always unchanged, and then walk
+the entire result to fix ownership. The snapshot now hardlinks everything it
+can from the baseline and only the transferred files get chowned. These tests
+pin that, plus the fallbacks, which must never be silent.
+"""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from oduflow.docker_ops import system_ops
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(content)
+
+
+def _tree(root):
+    out = {}
+    for dirpath, _dirs, files in os.walk(root):
+        for name in files:
+            full = os.path.join(dirpath, name)
+            with open(full) as fh:
+                out[os.path.relpath(full, root)] = fh.read()
+    return out
+
+
+def _fixture(tmp_path):
+    """Baseline template filestore + an env merged view derived from it."""
+    baseline = tmp_path / "baseline"
+    merged = tmp_path / "merged"
+    for root in (baseline, merged):
+        _write(str(root / "aa" / "unchanged"), "same")
+        _write(str(root / "bb" / "edited"), "same")
+    _write(str(merged / "bb" / "edited"), "changed by the env")
+    _write(str(merged / "cc" / "added"), "new in the env")
+    return str(baseline), str(merged)
+
+
+def test_snapshot_hardlinks_unchanged_files(tmp_path):
+    baseline, merged = _fixture(tmp_path)
+    dest = str(tmp_path / "snapshot")
+
+    transferred = system_ops._snapshot_filestore(merged, dest, link_dests=[baseline])
+
+    assert transferred is not None, "rsync path expected on a dev/CI host"
+    assert _tree(dest) == _tree(merged)
+
+    unchanged = os.stat(os.path.join(dest, "aa/unchanged"))
+    assert unchanged.st_ino == os.stat(os.path.join(baseline, "aa/unchanged")).st_ino
+
+    edited = os.stat(os.path.join(dest, "bb/edited"))
+    assert edited.st_ino != os.stat(os.path.join(baseline, "bb/edited")).st_ino
+    assert edited.st_nlink == 1
+
+
+def test_snapshot_survives_removal_of_the_linked_baseline(tmp_path):
+    # The baseline is rmtree'd right after the snapshot is taken; unlinking one
+    # name must not take the shared content with it.
+    baseline, merged = _fixture(tmp_path)
+    dest = str(tmp_path / "snapshot")
+    expected = _tree(merged)
+
+    system_ops._snapshot_filestore(merged, dest, link_dests=[baseline])
+    import shutil
+
+    shutil.rmtree(baseline)
+
+    assert _tree(dest) == expected
+
+
+def test_snapshot_replaces_a_stale_destination(tmp_path):
+    baseline, merged = _fixture(tmp_path)
+    dest = str(tmp_path / "snapshot")
+    _write(os.path.join(dest, "leftover"), "from a previous run")
+
+    system_ops._snapshot_filestore(merged, dest, link_dests=[baseline])
+
+    assert not os.path.exists(os.path.join(dest, "leftover"))
+    assert _tree(dest) == _tree(merged)
+
+
+def test_snapshot_skips_missing_link_dest(tmp_path):
+    _baseline, merged = _fixture(tmp_path)
+    dest = str(tmp_path / "snapshot")
+
+    with patch.object(system_ops.subprocess, "run", wraps=subprocess.run) as run:
+        system_ops._snapshot_filestore(
+            merged, dest, link_dests=[str(tmp_path / "nope")]
+        )
+
+    cmd = run.call_args.args[0]
+    assert not [arg for arg in cmd if arg.startswith("--link-dest")]
+    assert _tree(dest) == _tree(merged)
+
+
+def test_snapshot_falls_back_loudly_without_rsync(tmp_path, caplog):
+    baseline, merged = _fixture(tmp_path)
+    dest = str(tmp_path / "snapshot")
+
+    with patch.object(system_ops.shutil, "which", return_value=None):
+        transferred = system_ops._snapshot_filestore(
+            merged, dest, link_dests=[baseline]
+        )
+
+    assert transferred is None
+    assert _tree(dest) == _tree(merged)
+    assert "full copy" in caplog.text
+
+
+def test_snapshot_falls_back_loudly_when_rsync_fails(tmp_path, caplog):
+    baseline, merged = _fixture(tmp_path)
+    dest = str(tmp_path / "snapshot")
+    failed = subprocess.CompletedProcess([], 23, b"", b"rsync: partial transfer")
+
+    with patch.object(system_ops.subprocess, "run", return_value=failed):
+        transferred = system_ops._snapshot_filestore(
+            merged, dest, link_dests=[baseline]
+        )
+
+    assert transferred is None
+    assert _tree(dest) == _tree(merged)
+    assert "partial transfer" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# _chown_filestore
+# --------------------------------------------------------------------------
+
+
+def test_chown_touches_only_transferred_paths(tmp_path):
+    root = tmp_path / "filestore"
+    _write(str(root / "aa" / "linked"), "x")
+    _write(str(root / "bb" / "fresh"), "y")
+
+    with patch.object(system_ops.os, "chown") as chown:
+        system_ops._chown_filestore(
+            str(root), ["bb/fresh"], 101, 102, MagicMock(), "odoo:19.0"
+        )
+
+    chowned = {call.args[0] for call in chown.call_args_list}
+    assert chowned == {str(root), str(root / "bb" / "fresh")}
+
+
+def test_chown_ignores_paths_escaping_the_root(tmp_path):
+    root = tmp_path / "filestore"
+    _write(str(root / "safe"), "x")
+    _write(str(tmp_path / "outside"), "y")
+
+    with patch.object(system_ops.os, "chown") as chown:
+        system_ops._chown_filestore(
+            str(root), ["../outside", "safe"], 101, 102, MagicMock(), "odoo:19.0"
+        )
+
+    chowned = {call.args[0] for call in chown.call_args_list}
+    assert chowned == {str(root), str(root / "safe")}
+
+
+def test_chown_walks_everything_after_a_full_copy(tmp_path):
+    root = tmp_path / "filestore"
+    _write(str(root / "a"), "x")
+
+    with patch.object(system_ops, "chown_recursive") as recursive:
+        system_ops._chown_filestore(str(root), None, 101, 102, MagicMock(), "odoo:19.0")
+
+    recursive.assert_called_once()
+
+
+def test_chown_falls_back_to_container_on_permission_error(tmp_path):
+    root = tmp_path / "filestore"
+    _write(str(root / "a"), "x")
+
+    with (
+        patch.object(system_ops.os, "chown", side_effect=PermissionError),
+        patch.object(system_ops, "chown_recursive") as recursive,
+    ):
+        system_ops._chown_filestore(
+            str(root), ["a"], 101, 102, MagicMock(), "odoo:19.0"
+        )
+
+    recursive.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# publish_env_as_template wiring
+# --------------------------------------------------------------------------
+
+
+def _publish(tmp_path, *, env_template: str, target_template: str):
+    """Drive publish_env_as_template over a real on-disk filestore layout."""
+    import contextlib
+
+    from oduflow.docker_ops import env_ops
+    from oduflow.naming import get_db_name, get_filestore_paths
+    from oduflow.settings import Settings, TeamSettings
+
+    settings = Settings()
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path))
+    env_name = "feature-x"
+
+    baseline = team.get_template_filestore_path(env_template)
+    merged = get_filestore_paths(env_name, team.workspaces_dir)["merged"]
+    for root in (baseline, merged):
+        _write(os.path.join(root, "aa", "unchanged"), "same")
+    _write(os.path.join(merged, "cc", "added"), "new in the env")
+
+    container = MagicMock()
+    container.status = "exited"
+    container.image.tags = ["odoo:19.0"]
+    container.labels = {"oduflow.template": env_template}
+    client = MagicMock()
+    client.containers.get.return_value = container
+
+    @contextlib.contextmanager
+    def _no_remount(*args, **kwargs):
+        yield MagicMock(affected=[], failures=[])
+
+    with (
+        patch.object(system_ops, "get_client", return_value=client),
+        patch.object(
+            system_ops,
+            "_db_exists",
+            side_effect=lambda c, s, db: db == get_db_name(env_name, team.team_id),
+        ),
+        patch.object(system_ops, "check_db_quota"),
+        patch.object(system_ops, "_wait_pg_ready"),
+        patch.object(system_ops, "_stream_exec_to_file"),
+        patch.object(system_ops, "reload_template"),
+        patch.object(system_ops, "get_odoo_uid_gid", return_value="101:102"),
+        patch.object(system_ops, "chown_recursive"),
+        patch.object(system_ops.os, "chown"),
+        patch.object(
+            system_ops, "_update_template_sizes", side_effect=lambda *a: a[-1]
+        ),
+        patch.object(env_ops, "remount_template_overlays", _no_remount),
+        patch.object(
+            system_ops, "_snapshot_filestore", wraps=system_ops._snapshot_filestore
+        ) as snapshot,
+    ):
+        system_ops.publish_env_as_template(
+            settings, team, env_name, target_template, overwrite=True
+        )
+
+    return team, snapshot, baseline, merged
+
+
+def test_publish_links_against_the_environments_own_baseline(tmp_path):
+    team, snapshot, baseline, merged = _publish(
+        tmp_path, env_template="prod", target_template="prod"
+    )
+
+    assert snapshot.call_args.kwargs["link_dests"] == [baseline]
+    published = team.get_template_filestore_path("prod")
+    assert _tree(published) == _tree(merged)
+
+
+def test_publish_links_against_both_source_and_target_templates(tmp_path):
+    # Publishing an env under a NEW template name: its own baseline holds the
+    # matching files, the target template is where a re-baseline would match.
+    team, snapshot, baseline, _merged = _publish(
+        tmp_path, env_template="base", target_template="prod"
+    )
+
+    assert snapshot.call_args.kwargs["link_dests"] == [
+        baseline,
+        team.get_template_filestore_path("prod"),
+    ]

--- a/tests/test_filestore_snapshot.py
+++ b/tests/test_filestore_snapshot.py
@@ -285,6 +285,18 @@ def test_publish_links_against_the_environments_own_baseline(tmp_path):
     assert _tree(published) == _tree(merged)
 
 
+def test_publish_ignores_the_none_template_sentinel(tmp_path):
+    # An env created without a template is labelled "none" (env_ops._env_labels);
+    # that is a sentinel, not a template directory to link against.
+    team, snapshot, _baseline, _merged = _publish(
+        tmp_path, env_template="none", target_template="prod"
+    )
+
+    assert snapshot.call_args.kwargs["link_dests"] == [
+        team.get_template_filestore_path("prod")
+    ]
+
+
 def test_publish_links_against_both_source_and_target_templates(tmp_path):
     # Publishing an env under a NEW template name: its own baseline holds the
     # matching files, the target template is where a re-baseline would match.

--- a/tests/test_filestore_snapshot.py
+++ b/tests/test_filestore_snapshot.py
@@ -217,7 +217,13 @@ def _fake_pg_dump(client, container, cmd, dest_path, *, tool):
     return 5
 
 
-def _publish(tmp_path, *, env_template: str, target_template: str):
+def _publish(
+    tmp_path,
+    *,
+    env_template: str,
+    target_template: str,
+    existing_dump_name: str | None = None,
+):
     """Drive publish_env_as_template over a real on-disk filestore layout."""
     import contextlib
 
@@ -234,6 +240,11 @@ def _publish(tmp_path, *, env_template: str, target_template: str):
     for root in (baseline, merged):
         _write(os.path.join(root, "aa", "unchanged"), "same")
     _write(os.path.join(merged, "cc", "added"), "new in the env")
+    if existing_dump_name:
+        _write(
+            os.path.join(team.get_template_dir(target_template), existing_dump_name),
+            "old dump",
+        )
 
     container = MagicMock()
     container.status = "exited"
@@ -256,7 +267,7 @@ def _publish(tmp_path, *, env_template: str, target_template: str):
         patch.object(system_ops, "check_db_quota"),
         patch.object(system_ops, "_wait_pg_ready"),
         patch.object(system_ops, "_stream_exec_to_file", side_effect=_fake_pg_dump),
-        patch.object(system_ops, "reload_template"),
+        patch.object(system_ops, "reload_template") as reload_db,
         patch.object(system_ops, "get_odoo_uid_gid", return_value="101:102"),
         patch.object(system_ops, "chown_recursive"),
         patch.object(system_ops.os, "chown"),
@@ -272,11 +283,11 @@ def _publish(tmp_path, *, env_template: str, target_template: str):
             settings, team, env_name, target_template, overwrite=True
         )
 
-    return team, snapshot, baseline, merged
+    return team, snapshot, baseline, merged, reload_db
 
 
 def test_publish_links_against_the_environments_own_baseline(tmp_path):
-    team, snapshot, baseline, merged = _publish(
+    team, snapshot, baseline, merged, _reload_db = _publish(
         tmp_path, env_template="prod", target_template="prod"
     )
 
@@ -288,7 +299,7 @@ def test_publish_links_against_the_environments_own_baseline(tmp_path):
 def test_publish_ignores_the_none_template_sentinel(tmp_path):
     # An env created without a template is labelled "none" (env_ops._env_labels);
     # that is a sentinel, not a template directory to link against.
-    team, snapshot, _baseline, _merged = _publish(
+    team, snapshot, _baseline, _merged, _reload_db = _publish(
         tmp_path, env_template="none", target_template="prod"
     )
 
@@ -300,7 +311,7 @@ def test_publish_ignores_the_none_template_sentinel(tmp_path):
 def test_publish_links_against_both_source_and_target_templates(tmp_path):
     # Publishing an env under a NEW template name: its own baseline holds the
     # matching files, the target template is where a re-baseline would match.
-    team, snapshot, baseline, _merged = _publish(
+    team, snapshot, baseline, _merged, _reload_db = _publish(
         tmp_path, env_template="base", target_template="prod"
     )
 
@@ -308,3 +319,19 @@ def test_publish_links_against_both_source_and_target_templates(tmp_path):
         baseline,
         team.get_template_filestore_path("prod"),
     ]
+
+
+def test_publish_installs_one_canonical_dump_after_restore(tmp_path):
+    team, _snapshot, _baseline, _merged, reload_db = _publish(
+        tmp_path,
+        env_template="base",
+        target_template="prod",
+        existing_dump_name="dump.sql.gz",
+    )
+
+    template_dir = team.get_template_dir("prod")
+    with open(os.path.join(template_dir, "dump.pgdump")) as dump:
+        assert dump.read() == "PGDMP"
+    assert not os.path.exists(os.path.join(template_dir, "dump.sql.gz"))
+    assert reload_db.call_args.kwargs["persist_dump"] is False
+    assert reload_db.call_args.kwargs["dump_path"].endswith("dump.pgdump.staged")

--- a/tests/test_pg_exchange.py
+++ b/tests/test_pg_exchange.py
@@ -194,6 +194,32 @@ def test_staged_dump_reports_pg_dump_failure(tmp_path):
     assert not dest.exists()
 
 
+def test_staged_dump_cleans_partial_file_when_docker_exec_raises(tmp_path):
+    settings, team = _settings(tmp_path), _team(tmp_path)
+    host_dir = tmp_path / "pg_exchange" / "team_7"
+    host_dir.mkdir(parents=True)
+    client, container = _client([{"Destination": "/exchange"}])
+    dest = tmp_path / "templates" / "prod" / "dump.pgdump"
+    dest.parent.mkdir(parents=True)
+
+    def _disconnect_after_writing(cmd, **kwargs):
+        target = cmd[cmd.index("-f") + 1]
+        with open(host_dir / os.path.basename(target), "w") as fh:
+            fh.write("partial dump")
+        raise docker.errors.APIError("daemon connection lost")
+
+    container.exec_run.side_effect = _disconnect_after_writing
+
+    with pytest.raises(docker.errors.APIError, match="connection lost"):
+        with system_ops._staged_db_dump(
+            client, settings, team, "oduflow_7_main", str(dest)
+        ):
+            pytest.fail("body must not run after Docker exec fails")
+
+    assert not dest.exists()
+    assert list(host_dir.iterdir()) == []
+
+
 # --------------------------------------------------------------------------
 # reload_template
 # --------------------------------------------------------------------------
@@ -235,3 +261,39 @@ def test_reload_skips_the_container_copy_for_an_already_readable_dump(tmp_path):
     assert restore[-1] == "/exchange/team_7/staged.pgdump"
     # The staged dump belongs to the caller; only copies made here are removed.
     assert not [cmd for cmd in cmds if cmd[:2] == ["rm", "-f"]]
+
+
+def test_reload_does_not_persist_a_dump_owned_by_the_staging_context(tmp_path):
+    team = _team(tmp_path)
+    staged = tmp_path / "pg_exchange" / "team_7" / "staged.pgdump"
+    staged.parent.mkdir(parents=True)
+    staged.write_bytes(b"PGDMP")
+
+    db_container = MagicMock()
+    db_container.exec_run.return_value = (0, b"")
+    client = MagicMock()
+    client.containers.get.return_value = db_container
+
+    with (
+        patch.object(system_ops, "get_client", return_value=client),
+        patch.object(system_ops, "_wait_pg_ready"),
+        patch.object(system_ops, "_exec_sql", return_value="5"),
+        patch.object(system_ops, "_db_exists", return_value=False),
+        patch.object(system_ops, "_is_text_dump", return_value=False),
+        patch.object(
+            system_ops, "ensure_team_tablespace", return_value="oduflow_team_7"
+        ),
+        patch.object(system_ops, "_update_template_sizes"),
+        patch.object(system_ops.shutil, "copy2") as copy_dump,
+    ):
+        system_ops.reload_template(
+            Settings(),
+            team,
+            template_name="prod",
+            dump_path=str(staged),
+            container_dump_path="/exchange/team_7/staged.pgdump",
+            persist_dump=False,
+        )
+
+    copy_dump.assert_not_called()
+    assert not os.path.exists(team.get_template_sql_path("prod"))

--- a/tests/test_pg_exchange.py
+++ b/tests/test_pg_exchange.py
@@ -1,0 +1,237 @@
+"""Staging database dumps through the pg_exchange mount.
+
+A dump written straight into a directory the PostgreSQL container also sees
+costs one write to its final filesystem, and a restore can read it in place
+instead of having a full-size copy pushed into the container's writable layer.
+The mount is only attached when the shared container is created, so an existing
+installation must keep working unchanged — detection is by inspection, never by
+recreating the container behind the operator's back.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import docker
+from oduflow.docker_ops import system_ops
+from oduflow.errors import ExternalCommandError
+from oduflow.settings import Settings, TeamSettings
+
+
+def _settings(tmp_path):
+    return Settings(base_data_dir=str(tmp_path))
+
+
+def _team(tmp_path):
+    return TeamSettings(team_id="7", data_dir=str(tmp_path / "team_7"))
+
+
+def _client(mounts):
+    container = MagicMock()
+    container.attrs = {"Mounts": mounts} if mounts is not None else MagicMock()
+    client = MagicMock()
+    client.containers.get.return_value = container
+    return client, container
+
+
+# --------------------------------------------------------------------------
+# detection
+# --------------------------------------------------------------------------
+
+
+def test_exchange_dirs_when_mounted(tmp_path):
+    client, _ = _client([{"Destination": "/tablespaces"}, {"Destination": "/exchange"}])
+
+    dirs = system_ops._pg_exchange_dirs(client, _settings(tmp_path), _team(tmp_path))
+
+    assert dirs == (str(tmp_path / "pg_exchange" / "team_7"), "/exchange/team_7")
+
+
+def test_no_exchange_on_a_container_predating_the_mount(tmp_path):
+    # Existing installations keep the streaming path until their PostgreSQL
+    # container happens to be recreated; nothing is migrated for them.
+    client, _ = _client([{"Destination": "/tablespaces"}])
+
+    assert (
+        system_ops._pg_exchange_dirs(client, _settings(tmp_path), _team(tmp_path))
+        is None
+    )
+
+
+def test_no_exchange_when_mounts_are_not_a_list(tmp_path):
+    client, _ = _client(None)
+
+    assert (
+        system_ops._pg_exchange_dirs(client, _settings(tmp_path), _team(tmp_path))
+        is None
+    )
+
+
+def test_no_exchange_without_a_postgres_container(tmp_path):
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("gone")
+
+    assert (
+        system_ops._pg_exchange_dirs(client, _settings(tmp_path), _team(tmp_path))
+        is None
+    )
+
+
+def test_pg_container_gets_the_exchange_mount(tmp_path):
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("absent")
+    settings = _settings(tmp_path)
+
+    with patch.object(system_ops, "_resolve_conf", return_value=tmp_path / "pg.conf"):
+        system_ops._ensure_pg_container(client, settings, {})
+
+    volumes = client.containers.run.call_args.kwargs["volumes"]
+    assert volumes[str(tmp_path / "pg_exchange")] == {
+        "bind": "/exchange",
+        "mode": "rw",
+    }
+    # The team's data dir stays out: PostgreSQL has no business seeing
+    # workspaces or credentials.
+    assert not any(str(tmp_path / "team_7") in host for host in volumes)
+    assert (tmp_path / "pg_exchange").is_dir()
+
+
+# --------------------------------------------------------------------------
+# _staged_db_dump
+# --------------------------------------------------------------------------
+
+
+def _dump_into_exchange(host_dir):
+    """exec_run stand-in: write the file pg_dump was told to write."""
+
+    def _run(cmd, **kwargs):
+        target = cmd[cmd.index("-f") + 1]
+        with open(os.path.join(host_dir, os.path.basename(target)), "w") as fh:
+            fh.write("PGDMP staged")
+        return 0, b""
+
+    return _run
+
+
+def test_staged_dump_writes_through_the_mount_and_moves_into_place(tmp_path):
+    settings, team = _settings(tmp_path), _team(tmp_path)
+    host_dir = tmp_path / "pg_exchange" / "team_7"
+    host_dir.mkdir(parents=True)
+    client, container = _client([{"Destination": "/exchange"}])
+    container.exec_run.side_effect = _dump_into_exchange(str(host_dir))
+    dest = tmp_path / "templates" / "prod" / "dump.pgdump"
+    dest.parent.mkdir(parents=True)
+
+    with system_ops._staged_db_dump(
+        client, settings, team, "oduflow_7_main", str(dest)
+    ) as (host_path, container_path):
+        assert container_path.startswith("/exchange/team_7/")
+        assert os.path.dirname(host_path) == str(host_dir)
+        assert os.path.exists(host_path)
+
+    assert dest.read_text() == "PGDMP staged"
+    assert list(host_dir.iterdir()) == []
+    cmd = container.exec_run.call_args.args[0]
+    assert cmd[:4] == ["pg_dump", "-U", settings.db_user, "-Fc"]
+    assert cmd[-1] == "oduflow_7_main"
+
+
+def test_staged_dump_streams_when_the_mount_is_absent(tmp_path):
+    settings, team = _settings(tmp_path), _team(tmp_path)
+    client, _ = _client([])
+    dest = tmp_path / "templates" / "prod" / "dump.pgdump"
+    dest.parent.mkdir(parents=True)
+
+    def _stream(client_, container_, cmd, path, *, tool):
+        with open(path, "w") as fh:
+            fh.write("PGDMP streamed")
+
+    with patch.object(system_ops, "_stream_exec_to_file", side_effect=_stream):
+        with system_ops._staged_db_dump(
+            client, settings, team, "oduflow_7_main", str(dest)
+        ) as (host_path, container_path):
+            assert container_path is None
+            assert host_path == str(dest) + ".staged"
+
+    assert dest.read_text() == "PGDMP streamed"
+    assert not os.path.exists(str(dest) + ".staged")
+
+
+def test_staged_dump_leaves_nothing_behind_when_the_restore_fails(tmp_path):
+    settings, team = _settings(tmp_path), _team(tmp_path)
+    host_dir = tmp_path / "pg_exchange" / "team_7"
+    host_dir.mkdir(parents=True)
+    client, container = _client([{"Destination": "/exchange"}])
+    container.exec_run.side_effect = _dump_into_exchange(str(host_dir))
+    dest = tmp_path / "templates" / "prod" / "dump.pgdump"
+    dest.parent.mkdir(parents=True)
+
+    with pytest.raises(RuntimeError):
+        with system_ops._staged_db_dump(
+            client, settings, team, "oduflow_7_main", str(dest)
+        ):
+            raise RuntimeError("restore blew up")
+
+    # A failed publish must not leave a dump for a template that was never built.
+    assert not dest.exists()
+    assert list(host_dir.iterdir()) == []
+
+
+def test_staged_dump_reports_pg_dump_failure(tmp_path):
+    settings, team = _settings(tmp_path), _team(tmp_path)
+    client, container = _client([{"Destination": "/exchange"}])
+    container.exec_run.return_value = (1, b"pg_dump: error: no such database")
+    dest = tmp_path / "templates" / "prod" / "dump.pgdump"
+    dest.parent.mkdir(parents=True)
+
+    with pytest.raises(ExternalCommandError, match="no such database"):
+        with system_ops._staged_db_dump(
+            client, settings, team, "oduflow_7_main", str(dest)
+        ):
+            pytest.fail("body must not run after pg_dump fails")
+
+    assert not dest.exists()
+
+
+# --------------------------------------------------------------------------
+# reload_template
+# --------------------------------------------------------------------------
+
+
+def test_reload_skips_the_container_copy_for_an_already_readable_dump(tmp_path):
+    team = _team(tmp_path)
+    os.makedirs(team.get_template_dir("prod"), exist_ok=True)
+    with open(team.get_template_sql_path("prod"), "wb") as fh:
+        fh.write(b"PGDMP")
+
+    db_container = MagicMock()
+    db_container.exec_run.return_value = (0, b"")
+    client = MagicMock()
+    client.containers.get.return_value = db_container
+
+    with (
+        patch.object(system_ops, "get_client", return_value=client),
+        patch.object(system_ops, "_wait_pg_ready"),
+        patch.object(system_ops, "_exec_sql", return_value="5"),
+        patch.object(system_ops, "_db_exists", return_value=False),
+        patch.object(system_ops, "_is_text_dump", return_value=False),
+        patch.object(
+            system_ops, "ensure_team_tablespace", return_value="oduflow_team_7"
+        ),
+        patch.object(system_ops, "_update_template_sizes"),
+        patch.object(system_ops, "_copy_file_to_container") as copy_in,
+    ):
+        system_ops.reload_template(
+            Settings(),
+            team,
+            template_name="prod",
+            container_dump_path="/exchange/team_7/staged.pgdump",
+        )
+
+    copy_in.assert_not_called()
+    cmds = [call.args[0] for call in db_container.exec_run.call_args_list]
+    restore = next(cmd for cmd in cmds if cmd[0] == "pg_restore")
+    assert restore[-1] == "/exchange/team_7/staged.pgdump"
+    # The staged dump belongs to the caller; only copies made here are removed.
+    assert not [cmd for cmd in cmds if cmd[:2] == ["rm", "-f"]]

--- a/tests/test_prereqs.py
+++ b/tests/test_prereqs.py
@@ -1,4 +1,4 @@
-"""Unit tests for the fuse-overlayfs startup preflight (``oduflow.prereqs``)."""
+"""Unit tests for the host-binary startup preflight (``oduflow.prereqs``)."""
 
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -129,3 +129,71 @@ class TestEnsureFuseOverlayfs:
             with caplog.at_level("WARNING"):
                 prereqs.ensure_fuse_overlayfs()  # must not raise
         assert "timed out" in caplog.text
+
+
+class TestEnsureRsync:
+    def test_already_installed_is_noop(self):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("rsync")),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            prereqs.ensure_rsync()
+        run.assert_not_called()
+
+    def test_installs_via_apt_get_when_root(self):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run", return_value=_completed(0)) as run,
+        ):
+            prereqs.ensure_rsync()
+        assert run.call_args.kwargs["args"] == ["apt-get", "install", "-y", "rsync"]
+
+    def test_missing_on_non_linux_warns_instead_of_passing_over(self, caplog):
+        # Unlike fuse-overlayfs, rsync matters on macOS too: without it every
+        # publish re-copies the whole filestore.
+        with (
+            patch.object(prereqs.sys, "platform", "darwin"),
+            patch.object(prereqs.shutil, "which", _which()),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_rsync()
+        run.assert_not_called()
+        assert "rsync is missing" in caplog.text
+
+    def test_present_on_non_linux_is_silent(self, caplog):
+        with (
+            patch.object(prereqs.sys, "platform", "darwin"),
+            patch.object(prereqs.shutil, "which", _which("rsync")),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_rsync()
+        run.assert_not_called()
+        assert caplog.text == ""
+
+    def test_missing_but_not_root_warns_without_installing(self, caplog):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=1000),
+            patch.object(prereqs.subprocess, "run") as run,
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_rsync()
+        run.assert_not_called()
+        assert "sudo apt install rsync" in caplog.text
+
+    def test_install_failure_never_raises(self, caplog):
+        with (
+            patch.object(prereqs.sys, "platform", "linux"),
+            patch.object(prereqs.shutil, "which", _which("apt-get")),
+            patch.object(prereqs.os, "geteuid", return_value=0),
+            patch.object(prereqs.subprocess, "run", return_value=_completed(100)),
+        ):
+            with caplog.at_level("WARNING"):
+                prereqs.ensure_rsync()  # must not raise
+        assert "Could not auto-install rsync" in caplog.text

--- a/tests/test_quotas.py
+++ b/tests/test_quotas.py
@@ -87,13 +87,18 @@ class TestApplyAll:
 
         team_dir = str(tmp_path / "team_1")
         pg_dir = str(tmp_path / "pg_tablespaces" / "team_1")
+        exchange_dir = str(tmp_path / "pg_exchange" / "team_1")
         assert xfs.call_args_list == [
             call("/srv", f"project -s -p {team_dir} 1001"),
             call("/srv", f"project -s -p {pg_dir} 1001"),
+            # Staged dumps must share the team's project ID: XFS refuses to
+            # rename a file into a project-inheriting dir with a different ID.
+            call("/srv", f"project -s -p {exchange_dir} 1001"),
             call("/srv", "limit -p bhard=25g 1001"),
         ]
-        # Both trees exist (created if missing so the project can be set up).
+        # Every tree exists (created if missing so the project can be set up).
         assert (tmp_path / "pg_tablespaces" / "team_1").is_dir()
+        assert (tmp_path / "pg_exchange" / "team_1").is_dir()
 
     def test_one_team_failure_does_not_block_others(self, tmp_path, monkeypatch):
         t1 = TeamSettings(

--- a/tests/test_storage_stats.py
+++ b/tests/test_storage_stats.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 from oduflow.docker_ops.stats import (
+    _dir_size_bytes,
     read_storage_cache,
     refresh_env_storage,
     refresh_team_storage,
@@ -32,6 +33,17 @@ def _make_workspace(team: TeamSettings, env: str, overlay: bool) -> str:
 
 def test_read_cache_missing(tmp_path):
     assert read_storage_cache(_team(tmp_path)) == {"envs": {}, "team": None}
+
+
+def test_directory_size_counts_hardlinked_template_files_once(tmp_path):
+    first = tmp_path / "templates" / "base" / "filestore" / "aa" / "blob"
+    second = tmp_path / "templates" / "derived" / "filestore" / "aa" / "blob"
+    first.parent.mkdir(parents=True)
+    second.parent.mkdir(parents=True)
+    first.write_bytes(b"x" * 4096)
+    os.link(first, second)
+
+    assert _dir_size_bytes(str(tmp_path)) == 4096
 
 
 @patch("oduflow.docker_ops.stats.get_client", return_value=None)


### PR DESCRIPTION
## Summary

- stream PostgreSQL dumps directly to their destination and restore custom archives in parallel
- stage publish dumps through a quota-aware PostgreSQL exchange mount when available
- snapshot template filestores with rsync hardlinks so only environment deltas consume new disk
- provision rsync alongside fuse-overlayfs on supported installations
- keep staged dump publication atomic, clean partial exchange files, and count hardlinked storage correctly

## Why

Template publishing previously copied large database dumps and filestores multiple times. That increased runtime and transient disk usage, while interrupted staging could leave quota-consuming files behind. The incremental snapshot path also needed hardlink-aware storage accounting.

## Impact

Publishing large templates now writes substantially less data, remains compatible with PostgreSQL containers that predate the exchange mount, and reports physical hardlinked usage accurately.

## Validation

- `pytest -q -m "not integration and not heavyweight"` — 2,181 passed
- focused regression suite — 37 passed
- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow tests`
- `mypy src/oduflow`
- `git diff --check`