### PR TITLE
Add OpenCode as a third hosted coding agent

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -12,9 +12,10 @@
 # alive.
 #
 # LICENSING: the published image contains redistributable open-source software.
-# Codex CLI, codex-acp and agent-browser are Apache-2.0; ruff is MIT/Apache-2.0;
-# Debian's Chromium package carries its upstream BSD-style/component licenses and
-# preserves the corresponding notices under /usr/share/doc. Claude Code
+# Codex CLI, codex-acp and agent-browser are Apache-2.0; OpenCode is MIT; ruff is
+# MIT/Apache-2.0; Debian's Chromium package carries its upstream
+# BSD-style/component licenses and preserves the corresponding notices under
+# /usr/share/doc. Claude Code
 # (@anthropic-ai/claude-code) and its ACP adapter are PROPRIETARY-adjacent
 # (Anthropic Commercial Terms; the adapter pulls Anthropic's closed SDK), so
 # they are NOT part of the published image: entrypoint.sh npm-installs them at
@@ -28,7 +29,7 @@
 
 FROM node:24-bookworm-slim
 
-ARG CODER_VERSION=0.2.3
+ARG CODER_VERSION=0.3.0
 LABEL org.opencontainers.image.title="oduflow-coder" \
       org.opencontainers.image.version="${CODER_VERSION}" \
       org.opencontainers.image.source="https://github.com/oduist/oduflow"
@@ -71,17 +72,22 @@ RUN usermod --login agent --home /home/agent --move-home --shell /bin/bash node 
 #   - OpenAI Codex CLI + its ACP (Agent Client Protocol) adapter;
 #   - agent-browser, including its stdio MCP server. Pin the browser package so
 #     its MCP surface is deterministic; current releases require Node >= 24.
+# MIT component:
+#   - OpenCode, including its native `opencode acp` server. The coder image is
+#     immutable, and Oduflow disables OpenCode's runtime self-update per session.
 # NOTE: the Codex ACP bridge package is still settling (published
 # `@agentclientprotocol/codex-acp`, `@zed-industries/codex-acp` on GitHub, and an
 # emerging native `codex --acp`). Confirm the working one at build time.
 RUN npm install -g \
         @openai/codex \
         @agentclientprotocol/codex-acp \
+        opencode-ai \
         agent-browser@0.32.3 \
     && npm cache clean --force
 
 # Agent auth + sessions live under HOME (mounted from the persistent home
-# volume: ~/.claude.json, ~/.claude/ incl. projects/ = sessions, ~/.codex/).
+# volume: ~/.claude.json, ~/.claude/ incl. projects/ = sessions, ~/.codex/,
+# ~/.config/opencode and ~/.local/share/opencode).
 # Per-env checkouts live under /workspace (persistent workspace volume) at
 # /workspace/<slug>. Config dirs are pinned under HOME explicitly so they land
 # on the volume regardless of each CLI's default resolution. The npm prefix

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -15,12 +15,13 @@
 #      redistribute them; the container downloads them directly, once.
 #   3. Write the base Codex config (feature flags + built-in Agent Browser MCP;
 #      NO Oduflow endpoint or token here) and add Agent Browser to existing
-#      Claude checkout configs; see the MCP note below.
+#      Claude checkout configs. OpenCode receives its high-precedence config per
+#      session; see the MCP note below.
 #   4. Resolve provider auth: subscription if a subscription credential is
 #      present, otherwise an API key (per provider).
 #   5. Stay alive. Per-env checkouts are created on demand by the env_ops hooks
 #      (`docker exec clone-env.sh ...`); the agent process itself is spawned on
-#      demand by the web console via `docker exec` (claude | codex).
+#      demand by the web console via `docker exec` (claude | codex | opencode).
 #
 # MCP wiring is per SESSION, not per container: the container holds no Oduflow
 # token at all (nothing in its env or on disk to read from a console). Each
@@ -28,14 +29,17 @@
 # token (see ADR 0028) — plus the /mcp/<env> URL into its own environment;
 # Claude reads them through the ${VAR} placeholders in the checkout's
 # .mcp.json. Codex CLI uses `-c mcp_servers.*` overrides; the web relay adds
-# the same scoped server to Codex ACP session-open requests. Agent Browser is a
-# local stdio MCP available to both agents and contains no Oduflow credential.
+# the same scoped server to Codex/OpenCode ACP session-open requests. OpenCode
+# CLI receives a session-local OPENCODE_CONFIG_CONTENT with environment
+# placeholders. Agent Browser is a local stdio MCP available to all agents and
+# contains no Oduflow credential.
 #
 # Expected environment (injected by _ensure_agent_container; team-wide):
 #   ODUFLOW_GIT_USER    credential username to match in the store (optional)
 # Provider auth (subscription takes precedence over key, per provider):
 #   CLAUDE_CODE_OAUTH_TOKEN | ANTHROPIC_API_KEY   (+ optional ANTHROPIC_MODEL)
 #   OPENAI_API_KEY                                 (+ optional CODEX_MODEL)
+#   OPENCODE_API_KEY | any provider-specific variables supported by OpenCode
 # Mounts:
 #   HOME already contains the copied team git credential store; a readable
 #   /run/oduflow/git-credentials is also accepted for standalone use.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -3,8 +3,8 @@
 Oduflow can host a **coding agent** for a team: an opt-in feature where the
 client grows their Odoo by chatting with an AI agent directly from the browser
 dashboard. Oduflow runs one agent container per team
-(`oduist/oduflow-coder`, running Claude Code + OpenAI Codex) and exposes two
-front-ends for every environment.
+(`oduist/oduflow-coder`, running Claude Code + OpenAI Codex + OpenCode) and
+exposes two front-ends for every environment.
 
 !!! note "Hosting feature — off by default"
     The coding agent is for **hosted** deployments. A local developer already
@@ -38,9 +38,10 @@ server** (`pull_and_apply`, `run_odoo_tests`, etc.) — the same closed loop a
 remote MCP client uses.
 
 The image also includes **Agent Browser MCP** backed by Debian Chromium. It is
-wired automatically into both Claude and Codex with the complete Agent Browser
-tool set. Each environment gets a separate browser profile, while browser data
-persists with the team's agent HOME volume across container recreation.
+wired automatically into Claude, Codex, and OpenCode with the complete Agent
+Browser tool set. Each environment gets a separate browser profile, while
+browser data persists with the team's agent HOME volume across container
+recreation.
 
 Lifecycle is automatic: the container is created on startup for each enabled
 team and removed for disabled ones; `create_environment` adds the environment's
@@ -58,21 +59,23 @@ enablement and credentials live in the `[team.*]` sections:
 ```toml
 # Deployment-wide (optional)
 [agent]
-image = "oduist/oduflow-coder:0.2.3"
+image = "oduist/oduflow-coder:0.3.0"
 # claude_model = ""     # optional Claude model override; empty = CLI default
 # codex_model = ""      # optional Codex model override; empty = CLI default
+# opencode_model = ""   # optional provider/model override; empty = OpenCode default
 
 [team.1]
 hostname = "localhost"
 auth_token = "…"
 agent_enabled = true    # turn the coding agent on for this team
-agent_default = "claude"  # "claude" | "codex" — which agent opens by default
+agent_default = "claude"  # "claude" | "codex" | "opencode"
 
 # Provider credentials injected into the team's agent container
 [team.1.agent_env]
 CLAUDE_CODE_OAUTH_TOKEN = ""   # Claude subscription token (`claude setup-token`); outranks the API key
 ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
 OPENAI_API_KEY = ""            # Codex API key
+OPENCODE_API_KEY = ""          # OpenCode Zen; other providers use their own variables
 ```
 
 The default coder image is an immutable versioned tag coupled to this Oduflow
@@ -94,6 +97,15 @@ around a token is not sent to Anthropic. A configured environment credential
 always overrides the persisted interactive login; if Anthropic rejects it,
 Agent Chat fails closed with mode-specific recovery guidance instead of silently
 trying another account or billing method.
+
+OpenCode is provider-neutral. Any provider environment variable can be placed
+under `[team.X.agent_env]`; `OPENCODE_API_KEY` is the standard OpenCode Zen
+credential and is also inherited from the server environment in single-team
+deployments. Alternatively, open **Agent CLI** and run `opencode auth login`;
+the resulting provider credentials live on the team's persistent HOME volume
+and survive container recreation. OpenCode's runtime self-update is disabled,
+so its executable changes only when Oduflow moves to a new immutable coder
+image.
 
 See the [`[agent]`](installation.md#agent-settings) and
 [per-team](installation.md#per-team-settings) settings tables for the full
@@ -119,7 +131,7 @@ reference.
   only in single-team deployments; with several teams, each team sets its own
   keys in `[team.X.agent_env]` so an operator credential never leaks to
   tenants.
-- **Sandbox and approvals.** Both agents run approval-free — the security
+- **Sandbox and approvals.** All three agents run approval-free — the security
   boundary is the unprivileged `agent` user inside the per-team Docker
   container, not per-tool prompts. Codex CLI uses
   `--dangerously-bypass-approvals-and-sandbox` and Codex ACP starts in
@@ -127,8 +139,10 @@ reference.
   Agent CLI console runs `claude --dangerously-skip-permissions`, and Agent
   Chat's ACP adapter (`claude-agent-acp`) starts in `bypassPermissions`, seeded
   via the container's user-tier `~/.claude/settings.json`
-  (`permissions.defaultMode`). So installed MCP tools run without interactive
-  permission prompts for either agent.
+  (`permissions.defaultMode`). OpenCode CLI uses `--auto`; both CLI and its
+  native `opencode acp` runtime receive a high-precedence session config with
+  `permission = "allow"`. So installed MCP tools run without interactive
+  permission prompts for any hosted agent.
 
 ## Limitations
 
@@ -142,7 +156,7 @@ reference.
   the history entry.
 
 The published image contains redistributable open-source software: Codex CLI,
-Codex ACP and Agent Browser are Apache-2.0, and Debian Chromium includes its
-upstream component license notices. Claude Code and its adapter are installed
-at first container start onto the persistent home volume — downloaded directly
-from npm by the end user's container.
+Codex ACP and Agent Browser are Apache-2.0, OpenCode is MIT, and Debian Chromium
+includes its upstream component license notices. Claude Code and its adapter
+are installed at first container start onto the persistent home volume —
+downloaded directly from npm by the end user's container.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **OpenCode hosted agent** — OpenCode joins Claude Code and Codex as a full Agent CLI and Agent Chat runtime. The new immutable coder image includes the MIT-licensed `opencode` CLI and native ACP server; OpenCode gets generic provider authentication, an optional `provider/model` override, approval-free execution inside the existing container boundary, per-environment Agent Browser, scoped Oduflow MCP, modern ACP model selection, and isolated conversation history.
 - **Non-interactive bundled-file upgrades** — `oduflow upgrade --force` prints
   the usual overwrite warning and affected paths but proceeds without waiting
   for terminal input, enabling unattended deployments while continuing to

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 
 ### Integration
 - **AI-agent friendly** — the server exposes tools via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), so LLM-based coding agents (Cursor, Cline, Amp, etc.) can provision and manage Odoo environments programmatically
-- **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
+- **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex / OpenCode) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
 - **Web dashboard** — a built-in HTML dashboard for managing environments from a browser
 - **REST API** — full JSON API for programmatic control from any HTTP client
 - **CLI tools** — every MCP tool can be called directly from the command line via `oduflow call`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -179,12 +179,14 @@ auto_stop_hours = 48        # auto-stop environments idle for N hours (no MCP/da
 auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 disables (opt-in; DESTRUCTIVE, protected envs exempt)
 
 # ── Coding agent (optional) ───────────────────────────
-# One agent container per team (Claude Code + OpenAI Codex), driven from the
-# dashboard (Agent Chat / Agent CLI). Opt-in per team via agent_enabled below.
+# One agent container per team (Claude Code + OpenAI Codex + OpenCode), driven
+# from the dashboard (Agent Chat / Agent CLI). Opt-in per team via
+# agent_enabled below.
 # [agent]
-# image = "oduist/oduflow-coder:0.2.3"
+# image = "oduist/oduflow-coder:0.3.0"
 # claude_model = ""         # optional Claude model override; empty = CLI default
 # codex_model = ""          # optional Codex model override; empty = CLI default
+# opencode_model = ""       # optional provider/model override; empty = OpenCode default
 
 # ── Production hosting (optional) ─────────────────────
 # [production]
@@ -215,13 +217,14 @@ auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Be
 ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
 # agent_enabled = false              # enable the per-team coding agent (Agent Chat / Agent CLI)
-# agent_default = "claude"           # "claude" | "codex" — default agent for consoles/chats
+# agent_default = "claude"           # "claude" | "codex" | "opencode" — default agent
 # db_quota_gb = 50                   # combined PostgreSQL database cap; 0 disables
 # disk_quota_gb = 0                  # XFS project quota for team files + databases; 0 disables
 # [team.1.agent_env]                 # provider credentials injected into the agent container
 # CLAUDE_CODE_OAUTH_TOKEN = ""
 # ANTHROPIC_API_KEY = ""
 # OPENAI_API_KEY = ""
+# OPENCODE_API_KEY = ""              # OpenCode Zen; arbitrary provider vars also work
 ```
 
 ### Server settings
@@ -273,9 +276,10 @@ The global `[agent]` section holds deployment-wide settings for the per-team cod
 
 | Key | Default | Description |
 |---|---|---|
-| `[agent].image` | `oduist/oduflow-coder:0.2.3` | Immutable image for the per-team coding-agent container (Claude Code + OpenAI Codex); the default is coupled to the Oduflow release |
+| `[agent].image` | `oduist/oduflow-coder:0.3.0` | Immutable image for the per-team coding-agent container (Claude Code + OpenAI Codex + OpenCode); the default is coupled to the Oduflow release |
 | `[agent].claude_model` | *(empty)* | Optional Claude model override for the agent; empty = CLI default |
 | `[agent].codex_model` | *(empty)* | Optional Codex model override for the agent; empty = CLI default |
+| `[agent].opencode_model` | *(empty)* | Optional OpenCode model override in `provider/model` format; empty = OpenCode default |
 
 ### Production settings
 
@@ -319,10 +323,10 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
 | `agent_enabled` | `false` | Enable the per-team coding agent (dashboard Agent Chat / Agent CLI). Off by default |
-| `agent_default` | `claude` | Which agent consoles/chats open by default: `claude` or `codex` |
+| `agent_default` | `claude` | Which agent consoles/chats open by default: `claude`, `codex`, or `opencode` |
 | `db_quota_gb` | `50` | Combined size cap for the team's environment and template PostgreSQL databases. `0` disables the check |
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
-| `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and any custom vars |
+| `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
 
 Team data is stored at `{data_dir}/team_{ID}/`:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -66,7 +66,8 @@ auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disabl
 
 # Per-team coding agent (dashboard Agent Chat / Agent CLI); opt-in, off by default.
 # [agent]
-# image = "oduist/oduflow-coder:0.2.3"
+# image = "oduist/oduflow-coder:0.3.0"
+# opencode_model = ""               # optional provider/model override
 
 [team.1]
 hostname = "localhost"
@@ -74,11 +75,12 @@ auth_token = ""                       # auto-filled in fresh configs; HTTP MCP B
 ui_password = ""                      # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]           # port range for Odoo containers
 # agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
-# agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
+# agent_default = "claude"            # "claude" | "codex" | "opencode"
 # [team.1.agent_env]                  # provider credentials injected into the agent container
 # CLAUDE_CODE_OAUTH_TOKEN = ""
 # ANTHROPIC_API_KEY = ""
 # OPENAI_API_KEY = ""
+# OPENCODE_API_KEY = ""               # OpenCode Zen; arbitrary provider vars work
 ```
 
 ### First launch
@@ -208,7 +210,7 @@ feature is enabled; public `/healthz` reports dev/prod infrastructure health.
 
 ## Coding Agent (hosting)
 
-An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with per-environment conversation history). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to both agents, with one persistent profile per environment. Codex runs installed MCP methods without interactive approval prompts. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
+An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex + OpenCode) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with per-environment conversation history). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to all three agents, with one persistent profile per environment. Hosted agents run installed MCP methods without interactive approval prompts. OpenCode supports arbitrary provider environment variables or persistent `opencode auth login`. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
 
 ## Database Sanitization
 
@@ -370,7 +372,7 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 
 ### Integration
 - **AI-agent friendly** — the server exposes tools via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), so LLM-based coding agents (Cursor, Cline, Amp, etc.) can provision and manage Odoo environments programmatically
-- **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
+- **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex / OpenCode) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
 - **Web dashboard** — a built-in HTML dashboard for managing environments from a browser
 - **REST API** — full JSON API for programmatic control from any HTTP client
 - **CLI tools** — every MCP tool can be called directly from the command line via `oduflow call`
@@ -728,12 +730,14 @@ auto_stop_hours = 48        # auto-stop environments idle for N hours (no MCP/da
 auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 disables (opt-in; DESTRUCTIVE, protected envs exempt)
 
 # ── Coding agent (optional) ───────────────────────────
-# One agent container per team (Claude Code + OpenAI Codex), driven from the
-# dashboard (Agent Chat / Agent CLI). Opt-in per team via agent_enabled below.
+# One agent container per team (Claude Code + OpenAI Codex + OpenCode), driven
+# from the dashboard (Agent Chat / Agent CLI). Opt-in per team via
+# agent_enabled below.
 # [agent]
-# image = "oduist/oduflow-coder:0.2.3"
+# image = "oduist/oduflow-coder:0.3.0"
 # claude_model = ""         # optional Claude model override; empty = CLI default
 # codex_model = ""          # optional Codex model override; empty = CLI default
+# opencode_model = ""       # optional provider/model override; empty = OpenCode default
 
 # ── Production hosting (optional) ─────────────────────
 # [production]
@@ -764,13 +768,14 @@ auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Be
 ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
 # agent_enabled = false              # enable the per-team coding agent (Agent Chat / Agent CLI)
-# agent_default = "claude"           # "claude" | "codex" — default agent for consoles/chats
+# agent_default = "claude"           # "claude" | "codex" | "opencode" — default agent
 # db_quota_gb = 50                   # combined PostgreSQL database cap; 0 disables
 # disk_quota_gb = 0                  # XFS project quota for team files + databases; 0 disables
 # [team.1.agent_env]                 # provider credentials injected into the agent container
 # CLAUDE_CODE_OAUTH_TOKEN = ""
 # ANTHROPIC_API_KEY = ""
 # OPENAI_API_KEY = ""
+# OPENCODE_API_KEY = ""              # OpenCode Zen; arbitrary provider vars also work
 ```
 
 ### Server settings
@@ -822,9 +827,10 @@ The global `[agent]` section holds deployment-wide settings for the per-team cod
 
 | Key | Default | Description |
 |---|---|---|
-| `[agent].image` | `oduist/oduflow-coder:0.2.3` | Immutable image for the per-team coding-agent container (Claude Code + OpenAI Codex); the default is coupled to the Oduflow release |
+| `[agent].image` | `oduist/oduflow-coder:0.3.0` | Immutable image for the per-team coding-agent container (Claude Code + OpenAI Codex + OpenCode); the default is coupled to the Oduflow release |
 | `[agent].claude_model` | *(empty)* | Optional Claude model override for the agent; empty = CLI default |
 | `[agent].codex_model` | *(empty)* | Optional Codex model override for the agent; empty = CLI default |
+| `[agent].opencode_model` | *(empty)* | Optional OpenCode model override in `provider/model` format; empty = OpenCode default |
 
 ### Production settings
 
@@ -868,10 +874,10 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
 | `agent_enabled` | `false` | Enable the per-team coding agent (dashboard Agent Chat / Agent CLI). Off by default |
-| `agent_default` | `claude` | Which agent consoles/chats open by default: `claude` or `codex` |
+| `agent_default` | `claude` | Which agent consoles/chats open by default: `claude`, `codex`, or `opencode` |
 | `db_quota_gb` | `50` | Combined size cap for the team's environment and template PostgreSQL databases. `0` disables the check |
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
-| `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`) and any custom vars |
+| `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
 
 Team data is stored at `{data_dir}/team_{ID}/`:
 
@@ -2144,8 +2150,8 @@ status bar shows the same checks as chips.
 Oduflow can host a **coding agent** for a team: an opt-in feature where the
 client grows their Odoo by chatting with an AI agent directly from the browser
 dashboard. Oduflow runs one agent container per team
-(`oduist/oduflow-coder`, running Claude Code + OpenAI Codex) and exposes two
-front-ends for every environment.
+(`oduist/oduflow-coder`, running Claude Code + OpenAI Codex + OpenCode) and
+exposes two front-ends for every environment.
 
 !!! note "Hosting feature — off by default"
     The coding agent is for **hosted** deployments. A local developer already
@@ -2179,9 +2185,10 @@ server** (`pull_and_apply`, `run_odoo_tests`, etc.) — the same closed loop a
 remote MCP client uses.
 
 The image also includes **Agent Browser MCP** backed by Debian Chromium. It is
-wired automatically into both Claude and Codex with the complete Agent Browser
-tool set. Each environment gets a separate browser profile, while browser data
-persists with the team's agent HOME volume across container recreation.
+wired automatically into Claude, Codex, and OpenCode with the complete Agent
+Browser tool set. Each environment gets a separate browser profile, while
+browser data persists with the team's agent HOME volume across container
+recreation.
 
 Lifecycle is automatic: the container is created on startup for each enabled
 team and removed for disabled ones; `create_environment` adds the environment's
@@ -2199,21 +2206,23 @@ enablement and credentials live in the `[team.*]` sections:
 ```toml
 # Deployment-wide (optional)
 [agent]
-image = "oduist/oduflow-coder:0.2.3"
+image = "oduist/oduflow-coder:0.3.0"
 # claude_model = ""     # optional Claude model override; empty = CLI default
 # codex_model = ""      # optional Codex model override; empty = CLI default
+# opencode_model = ""   # optional provider/model override; empty = OpenCode default
 
 [team.1]
 hostname = "localhost"
 auth_token = "…"
 agent_enabled = true    # turn the coding agent on for this team
-agent_default = "claude"  # "claude" | "codex" — which agent opens by default
+agent_default = "claude"  # "claude" | "codex" | "opencode"
 
 # Provider credentials injected into the team's agent container
 [team.1.agent_env]
 CLAUDE_CODE_OAUTH_TOKEN = ""   # Claude subscription token (`claude setup-token`); outranks the API key
 ANTHROPIC_API_KEY = ""         # Claude API key (used when no OAuth token)
 OPENAI_API_KEY = ""            # Codex API key
+OPENCODE_API_KEY = ""          # OpenCode Zen; other providers use their own variables
 ```
 
 The default coder image is an immutable versioned tag coupled to this Oduflow
@@ -2235,6 +2244,15 @@ around a token is not sent to Anthropic. A configured environment credential
 always overrides the persisted interactive login; if Anthropic rejects it,
 Agent Chat fails closed with mode-specific recovery guidance instead of silently
 trying another account or billing method.
+
+OpenCode is provider-neutral. Any provider environment variable can be placed
+under `[team.X.agent_env]`; `OPENCODE_API_KEY` is the standard OpenCode Zen
+credential and is also inherited from the server environment in single-team
+deployments. Alternatively, open **Agent CLI** and run `opencode auth login`;
+the resulting provider credentials live on the team's persistent HOME volume
+and survive container recreation. OpenCode's runtime self-update is disabled,
+so its executable changes only when Oduflow moves to a new immutable coder
+image.
 
 See the [`[agent]`](installation.md#agent-settings) and
 [per-team](installation.md#per-team-settings) settings tables for the full
@@ -2260,7 +2278,7 @@ reference.
   only in single-team deployments; with several teams, each team sets its own
   keys in `[team.X.agent_env]` so an operator credential never leaks to
   tenants.
-- **Sandbox and approvals.** Both agents run approval-free — the security
+- **Sandbox and approvals.** All three agents run approval-free — the security
   boundary is the unprivileged `agent` user inside the per-team Docker
   container, not per-tool prompts. Codex CLI uses
   `--dangerously-bypass-approvals-and-sandbox` and Codex ACP starts in
@@ -2268,8 +2286,10 @@ reference.
   Agent CLI console runs `claude --dangerously-skip-permissions`, and Agent
   Chat's ACP adapter (`claude-agent-acp`) starts in `bypassPermissions`, seeded
   via the container's user-tier `~/.claude/settings.json`
-  (`permissions.defaultMode`). So installed MCP tools run without interactive
-  permission prompts for either agent.
+  (`permissions.defaultMode`). OpenCode CLI uses `--auto`; both CLI and its
+  native `opencode acp` runtime receive a high-precedence session config with
+  `permission = "allow"`. So installed MCP tools run without interactive
+  permission prompts for any hosted agent.
 
 ## Limitations
 
@@ -2283,10 +2303,10 @@ reference.
   the history entry.
 
 The published image contains redistributable open-source software: Codex CLI,
-Codex ACP and Agent Browser are Apache-2.0, and Debian Chromium includes its
-upstream component license notices. Claude Code and its adapter are installed
-at first container start onto the persistent home volume — downloaded directly
-from npm by the end user's container.
+Codex ACP and Agent Browser are Apache-2.0, OpenCode is MIT, and Debian Chromium
+includes its upstream component license notices. Claude Code and its adapter
+are installed at first container start onto the persistent home volume —
+downloaded directly from npm by the end user's container.
 
 ---
 
@@ -2755,7 +2775,7 @@ environments.
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/agent` | Agent enablement and effective default (`claude` or `codex`) |
+| `GET` | `/api/agent` | Agent enablement and effective default (`claude`, `codex`, or `opencode`) |
 | `GET` | `/api/environments/{branch}/agent-acp/info?type=` | ACP working directory, selected/recent sessions, and attachment limits |
 | `POST` | `/api/environments/{branch}/agent-acp/session` | Select, title, or clear the current session for body `type` |
 | `POST` | `/api/environments/{branch}/agent-acp/attachments?name=` | Stream an attachment into the agent checkout |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -66,7 +66,8 @@ auto_delete_hours = 0                 # auto-delete N hours after stop; 0 disabl
 
 # Per-team coding agent (dashboard Agent Chat / Agent CLI); opt-in, off by default.
 # [agent]
-# image = "oduist/oduflow-coder:0.2.3"
+# image = "oduist/oduflow-coder:0.3.0"
+# opencode_model = ""               # optional provider/model override
 
 [team.1]
 hostname = "localhost"
@@ -74,11 +75,12 @@ auth_token = ""                       # auto-filled in fresh configs; HTTP MCP B
 ui_password = ""                      # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]           # port range for Odoo containers
 # agent_enabled = false               # enable the per-team coding agent (Agent Chat / Agent CLI)
-# agent_default = "claude"            # "claude" | "codex" — default agent for consoles/chats
+# agent_default = "claude"            # "claude" | "codex" | "opencode"
 # [team.1.agent_env]                  # provider credentials injected into the agent container
 # CLAUDE_CODE_OAUTH_TOKEN = ""
 # ANTHROPIC_API_KEY = ""
 # OPENAI_API_KEY = ""
+# OPENCODE_API_KEY = ""               # OpenCode Zen; arbitrary provider vars work
 ```
 
 ### First launch
@@ -208,7 +210,7 @@ feature is enabled; public `/healthz` reports dev/prod infrastructure health.
 
 ## Coding Agent (hosting)
 
-An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with per-environment conversation history). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to both agents, with one persistent profile per environment. Codex runs installed MCP methods without interactive approval prompts. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
+An opt-in, per-team hosting feature: Oduflow runs one coding-agent container per team (`oduist/oduflow-coder`, Claude Code + OpenAI Codex + OpenCode) and exposes two dashboard surfaces — **Agent CLI** (the agent's TUI in the browser) and **Agent Chat** (a browser ACP chat with per-environment conversation history). The agent edits its own git checkout, `git push`es, and drives the environment through the Oduflow MCP server with a scoped per-environment token. A built-in Agent Browser MCP and Chromium provide browser automation to all three agents, with one persistent profile per environment. Hosted agents run installed MCP methods without interactive approval prompts. OpenCode supports arbitrary provider environment variables or persistent `opencode auth login`. It is off by default; enable it per team with `agent_enabled` and set provider credentials under `[team.X.agent_env]`. The agent UI is hidden for live-mount (`local_path`) environments.
 
 ## Database Sanitization
 

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -150,7 +150,7 @@ environments.
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `GET` | `/api/agent` | Agent enablement and effective default (`claude` or `codex`) |
+| `GET` | `/api/agent` | Agent enablement and effective default (`claude`, `codex`, or `opencode`) |
 | `GET` | `/api/environments/{branch}/agent-acp/info?type=` | ACP working directory, selected/recent sessions, and attachment limits |
 | `POST` | `/api/environments/{branch}/agent-acp/session` | Select, title, or clear the current session for body `type` |
 | `POST` | `/api/environments/{branch}/agent-acp/attachments?name=` | Stream an attachment into the agent checkout |

--- a/specs/0029-agent-console-and-chat.md
+++ b/specs/0029-agent-console-and-chat.md
@@ -10,8 +10,9 @@
 The dashboard already streams two `WebSocket ↔ docker exec` consoles per
 environment (Odoo shell, psql) rendered with xterm.js. Odusphere-cli built on
 that same bridge a full coding-agent surface: a per-installation agent
-container (Claude Code + OpenAI Codex in one image) whose interactive CLI opens
-in a browser terminal, plus a structured **ACP chat** (Agent Client Protocol,
+container (now Claude Code + OpenAI Codex + OpenCode in one image) whose
+interactive CLI opens in a browser terminal, plus a structured **ACP chat**
+(Agent Client Protocol,
 JSON-RPC over stdio, bridged to the browser over the same WebSocket pattern)
 with durable per-environment conversations. This change ports that capability.
 
@@ -38,8 +39,9 @@ WebSocket↔`docker exec` bridge:
 - **Agent CLI** (`ws_agent_console`): the agent's own TUI in xterm.js, exec'd
   with a PTY at the environment's checkout.
 - **Agent Chat** (`ws_agent_acp`): a TTY-less, line-framed relay to the agent's
-  ACP adapter (`claude-agent-acp` / `codex-acp`), rendered by a vendored,
-  framework-free browser client (`acp-client.js` + `chat.js`). A current
+  ACP runtime (`claude-agent-acp` / `codex-acp` / native `opencode acp`),
+  rendered by a vendored, framework-free browser client (`acp-client.js` +
+  `chat.js`). A current
   session and bounded recent history per (environment, agent) are persisted;
   any selected conversation resumes via ACP `session/load`. Chats minimize to
   a dock so several run in parallel.
@@ -66,7 +68,8 @@ leaked session credential grants only the ADR-0028 dev-loop allowlist on the
 one environment the session already controls.
 
 **Configuration lives in `oduflow.toml`, not in the dashboard.** Per team:
-`agent_enabled` (default **false**), `agent_default` (claude | codex) and the
+`agent_enabled` (default **false**), `agent_default` (claude | codex | opencode)
+and the
 `[team.X.agent_env]` table (provider credentials + custom vars injected into
 the container). The global `[agent]` section holds only deployment-wide bits
 (image, optional model overrides). There is no runtime editing and no Agents
@@ -146,8 +149,20 @@ id and does not inspect Claude Code or Codex transcript files. This keeps the
 integration independent of private CLI storage formats; it also means Codex
 history loading remains best-effort while its adapter matures.
 
+OpenCode was later added as a third first-class runtime. Its MIT-licensed CLI is
+baked into the immutable coder image, Agent CLI receives a high-precedence
+session-only config with approval-free permissions and scoped MCP placeholders,
+and Agent Chat uses native `opencode acp`. Because OpenCode supports
+client-provided HTTP/SSE MCP servers, its ACP sessions share the same
+session-open injection used by Codex. The browser client accepts both the
+legacy ACP `models` response and modern `configOptions`, selecting the matching
+model-change method per session.
+
 ## History
 
+- 2026-07-24 — added OpenCode as a third hosted agent with CLI and native ACP
+  chat, generic provider authentication, Agent Browser, scoped Oduflow MCP,
+  modern ACP model options, and isolated conversation history.
 - 2026-07-22 — replaced the rolling coder-image tag and manual runtime epoch
   with the immutable, release-coupled image contract in
   [[0040-versioned-coder-image-contract]].
@@ -186,6 +201,7 @@ history loading remains best-effort while its adapter matures.
   API-key auth was also adapted to current Codex releases by materializing
   persistent `auth.json` through `codex login --with-api-key` at startup.
 - 2026-07-21 — added the built-in Agent Browser MCP and Chromium runtime for
-  both Claude and Codex, with per-environment browser profiles. Codex CLI and
+  Claude and Codex (later extended to OpenCode), with per-environment browser
+  profiles. Codex CLI and
   ACP sessions now run non-interactively without approval prompts or a nested
   process sandbox; see [[0037-built-in-agent-browser-and-noninteractive-codex]].

--- a/specs/0037-built-in-agent-browser-and-noninteractive-codex.md
+++ b/specs/0037-built-in-agent-browser-and-noninteractive-codex.md
@@ -3,7 +3,7 @@
 **Status:** Adopted
 **Type:** Architecture — agent runtime capability and trust model
 **First introduced:** this change (2026-07-21), branch `litnimax/codex-agent-env-key`
-**Key code today:** `docker/agent/Dockerfile`; `docker/agent/entrypoint.sh`; `docker/agent/clone-env.sh`; `_wire_codex_acp_mcp`, `ws_agent_console`, and `ws_agent_acp` in `web_ui.py`; `_ensure_agent_container` in `docker_ops/env_ops.py`
+**Key code today:** `docker/agent/Dockerfile`; `docker/agent/entrypoint.sh`; `docker/agent/clone-env.sh`; `_wire_client_acp_mcp`, `ws_agent_console`, and `ws_agent_acp` in `web_ui.py`; `_ensure_agent_container` in `docker_ops/env_ops.py`
 
 ## Context
 
@@ -23,9 +23,9 @@ Codex approval boundary adds friction without separating a different principal.
 
 The published coder image includes a pinned Agent Browser CLI/MCP package and
 Debian Chromium. Agent Browser is configured as a local stdio MCP with all of
-its tools for both Claude and Codex. Every console/chat exec sets a profile name
-derived from the environment slug, preventing two environments in the same
-team container from sharing a browser daemon or session accidentally.
+its tools for Claude, Codex, and OpenCode. Every console/chat exec sets a
+profile name derived from the environment slug, preventing two environments in
+the same team container from sharing a browser daemon or session accidentally.
 
 Codex runs without interactive approval requests or a nested process sandbox:
 Agent CLI passes `--dangerously-bypass-approvals-and-sandbox`; Codex ACP starts
@@ -69,5 +69,8 @@ blocks; Oduflow does not weaken that outer profile to make a nested sandbox run.
 
 ## History
 
+- 2026-07-24 — extended the same browser and container-boundary trust model to
+  OpenCode: Agent CLI uses auto approval, native ACP uses `permission = allow`,
+  and both receive the environment-specific Agent Browser profile.
 - 2026-07-21 — adopted built-in Agent Browser MCP, per-environment browser
   profiles, and non-interactive Codex approval policy.

--- a/src/oduflow/agent_config.py
+++ b/src/oduflow/agent_config.py
@@ -16,7 +16,7 @@ from oduflow.settings import TeamSettings
 # through resolve_agent_type() rather than their own literals. The browser keeps
 # a small mirror of this list in chat.js / dashboard.html (JS cannot import this
 # constant), so a new agent must be added there too.
-VALID_AGENTS: tuple[str, ...] = ("claude", "codex")
+VALID_AGENTS: tuple[str, ...] = ("claude", "codex", "opencode")
 FALLBACK_AGENT = "claude"
 
 
@@ -30,7 +30,7 @@ def effective_agent_default(team: TeamSettings) -> str:
 def resolve_agent_type(requested: str | None, team: TeamSettings) -> str:
     """Pick the agent for a connection: the client-requested type if it is one of
     :data:`VALID_AGENTS`, otherwise the team default. Always returns a valid
-    value, so callers never need their own ``("claude", "codex")`` check."""
+    value, so callers never need their own agent-name check."""
     candidate = (requested or "").strip().lower()
     if candidate in VALID_AGENTS:
         return candidate

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1488,6 +1488,7 @@ _AGENT_PROVIDER_CREDENTIALS = (
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
+    "OPENCODE_API_KEY",
 )
 
 
@@ -1497,9 +1498,9 @@ def _agent_env_vars(settings: Settings, team: TeamSettings) -> dict[str, str]:
     Two sources, in order of increasing precedence:
       1. Known provider keys present in the SERVER environment (convenient for
          headless/prod: CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY /
-         OPENAI_API_KEY) — but only in single-team deployments; with several
-         teams a server-level key would leak the operator's credential into
-         every tenant's container.
+         OPENAI_API_KEY / OPENCODE_API_KEY) — but only in single-team
+         deployments; with several teams a server-level key would leak the
+         operator's credential into every tenant's container.
       2. The team's ``[team.X.agent_env]`` TOML table (arbitrary KEY=VALUE,
          including those same credentials).
 

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("oduflow")
 
 TRACE: bool = False
 
-DEFAULT_AGENT_IMAGE = "oduist/oduflow-coder:0.2.3"
+DEFAULT_AGENT_IMAGE = "oduist/oduflow-coder:0.3.0"
 _LEGACY_AGENT_IMAGE = "oduist/oduflow-coder:latest"
 
 # Active MCP transport for the running server ("stdio" | "http").
@@ -224,14 +224,15 @@ class Settings:
 
     # Coding agent — deployment-wide bits only; enabling the agent and its
     # credentials are per team (TeamSettings.agent_*). When enabled for a team,
-    # a single agent container (Claude Code + OpenAI Codex) serves all of its
-    # environments: one git checkout per environment on a persistent volume,
+    # a single agent container (Claude Code + OpenAI Codex + OpenCode) serves all
+    # of its environments: one git checkout per environment on a persistent volume,
     # driving environments only through the Oduflow MCP server. Container and
     # volume names are derived per team in naming.py.
     # See specs/0029-agent-console-and-chat.md.
     agent_image: str = DEFAULT_AGENT_IMAGE
     agent_claude_model: str = ""  # optional; empty = CLI default
     agent_codex_model: str = ""  # optional; empty = CLI default
+    agent_opencode_model: str = ""  # optional provider/model; empty = CLI default
 
     # Lifecycle: automatic stop of idle environments and cleanup of stopped
     # ones (see oduflow.reaper). 0 disables either behavior. Protected
@@ -597,6 +598,7 @@ class Settings:
             agent_image=_normalize_agent_image(agent.get("image")),
             agent_claude_model=str(agent.get("claude_model", "")).strip(),
             agent_codex_model=str(agent.get("codex_model", "")).strip(),
+            agent_opencode_model=str(agent.get("opencode_model", "")).strip(),
             auto_stop_hours=int(lifecycle.get("auto_stop_hours", 48)),
             auto_delete_hours=int(lifecycle.get("auto_delete_hours", 0)),
             oauth_base_url=str(oauth.get("oauth_base_url", "")).strip(),

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -5036,7 +5036,8 @@ async function doDeleteExtraRepo(name) {
 // The coding agent is configured per team in oduflow.toml ([team.X] agent_*
 // keys) and is off by default — it is a hosting feature. The dashboard only
 // needs to know whether it is enabled (to show the Agent Chat / Agent CLI
-// actions) and the default agent type (claude | codex) for opens without an
+// actions) and the default agent type (claude | codex | opencode) for opens
+// without an
 // explicit type. One-shot fetch at boot; cards re-render once it lands.
 window.ODU_AGENT_ENABLED = false;
 window.ODU_AGENT_DEFAULT = 'claude';
@@ -5049,7 +5050,7 @@ async function refreshAgentInfo() {
     var enabled = !!data.enabled;
     var changed = enabled !== window.ODU_AGENT_ENABLED;
     window.ODU_AGENT_ENABLED = enabled;
-    if (data.default === 'claude' || data.default === 'codex') {
+    if (data.default === 'claude' || data.default === 'codex' || data.default === 'opencode') {
       window.ODU_AGENT_DEFAULT = data.default;
     }
     // The first environments render may have raced this fetch; redraw so the
@@ -5255,7 +5256,7 @@ function ensureChatAssets() {
   // chat.js and acp-client.js are an interdependent pair of our own code; bump
   // this shared CHAT_V whenever either one changes (see AGENTS.md). One version
   // busts both at once, preventing a stale chat.js/acp-client.js mismatch.
-  var CHAT_V = '5';
+  var CHAT_V = '6';
   _chatAssets = Promise.all([
     loadScript('/static/marked.min.js'),
     loadScript('/static/acp-client.js?v=' + CHAT_V)
@@ -5431,7 +5432,8 @@ async function openAgentConsole(branch, agentType) {
     showToast('Failed to load terminal assets: ' + e.message, true);
     return;
   }
-  var label = agentType === 'codex' ? 'Codex' : 'Claude';
+  var label = agentType === 'codex' ? 'Codex' :
+    (agentType === 'opencode' ? 'OpenCode' : 'Claude');
   document.getElementById('agent-title').textContent = 'Agent · ' + label + ' — ' + branch;
   showModal('agent-modal');
 

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -51,8 +51,8 @@ auto_stop_hours = 48              # stop idle environments after N hours (non-de
 auto_delete_hours = 0             # delete stopped environments after N hours (DESTRUCTIVE; opt-in)
 
 # ── Coding agent ──────────────────────────────────────
-# One agent container per team (Claude Code + OpenAI Codex), driven from the
-# dashboard: "Agent Chat" (structured browser chat) and "Agent CLI"
+# One agent container per team (Claude Code + OpenAI Codex + OpenCode), driven
+# from the dashboard: "Agent Chat" (structured browser chat) and "Agent CLI"
 # (terminal). The agent holds a git checkout per environment and reaches
 # environments only through the Oduflow MCP server. It is a HOSTING feature —
 # enable it per team (agent_enabled, below); local developers use their own
@@ -60,9 +60,10 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 # deployment-wide bits; changes apply on server restart (the agent container
 # is recreated automatically when its config changed).
 # [agent]
-# image = "oduist/oduflow-coder:0.2.3"
+# image = "oduist/oduflow-coder:0.3.0"
 # claude_model = ""                # optional model override; empty = CLI default
 # codex_model = ""                 # optional model override; empty = CLI default
+# opencode_model = ""              # optional provider/model; empty = OpenCode default
 
 # ── OAuth (optional) ──────────────────────────────────
 # In traefik mode the self-hosted OAuth Authorization Server is enabled
@@ -119,7 +120,7 @@ port_range = [50000, 50100]       # port range for Odoo containers
 # disk_quota_gb = 0               # cap on team files + databases via XFS project quotas (needs data dir on XFS with prjquota)
 # agent_enabled = false           # per-team coding agent (dashboard Agent Chat / Agent CLI); off by default
 #                                  # Agent UI is hidden for local_path live-mount environments.
-# agent_default = "claude"        # "claude" | "codex" — which agent consoles/chats open by default
+# agent_default = "claude"        # "claude" | "codex" | "opencode" — default agent
 
 # Variables injected into the team's agent container — provider credentials
 # and anything custom. Uncomment together with agent_enabled above.
@@ -127,3 +128,4 @@ port_range = [50000, 50100]       # port range for Odoo containers
 # CLAUDE_CODE_OAUTH_TOKEN = ""    # Claude subscription token (`claude setup-token`); outranks the API key
 # ANTHROPIC_API_KEY = ""          # Claude API key (used when no OAuth token)
 # OPENAI_API_KEY = ""             # Codex API key (recommended over subscription)
+# OPENCODE_API_KEY = ""           # OpenCode Zen; other providers use their own variables

--- a/src/oduflow/templates/static/acp-client.js
+++ b/src/oduflow/templates/static/acp-client.js
@@ -31,6 +31,7 @@
     this._listeners = {};     // event -> [cb]
     this._heartbeat = null;
     this._rxBuffer = '';
+    this._configOptionSessions = {}; // session id -> modern ACP configOptions
   }
 
   // -- tiny event emitter -----------------------------------------------------
@@ -203,11 +204,20 @@
     });
   };
   AcpClient.prototype.newSession = function (cwd) {
-    return this._request('session/new', { cwd: cwd, mcpServers: [] });
+    var self = this;
+    return this._request('session/new', { cwd: cwd, mcpServers: [] }).then(function (result) {
+      if (result && result.sessionId) self._rememberConfigOptions(result.sessionId, result);
+      return result;
+    });
   };
   AcpClient.prototype.loadSession = function (sessionId, cwd) {
+    var self = this;
     // No timeout: replaying a long transcript legitimately takes a while.
-    return this._request('session/load', { sessionId: sessionId, cwd: cwd, mcpServers: [] }, 0);
+    return this._request('session/load', { sessionId: sessionId, cwd: cwd, mcpServers: [] }, 0)
+      .then(function (result) {
+        self._rememberConfigOptions(sessionId, result);
+        return result;
+      });
   };
   AcpClient.prototype.prompt = function (sessionId, content) {
     var prompt = Array.isArray(content)
@@ -223,6 +233,17 @@
     try { this._notify('session/cancel', { sessionId: sessionId }); } catch (e) { /* closed */ }
   };
   AcpClient.prototype.setModel = function (sessionId, modelId) {
+    var self = this;
+    if (this._configOptionSessions[sessionId]) {
+      return this._request('session/set_config_option', {
+        sessionId: sessionId,
+        configId: 'model',
+        value: modelId
+      }).then(function (result) {
+        self._rememberConfigOptions(sessionId, result);
+        return result;
+      });
+    }
     return this._request('session/set_model', { sessionId: sessionId, modelId: modelId });
   };
   AcpClient.prototype.setMode = function (sessionId, modeId) {
@@ -235,6 +256,17 @@
       this._sendResult(requestId, { outcome: { outcome: 'selected', optionId: optionId } });
     } else {
       this._sendResult(requestId, { outcome: { outcome: 'cancelled' } });
+    }
+  };
+
+  AcpClient.prototype._rememberConfigOptions = function (sessionId, result) {
+    var options = result && result.configOptions;
+    if (!Array.isArray(options)) return;
+    for (var i = 0; i < options.length; i++) {
+      if (options[i] && (options[i].id === 'model' || options[i].category === 'model')) {
+        this._configOptionSessions[sessionId] = true;
+        return;
+      }
     }
   };
 

--- a/src/oduflow/templates/static/chat.js
+++ b/src/oduflow/templates/static/chat.js
@@ -11,7 +11,7 @@
 (function () {
   'use strict';
 
-  var AGENT_LABELS = { claude: 'Claude', codex: 'Codex' };
+  var AGENT_LABELS = { claude: 'Claude', codex: 'Codex', opencode: 'OpenCode' };
   var STATUS = {
     connecting: { label: 'Connecting…', cls: 'is-dim' },
     ready: { label: 'Ready', cls: 'is-green' },
@@ -677,8 +677,49 @@
     }
     sel.hidden = false;
     sel.onchange = function () {
-      if (inst.sessionId) inst.client.setModel(inst.sessionId, sel.value).catch(function () {});
+      if (inst.sessionId) {
+        inst.client.setModel(inst.sessionId, sel.value)
+          .then(function (res) { applySessionModels(inst, res); })
+          .catch(function () {});
+      }
     };
+  }
+
+  function flattenConfigOptions(options, result) {
+    if (!Array.isArray(options)) return result;
+    for (var i = 0; i < options.length; i++) {
+      var option = options[i];
+      if (!option) continue;
+      if (Array.isArray(option.options)) {
+        flattenConfigOptions(option.options, result);
+      } else if (option.value != null) {
+        result.push({ modelId: String(option.value), name: option.name || String(option.value) });
+      }
+    }
+    return result;
+  }
+
+  function sessionModels(res) {
+    if (!res) return null;
+    if (res.models) return res.models;
+    var configOptions = res.configOptions;
+    if (!Array.isArray(configOptions)) return null;
+    for (var i = 0; i < configOptions.length; i++) {
+      var option = configOptions[i];
+      if (!option || (option.id !== 'model' && option.category !== 'model')) continue;
+      var available = flattenConfigOptions(option.options || [], []);
+      if (!available.length) return null;
+      return {
+        availableModels: available,
+        currentModelId: String(option.currentValue || '')
+      };
+    }
+    return null;
+  }
+
+  function applySessionModels(inst, res) {
+    var models = sessionModels(res);
+    if (models) applyModels(inst, models);
   }
 
   function applyPromptCapabilities(inst, initializeResult) {
@@ -1202,7 +1243,7 @@
       inst.sessionId = res.sessionId;
       inst.titled = false;
       resetTranscript(inst);
-      applyModels(inst, res.models);
+      applySessionModels(inst, res);
       postSession(inst.branch, inst.type, res.sessionId)
         .then(function (saved) { refreshHistory(inst, saved); });
       setStatus(inst, 'ready');
@@ -1227,7 +1268,7 @@
     inst.client.loadSession(sid, inst.cwd).then(function (res) {
       finalizeTurn(inst);
       inst.sessionId = sid;
-      if (res && res.models) applyModels(inst, res.models);
+      applySessionModels(inst, res);
       addSystemLine(inst, 'Switched to a previous conversation.');
       setStatus(inst, 'ready');
       return postSession(inst.branch, inst.type, sid)
@@ -1238,7 +1279,7 @@
       return inst.client.loadSession(previousId, inst.cwd).then(function (res) {
         finalizeTurn(inst);
         inst.sessionId = previousId;
-        if (res && res.models) applyModels(inst, res.models);
+        applySessionModels(inst, res);
         addSystemLine(inst, 'Could not open that conversation. Restored the current conversation.');
         setStatus(inst, 'ready');
         return postSession(inst.branch, inst.type, previousId)
@@ -1257,7 +1298,7 @@
     return inst.client.newSession(inst.cwd).then(function (res) {
       inst.sessionId = res.sessionId;
       inst.titled = false;
-      applyModels(inst, res.models);
+      applySessionModels(inst, res);
       addSystemLine(inst, 'Could not restore the conversation. Started a new conversation.');
       setStatus(inst, 'ready');
       return postSession(inst.branch, inst.type, res.sessionId)
@@ -1295,7 +1336,7 @@
           return inst.client.loadSession(info.session_id, inst.cwd).then(function (res) {
             finalizeTurn(inst);
             inst.sessionId = info.session_id;
-            if (res && res.models) applyModels(inst, res.models);
+            applySessionModels(inst, res);
             renderHistoryMenu(inst);
             addSystemLine(inst, 'Resumed your previous conversation.');
           }).catch(function () {
@@ -1304,7 +1345,7 @@
             return inst.client.newSession(inst.cwd).then(function (res) {
               inst.sessionId = res.sessionId;
               inst.titled = false;
-              applyModels(inst, res.models);
+              applySessionModels(inst, res);
               return postSession(inst.branch, inst.type, res.sessionId)
                 .then(function (saved) { refreshHistory(inst, saved); });
             });
@@ -1313,7 +1354,7 @@
         return inst.client.newSession(inst.cwd).then(function (res) {
           inst.sessionId = res.sessionId;
           inst.titled = false;
-          applyModels(inst, res.models);
+          applySessionModels(inst, res);
           return postSession(inst.branch, inst.type, res.sessionId)
             .then(function (saved) { refreshHistory(inst, saved); });
         });
@@ -1330,7 +1371,7 @@
   // -- window manager ---------------------------------------------------------
   function open(branch, type) {
     type = (type || window.ODU_AGENT_DEFAULT || 'claude').toLowerCase();
-    if (type !== 'claude' && type !== 'codex') type = 'claude';
+    if (type !== 'claude' && type !== 'codex' && type !== 'opencode') type = 'claude';
     var key = keyOf(branch, type);
     if (instances[key]) { activate(instances[key]); return; }
     var inst = {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -410,24 +410,27 @@ def _acp_adapter_cmd(agent_type: str) -> list[str]:
     ``docker/agent/Dockerfile``."""
     if agent_type == "codex":
         return ["codex-acp"]
+    if agent_type == "opencode":
+        return ["opencode", "acp"]
     return ["claude-agent-acp"]
 
 
 _CLAUDE_AUTH_GUIDANCE_MARKER = "Oduflow authentication guidance:"
+_OPENCODE_AUTH_GUIDANCE_MARKER = "Oduflow OpenCode authentication guidance:"
 
 
 def _annotate_acp_auth_error(
     frame: str, agent_type: str, auth_mode: str, team_id: str
 ) -> str:
-    """Add mode-specific recovery to Claude ACP authentication errors.
+    """Add mode-specific recovery to recognized ACP authentication errors.
 
-    The adapter returns provider failures as JSON-RPC response frames. Keep the
+    Adapters return provider failures as JSON-RPC response frames. Keep the
     provider's original code/data/message intact and append guidance only for
     recognizable authentication failures. In particular, quota/spend-limit
     failures must remain untouched: silently trying a different credential
     could switch accounts or billing modes.
     """
-    if agent_type != "claude":
+    if agent_type not in {"claude", "opencode"}:
         return frame
     try:
         message = json.loads(frame)
@@ -441,6 +444,22 @@ def _annotate_acp_auth_error(
         return frame
 
     lowered = error_message.lower()
+    if agent_type == "opencode":
+        if "provider authentication required" not in lowered:
+            return frame
+        if _OPENCODE_AUTH_GUIDANCE_MARKER in error_message:
+            return frame
+        guidance = (
+            "Open Agent CLI and run `opencode auth login`, or configure the "
+            "selected provider's credential in "
+            f"[team.{team_id}.agent_env] (or the single-team server environment), "
+            "then restart Oduflow."
+        )
+        error["message"] = (
+            f"{error_message}\n\n{_OPENCODE_AUTH_GUIDANCE_MARKER} {guidance}"
+        )
+        return json.dumps(message, separators=(",", ":"), ensure_ascii=False)
+
     specific_markers = (
         "invalid bearer token",
         "invalid api key",
@@ -503,17 +522,73 @@ def _codex_cli_cmd(mcp_url: str, model: str = "") -> list[str]:
     return cmd
 
 
-def _wire_codex_acp_mcp(
+def _opencode_cli_cmd(model: str = "") -> list[str]:
+    """Build the hosted OpenCode TUI command.
+
+    Docker and the unprivileged ``agent`` user are the security boundary, so
+    permission requests are auto-approved inside the container.
+    """
+    cmd = ["opencode", "--auto"]
+    if model:
+        cmd += ["--model", model]
+    return cmd
+
+
+def _opencode_config(
+    mcp_url: str = "",
+    *,
+    include_browser: bool = True,
+    include_oduflow: bool = False,
+    model: str = "",
+) -> str:
+    """Return session-local OpenCode config with no embedded credential.
+
+    ``OPENCODE_CONFIG_CONTENT`` has high precedence, so Oduflow's approval-free
+    trust model and scoped MCP wiring cannot be silently shadowed by a checkout
+    config. The bearer remains an environment placeholder resolved only inside
+    this docker-exec process.
+    """
+    config: dict[str, Any] = {
+        "autoupdate": False,
+        "permission": "allow",
+    }
+    if include_browser:
+        config["mcp"] = {
+            "agent_browser": {
+                "type": "local",
+                "command": ["agent-browser", "mcp", "--tools", "all"],
+                "environment": {
+                    "AGENT_BROWSER_SESSION": "{env:AGENT_BROWSER_SESSION}",
+                    "AGENT_BROWSER_EXECUTABLE_PATH": "/usr/bin/chromium",
+                },
+            },
+        }
+    if model:
+        config["model"] = model
+    if include_oduflow:
+        config.setdefault("mcp", {})["oduflow"] = {
+            "type": "remote",
+            "url": mcp_url,
+            "enabled": True,
+            "oauth": False,
+            "headers": {
+                "Authorization": "Bearer {env:ODUFLOW_MCP_TOKEN}",
+            },
+        }
+    return json.dumps(config, separators=(",", ":"))
+
+
+def _wire_client_acp_mcp(
     frame: str, mcp_url: str, mcp_token: str, browser_session: str
 ) -> str:
-    """Inject built-in MCP servers into Codex ACP session-open requests.
+    """Inject built-in MCP servers into client-configurable ACP sessions.
 
     The browser intentionally knows neither URL nor token. The WebSocket relay
     augments only ``session/new``/``session/load``/``session/resume`` frames on
-    their way to the adapter, using codex-acp's native client-provided MCP
-    contract. Agent Browser is a local credentialless stdio server. Oduflow is
-    added only when a scoped token exists; that credential lives only in this
-    exec's environment and stdio and is never returned to the browser or disk.
+    their way to Codex/OpenCode, using ACP's client-provided MCP contract. Agent
+    Browser is a local credentialless stdio server. Oduflow is added only when a
+    scoped token exists; that credential lives only in this exec's environment
+    and stdio and is never returned to the browser or disk.
     """
     try:
         message = json.loads(frame)
@@ -3495,7 +3570,7 @@ def _build_routes(
                 await websocket.close(code=1011)
                 return
 
-            # Which agent to run (claude | codex); default from config.
+            # Which agent to run (claude | codex | opencode); default from config.
             agent_type = agent_config.resolve_agent_type(
                 websocket.query_params.get("type"), team
             )
@@ -3590,6 +3665,16 @@ def _build_routes(
                 # server via CLI overrides. Docker is the outer sandbox, so
                 # Codex does not attempt a nested bubblewrap sandbox.
                 cmd = _codex_cli_cmd(mcp_url, settings.agent_codex_model)
+            elif agent_type == "opencode":
+                # OpenCode's high-precedence inline config carries only
+                # placeholders, never the scoped bearer itself. It also locks
+                # the hosted trust model and disables runtime self-updates.
+                exec_env["OPENCODE_CONFIG_CONTENT"] = _opencode_config(
+                    mcp_url,
+                    include_oduflow=bool(mcp_token),
+                    model=settings.agent_opencode_model,
+                )
+                cmd = _opencode_cli_cmd(settings.agent_opencode_model)
             else:
                 # Approval-free like Codex: Docker + the unprivileged `agent`
                 # user are the security boundary, so the console skips per-tool
@@ -3812,7 +3897,8 @@ def _build_routes(
                 return
 
             # Keep Claude ACP's project-scoped .mcp.json current for persistent
-            # checkouts. Codex receives the same URL through session wiring.
+            # checkouts. Codex/OpenCode receive the same URL through session
+            # wiring.
             await asyncio.get_event_loop().run_in_executor(
                 None,
                 lambda: env_ops.refresh_agent_mcp_config(
@@ -3823,8 +3909,8 @@ def _build_routes(
             # SCOPED per-env MCP credentials for THIS session only (see the
             # matching block in ws_agent_console). Claude's adapter picks them
             # up via the ${VAR} placeholders in the checkout's .mcp.json;
-            # Codex ACP receives the same server through its native session
-            # request contract in browser_to_docker below.
+            # Codex/OpenCode ACP receive the same server through their native
+            # session request contract in browser_to_docker below.
             try:
                 mcp_token = await asyncio.get_event_loop().run_in_executor(
                     None, lambda: env_ops.get_env_token(settings, team, branch)
@@ -3848,6 +3934,14 @@ def _build_routes(
                 # and dangerFullAccess. Docker + the unprivileged agent user
                 # remain the outer security boundary for browser chat.
                 exec_env["INITIAL_AGENT_MODE"] = "agent-full-access"
+            elif agent_type == "opencode":
+                # MCP servers arrive through the ACP session-open frame below,
+                # avoiding duplicate registrations. Runtime policy and the
+                # optional default model still come from inline config.
+                exec_env["OPENCODE_CONFIG_CONTENT"] = _opencode_config(
+                    include_browser=False,
+                    model=settings.agent_opencode_model,
+                )
 
             exec_id = client.api.exec_create(
                 container.id,
@@ -3915,8 +4009,8 @@ def _build_routes(
                         text = await websocket.receive_text()
                         if not text:
                             continue
-                        if agent_type == "codex":
-                            text = _wire_codex_acp_mcp(
+                        if agent_type in {"codex", "opencode"}:
+                            text = _wire_client_acp_mcp(
                                 text,
                                 mcp_url,
                                 mcp_token or "",

--- a/tests/test_agent_config.py
+++ b/tests/test_agent_config.py
@@ -11,6 +11,7 @@ def _team(default="claude") -> TeamSettings:
 def test_effective_uses_team_config():
     assert agent_config.effective_agent_default(_team("codex")) == "codex"
     assert agent_config.effective_agent_default(_team("claude")) == "claude"
+    assert agent_config.effective_agent_default(_team("opencode")) == "opencode"
 
 
 def test_effective_falls_back_on_invalid_config():
@@ -18,9 +19,18 @@ def test_effective_falls_back_on_invalid_config():
     assert agent_config.effective_agent_default(_team("")) == "claude"
 
 
-@pytest.mark.parametrize("requested", ["codex", " Codex ", "CODEX"])
-def test_resolve_uses_valid_request(requested):
-    assert agent_config.resolve_agent_type(requested, _team("claude")) == "codex"
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        ("codex", "codex"),
+        (" Codex ", "codex"),
+        ("CODEX", "codex"),
+        ("opencode", "opencode"),
+        (" OpenCode ", "opencode"),
+    ],
+)
+def test_resolve_uses_valid_request(requested, expected):
+    assert agent_config.resolve_agent_type(requested, _team("claude")) == expected
 
 
 @pytest.mark.parametrize("requested", [None, "", "  ", "gpt", "claude-code"])

--- a/tests/test_agent_sessions.py
+++ b/tests/test_agent_sessions.py
@@ -4,7 +4,13 @@ import stat
 
 from oduflow import agent_sessions
 from oduflow.settings import Settings, TeamSettings
-from oduflow.web_ui import _acp_adapter_cmd, _codex_cli_cmd, _wire_codex_acp_mcp
+from oduflow.web_ui import (
+    _acp_adapter_cmd,
+    _codex_cli_cmd,
+    _opencode_cli_cmd,
+    _opencode_config,
+    _wire_client_acp_mcp,
+)
 
 
 def _team(tmp_path) -> TeamSettings:
@@ -19,9 +25,11 @@ def test_set_get_roundtrip_per_branch_and_agent(tmp_path):
     t = _team(tmp_path)
     agent_sessions.set_session(t, "feature/x", "claude", "sid-1")
     agent_sessions.set_session(t, "feature/x", "codex", "sid-2")
+    agent_sessions.set_session(t, "feature/x", "opencode", "sid-4")
     agent_sessions.set_session(t, "main", "claude", "sid-3")
     assert agent_sessions.get_session(t, "feature/x", "claude") == "sid-1"
     assert agent_sessions.get_session(t, "feature/x", "codex") == "sid-2"
+    assert agent_sessions.get_session(t, "feature/x", "opencode") == "sid-4"
     assert agent_sessions.get_session(t, "main", "claude") == "sid-3"
 
 
@@ -166,6 +174,7 @@ def test_file_permissions_are_restrictive(tmp_path):
 def test_acp_adapter_cmd():
     assert _acp_adapter_cmd("claude") == ["claude-agent-acp"]
     assert _acp_adapter_cmd("codex") == ["codex-acp"]
+    assert _acp_adapter_cmd("opencode") == ["opencode", "acp"]
     # Unknown agent falls back to Claude (the configured default agent).
     assert _acp_adapter_cmd("something-else") == ["claude-agent-acp"]
 
@@ -183,7 +192,56 @@ def test_codex_cli_cmd_uses_docker_as_the_sandbox():
     ]
 
 
-def test_wire_codex_acp_mcp_adds_scoped_server_and_preserves_others():
+def test_opencode_cli_and_session_config():
+    assert _opencode_cli_cmd("anthropic/test-model") == [
+        "opencode",
+        "--auto",
+        "--model",
+        "anthropic/test-model",
+    ]
+    config = json.loads(
+        _opencode_config(
+            "http://scoped/mcp/env",
+            include_oduflow=True,
+            model="anthropic/test-model",
+        )
+    )
+    assert config["autoupdate"] is False
+    assert config["permission"] == "allow"
+    assert config["model"] == "anthropic/test-model"
+    assert config["mcp"]["agent_browser"]["command"] == [
+        "agent-browser",
+        "mcp",
+        "--tools",
+        "all",
+    ]
+    assert config["mcp"]["oduflow"] == {
+        "type": "remote",
+        "url": "http://scoped/mcp/env",
+        "enabled": True,
+        "oauth": False,
+        "headers": {
+            "Authorization": "Bearer {env:ODUFLOW_MCP_TOKEN}",
+        },
+    }
+    assert "scoped-token" not in json.dumps(config)
+
+
+def test_opencode_acp_config_omits_mcp_servers():
+    config = json.loads(
+        _opencode_config(
+            include_browser=False,
+            model="openai/test-model",
+        )
+    )
+    assert config == {
+        "autoupdate": False,
+        "permission": "allow",
+        "model": "openai/test-model",
+    }
+
+
+def test_wire_client_acp_mcp_adds_scoped_server_and_preserves_others():
     frame = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -205,7 +263,7 @@ def test_wire_codex_acp_mcp_adds_scoped_server_and_preserves_others():
         }
     )
     wired = json.loads(
-        _wire_codex_acp_mcp(
+        _wire_client_acp_mcp(
             frame, "http://scoped/mcp/env", "scoped-token", "environment-x"
         )
     )
@@ -232,7 +290,7 @@ def test_wire_codex_acp_mcp_adds_scoped_server_and_preserves_others():
     ]
 
 
-def test_wire_codex_acp_mcp_handles_load_but_not_other_frames():
+def test_wire_client_acp_mcp_handles_load_but_not_other_frames():
     load = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -242,13 +300,13 @@ def test_wire_codex_acp_mcp_handles_load_but_not_other_frames():
         }
     )
     assert (
-        json.loads(_wire_codex_acp_mcp(load, "http://scoped", "token", "env"))[
+        json.loads(_wire_client_acp_mcp(load, "http://scoped", "token", "env"))[
             "params"
         ]["mcpServers"][0]["name"]
         == "agent_browser"
     )
     load_servers = json.loads(
-        _wire_codex_acp_mcp(load, "http://scoped", "token", "env")
+        _wire_client_acp_mcp(load, "http://scoped", "token", "env")
     )["params"]["mcpServers"]
     assert [server["name"] for server in load_servers] == [
         "agent_browser",
@@ -256,13 +314,13 @@ def test_wire_codex_acp_mcp_handles_load_but_not_other_frames():
     ]
 
     prompt = '{"jsonrpc":"2.0","method":"session/prompt","params":{}}'
-    assert _wire_codex_acp_mcp(prompt, "http://scoped", "token", "env") == prompt
-    no_token = json.loads(_wire_codex_acp_mcp(load, "http://scoped", "", "env"))
+    assert _wire_client_acp_mcp(prompt, "http://scoped", "token", "env") == prompt
+    no_token = json.loads(_wire_client_acp_mcp(load, "http://scoped", "", "env"))
     assert [server["name"] for server in no_token["params"]["mcpServers"]] == [
         "agent_browser"
     ]
     assert (
-        _wire_codex_acp_mcp("not-json", "http://scoped", "token", "env") == "not-json"
+        _wire_client_acp_mcp("not-json", "http://scoped", "token", "env") == "not-json"
     )
 
 

--- a/tests/test_chat_acp_config_options.py
+++ b/tests/test_chat_acp_config_options.py
@@ -1,0 +1,99 @@
+"""Browser-client compatibility with modern ACP session config options."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_ROOT = Path(__file__).parents[1]
+_CHAT_JS = _ROOT / "src" / "oduflow" / "templates" / "static" / "chat.js"
+_ACP_JS = _ROOT / "src" / "oduflow" / "templates" / "static" / "acp-client.js"
+
+
+def _run_node(source: str) -> dict[str, object]:
+    result = subprocess.run(
+        ["node", "-"],
+        input=source,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_chat_normalizes_model_config_option():
+    source = _CHAT_JS.read_text(encoding="utf-8")
+    body, separator, trailer = source.rpartition("})();")
+    assert separator
+    instrumented = (
+        body
+        + "\nwindow.__acpConfigTest = { sessionModels: sessionModels };\n"
+        + separator
+        + trailer
+    )
+    harness = (
+        "global.window = {};\n"
+        "global.document = {};\n"
+        + instrumented
+        + "\nvar result = window.__acpConfigTest.sessionModels({configOptions:[{\n"
+        "  id:'model', category:'model', type:'select', currentValue:'openai/gpt-5',\n"
+        "  options:[\n"
+        "    {value:'openai/gpt-5', name:'OpenAI/GPT-5'},\n"
+        "    {name:'Anthropic', options:[{value:'anthropic/sonnet', name:'Claude Sonnet'}]}\n"
+        "  ]\n"
+        "}]});\n"
+        "process.stdout.write(JSON.stringify(result));\n"
+    )
+
+    assert _run_node(harness) == {
+        "availableModels": [
+            {"modelId": "openai/gpt-5", "name": "OpenAI/GPT-5"},
+            {"modelId": "anthropic/sonnet", "name": "Claude Sonnet"},
+        ],
+        "currentModelId": "openai/gpt-5",
+    }
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_acp_client_uses_config_option_setter_only_for_modern_session():
+    source = _ACP_JS.read_text(encoding="utf-8")
+    harness = (
+        "global.window = {};\n" + source + "\n(async function () {\n"
+        "  var client = new window.AcpClient('ws://unused');\n"
+        "  var calls = [];\n"
+        "  client._request = function(method, params) {\n"
+        "    calls.push({method:method, params:params});\n"
+        "    if (method === 'session/new') return Promise.resolve({\n"
+        "      sessionId:'modern', configOptions:[{id:'model', category:'model', options:[]}]\n"
+        "    });\n"
+        "    return Promise.resolve({});\n"
+        "  };\n"
+        "  await client.newSession('/workspace');\n"
+        "  await client.setModel('modern', 'anthropic/sonnet');\n"
+        "  await client.setModel('legacy', 'gpt-test');\n"
+        "  process.stdout.write(JSON.stringify({calls:calls}));\n"
+        "})().catch(function (error) {\n"
+        "  process.stderr.write(String(error && error.stack || error));\n"
+        "  process.exit(1);\n"
+        "});\n"
+    )
+
+    calls = _run_node(harness)["calls"]
+    assert calls[1] == {
+        "method": "session/set_config_option",
+        "params": {
+            "sessionId": "modern",
+            "configId": "model",
+            "value": "anthropic/sonnet",
+        },
+    }
+    assert calls[2] == {
+        "method": "session/set_model",
+        "params": {"sessionId": "legacy", "modelId": "gpt-test"},
+    }

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -2486,11 +2486,16 @@ class TestAgentContainer:
         )
 
         api_team = self._team(
-            agent_env={"ANTHROPIC_API_KEY": "  sk-ant-api  ", "MY_FLAG": "  keep  "}
+            agent_env={
+                "ANTHROPIC_API_KEY": "  sk-ant-api  ",
+                "OPENCODE_API_KEY": "  sk-open  ",
+                "MY_FLAG": "  keep  ",
+            }
         )
         api_settings = self._settings(team=api_team)
         api_env = env_ops._agent_env_vars(api_settings, api_team)
         assert api_env["ANTHROPIC_API_KEY"] == "sk-ant-api"
+        assert api_env["OPENCODE_API_KEY"] == "sk-open"
         assert api_env["MY_FLAG"] == "  keep  "
         assert env_ops._claude_auth_mode(api_settings, api_team) == "api_key"
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -323,9 +323,10 @@ class TestQuotas:
 class TestAgentSettings:
     def test_global_defaults(self):
         s = Settings()
-        assert s.agent_image == "oduist/oduflow-coder:0.2.3"
+        assert s.agent_image == "oduist/oduflow-coder:0.3.0"
         assert s.agent_claude_model == ""
         assert s.agent_codex_model == ""
+        assert s.agent_opencode_model == ""
 
     def test_default_image_matches_dockerfile_version(self):
         dockerfile = Path(__file__).parents[1] / "docker" / "agent" / "Dockerfile"
@@ -349,6 +350,7 @@ class TestAgentSettings:
             "[agent]\n"
             'image = "oduist/oduflow-coder:dev"\n'
             'claude_model = "claude-sonnet-4-6"\n'
+            'opencode_model = "anthropic/claude-sonnet-4-6"\n'
             "\n"
             '[team.1]\nhostname = "localhost"\n'
             "agent_enabled = true\n"
@@ -361,6 +363,7 @@ class TestAgentSettings:
         assert s.agent_image == "oduist/oduflow-coder:dev"
         assert s.agent_claude_model == "claude-sonnet-4-6"
         assert s.agent_codex_model == ""
+        assert s.agent_opencode_model == "anthropic/claude-sonnet-4-6"
         team = s.teams["1"]
         assert team.agent_enabled is True
         assert team.agent_default == "codex"  # normalised to lowercase

--- a/tests/test_web_ui_agent_acp.py
+++ b/tests/test_web_ui_agent_acp.py
@@ -254,6 +254,28 @@ def test_specific_claude_auth_errors_are_recognized(provider_message):
     )
 
 
+def test_opencode_auth_error_gets_recovery_guidance():
+    original = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "error": {
+            "code": -32000,
+            "message": "Authentication required: provider authentication required",
+            "data": {"providerId": "anthropic"},
+        },
+    }
+
+    annotated = json.loads(
+        _annotate_acp_auth_error(json.dumps(original), "opencode", "interactive", "9")
+    )
+
+    assert annotated["error"]["code"] == original["error"]["code"]
+    assert annotated["error"]["data"] == original["error"]["data"]
+    assert "Oduflow OpenCode authentication guidance:" in annotated["error"]["message"]
+    assert "opencode auth login" in annotated["error"]["message"]
+    assert "[team.9.agent_env]" in annotated["error"]["message"]
+
+
 @pytest.mark.parametrize(
     ("frame", "agent_type"),
     [
@@ -291,9 +313,19 @@ def test_specific_claude_auth_errors_are_recognized(provider_message):
             ),
             "codex",
         ),
+        (
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32603, "message": "Model quota exhausted"},
+                }
+            ),
+            "opencode",
+        ),
     ],
 )
-def test_non_claude_auth_failures_are_unchanged(frame, agent_type):
+def test_unrecognized_auth_failures_are_unchanged(frame, agent_type):
     assert _annotate_acp_auth_error(frame, agent_type, "setup_token", "1") == frame
 
 
@@ -308,3 +340,13 @@ def test_auth_guidance_is_not_appended_twice():
     once = _annotate_acp_auth_error(frame, "claude", "setup_token", "1")
 
     assert _annotate_acp_auth_error(once, "claude", "setup_token", "1") == once
+
+    opencode = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {"code": -32000, "message": "provider authentication required"},
+        }
+    )
+    once = _annotate_acp_auth_error(opencode, "opencode", "interactive", "1")
+    assert _annotate_acp_auth_error(once, "opencode", "interactive", "1") == once

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -84,3 +84,12 @@ def test_feedback_modal_is_registered_for_escape_key(tmp_path):
 
     assert dashboard.status_code == 200
     assert re.search(r"'feedback-modal':\s*closeFeedbackModal", dashboard.text)
+
+
+def test_dashboard_accepts_opencode_default_and_labels_it(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert "data.default === 'opencode'" in dashboard.text
+    assert "(agentType === 'opencode' ? 'OpenCode' : 'Claude')" in dashboard.text
+    assert "var CHAT_V = '6'" in dashboard.text


### PR DESCRIPTION
## Summary

Adds **OpenCode** as a third hosted coding-agent runtime alongside Claude Code and Codex, in both **Agent CLI** and **Agent Chat**. Coder image bumped to `oduist/oduflow-coder:0.3.0` (ships MIT-licensed `opencode` CLI + native `opencode acp`).

## Changes

- **settings/toml**: `agent_opencode_model` override; `OPENCODE_API_KEY` passthrough in `_agent_env_vars`.
- **web_ui**: `_opencode_cli_cmd`, `_opencode_config` (approval-free `permission: "allow"`, `autoupdate: false`, credentialless placeholders); opencode branches in console/chat; rename `_wire_codex_acp_mcp` → `_wire_client_acp_mcp`.
- **acp-client.js / chat.js**: modern ACP `configOptions` model selection (`session/set_config_option`) with legacy `session/set_model` fallback; `CHAT_V` 5 → 6.
- **Dockerfile / entrypoint**: install `opencode-ai`; pin HOME config dirs; doc/comment updates.
- **docs / specs**: agent.md, installation.md, web-api.md, changelog, specs 0029 & 0037; `llms-full.txt` regenerated.
- **tests**: opencode coverage across agent-config, sessions, ACP, settings, static, doc-sync.

## Security

- Scoped per-environment MCP token never enters config/disk — inline config carries only `{env:...}` placeholders; oduflow/browser MCP injected per ACP session.
- Approval-free model matches Claude/Codex: unprivileged `agent` user inside per-team Docker container is the boundary. `permission: "allow"` is valid per OpenCode's official config schema.

## Tests

Affected + doc-sync suites: 105 passed.