### PR TITLE
Fix actionable Greptile findings and harden Odoo.sh imports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
 
 jobs:
   lint:

--- a/LICENSE
+++ b/LICENSE
@@ -56,7 +56,8 @@ Additional Use Grant: You may make production use of the Licensed Work,
                       commercial license agreement, available at
                       https://oduflow.dev.
 
-Change Date:          Four years from the date the Licensed Work is published.
+Change Date:          Four years after the date on which each version of the
+                      Licensed Work is first publicly distributed.
 
 Change License:       MPL 2.0
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -69,7 +69,7 @@ xfonts-75dpi
 
 When an environment is created from a template, Oduflow **automatically sanitizes** the database to prevent the test instance from sending real emails or polling mailboxes. This is enabled by default (`sanitize=True`).
 
-For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutralize` command inside the serving container, after any auto-installed modules are present. Odoo 15.0 does not include this command, so Oduflow skips the native neutralization step for Odoo 15 and continues with the custom scripts below.
+For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutralize` command inside the serving container, after any auto-installed modules are present. Odoo 15 and earlier do not include this command, so Oduflow detects the version from both official and custom Docker image references, skips the native step there, and continues with the custom scripts below.
 
 Custom sanitization then uses a **two-tier** approach:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1583,7 +1583,7 @@ xfonts-75dpi
 
 When an environment is created from a template, Oduflow **automatically sanitizes** the database to prevent the test instance from sending real emails or polling mailboxes. This is enabled by default (`sanitize=True`).
 
-For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutralize` command inside the serving container, after any auto-installed modules are present. Odoo 15.0 does not include this command, so Oduflow skips the native neutralization step for Odoo 15 and continues with the custom scripts below.
+For Odoo versions that provide it, Oduflow first runs Odoo's native `odoo neutralize` command inside the serving container, after any auto-installed modules are present. Odoo 15 and earlier do not include this command, so Oduflow detects the version from both official and custom Docker image references, skips the native step there, and continues with the custom scripts below.
 
 Custom sanitization then uses a **two-tier** approach:
 

--- a/specs/0004-stable-addressing-port-registry-and-traefik.md
+++ b/specs/0004-stable-addressing-port-registry-and-traefik.md
@@ -56,6 +56,17 @@ Separate **port allocation** (stable, persisted) from **request routing**
   multi-instance / multi-team routing and for hosting the dashboard behind the
   same proxy.
 
+## Evolution
+
+Traefik routing later gained a deploy-time `[routing].tls` choice. The default
+`true` mode keeps Traefik responsible for :443, Let's Encrypt, and HTTP→HTTPS
+redirects. With `tls = false`, an upstream such as a Cloudflare tunnel owns TLS:
+Traefik listens on plain HTTP :80, does not configure ACME or redirects, and
+trusts the upstream's forwarded scheme while Oduflow continues to advertise
+public `https://` URLs. Because routing entrypoints are baked into environment
+and service container labels, changing this setting recreates Traefik and
+requires existing routed containers to be recreated to eliminate label drift.
+
 ## History
 
 - `c60eb5f` (2026-02-07) — persistent port mapping: `port_registry.py` + `ports.json`,
@@ -65,3 +76,5 @@ Separate **port allocation** (stable, persisted) from **request routing**
   provider with watch; each instance writes its own `instance-{id}.yml`, no
   Traefik restart needed.
 - `727448b` — match TLS certresolver name to Traefik's ACME provider.
+- 2026-07-03 — add HTTP-only Traefik mode for upstream TLS termination,
+  including drift detection and forwarded-scheme handling (#103).

--- a/specs/0024-business-source-license.md
+++ b/specs/0024-business-source-license.md
@@ -52,6 +52,17 @@ parameters:
   Licensor — eventual open-sourcing of each release is inherent to adopting
   BSL, not an optional extra.
 
+## How it works (macro)
+
+- BUSL applies separately to each publicly distributed version; its own
+  four-year clock starts on that version's first public distribution.
+- Non-production and the enumerated non-commercial production uses remain
+  available under the Additional Use Grant. Other production use is licensed
+  through the Individual, Business, or Integrator agreement matching who
+  operates the Odoo systems and for whose benefit.
+- At the end of a version's four-year period, that version automatically
+  transitions to MPL 2.0; newer versions continue on their independent clocks.
+
 ## Consequences
 
 - The commercial taxonomy is now part of the legal terms rather than only

--- a/specs/0030-odoo-sh-addons-import.md
+++ b/specs/0030-odoo-sh-addons-import.md
@@ -56,6 +56,9 @@ The design deliberately does **not** offer to push imported addons into a
 user-supplied empty repo, and does not try to preserve both the exact Odoo.sh
 commit *and* updatability: a branch-based extra-addons model can give one or the
 other, and updatability (a reachable remote) is the more useful of the two.
+Addon wiring is strict by default so a template is not reported ready with
+missing module code. Operators may explicitly choose best-effort import when
+preserving the database/filestore is more important than addon completeness.
 
 ## How it works (macro)
 
@@ -84,8 +87,14 @@ other, and updatability (a reachable remote) is the more useful of the two.
   normal `update_extra_repo`), everything else is seeded by the new
   `create_local_repo`. Their `{name: branch}` is merged into the template's
   `extra_addons` metadata, so environments created from the template mount the
-  same addons-path Odoo.sh ran with. One bad addon is logged, never fatal — the
-  database/filestore is the critical artifact.
+  same addons-path Odoo.sh ran with. In the default **strict** policy, an
+  unusable declared addon keeps finalization retryable and fails rather than
+  producing an incomplete template. The import dialog also offers an explicit
+  **best-effort** policy: a failed remote uses an already staged local copy when
+  available, otherwise only that addon is skipped. Invalid manifests and
+  database, filestore, or metadata failures remain fatal in both policies.
+  Every fallback or skip is returned as a structured warning and printed by the
+  Odoo.sh client.
 - **Local (remote-less) extra-addons.** `create_local_repo` builds a real bare
   git repo with a single branch seeded from the uploaded files and drops a
   `.local` marker. The whole worktree / mount / `pull_and_apply` machinery is
@@ -129,6 +138,13 @@ other, and updatability (a reachable remote) is the more useful of the two.
 
 ## Evolution
 
+- **Selectable addon error policy (2026-07-23).** The import dialog gained a
+  disabled-by-default "Continue if some addons are unavailable" option. Its
+  `strict` / `best_effort` policy is bound to the short-lived import token and
+  applied at finalize, so retries can deliberately choose a different policy.
+  Strict mode protects template completeness; best-effort mode preserves a
+  costly database/filestore import while making every local fallback or skipped
+  addon explicit in the command output.
 - **Chunked large-payload upload (2026-07-04).** Deploying behind a Cloudflare
   Tunnel surfaced Cloudflare's 100 MB request-body cap: the ~114 MB SQL dump (and
   Enterprise/Themes tars, also >100 MB) were rejected at the edge with `413`

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -2877,7 +2877,7 @@ def pull_environment(
       path-only ``shallow_classify`` in live-mount mode.
     """
     from oduflow.git_analysis import (
-        _is_dep_file,
+        _is_active_dep_file,
         guardrail_warnings,
         merge_recommendations,
         recommend,
@@ -3023,7 +3023,7 @@ def pull_environment(
     # MAIN repo must reinstall apt/pip deps into the running container and restart.
     # Scoped to the main repo because the install helpers only read its repo_path;
     # applies to both explicit and auto modes (a prerequisite, not an agent action).
-    deps_changed = any(_is_dep_file(f) for f in main_changed_files)
+    deps_changed = any(_is_active_dep_file(f, repo_path) for f in main_changed_files)
 
     warnings: list[str] = []
     if explicit:

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3077,8 +3077,9 @@ def _wire_imported_addons(
     the staging dir. For each entry: ``kind == "remote"`` is cloned from its
     origin (updatable via update_extra_repo); everything else is seeded as a
     local (remote-less) repo from ``addons/<name>/``. A repo that already exists
-    is left as-is. Returns ``{name: branch}`` for every addon that is available
-    for the template to reference (existing or freshly created).
+    is reused only when the requested branch exists. Every declared addon must
+    be usable; otherwise finalization remains retryable and fails rather than
+    creating a template with an incomplete addons path.
     """
     from oduflow import extra_addons
 
@@ -3089,10 +3090,13 @@ def _wire_imported_addons(
         with open(manifest) as f:
             entries = json.load(f)
         if not isinstance(entries, list):
-            return {}
+            raise PrerequisiteNotMetError(
+                "The staged addons manifest must contain a JSON list."
+            )
     except (OSError, ValueError):
-        logger.warning("Could not read staged addons manifest %s", manifest)
-        return {}
+        raise PrerequisiteNotMetError(
+            "Could not read the staged addons manifest."
+        ) from None
 
     addons_src = os.path.join(staging_dir, "addons")
     wired: dict[str, str] = {}
@@ -3110,37 +3114,37 @@ def _wire_imported_addons(
         repo_path = os.path.join(team.shared_repos_dir, name)
 
         # Already registered (e.g. a re-run, or the user added it manually):
-        # reference it, don't recreate.
+        # reference it only if the requested branch is genuinely available.
         if os.path.isdir(repo_path):
+            extra_addons._resolve_branch_revision(repo_path, name, branch)
             wired[name] = branch
             logger.info("Extra repo '%s' already exists; referencing it", name)
             continue
 
         src_dir = os.path.join(addons_src, name)
-        try:
-            if kind == "remote" and origin_url:
-                try:
-                    extra_addons.clone_extra_repo(team, name, origin_url)
-                    wired[name] = branch
-                    continue
-                except Exception as exc:  # noqa: BLE001 - fall back to local files
-                    logger.warning(
-                        "Clone of extra repo '%s' from %s failed (%s); "
-                        "falling back to local copy if available",
-                        name,
-                        origin_url,
-                        exc,
-                    )
-            if os.path.isdir(src_dir):
-                extra_addons.create_local_repo(team, name, src_dir, branch)
+        if kind == "remote" and origin_url:
+            try:
+                extra_addons.clone_extra_repo(team, name, origin_url)
+                extra_addons._resolve_branch_revision(repo_path, name, branch)
                 wired[name] = branch
-            else:
+                continue
+            except Exception:
+                # A failed clone may leave a partial bare repo. It belongs to
+                # this import attempt, so remove it before a retry or fallback.
+                shutil.rmtree(repo_path, ignore_errors=True)
+                if not os.path.isdir(src_dir):
+                    raise
                 logger.warning(
-                    "Addon '%s' has no uploaded files and no usable origin; skipped",
+                    "Clone of extra repo '%s' failed; using uploaded files",
                     name,
                 )
-        except Exception as exc:  # noqa: BLE001 - one bad addon must not abort import
-            logger.warning("Could not wire imported addon '%s': %s", name, exc)
+        if not os.path.isdir(src_dir):
+            raise PrerequisiteNotMetError(
+                f"Addon '{name}' has no uploaded files and no usable origin."
+            )
+        extra_addons.create_local_repo(team, name, src_dir, branch)
+        extra_addons._resolve_branch_revision(repo_path, name, branch)
+        wired[name] = branch
 
     return wired
 
@@ -3163,44 +3167,62 @@ def finalize_imported_template(
     """
     from oduflow.docker_ops import env_ops
 
+    os.makedirs(staging_dir, exist_ok=True)
+    promoted_marker = os.path.join(staging_dir, ".promoted")
     staged_meta = os.path.join(staging_dir, "metadata.json")
     staged_dump = os.path.join(staging_dir, "dump.sql.gz")
     staged_fs = os.path.join(staging_dir, "filestore")
-    if not os.path.isfile(staged_meta) or not os.path.isfile(staged_dump):
+    tpl_dir = team.get_template_dir(template_name)
+    live_meta = team.get_template_metadata_path(template_name)
+    live_dump = os.path.join(tpl_dir, "dump.sql.gz")
+    promoted = os.path.isfile(promoted_marker)
+    if not (
+        os.path.isfile(staged_meta) or (promoted and os.path.isfile(live_meta))
+    ) or not (os.path.isfile(staged_dump) or (promoted and os.path.isfile(live_dump))):
         raise PrerequisiteNotMetError(
             "Manifest and SQL dump must be uploaded before finalize."
         )
+    metadata_source = staged_meta if os.path.isfile(staged_meta) else live_meta
     try:
-        with open(staged_meta) as f:
+        with open(metadata_source) as f:
             major_version = str(json.load(f).get("odoo_version") or "")
     except (OSError, ValueError):
         major_version = ""
 
     client = get_client()
-    tpl_dir = team.get_template_dir(template_name)
     template_filestore_path = team.get_template_filestore_path(template_name)
 
+    # Written before promotion so a crash after any individual rename can be
+    # retried from the mix of remaining staged and already-live artifacts.
+    open(promoted_marker, "a").close()
     with env_ops.remount_template_overlays(
         client, settings, team, template_name
     ) as remount:
         os.makedirs(tpl_dir, exist_ok=True)
 
         # Swap filestore (the overlay lower layer) while envs are unmounted.
-        if os.path.exists(template_filestore_path):
-            shutil.rmtree(template_filestore_path)
         if os.path.isdir(staged_fs):
+            if os.path.exists(template_filestore_path):
+                shutil.rmtree(template_filestore_path)
             os.rename(staged_fs, template_filestore_path)
-        else:
+        elif not os.path.isdir(template_filestore_path):
             os.makedirs(template_filestore_path, exist_ok=True)
 
         # Swap dump: drop stale dumps under other names so
         # get_template_sql_path resolves to the new gzip'd SQL dump.
-        for stale in ("dump.pgdump", "dump.sql", "dump.pgdump.gz", "dump.sql.gz"):
-            stale_path = os.path.join(tpl_dir, stale)
-            if os.path.isfile(stale_path):
-                os.remove(stale_path)
-        os.rename(staged_dump, os.path.join(tpl_dir, "dump.sql.gz"))
-        os.replace(staged_meta, team.get_template_metadata_path(template_name))
+        if os.path.isfile(staged_dump):
+            for stale in (
+                "dump.pgdump",
+                "dump.sql",
+                "dump.pgdump.gz",
+                "dump.sql.gz",
+            ):
+                stale_path = os.path.join(tpl_dir, stale)
+                if os.path.isfile(stale_path):
+                    os.remove(stale_path)
+            os.rename(staged_dump, live_dump)
+        if os.path.isfile(staged_meta):
+            os.replace(staged_meta, live_meta)
 
         if major_version:
             try:
@@ -3223,8 +3245,8 @@ def finalize_imported_template(
     # Turn any uploaded/announced addons (Enterprise, Themes, extra repos) into
     # Oduflow extra-addons repos and record them on the template so environments
     # created from it mount the same addons-path Odoo.sh ran with. Done after the
-    # DB restore and before staging cleanup; a single bad addon is logged, not
-    # fatal — the database/filestore import is the critical part.
+    # DB restore and before staging cleanup. Declared addons are part of the
+    # template contract, so a missing repo/branch keeps the import retryable.
     wired = _wire_imported_addons(team, staging_dir, major_version)
     if wired:
         meta_path = team.get_template_metadata_path(template_name)
@@ -3236,7 +3258,9 @@ def finalize_imported_template(
             with open(meta_path, "w") as f:
                 json.dump(md, f, indent=2)
         except (OSError, ValueError) as exc:
-            logger.warning("Could not record imported addons on template: %s", exc)
+            raise PrerequisiteNotMetError(
+                f"Could not record imported addons on the template: {exc}"
+            ) from exc
 
     shutil.rmtree(staging_dir, ignore_errors=True)
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3069,7 +3069,12 @@ def extract_addon_dir(tar_path: str, addons_dir: str, name: str) -> int:
 
 
 def _wire_imported_addons(
-    team: TeamSettings, staging_dir: str, major_version: str
+    team: TeamSettings,
+    staging_dir: str,
+    major_version: str,
+    *,
+    addon_error_policy: str = "strict",
+    addon_warnings: list[dict[str, str]] | None = None,
 ) -> dict[str, str]:
     """Turn staged Odoo.sh addons into Oduflow extra-addons repos.
 
@@ -3078,10 +3083,25 @@ def _wire_imported_addons(
     origin (updatable via update_extra_repo); everything else is seeded as a
     local (remote-less) repo from ``addons/<name>/``. A repo that already exists
     is reused only when the requested branch exists. Every declared addon must
-    be usable; otherwise finalization remains retryable and fails rather than
-    creating a template with an incomplete addons path.
+    be usable in ``strict`` mode. ``best_effort`` uses a staged local fallback
+    when possible and otherwise skips only the failing addon, recording every
+    fallback or skip in ``addon_warnings``.
     """
     from oduflow import extra_addons
+
+    if addon_error_policy not in {"strict", "best_effort"}:
+        raise ValueError("addon_error_policy must be 'strict' or 'best_effort'.")
+    best_effort = addon_error_policy == "best_effort"
+    warnings = addon_warnings if addon_warnings is not None else []
+
+    def record_warning(name: str, action: str, reason: str) -> None:
+        warnings.append({"name": name, "action": action, "reason": reason})
+        logger.warning(
+            "Imported addon '%s': %s (%s)",
+            name,
+            action.replace("_", " "),
+            reason,
+        )
 
     manifest = os.path.join(staging_dir, "addons.json")
     if not os.path.isfile(manifest):
@@ -3116,21 +3136,32 @@ def _wire_imported_addons(
         # Already registered (e.g. a re-run, or the user added it manually):
         # reference it only if the requested branch is genuinely available.
         if os.path.isdir(repo_path):
-            extra_addons._resolve_branch_revision(repo_path, name, branch)
+            try:
+                extra_addons._resolve_branch_revision(repo_path, name, branch)
+            except Exception as exc:
+                if not best_effort:
+                    raise
+                record_warning(name, "skipped", str(exc))
+                continue
             wired[name] = branch
             logger.info("Extra repo '%s' already exists; referencing it", name)
             continue
 
         src_dir = os.path.join(addons_src, name)
+        local_fallback_reason = ""
         if kind == "remote" and origin_url:
             try:
                 extra_addons.clone_extra_repo(team, name, origin_url)
-            except Exception:
+            except Exception as exc:
                 # A failed clone may leave a partial bare repo. It belongs to
                 # this import attempt, so remove it before a retry or fallback.
                 shutil.rmtree(repo_path, ignore_errors=True)
                 if not os.path.isdir(src_dir):
+                    if best_effort:
+                        record_warning(name, "skipped", str(exc))
+                        continue
                     raise
+                local_fallback_reason = str(exc)
                 logger.warning(
                     "Clone of extra repo '%s' failed; using uploaded files",
                     name,
@@ -3138,23 +3169,43 @@ def _wire_imported_addons(
             else:
                 try:
                     extra_addons._resolve_branch_revision(repo_path, name, branch)
-                except Exception:
+                except Exception as exc:
                     # Clone succeeded but the requested branch is missing on
                     # the remote: the bare repo cannot serve this branch, so
-                    # discard it and let the caller fail loudly on the wrong
-                    # branch instead of silently masking the issue with local
-                    # files that the user did not request.
+                    # discard the repo created by this import attempt.
                     shutil.rmtree(repo_path, ignore_errors=True)
-                    raise
-                wired[name] = branch
-                continue
+                    if not best_effort:
+                        raise
+                    reason = str(exc)
+                    if not os.path.isdir(src_dir):
+                        record_warning(name, "skipped", reason)
+                        continue
+                    local_fallback_reason = reason
+                else:
+                    wired[name] = branch
+                    continue
         if not os.path.isdir(src_dir):
-            raise PrerequisiteNotMetError(
+            error = PrerequisiteNotMetError(
                 f"Addon '{name}' has no uploaded files and no usable origin."
             )
-        extra_addons.create_local_repo(team, name, src_dir, branch)
-        extra_addons._resolve_branch_revision(repo_path, name, branch)
+            if best_effort:
+                record_warning(name, "skipped", str(error))
+                continue
+            raise error
+        try:
+            extra_addons.create_local_repo(team, name, src_dir, branch)
+            extra_addons._resolve_branch_revision(repo_path, name, branch)
+        except Exception as exc:
+            if not best_effort:
+                raise
+            # No repo existed before this entry, so any partial target belongs
+            # to this import attempt and must not poison a later retry.
+            shutil.rmtree(repo_path, ignore_errors=True)
+            record_warning(name, "skipped", str(exc))
+            continue
         wired[name] = branch
+        if local_fallback_reason:
+            record_warning(name, "used_local_copy", local_fallback_reason)
 
     return wired
 
@@ -3164,6 +3215,8 @@ def finalize_imported_template(
     team: TeamSettings,
     template_name: str,
     staging_dir: str,
+    *,
+    addon_error_policy: str = "strict",
 ) -> dict[str, object]:
     """Promote a fully-staged push import into the live template and load it.
 
@@ -3257,7 +3310,14 @@ def finalize_imported_template(
     # created from it mount the same addons-path Odoo.sh ran with. Done after the
     # DB restore and before staging cleanup. Declared addons are part of the
     # template contract, so a missing repo/branch keeps the import retryable.
-    wired = _wire_imported_addons(team, staging_dir, major_version)
+    addon_warnings: list[dict[str, str]] = []
+    wired = _wire_imported_addons(
+        team,
+        staging_dir,
+        major_version,
+        addon_error_policy=addon_error_policy,
+        addon_warnings=addon_warnings,
+    )
     if wired:
         meta_path = team.get_template_metadata_path(template_name)
         try:
@@ -3282,6 +3342,7 @@ def finalize_imported_template(
         "affected_envs": remount.affected,
         "remount_failures": remount.failures,
         "extra_addons": wired,
+        "addon_warnings": addon_warnings,
     }
 
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3125,9 +3125,6 @@ def _wire_imported_addons(
         if kind == "remote" and origin_url:
             try:
                 extra_addons.clone_extra_repo(team, name, origin_url)
-                extra_addons._resolve_branch_revision(repo_path, name, branch)
-                wired[name] = branch
-                continue
             except Exception:
                 # A failed clone may leave a partial bare repo. It belongs to
                 # this import attempt, so remove it before a retry or fallback.
@@ -3138,6 +3135,19 @@ def _wire_imported_addons(
                     "Clone of extra repo '%s' failed; using uploaded files",
                     name,
                 )
+            else:
+                try:
+                    extra_addons._resolve_branch_revision(repo_path, name, branch)
+                except Exception:
+                    # Clone succeeded but the requested branch is missing on
+                    # the remote: the bare repo cannot serve this branch, so
+                    # discard it and let the caller fail loudly on the wrong
+                    # branch instead of silently masking the issue with local
+                    # files that the user did not request.
+                    shutil.rmtree(repo_path, ignore_errors=True)
+                    raise
+                wired[name] = branch
+                continue
         if not os.path.isdir(src_dir):
             raise PrerequisiteNotMetError(
                 f"Addon '{name}' has no uploaded files and no usable origin."

--- a/src/oduflow/env_tokens.py
+++ b/src/oduflow/env_tokens.py
@@ -40,10 +40,12 @@ MCP_TOKEN_LABEL = "oduflow.mcp_token"
 _MIN_SCAN_INTERVAL = 5.0
 
 _lock = threading.Lock()
+_scan_condition = threading.Condition(_lock)
 # token -> (team_id, env_name) for env-scoped tokens. Team tokens are resolved
 # directly from settings and are never cached here.
 _env_tokens: dict[str, tuple[str, str]] = {}
 _last_scan: float = 0.0
+_scan_in_progress = False
 
 
 def generate_token() -> str:
@@ -84,7 +86,7 @@ def resolve_token(settings: Settings, token: str) -> tuple[str, str | None] | No
     May block on a Docker scan (rate-limited); async callers should prefer
     :func:`resolve_token_async` to keep the event loop free.
     """
-    global _last_scan
+    global _last_scan, _scan_in_progress
     if not token:
         return None
     # 1. Team tokens (static, from settings) — never touches Docker.
@@ -92,18 +94,31 @@ def resolve_token(settings: Settings, token: str) -> tuple[str, str | None] | No
         if team.auth_token and secrets.compare_digest(token, team.auth_token):
             return (team_id, None)
     # 2. Env tokens: serve from cache; rescan at most once per interval.
-    with _lock:
+    with _scan_condition:
         hit = _env_tokens.get(token)
         if hit is not None:
             return hit
         fresh_enough = (time.monotonic() - _last_scan) < _MIN_SCAN_INTERVAL
-    if fresh_enough:
-        return None  # unknown token, rate-limited: don't rescan
-    fresh = _scan_env_tokens(settings)  # outside the lock (blocking Docker call)
-    with _lock:
+        if fresh_enough:
+            return None  # unknown token, rate-limited: don't rescan
+        if _scan_in_progress:
+            while _scan_in_progress:
+                _scan_condition.wait()
+            return _env_tokens.get(token)
+        _scan_in_progress = True
+    try:
+        fresh = _scan_env_tokens(settings)  # outside lock (blocking Docker call)
+    except Exception:
+        with _scan_condition:
+            _scan_in_progress = False
+            _scan_condition.notify_all()
+        raise
+    with _scan_condition:
         _env_tokens.clear()
         _env_tokens.update(fresh)
         _last_scan = time.monotonic()
+        _scan_in_progress = False
+        _scan_condition.notify_all()
     return fresh.get(token)
 
 
@@ -119,6 +134,6 @@ async def resolve_token_async(
 def invalidate_cache() -> None:
     """Drop the cached env-token map and force the next lookup to rescan."""
     global _last_scan
-    with _lock:
+    with _scan_condition:
         _env_tokens.clear()
         _last_scan = 0.0

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -21,9 +21,10 @@ def _trace(msg: str, *args: object) -> None:
 MANIFEST_KEYS_WITH_FILES = ("data", "demo", "assets", "qweb")
 RESTART_REQUIRED_PATHS = {".oduflow/odoo.conf", ".oduflow/odoo.prod.conf"}
 
-# Dependency descriptors Oduflow actually reads into the container. A change to
-# any of these means Python/apt deps changed → reinstall + restart. Only these
-# exact repo-root-relative paths are installed (see
+# Dependency descriptors Oduflow can read into the container. A change to the
+# active one means Python/apt deps changed → reinstall + restart. The
+# .oduflow/requirements.txt file shadows the root fallback when both exist.
+# Only these exact repo-root-relative paths are installed (see
 # env_ops._install_pip_requirements / _install_apt_packages); a nested
 # ``foo/requirements.txt`` or a repo-root ``apt_packages.txt`` is intentionally
 # NOT a dependency descriptor.
@@ -177,6 +178,16 @@ def _is_translation_file(file_path: str) -> bool:
     return os.path.splitext(file_path)[1].lower() == ".po"
 
 
+def _is_active_dep_file(file_path: str, repo_path: str) -> bool:
+    """Whether a changed dependency file is the one Oduflow actually reads."""
+    normalized = file_path.replace(os.sep, "/")
+    if normalized == "requirements.txt" and os.path.isfile(
+        os.path.join(repo_path, ".oduflow", "requirements.txt")
+    ):
+        return False
+    return normalized in DEP_FILE_PATHS
+
+
 def classify_changes(
     changed_files: list[str], repo_path: str, base_ref: str = "HEAD~1"
 ) -> dict[str, Any]:
@@ -235,7 +246,7 @@ def classify_changes(
             )
             continue
 
-        if _is_dep_file(f):
+        if _is_active_dep_file(f, repo_path):
             deps_changed.append(f)
             _trace(
                 "  file=%s -> dependency descriptor, reinstall + restart",
@@ -449,7 +460,7 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict[str,
         if _requires_restart_path(f):
             restart_required.append(f)
             continue
-        if _is_dep_file(f):
+        if _is_active_dep_file(f, repo_path):
             deps_changed.append(f)
             continue
         if os.path.basename(f) == "__manifest__.py" and module:

--- a/src/oduflow/import_tokens.py
+++ b/src/oduflow/import_tokens.py
@@ -6,11 +6,11 @@ ingest call. Because the token expires quickly, a copy left in the terminal
 scrollback is useless afterwards.
 
 Each token is one JSON file under ``<team.data_dir>/import_tokens/<token>.json``.
-The token carries only auth + the target template; it deliberately does NOT
-store upload progress. Resume is instead derived from what is actually staged on
-disk in the template directory (see ``web_ui``), so a re-run — even with a freshly
-minted token after the previous one expired mid-upload — continues where it left
-off instead of restarting.
+The token carries auth, the target template, and the selected addon error policy;
+it deliberately does NOT store upload progress. Resume is instead derived from
+what is actually staged on disk in the template directory (see ``web_ui``), so a
+re-run — even with a freshly minted token after the previous one expired
+mid-upload — continues where it left off instead of restarting.
 """
 
 from __future__ import annotations
@@ -30,6 +30,12 @@ from oduflow.settings import Settings, TeamSettings
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{16,64}$")
 _DEFAULT_TTL_SECONDS = 15 * 60
 _lock = threading.Lock()
+
+ADDON_ERROR_POLICY_STRICT = "strict"
+ADDON_ERROR_POLICY_BEST_EFFORT = "best_effort"
+ADDON_ERROR_POLICIES = frozenset(
+    {ADDON_ERROR_POLICY_STRICT, ADDON_ERROR_POLICY_BEST_EFFORT}
+)
 
 
 def _tokens_dir(team: TeamSettings) -> str:
@@ -82,6 +88,7 @@ def create_token(
     team: TeamSettings,
     template_name: str,
     *,
+    addon_error_policy: str = ADDON_ERROR_POLICY_STRICT,
     ttl_seconds: int = _DEFAULT_TTL_SECONDS,
     now: float | None = None,
 ) -> dict[str, object]:
@@ -90,12 +97,15 @@ def create_token(
     from oduflow.naming import validate_template_name
 
     validate_template_name(template_name)
+    if addon_error_policy not in ADDON_ERROR_POLICIES:
+        raise ValueError("addon_error_policy must be 'strict' or 'best_effort'.")
     now = time.time() if now is None else now
     _cleanup_expired(team, now=now)
     record = {
         "token": secrets.token_urlsafe(24),
         "team_id": team.team_id,
         "template_name": template_name,
+        "addon_error_policy": addon_error_policy,
         "created_at": now,
         "expires_at": now + ttl_seconds,
     }

--- a/src/oduflow/sanitizer.py
+++ b/src/oduflow/sanitizer.py
@@ -29,8 +29,13 @@ def _detect_odoo_major_from_container(
     # including registries with ports (registry:5000/acme/odoo-ee:15.0).
     reference = image.split("@", 1)[0]
     leaf = reference.rsplit("/", 1)[-1]
-    tag = leaf.rsplit(":", 1)[1] if ":" in leaf else ""
-    match = re.match(r"(\d+)(?:\.\d+)?(?:$|[-_])", tag)
+    has_tag = ":" in leaf
+    tag = leaf.rsplit(":", 1)[1] if has_tag else ""
+    repository = reference.rsplit(":", 1)[0] if has_tag else reference
+    is_odoo_image = (
+        re.search(r"(?:^|[/_-])odoo(?:$|[/_-])", repository, re.I) is not None
+    )
+    match = re.match(r"(\d+)(?:\.\d+)?(?:$|[-_])", tag) if is_odoo_image else None
     if not match:
         # Also accept versioned repository names such as acme/odoo-15.
         match = re.search(r"odoo[-_:/]?(\d+)(?:\.\d+)?(?:$|[-_])", reference, re.I)

--- a/src/oduflow/sanitizer.py
+++ b/src/oduflow/sanitizer.py
@@ -25,7 +25,15 @@ def _detect_odoo_major_from_container(
     if not isinstance(image, str):
         return None
 
-    match = re.search(r"odoo[:/](\d+)", image)
+    # Prefer the Docker tag: this handles official and custom repositories,
+    # including registries with ports (registry:5000/acme/odoo-ee:15.0).
+    reference = image.split("@", 1)[0]
+    leaf = reference.rsplit("/", 1)[-1]
+    tag = leaf.rsplit(":", 1)[1] if ":" in leaf else ""
+    match = re.match(r"(\d+)(?:\.\d+)?(?:$|[-_])", tag)
+    if not match:
+        # Also accept versioned repository names such as acme/odoo-15.
+        match = re.search(r"odoo[-_:/]?(\d+)(?:\.\d+)?(?:$|[-_])", reference, re.I)
     if match:
         return int(match.group(1))
     return None
@@ -149,8 +157,9 @@ def neutralize_environment(
     untouched — it only stops transmission by disabling crons; it does not
     change the database's identity.
 
-    Odoo 15.0 does not provide the native ``neutralize`` CLI command, so it is
-    skipped for that version. Custom sanitization scripts still run afterwards.
+    Odoo 15 and earlier do not provide the native ``neutralize`` CLI command,
+    so it is skipped for those versions. Custom sanitization scripts still run
+    afterwards.
 
     Returns a list of human-readable log lines.
     """

--- a/src/oduflow/scoped_access.py
+++ b/src/oduflow/scoped_access.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import copy
 import logging
+from contextvars import ContextVar
 from typing import Any
 
 from fastmcp.exceptions import ToolError
@@ -42,6 +43,10 @@ logger = logging.getLogger("oduflow")
 SCOPE_KEY = "oduflow_scoped_env"
 # Prefix of the access-token scope that binds a per-env token to its env.
 ENV_SCOPE_PREFIX = "oduflow_env:"
+_HTTP_REQUEST_ACTIVE: ContextVar[bool] = ContextVar(
+    "oduflow_http_request_active", default=False
+)
+_HTTP_URL_ENV: ContextVar[str | None] = ContextVar("oduflow_http_url_env", default=None)
 
 # Tools exposed on the scoped endpoint: full dev loop + restart, read-only and
 # diagnostics. Everything else (create/delete/stop/start/update/recreate,
@@ -144,6 +149,8 @@ def build_env_param_tools(mcp: Any) -> set[str]:
 
 def scoped_env_from_request() -> str | None:
     """The env parsed from a /mcp/<env> URL for the current request, if any."""
+    if _HTTP_REQUEST_ACTIVE.get():
+        return _HTTP_URL_ENV.get()
     try:
         from fastmcp.server.dependencies import get_http_request
 
@@ -160,6 +167,8 @@ def env_from_access_token() -> str | None:
 
         token = get_access_token()
     except Exception:
+        if _HTTP_REQUEST_ACTIVE.get():
+            raise
         return None
     if not token:
         return None
@@ -230,6 +239,7 @@ class ScopedEnvASGI:
         self.app = app
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        url_env: str | None = None
         if scope.get("type") == "http":
             path = scope.get("path", "")
             oauth_path = self._OAUTH_SUBPATHS.get(path)
@@ -244,6 +254,7 @@ class ScopedEnvASGI:
                 # plain environment name (slashes in branch names included).
                 scope = dict(scope)
                 scope[SCOPE_KEY] = env
+                url_env = env
                 scope["path"] = "/mcp"
                 scope["raw_path"] = b"/mcp"
             else:
@@ -252,6 +263,14 @@ class ScopedEnvASGI:
                     scope = dict(scope)
                     scope["path"] = rewritten
                     scope["raw_path"] = rewritten.encode()
+            active_token = _HTTP_REQUEST_ACTIVE.set(True)
+            env_token = _HTTP_URL_ENV.set(url_env)
+            try:
+                await self.app(scope, receive, send)
+            finally:
+                _HTTP_URL_ENV.reset(env_token)
+                _HTTP_REQUEST_ACTIVE.reset(active_token)
+            return
         await self.app(scope, receive, send)
 
     @staticmethod
@@ -292,7 +311,11 @@ class ScopedAccessMiddleware(Middleware):
         self._env_param = frozenset(env_param_tools)
 
     def _decide(self) -> tuple[str, str | None]:
-        return decide(scoped_env_from_request(), env_from_access_token())
+        try:
+            return decide(scoped_env_from_request(), env_from_access_token())
+        except Exception:
+            logger.exception("Could not resolve scoped MCP request context")
+            return ("deny", None)
 
     async def on_list_tools(
         self, context: MiddlewareContext[Any], call_next: CallNext[Any, Any]

--- a/src/oduflow/templates/agent_guides/odoo_19_guide.md
+++ b/src/oduflow/templates/agent_guides/odoo_19_guide.md
@@ -9,7 +9,7 @@ Quick orientation for an agent about to author or refactor a module on 19.0.
 ## Runtime baseline
 
 - Python **3.10–3.14** (minimum is 3.10 — same as 18)
-- PostgreSQL **14+** (15+ recommended)
+- PostgreSQL **13+** (15+ recommended)
 
 ### If you run on Python 3.12+
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1857,7 +1857,7 @@
   <span>RAM: <span class="sys-val" id="sys-ram">—</span></span>
   <span>Load: <span class="sys-val" id="sys-load">—</span></span>
   <span id="health-chips"></span>
-  <div class="min-dock" id="min-dock" aria-label="Minimized windows"></div>
+  <div class="min-dock" id="min-dock" role="group" aria-label="Minimized windows"></div>
 </div>
 
 <div class="modal-overlay" id="confirm-modal" onclick="cancelConfirm(event)">
@@ -2177,8 +2177,10 @@ function restorePanel(id) {
 }
 
 function closeMinimized(id) {
+  var returnFocus = _minimized[id] && _minimized[id].returnFocus;
   var closer = MODAL_CLOSERS[id];
   if (closer) closer();   // per-type closer drops the chip and tears down WS/term
+  if (returnFocus && document.contains(returnFocus)) returnFocus.focus();
 }
 
 document.querySelectorAll('.modal-overlay').forEach(function(overlay) {

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1757,16 +1757,20 @@
           <label>Also bring over addons</label>
           <div class="hint" style="margin-top:0;">The standard Odoo modules ship with the image. These options download the rest of the Odoo.sh addons-path into extra-addons for this template.</div>
           <div class="check-row" style="margin-top:8px;">
-            <input type="checkbox" id="import-with-enterprise" disabled>
+            <input type="checkbox" id="import-with-enterprise" onchange="onImportAddonSelectionChange()" disabled>
             <label for="import-with-enterprise">Enterprise addons <span class="label-hint">— downloaded as a local repo (no remote)</span></label>
           </div>
           <div class="check-row" style="margin-top:6px;">
-            <input type="checkbox" id="import-with-themes" disabled>
+            <input type="checkbox" id="import-with-themes" onchange="onImportAddonSelectionChange()" disabled>
             <label for="import-with-themes">Themes <span class="label-hint">— downloaded as a local repo (no remote)</span></label>
           </div>
           <div class="check-row" style="margin-top:6px;">
-            <input type="checkbox" id="import-with-extra" disabled>
+            <input type="checkbox" id="import-with-extra" onchange="onImportAddonSelectionChange()" disabled>
             <label for="import-with-extra">Extra addons <span class="label-hint">— OCA and other repos; reachable ones stay updatable</span></label>
+          </div>
+          <div class="check-row" style="margin-top:10px;">
+            <input type="checkbox" id="import-best-effort" disabled>
+            <label for="import-best-effort">Continue if some addons are unavailable <span class="label-hint">— may create a template that cannot start until the missing modules are restored</span></label>
           </div>
         </div>
         <div class="form-actions">
@@ -3330,7 +3334,7 @@ function openImportOdooModal() {
   document.getElementById('import-odoo-command').textContent = '';
   document.getElementById('import-odoo-submit').disabled = false;
   document.getElementById('import-odoo-submit').textContent = 'Generate command';
-  ['import-with-enterprise', 'import-with-themes', 'import-with-extra'].forEach(function(id) {
+  ['import-with-enterprise', 'import-with-themes', 'import-with-extra', 'import-best-effort'].forEach(function(id) {
     var cb = document.getElementById(id);
     cb.checked = false;
     cb.disabled = true;
@@ -3349,6 +3353,20 @@ function onImportAckChange() {
     cb.disabled = !ack;
     if (!ack) cb.checked = false;
   });
+  if (!ack) {
+    document.getElementById('import-best-effort').checked = false;
+  }
+  onImportAddonSelectionChange();
+}
+
+function onImportAddonSelectionChange() {
+  var ack = document.getElementById('import-ack').checked;
+  var anySelected = ['import-with-enterprise', 'import-with-themes', 'import-with-extra'].some(function(id) {
+    return document.getElementById(id).checked;
+  });
+  var bestEffort = document.getElementById('import-best-effort');
+  bestEffort.disabled = !ack || !anySelected;
+  if (bestEffort.disabled) bestEffort.checked = false;
 }
 
 function closeImportOdooModal(event) {
@@ -3380,7 +3398,8 @@ async function submitImportOdoo() {
         template_name: name,
         with_enterprise: document.getElementById('import-with-enterprise').checked,
         with_themes: document.getElementById('import-with-themes').checked,
-        with_extra_addons: document.getElementById('import-with-extra').checked
+        with_extra_addons: document.getElementById('import-with-extra').checked,
+        addon_error_policy: document.getElementById('import-best-effort').checked ? 'best_effort' : 'strict'
       })
     });
     var data = await readResult(r);

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -55,7 +55,7 @@ SERVER="${SERVER%/}"
 # final URL directly — POSTs must not rely on redirect-following, which would
 # drop the request body.
 EFFECTIVE="$(curl -fsSIL -o /dev/null -w '%{url_effective}' "${SERVER}/import-odoo.sh" 2>/dev/null || true)"
-if [ -n "$EFFECTIVE" ]; then
+if [ -n "$EFFECTIVE" ] && [ "${EFFECTIVE%/import-odoo.sh}" != "$EFFECTIVE" ]; then
     SERVER="${EFFECTIVE%/import-odoo.sh}"
 fi
 
@@ -92,6 +92,14 @@ API="${SERVER}/api/templates/import"
 # bodies over 100 MB with a 413. 90 MiB per part stays safely under that.
 PART_BYTES=$((90 * 1024 * 1024))
 
+# curl 7.76 added --fail-with-body; Odoo.sh images with older curl still need
+# to run the importer, even though their -f fallback cannot preserve error
+# bodies. Keep the richer diagnostic whenever the installed curl supports it.
+CURL_FAIL=(-f)
+if curl --help all 2>/dev/null | grep -q -- '--fail-with-body'; then
+    CURL_FAIL=(--fail-with-body)
+fi
+
 # ---- helpers ---------------------------------------------------------------
 
 human() {  # bytes -> human readable
@@ -106,6 +114,17 @@ json_field() {  # file expr  (expr is python on obj `d`)
     python3 -c 'import sys,json
 d=json.load(open(sys.argv[1]))
 print('"$2"')' "$1" 2>/dev/null || true
+}
+
+urlencode() {  # one query-string component
+    python3 -c 'import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=""))' "$1"
+}
+
+addon_remote_json() {  # name origin branch
+    python3 -c 'import json, sys
+print(json.dumps({"name": sys.argv[1], "origin_url": sys.argv[2], "branch": sys.argv[3]}))' \
+        "$1" "$2" "$3"
 }
 
 upload_ranges() {  # file url extra_query start_offset [label]
@@ -152,7 +171,7 @@ echo ">> Importing '$DB' into Oduflow at $SERVER"
 
 STATUS_FILE="$(mktemp)"
 trap 'rm -f "$STATUS_FILE"' EXIT
-if ! curl -sS --fail-with-body -H "$AUTH" "${API}/status" -o "$STATUS_FILE" 2>/dev/null; then
+if ! curl -sS "${CURL_FAIL[@]}" -H "$AUTH" "${API}/status" -o "$STATUS_FILE" 2>/dev/null; then
     echo "ERROR: could not reach $SERVER or token is invalid/expired." >&2
     [ -s "$STATUS_FILE" ] && { echo "       Server said:" >&2; head -c 300 "$STATUS_FILE" >&2; echo >&2; }
     echo "       Generate a fresh token from the dashboard and retry." >&2
@@ -331,7 +350,8 @@ upload_addon_files() {  # path name branch category
         rm -f "$tmptar"; return 1
     fi
     upload_ranges "$tmptar" "${API}/addon" \
-        "name=${name}&branch=${branch}&category=${cat}" 0 "addon ${name}"
+        "name=$(urlencode "$name")&branch=$(urlencode "$branch")&category=$(urlencode "$cat")" \
+        0 "addon ${name}"
     rc=$?
     rm -f "$tmptar"
     return "$rc"
@@ -339,7 +359,7 @@ upload_addon_files() {  # path name branch category
 
 announce_addon_remote() {  # name origin branch
     curl -fsS -H "$AUTH" -H "Content-Type: application/json" \
-        --data-binary "$(printf '{"name":"%s","origin_url":"%s","branch":"%s"}' "$1" "$2" "$3")" \
+        --data-binary "$(addon_remote_json "$1" "$2" "$3")" \
         -X POST "${API}/addon-remote" >/dev/null
 }
 
@@ -421,7 +441,7 @@ RESULT_FILE="$(mktemp)"
 trap 'rm -f "$STATUS_FILE" "$RESULT_FILE"' EXIT
 # --fail-with-body keeps the server's error body on HTTP >= 400 (plain -f
 # would discard it, hiding the reason the riskiest step failed).
-if ! curl -sS --fail-with-body -H "$AUTH" -X POST "${API}/finalize" -o "$RESULT_FILE"; then
+if ! curl -sS "${CURL_FAIL[@]}" -H "$AUTH" -X POST "${API}/finalize" -o "$RESULT_FILE"; then
     echo "ERROR: finalize request failed:" >&2
     cat "$RESULT_FILE" >&2 || true
     echo >&2

--- a/src/oduflow/templates/import-odoo.sh
+++ b/src/oduflow/templates/import-odoo.sh
@@ -462,4 +462,12 @@ if not d.get("ok"):
     print(">> ERROR:", d.get("error","unknown error")); sys.exit(1)
 r=d.get("result",{})
 print(">> Done — template ready:", r.get("template_name"))
-print("   DB:", r.get("template_db"), " restore:", r.get("restore_seconds"), "s")' "$RESULT_FILE"
+print("   DB:", r.get("template_db"), " restore:", r.get("restore_seconds"), "s")
+warnings = r.get("addon_warnings") or []
+if warnings:
+    print(">> Addon warnings:")
+    for warning in warnings:
+        name = warning.get("name") or "unknown"
+        action = warning.get("action") or "warning"
+        reason = warning.get("reason") or "No reason reported."
+        print("   WARNING:", name, "—", action, "—", reason)' "$RESULT_FILE"

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1650,7 +1650,8 @@ def _build_routes(
         Optional booleans ``with_enterprise`` / ``with_themes`` /
         ``with_extra_addons`` append the matching ``--with-*`` flags to the
         returned command so the checkboxes in the import dialog drive what the
-        Odoo.sh client downloads.
+        Odoo.sh client downloads. ``addon_error_policy`` is stored with the
+        token and controls strict versus best-effort addon wiring at finalize.
         """
         team = _get_ui_team(request)
         with_flags: list[str] = []
@@ -1672,7 +1673,15 @@ def _build_routes(
                 with_flags.append("--with-themes")
             if data.get("with_extra_addons"):
                 with_flags.append("--with-extra-addons")
-            record = import_tokens.create_token(team, template_name)
+            addon_error_policy = str(
+                data.get("addon_error_policy")
+                or import_tokens.ADDON_ERROR_POLICY_STRICT
+            )
+            record = import_tokens.create_token(
+                team,
+                template_name,
+                addon_error_policy=addon_error_policy,
+            )
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except Exception:
@@ -2140,6 +2149,10 @@ def _build_routes(
                 team,
                 template_name,
                 staging_dir=team.get_import_staging_dir(template_name),
+                addon_error_policy=str(
+                    record.get("addon_error_policy")
+                    or import_tokens.ADDON_ERROR_POLICY_STRICT
+                ),
             )
             import_tokens.invalidate(team, str(record["token"]))
             return JSONResponse({"ok": True, "result": result})

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -15,8 +15,7 @@ import socket
 import tempfile
 import threading
 import time
-from collections.abc import Awaitable, Callable
-from functools import wraps
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import quote, urlsplit
 
@@ -700,7 +699,6 @@ def _build_routes(
     # Per-app so test apps and real deployments don't share failure counters.
     login_limiter = _LoginRateLimiter()
     import_staging_locks = _ImportStagingLocks()
-    import_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     def _set_session_cookie(
         response: Response, team: TeamSettings, request: Request
@@ -1530,24 +1528,6 @@ def _build_routes(
     ) -> tuple[TeamSettings, dict[str, object]]:
         return import_tokens.load_token(get_settings(), _import_token_value(request))
 
-    def _serialize_import(
-        handler: Callable[[Request], Awaitable[Response]],
-    ) -> Callable[[Request], Awaitable[Response]]:
-        """Serialize import mutations for one team/template upload."""
-
-        @wraps(handler)
-        async def wrapped(request: Request) -> Response:
-            try:
-                team, record = _resolve_import_token(request)
-            except FlowError as e:
-                return _error_response(e)
-            key = (team.team_id, str(record["template_name"]))
-            lock = import_locks.setdefault(key, asyncio.Lock())
-            async with lock:
-                return await handler(request)
-
-        return wrapped
-
     def _import_progress(team: TeamSettings, template_name: str) -> dict[str, object]:
         """Derive resumable upload progress from the import staging directory.
 
@@ -1729,7 +1709,6 @@ def _build_routes(
             }
         )
 
-    @_serialize_import
     async def api_import_manifest(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1793,7 +1772,6 @@ def _build_routes(
                 f.write(data)
         return "written", os.path.getsize(part_path)
 
-    @_serialize_import
     async def api_import_dump(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1859,7 +1837,6 @@ def _build_routes(
             os.replace(part, dest)
         return JSONResponse({"ok": True, "received": size, "complete": complete})
 
-    @_serialize_import
     async def api_import_filestore(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1945,7 +1922,6 @@ def _build_routes(
             if os.path.exists(staged_path):
                 os.remove(staged_path)
 
-    @_serialize_import
     async def api_import_addon(request: Request) -> JSONResponse:
         """Receive one addon directory (tar stream) that becomes a local
         (remote-less) extra-addons repo — Enterprise, Themes or a private extra
@@ -2065,7 +2041,6 @@ def _build_routes(
                     os.remove(final_tar)
         return JSONResponse({"ok": True, "received": size, "complete": complete})
 
-    @_serialize_import
     async def api_import_addon_remote(request: Request) -> JSONResponse:
         """Announce a reachable extra repo (no files uploaded) — it is cloned
         from its origin at finalize so it stays updatable via Oduflow."""
@@ -2120,8 +2095,7 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         return JSONResponse({"ok": True})
 
-    @_serialize_import
-    async def api_import_finalize(request: Request) -> JSONResponse:
+    def api_import_finalize(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
         except FlowError as e:

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -15,7 +15,8 @@ import socket
 import tempfile
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from functools import wraps
 from typing import Any
 from urllib.parse import quote, urlsplit
 
@@ -699,6 +700,7 @@ def _build_routes(
     # Per-app so test apps and real deployments don't share failure counters.
     login_limiter = _LoginRateLimiter()
     import_staging_locks = _ImportStagingLocks()
+    import_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
     def _set_session_cookie(
         response: Response, team: TeamSettings, request: Request
@@ -1528,24 +1530,59 @@ def _build_routes(
     ) -> tuple[TeamSettings, dict[str, object]]:
         return import_tokens.load_token(get_settings(), _import_token_value(request))
 
+    def _serialize_import(
+        handler: Callable[[Request], Awaitable[Response]],
+    ) -> Callable[[Request], Awaitable[Response]]:
+        """Serialize import mutations for one team/template upload."""
+
+        @wraps(handler)
+        async def wrapped(request: Request) -> Response:
+            try:
+                team, record = _resolve_import_token(request)
+            except FlowError as e:
+                return _error_response(e)
+            key = (team.team_id, str(record["template_name"]))
+            lock = import_locks.setdefault(key, asyncio.Lock())
+            async with lock:
+                return await handler(request)
+
+        return wrapped
+
     def _import_progress(team: TeamSettings, template_name: str) -> dict[str, object]:
-        """Derive upload progress from what sits in the import STAGING dir (not
-        the token, and never the live template). Disk-derived progress makes a
-        re-run resumable even with a fresh token after the old one expired;
-        reading staging (not the template) means importing over an existing
-        template re-uploads everything instead of silently "resuming" from the
-        old template's files."""
+        """Derive resumable upload progress from the import staging directory.
+
+        Before promotion, live template files are deliberately ignored so an
+        overwrite cannot fake progress from old data. A ``.promoted`` marker
+        explicitly switches missing artifacts to the live copy, allowing a
+        failed final restore to retry without re-uploading moved files.
+        """
         staging = team.get_import_staging_dir(template_name)  # validates name
-        manifest = os.path.isfile(os.path.join(staging, "metadata.json"))
-        dump = os.path.isfile(os.path.join(staging, "dump.sql.gz"))
+        promoted = os.path.isfile(os.path.join(staging, ".promoted"))
+        live_dir = team.get_template_dir(template_name)
+        staged_meta = os.path.join(staging, "metadata.json")
+        staged_dump = os.path.join(staging, "dump.sql.gz")
+        live_meta = team.get_template_metadata_path(template_name)
+        live_dump = os.path.join(live_dir, "dump.sql.gz")
+        manifest = os.path.isfile(staged_meta) or (
+            promoted and os.path.isfile(live_meta)
+        )
+        dump = os.path.isfile(staged_dump) or (promoted and os.path.isfile(live_dump))
         # dump_bytes lets a chunked upload resume mid-file: bytes already on the
         # server, whether the dump is complete (final file) or partial (.part).
         if dump:
-            dump_bytes = os.path.getsize(os.path.join(staging, "dump.sql.gz"))
+            dump_path = staged_dump if os.path.isfile(staged_dump) else live_dump
+            dump_bytes = os.path.getsize(dump_path)
         else:
             dpart = os.path.join(staging, "dump.sql.gz.part")
             dump_bytes = os.path.getsize(dpart) if os.path.isfile(dpart) else 0
-        fs_dir = os.path.join(staging, "filestore")
+        staged_fs_dir = os.path.join(staging, "filestore")
+        fs_dir = (
+            staged_fs_dir
+            if os.path.isdir(staged_fs_dir)
+            else team.get_template_filestore_path(template_name)
+            if promoted
+            else staged_fs_dir
+        )
         chunks: list[str] = []
         if os.path.isdir(fs_dir):
             # A chunk directory appears only after its tar was extracted in
@@ -1683,6 +1720,7 @@ def _build_routes(
             }
         )
 
+    @_serialize_import
     async def api_import_manifest(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1746,6 +1784,7 @@ def _build_routes(
                 f.write(data)
         return "written", os.path.getsize(part_path)
 
+    @_serialize_import
     async def api_import_dump(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1811,6 +1850,7 @@ def _build_routes(
             os.replace(part, dest)
         return JSONResponse({"ok": True, "received": size, "complete": complete})
 
+    @_serialize_import
     async def api_import_filestore(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
@@ -1896,6 +1936,7 @@ def _build_routes(
             if os.path.exists(staged_path):
                 os.remove(staged_path)
 
+    @_serialize_import
     async def api_import_addon(request: Request) -> JSONResponse:
         """Receive one addon directory (tar stream) that becomes a local
         (remote-less) extra-addons repo — Enterprise, Themes or a private extra
@@ -2015,6 +2056,7 @@ def _build_routes(
                     os.remove(final_tar)
         return JSONResponse({"ok": True, "received": size, "complete": complete})
 
+    @_serialize_import
     async def api_import_addon_remote(request: Request) -> JSONResponse:
         """Announce a reachable extra repo (no files uploaded) — it is cloned
         from its origin at finalize so it stays updatable via Oduflow."""
@@ -2039,6 +2081,12 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "origin_url is required"}, status_code=400
             )
+        try:
+            from oduflow.url_safety import assert_allowed_url
+
+            assert_allowed_url(origin_url, require_https=True, allow_private=False)
+        except FlowError as e:
+            return _error_response(e)
         branch = str((body or {}).get("branch") or "").strip()
         template_name = str(record["template_name"])
         try:
@@ -2063,7 +2111,8 @@ def _build_routes(
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         return JSONResponse({"ok": True})
 
-    def api_import_finalize(request: Request) -> JSONResponse:
+    @_serialize_import
+    async def api_import_finalize(request: Request) -> JSONResponse:
         try:
             team, record = _resolve_import_token(request)
         except FlowError as e:
@@ -3092,7 +3141,10 @@ def _build_routes(
             else:
                 base = (settings.oauth_base_url or str(request.base_url)).rstrip("/")
             url = f"{base}/mcp/{quote(branch, safe='/')}"
-            return JSONResponse({"ok": True, "result": {"url": url, "token": token}})
+            return JSONResponse(
+                {"ok": True, "result": {"url": url, "token": token}},
+                headers={"Cache-Control": "no-store"},
+            )
         except FlowError as e:
             return _error_response(e)
         except Exception:
@@ -3267,7 +3319,14 @@ def _build_routes(
         try:
             import docker as _docker
             from oduflow.docker_ops.client import get_client as _get_client
-            from oduflow.naming import get_db_name, get_resource_name
+            from oduflow.naming import get_db_name, get_resource_name, validate_env_name
+
+            try:
+                validate_env_name(branch)
+            except ValueError as e:
+                await websocket.send_text(f"\x1b[31mError: {e}\x1b[0m\r\n")
+                await websocket.close(code=1008)
+                return
 
             settings = get_settings()
             team = _get_ui_team(websocket)
@@ -3554,7 +3613,15 @@ def _build_routes(
             from oduflow.naming import (
                 get_agent_checkout_dir,
                 get_agent_container_name,
+                validate_env_name,
             )
+
+            try:
+                validate_env_name(branch)
+            except ValueError as e:
+                await websocket.send_text(f"\x1b[31mError: {e}\x1b[0m\r\n")
+                await websocket.close(code=1008)
+                return
 
             settings = get_settings()
             team = _get_ui_team(websocket)
@@ -3792,7 +3859,7 @@ def _build_routes(
         branch = websocket.path_params["branch"]
         await websocket.accept()
 
-        async def _err(msg: str) -> None:
+        async def _err(msg: str, close_code: int = 1011) -> None:
             try:
                 await websocket.send_text(
                     json.dumps(
@@ -3806,7 +3873,7 @@ def _build_routes(
             except Exception:
                 pass
             try:
-                await websocket.close(code=1011)
+                await websocket.close(code=close_code)
             except Exception:
                 pass
 
@@ -3824,6 +3891,14 @@ def _build_routes(
                 )
             except Exception:
                 pass
+
+        from oduflow.naming import validate_env_name
+
+        try:
+            validate_env_name(branch)
+        except ValueError as e:
+            await _err(str(e), close_code=1008)
+            return
 
         try:
             from docker.utils.socket import (

--- a/tests/test_chat_acp_config_options.py
+++ b/tests/test_chat_acp_config_options.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-
 _ROOT = Path(__file__).parents[1]
 _CHAT_JS = _ROOT / "src" / "oduflow" / "templates" / "static" / "chat.js"
 _ACP_JS = _ROOT / "src" / "oduflow" / "templates" / "static" / "acp-client.js"

--- a/tests/test_env_tokens.py
+++ b/tests/test_env_tokens.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from oduflow import env_tokens
@@ -91,3 +94,28 @@ def test_env_token_cached(monkeypatch):
     assert env_tokens.resolve_token(s, "env-secret") == ("1", "main")
     assert env_tokens.resolve_token(s, "env-secret") == ("1", "main")
     assert calls["n"] == 1  # second lookup served from the cache
+
+
+def test_concurrent_unknown_tokens_share_one_scan(monkeypatch):
+    s = _settings()
+    scan_started = threading.Event()
+    release_scan = threading.Event()
+    calls = {"n": 0}
+
+    def fake_scan(settings):
+        calls["n"] += 1
+        scan_started.set()
+        assert release_scan.wait(timeout=2)
+        return {"env-secret": ("1", "main")}
+
+    monkeypatch.setattr(env_tokens, "_scan_env_tokens", fake_scan)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [
+            pool.submit(env_tokens.resolve_token, s, "env-secret") for _ in range(8)
+        ]
+        assert scan_started.wait(timeout=2)
+        release_scan.set()
+        results = [future.result(timeout=2) for future in futures]
+
+    assert results == [("1", "main")] * 8
+    assert calls["n"] == 1

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -5,6 +5,7 @@ import textwrap
 import pytest
 
 from oduflow.git_analysis import (
+    _is_active_dep_file,
     _extract_field_lines,
     _extract_view_tag_attrs,
     _get_module_name,
@@ -72,6 +73,12 @@ class TestIsDepFile:
         # apt_packages.txt is only read from .oduflow/, never the repo root.
         assert _is_dep_file("apt_packages.txt") is False
 
+    def test_root_requirements_is_shadowed_by_oduflow_requirements(self, tmp_path):
+        (tmp_path / ".oduflow").mkdir()
+        (tmp_path / ".oduflow" / "requirements.txt").write_text("preferred\n")
+        assert _is_active_dep_file("requirements.txt", str(tmp_path)) is False
+        assert _is_active_dep_file(".oduflow/requirements.txt", str(tmp_path)) is True
+
 
 class TestIsTranslationFile:
     def test_po_catalog(self):
@@ -129,6 +136,13 @@ class TestClassifyChanges:
         result = classify_changes([".oduflow/requirements.txt"], "/tmp")
         assert result["action"] == "restart"
         assert result["details"]["deps_changed"] == [".oduflow/requirements.txt"]
+
+    def test_shadowed_root_requirements_does_not_restart(self, tmp_path):
+        (tmp_path / ".oduflow").mkdir()
+        (tmp_path / ".oduflow" / "requirements.txt").write_text("preferred\n")
+        result = classify_changes(["requirements.txt"], str(tmp_path))
+        assert result["action"] == "refresh"
+        assert result["details"]["deps_changed"] == []
 
     def test_apt_packages_restart(self):
         result = classify_changes([".oduflow/apt_packages.txt"], "/tmp")
@@ -700,6 +714,13 @@ class TestShallowClassify:
         result = shallow_classify([".oduflow/apt_packages.txt"], "/tmp")
         assert result["action"] == "restart"
         assert result["details"]["deps_changed"] == [".oduflow/apt_packages.txt"]
+
+    def test_shadowed_root_requirements_does_not_restart(self, tmp_path):
+        (tmp_path / ".oduflow").mkdir()
+        (tmp_path / ".oduflow" / "requirements.txt").write_text("preferred\n")
+        result = shallow_classify(["requirements.txt"], str(tmp_path))
+        assert result["action"] == "refresh"
+        assert result["details"]["deps_changed"] == []
 
     def test_only_xml_still_refresh(self):
         result = shallow_classify(["sale/views/sale_order.xml"], "/tmp")

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -5,10 +5,10 @@ import textwrap
 import pytest
 
 from oduflow.git_analysis import (
-    _is_active_dep_file,
     _extract_field_lines,
     _extract_view_tag_attrs,
     _get_module_name,
+    _is_active_dep_file,
     _is_data_path,
     _is_dep_file,
     _is_security_path,

--- a/tests/test_import_addons.py
+++ b/tests/test_import_addons.py
@@ -6,6 +6,7 @@ branch needs network and is not exercised here.
 """
 
 import json
+import os
 import tarfile
 
 import pytest
@@ -130,3 +131,51 @@ class TestWireImportedAddons:
         )
         with pytest.raises(PrerequisiteNotMetError, match="no uploaded files"):
             system_ops._wire_imported_addons(team, str(staging), "18.0")
+
+    def test_clone_success_with_wrong_branch_fails_loud(self, team, tmp_path):
+        """A successful clone whose branch is missing on the remote must NOT
+        silently fall back to local files; the user explicitly asked for the
+        remote version. The bare repo is removed and NotFoundError surfaces."""
+        from unittest.mock import patch
+
+        from oduflow import extra_addons
+        from oduflow.errors import NotFoundError
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        # Provision BOTH local files and a remote URL: a too-broad except
+        # used to silently use the local files when the branch check failed.
+        local_src = staging / "addons" / "enterprise"
+        local_src.mkdir(parents=True)
+        (local_src / "__manifest__.py").write_text("{}")
+        (staging / "addons.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "enterprise",
+                        "kind": "remote",
+                        "origin_url": "https://example.com/enterprise.git",
+                        "branch": "18.0",
+                    }
+                ]
+            )
+        )
+
+        with (
+            patch.object(
+                extra_addons,
+                "clone_extra_repo",
+                return_value={"name": "enterprise"},
+            ),
+            patch.object(
+                extra_addons,
+                "_resolve_branch_revision",
+                side_effect=NotFoundError("Branch '18.0' not found."),
+            ),
+        ):
+            with pytest.raises(NotFoundError, match="Branch '18.0'"):
+                system_ops._wire_imported_addons(team, str(staging), "18.0")
+
+        # The bare repo the clone created must be cleaned up so it cannot be
+        # referenced as if it were a fresh wiring of the correct branch.
+        assert not os.path.exists(os.path.join(team.shared_repos_dir, "enterprise"))

--- a/tests/test_import_addons.py
+++ b/tests/test_import_addons.py
@@ -134,8 +134,8 @@ class TestWireImportedAddons:
 
     def test_clone_success_with_wrong_branch_fails_loud(self, team, tmp_path):
         """A successful clone whose branch is missing on the remote must NOT
-        silently fall back to local files; the user explicitly asked for the
-        remote version. The bare repo is removed and NotFoundError surfaces."""
+        silently fall back in strict mode. The bare repo is removed and the
+        branch error surfaces."""
         from unittest.mock import patch
 
         from oduflow import extra_addons
@@ -161,11 +161,15 @@ class TestWireImportedAddons:
             )
         )
 
+        def fake_clone(*_args, **_kwargs):
+            os.makedirs(os.path.join(team.shared_repos_dir, "enterprise"))
+            return {"name": "enterprise"}
+
         with (
             patch.object(
                 extra_addons,
                 "clone_extra_repo",
-                return_value={"name": "enterprise"},
+                side_effect=fake_clone,
             ),
             patch.object(
                 extra_addons,
@@ -179,3 +183,131 @@ class TestWireImportedAddons:
         # The bare repo the clone created must be cleaned up so it cannot be
         # referenced as if it were a fresh wiring of the correct branch.
         assert not os.path.exists(os.path.join(team.shared_repos_dir, "enterprise"))
+
+    def test_best_effort_wrong_remote_branch_uses_local_copy(self, team, tmp_path):
+        from unittest.mock import patch
+
+        from oduflow import extra_addons
+        from oduflow.errors import NotFoundError
+
+        staging = tmp_path / "staging"
+        local_src = staging / "addons" / "enterprise"
+        local_src.mkdir(parents=True)
+        (local_src / "__manifest__.py").write_text("{}")
+        (staging / "addons.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "enterprise",
+                        "kind": "remote",
+                        "origin_url": "https://example.com/enterprise.git",
+                        "branch": "18.0",
+                    }
+                ]
+            )
+        )
+
+        def fake_clone(*_args, **_kwargs):
+            os.makedirs(os.path.join(team.shared_repos_dir, "enterprise"))
+            return {"name": "enterprise"}
+
+        warnings = []
+        with (
+            patch.object(extra_addons, "clone_extra_repo", side_effect=fake_clone),
+            patch.object(
+                extra_addons,
+                "_resolve_branch_revision",
+                side_effect=[
+                    NotFoundError("Branch '18.0' not found."),
+                    "a" * 40,
+                ],
+            ),
+        ):
+            wired = system_ops._wire_imported_addons(
+                team,
+                str(staging),
+                "18.0",
+                addon_error_policy="best_effort",
+                addon_warnings=warnings,
+            )
+
+        assert wired == {"enterprise": "18.0"}
+        assert is_local_repo(team, "enterprise")
+        assert warnings == [
+            {
+                "name": "enterprise",
+                "action": "used_local_copy",
+                "reason": "Branch '18.0' not found.",
+            }
+        ]
+
+    def test_best_effort_missing_addon_is_skipped(self, team, tmp_path):
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        (staging / "addons.json").write_text(
+            json.dumps([{"name": "missing", "kind": "local", "branch": "18.0"}])
+        )
+        warnings = []
+
+        wired = system_ops._wire_imported_addons(
+            team,
+            str(staging),
+            "18.0",
+            addon_error_policy="best_effort",
+            addon_warnings=warnings,
+        )
+
+        assert wired == {}
+        assert warnings == [
+            {
+                "name": "missing",
+                "action": "skipped",
+                "reason": "Addon 'missing' has no uploaded files and no usable origin.",
+            }
+        ]
+
+    def test_strict_clone_failure_can_use_uploaded_copy_with_warning(
+        self, team, tmp_path
+    ):
+        from unittest.mock import patch
+
+        from oduflow import extra_addons
+
+        staging = tmp_path / "staging"
+        local_src = staging / "addons" / "oca"
+        local_src.mkdir(parents=True)
+        (local_src / "__manifest__.py").write_text("{}")
+        (staging / "addons.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "oca",
+                        "kind": "remote",
+                        "origin_url": "https://example.com/oca.git",
+                        "branch": "18.0",
+                    }
+                ]
+            )
+        )
+        warnings = []
+
+        with patch.object(
+            extra_addons,
+            "clone_extra_repo",
+            side_effect=RuntimeError("remote unavailable"),
+        ):
+            wired = system_ops._wire_imported_addons(
+                team,
+                str(staging),
+                "18.0",
+                addon_warnings=warnings,
+            )
+
+        assert wired == {"oca": "18.0"}
+        assert warnings == [
+            {
+                "name": "oca",
+                "action": "used_local_copy",
+                "reason": "remote unavailable",
+            }
+        ]

--- a/tests/test_import_addons.py
+++ b/tests/test_import_addons.py
@@ -6,7 +6,6 @@ branch needs network and is not exercised here.
 """
 
 import json
-import os
 import tarfile
 
 import pytest
@@ -95,7 +94,10 @@ class TestWireImportedAddons:
         assert wired == {"themes": "17.0"}
 
     def test_existing_repo_is_referenced_not_recreated(self, team, tmp_path):
-        os.makedirs(os.path.join(team.shared_repos_dir, "enterprise"))
+        source = _make_repo_dir(tmp_path, top="existing-enterprise")
+        from oduflow.extra_addons import create_local_repo
+
+        create_local_repo(team, "enterprise", str(source), "18.0")
         staging = tmp_path / "staging"
         staging.mkdir()
         (staging / "addons.json").write_text(
@@ -103,3 +105,28 @@ class TestWireImportedAddons:
         )
         wired = system_ops._wire_imported_addons(team, str(staging), "18.0")
         assert wired == {"enterprise": "18.0"}
+
+    def test_existing_repo_without_requested_branch_fails(self, team, tmp_path):
+        source = _make_repo_dir(tmp_path, top="existing-enterprise")
+        from oduflow.errors import NotFoundError
+        from oduflow.extra_addons import create_local_repo
+
+        create_local_repo(team, "enterprise", str(source), "17.0")
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        (staging / "addons.json").write_text(
+            json.dumps([{"name": "enterprise", "kind": "local", "branch": "18.0"}])
+        )
+        with pytest.raises(NotFoundError, match="Branch '18.0'"):
+            system_ops._wire_imported_addons(team, str(staging), "18.0")
+
+    def test_declared_addon_without_remote_or_files_fails(self, team, tmp_path):
+        from oduflow.errors import PrerequisiteNotMetError
+
+        staging = tmp_path / "staging"
+        staging.mkdir()
+        (staging / "addons.json").write_text(
+            json.dumps([{"name": "enterprise", "kind": "local", "branch": "18.0"}])
+        )
+        with pytest.raises(PrerequisiteNotMetError, match="no uploaded files"):
+            system_ops._wire_imported_addons(team, str(staging), "18.0")

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -62,6 +62,7 @@ def test_import_script_served(tmp_path):
     assert "finalize" in r.text
     assert "curl --help all" in r.text
     assert "urllib.parse.quote" in r.text
+    assert "Addon warnings" in r.text
 
 
 def test_token_command_contains_server_and_token(tmp_path):
@@ -472,19 +473,70 @@ def test_addon_remote_requires_origin(tmp_path):
 
 
 def test_import_token_flags_in_command(tmp_path):
-    client, _s, _t = _client(tmp_path)
+    from oduflow import import_tokens
+
+    client, settings, _team = _client(tmp_path)
     r = client.post(
         "/api/templates/import-token",
         json={
             "template_name": "zipfit",
             "with_enterprise": True,
             "with_extra_addons": True,
+            "addon_error_policy": "best_effort",
         },
     )
     data = r.json()
     assert "--with-enterprise" in data["command"]
     assert "--with-extra-addons" in data["command"]
     assert "--with-themes" not in data["command"]
+    _resolved_team, record = import_tokens.load_token(settings, data["token"])
+    assert record["addon_error_policy"] == "best_effort"
+
+
+def test_import_token_rejects_unknown_addon_policy(tmp_path):
+    client, _settings, _team = _client(tmp_path)
+
+    r = client.post(
+        "/api/templates/import-token",
+        json={
+            "template_name": "zipfit",
+            "addon_error_policy": "ignore_everything",
+        },
+    )
+
+    assert r.status_code == 400
+    assert "addon_error_policy" in r.json()["error"]
+
+
+def test_finalize_uses_addon_policy_stored_in_token(tmp_path):
+    client, _settings, team = _client(tmp_path)
+    r = client.post(
+        "/api/templates/import-token",
+        json={
+            "template_name": "zipfit",
+            "addon_error_policy": "best_effort",
+        },
+    )
+    token = r.json()["token"]
+    staging = team.get_import_staging_dir("zipfit")
+    os.makedirs(staging)
+    with open(os.path.join(staging, "metadata.json"), "w") as f:
+        f.write("{}")
+    with open(os.path.join(staging, "dump.sql.gz"), "wb") as f:
+        f.write(b"gz")
+
+    with patch.object(
+        system_ops,
+        "finalize_imported_template",
+        return_value={"template_name": "zipfit", "addon_warnings": []},
+    ) as finalize:
+        response = client.post(
+            "/api/templates/import/finalize",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert finalize.call_args.kwargs["addon_error_policy"] == "best_effort"
 
 
 def test_filestore_tar_zip_slip_is_skipped(tmp_path):
@@ -757,6 +809,7 @@ def test_finalize_swaps_staging_into_template(tmp_path):
         )
 
     assert result["template_db"] == "tdb"
+    assert result["addon_warnings"] == []
     fs = team.get_template_filestore_path("zipfit")
     assert open(os.path.join(fs, "ab", "f"), "rb").read() == b"blob"
     assert not os.path.exists(os.path.join(fs, "ff"))  # old filestore replaced

--- a/tests/test_import_odoo_web.py
+++ b/tests/test_import_odoo_web.py
@@ -9,6 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Event, Lock
 from unittest.mock import patch
 
+import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
@@ -59,6 +60,8 @@ def test_import_script_served(tmp_path):
     assert "PGDATABASE" in r.text
     assert "backup.daily" in r.text
     assert "finalize" in r.text
+    assert "curl --help all" in r.text
+    assert "urllib.parse.quote" in r.text
 
 
 def test_token_command_contains_server_and_token(tmp_path):
@@ -556,6 +559,47 @@ def test_existing_template_does_not_fake_resume(tmp_path):
     assert st["progress"]["filestore_chunks"] == []
 
 
+def test_promoted_import_reports_live_artifacts_for_retry(tmp_path):
+    """After promotion, a fresh token must skip re-uploading live artifacts."""
+    client, _s, team = _client(tmp_path)
+    staging = team.get_import_staging_dir("zipfit")
+    os.makedirs(staging)
+    open(os.path.join(staging, ".promoted"), "w").close()
+    tpl_dir = team.get_template_dir("zipfit")
+    os.makedirs(os.path.join(tpl_dir, "filestore", "ab"))
+    with open(team.get_template_metadata_path("zipfit"), "w") as f:
+        f.write("{}")
+    with open(os.path.join(tpl_dir, "dump.sql.gz"), "wb") as f:
+        f.write(b"promoted")
+
+    token, _ = _mint(client, "zipfit")
+    st = client.get(
+        "/api/templates/import/status",
+        headers={"Authorization": f"Bearer {token}"},
+    ).json()
+
+    assert st["progress"]["manifest"] is True
+    assert st["progress"]["dump"] is True
+    assert st["progress"]["dump_bytes"] == len(b"promoted")
+    assert st["progress"]["filestore_chunks"] == ["ab"]
+
+
+def test_private_remote_addon_url_is_rejected(tmp_path):
+    client, _s, _team = _client(tmp_path)
+    token, _ = _mint(client, "zipfit")
+    r = client.post(
+        "/api/templates/import/addon-remote",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "name": "private",
+            "origin_url": "https://127.0.0.1/repo.git",
+            "branch": "18.0",
+        },
+    )
+    assert r.status_code == 400
+    assert "blocked address" in r.json()["error"]
+
+
 def test_corrupt_chunk_is_not_marked_complete(tmp_path):
     """Regression: a truncated/corrupt chunk tar must fail the request AND
     leave no chunk directory behind, so resume re-uploads it."""
@@ -723,3 +767,59 @@ def test_finalize_swaps_staging_into_template(tmp_path):
         == "18.0"
     )
     assert not os.path.exists(staging)  # staging cleaned up
+
+
+def test_finalize_can_retry_after_reload_failure_without_reupload(tmp_path):
+    """Promotion leaves a marker and live artifacts when DB reload fails."""
+    from contextlib import contextmanager
+    from unittest.mock import MagicMock
+
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team1"))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    staging = team.get_import_staging_dir("zipfit")
+    os.makedirs(os.path.join(staging, "filestore", "ab"))
+    with open(os.path.join(staging, "metadata.json"), "w") as f:
+        json.dump({"odoo_version": "18.0"}, f)
+    with open(os.path.join(staging, "dump.sql.gz"), "wb") as f:
+        f.write(b"gz")
+
+    remount = MagicMock(affected=[], failures=[])
+
+    @contextmanager
+    def fake_remount(*a, **kw):
+        yield remount
+
+    from oduflow.docker_ops import env_ops
+
+    reload_results = [
+        RuntimeError("temporary restore failure"),
+        {"template_db": "tdb", "restore_seconds": 2.0},
+    ]
+    with (
+        patch.object(system_ops, "get_client"),
+        patch.object(env_ops, "remount_template_overlays", fake_remount),
+        patch.object(system_ops, "get_odoo_uid_gid", return_value="101:101"),
+        patch.object(system_ops, "chown_recursive"),
+        patch.object(system_ops, "_update_template_sizes"),
+        patch.object(
+            system_ops, "reload_template", side_effect=reload_results
+        ) as reload,
+    ):
+        with pytest.raises(RuntimeError, match="temporary restore failure"):
+            system_ops.finalize_imported_template(
+                settings, team, "zipfit", staging_dir=staging
+            )
+
+        assert os.path.isfile(os.path.join(staging, ".promoted"))
+        assert not os.path.isfile(os.path.join(staging, "dump.sql.gz"))
+        assert os.path.isfile(
+            os.path.join(team.get_template_dir("zipfit"), "dump.sql.gz")
+        )
+
+        result = system_ops.finalize_imported_template(
+            settings, team, "zipfit", staging_dir=staging
+        )
+
+    assert result["template_db"] == "tdb"
+    assert reload.call_count == 2
+    assert not os.path.exists(staging)

--- a/tests/test_import_tokens.py
+++ b/tests/test_import_tokens.py
@@ -23,10 +23,35 @@ def test_create_and_load_roundtrip(tmp_path):
     settings = _settings(team)
     rec = import_tokens.create_token(team, "zipfit")
     assert rec["template_name"] == "zipfit"
+    assert rec["addon_error_policy"] == "strict"
     team2, rec2 = import_tokens.load_token(settings, rec["token"])
     assert team2.team_id == "1"
     assert rec2["token"] == rec["token"]
     assert rec2["template_name"] == "zipfit"
+    assert rec2["addon_error_policy"] == "strict"
+
+
+def test_best_effort_addon_policy_roundtrip(tmp_path):
+    team = _team(tmp_path)
+    settings = _settings(team)
+    rec = import_tokens.create_token(
+        team,
+        "zipfit",
+        addon_error_policy="best_effort",
+    )
+
+    _team2, loaded = import_tokens.load_token(settings, rec["token"])
+
+    assert loaded["addon_error_policy"] == "best_effort"
+
+
+def test_invalid_addon_policy_rejected(tmp_path):
+    with pytest.raises(ValueError, match="addon_error_policy"):
+        import_tokens.create_token(
+            _team(tmp_path),
+            "zipfit",
+            addon_error_policy="ignore_everything",
+        )
 
 
 def test_malformed_and_unknown_tokens_raise_not_found(tmp_path):

--- a/tests/test_neutralize.py
+++ b/tests/test_neutralize.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import docker as _docker
+import pytest
+
 from oduflow import sanitizer
 from oduflow.naming import get_db_name, get_resource_name
 
@@ -34,6 +36,24 @@ def _neutralize_cmd(container) -> str | None:
         if isinstance(cmd, str) and "neutralize" in cmd:
             return cmd
     return None
+
+
+@pytest.mark.parametrize(
+    "image,expected",
+    [
+        ("odoo:15.0", 15),
+        ("registry.example:5000/acme/odoo-enterprise:15.0-custom", 15),
+        ("ghcr.io/acme/odoo-16", 16),
+        ("ghcr.io/acme/platform:latest", None),
+    ],
+)
+def test_detect_odoo_major_from_official_and_custom_images(image, expected):
+    container = MagicMock()
+    container.labels = {"oduflow.image": image}
+    assert (
+        sanitizer._detect_odoo_major_from_container(container, "oduflow.image")
+        == expected
+    )
 
 
 class TestNeutralizeEnvironment:

--- a/tests/test_neutralize.py
+++ b/tests/test_neutralize.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import docker as _docker
 import pytest
 
+import docker as _docker
 from oduflow import sanitizer
 from oduflow.naming import get_db_name, get_resource_name
 

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -990,6 +990,36 @@ class TestPullEnvironmentLocalAndSharedExtraCheckouts:
         assert mock_apply.call_args.kwargs["repo_path"] == str(repo)
 
     @patch("oduflow.docker_ops.env_ops._apply_actions")
+    def test_shadowed_root_requirements_change_does_not_reinstall(
+        self, mock_apply, mock_docker_client, tmp_path
+    ):
+        repo = tmp_path / "repo"
+        (repo / ".oduflow").mkdir(parents=True)
+        (repo / ".oduflow" / "requirements.txt").write_text("preferred\n")
+        req = repo / "requirements.txt"
+        req.write_text("fallback\n")
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        env_ops._write_local_snapshot(str(repo), "env", team)
+
+        old_stat = req.stat()
+        req.write_text("fallback\nunused-change\n")
+        os.utime(req, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns + 1_000_000))
+
+        container = MagicMock()
+        container.labels = {"oduflow.local_path": str(repo)}
+        mock_docker_client.containers.get.return_value = container
+        mock_apply.return_value = {
+            "action": "refresh",
+            "changed_files": ["requirements.txt"],
+            "message": "Files refreshed.",
+        }
+
+        env_ops.pull_environment(TEST_SETTINGS, team, "env")
+
+        assert mock_apply.call_args.kwargs["deps_changed"] is False
+        assert mock_apply.call_args.kwargs["do_restart"] is False
+
+    @patch("oduflow.docker_ops.env_ops._apply_actions")
     def test_local_failed_apply_does_not_advance_snapshot(
         self, mock_apply, mock_docker_client, tmp_path
     ):

--- a/tests/test_scoped_access.py
+++ b/tests/test_scoped_access.py
@@ -308,6 +308,17 @@ def test_call_full_mode_passthrough(monkeypatch):
     assert res[0] == "called"
 
 
+def test_context_reader_failure_fails_closed(monkeypatch):
+    monkeypatch.setattr(
+        scoped_access,
+        "scoped_env_from_request",
+        lambda: (_ for _ in ()).throw(RuntimeError("request context unavailable")),
+    )
+    assert _run(_middleware().on_list_tools(object(), _list_next)) == []
+    with pytest.raises(ToolError):
+        _run(_middleware().on_call_tool(_Ctx("pull_and_apply"), _call_next))
+
+
 # --- OduflowTokenVerifier --------------------------------------------------
 
 
@@ -400,6 +411,7 @@ def test_mcp_access_endpoint_returns_url_and_token(monkeypatch):
     assert data["ok"] is True
     assert data["result"]["token"] == "the-secret"
     assert data["result"]["url"].endswith("/mcp/feature/x")
+    assert resp.headers["cache-control"] == "no-store"
 
 
 def test_mcp_access_endpoint_token_missing(monkeypatch):

--- a/tests/test_web_ui_agent_acp.py
+++ b/tests/test_web_ui_agent_acp.py
@@ -51,6 +51,20 @@ def _post(client: TestClient, session_id: str, title: str | None = None):
     return client.post(_SESSION_URL, json=body)
 
 
+@pytest.mark.parametrize("endpoint", ["terminal", "agent", "agent-acp"])
+def test_websockets_reject_invalid_branch_before_resource_lookup(tmp_path, endpoint):
+    client = _client(tmp_path)
+    with client.websocket_connect(
+        f"/api/environments/bad%5Cbranch/{endpoint}"
+    ) as websocket:
+        message = websocket.receive_text()
+        close = websocket.receive()
+
+    assert "Invalid environment name" in message
+    assert close["type"] == "websocket.close"
+    assert close["code"] == 1008
+
+
 def test_info_starts_with_empty_history(tmp_path):
     response = _client(tmp_path).get(_INFO_URL)
 

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -114,9 +114,18 @@ def test_minimized_window_dock_has_group_semantics_and_restores_focus(tmp_path):
     capture_at = body.find("returnFocus = _minimized")
     closer_at = body.find("closer()")
     focus_at = body.find("returnFocus.focus()")
-    assert (
-        0 <= capture_at < closer_at < focus_at
-    ), (
+    assert 0 <= capture_at < closer_at < focus_at, (
         f"closeMinimized statement order is wrong: "
         f"capture={capture_at}, closer={closer_at}, focus={focus_at}"
+    )
+
+
+def test_odoo_sh_import_exposes_best_effort_addon_policy(tmp_path):
+    dashboard = _client(tmp_path).get("/").text
+
+    assert 'id="import-best-effort" disabled' in dashboard
+    assert "Continue if some addons are unavailable" in dashboard
+    assert (
+        "addon_error_policy: document.getElementById('import-best-effort').checked "
+        "? 'best_effort' : 'strict'" in dashboard
     )

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -98,10 +98,25 @@ def test_dashboard_accepts_opencode_default_and_labels_it(tmp_path):
 def test_minimized_window_dock_has_group_semantics_and_restores_focus(tmp_path):
     dashboard = _client(tmp_path).get("/").text
     assert 'id="min-dock" role="group"' in dashboard
-    assert (
-        "var returnFocus = _minimized[id] && _minimized[id].returnFocus;" in dashboard
+
+    # closeMinimized must capture returnFocus BEFORE calling closer() (otherwise
+    # closer() would tear down the chip and the captured element would already
+    # be detached), and the focus call must happen AFTER closer() (so the
+    # trigger element is still in the DOM). Asserting on the literal text does
+    # not catch a reorder; pin down the order of the three statements.
+    match = re.search(
+        r"function closeMinimized\(id\) \{(.*?)\}\s*$",
+        dashboard,
+        re.DOTALL | re.MULTILINE,
     )
+    assert match is not None, "closeMinimized function not found in dashboard"
+    body = match.group(1)
+    capture_at = body.find("returnFocus = _minimized")
+    closer_at = body.find("closer()")
+    focus_at = body.find("returnFocus.focus()")
     assert (
-        "if (returnFocus && document.contains(returnFocus)) returnFocus.focus();"
-        in dashboard
+        0 <= capture_at < closer_at < focus_at
+    ), (
+        f"closeMinimized statement order is wrong: "
+        f"capture={capture_at}, closer={closer_at}, focus={focus_at}"
     )

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -93,3 +93,15 @@ def test_dashboard_accepts_opencode_default_and_labels_it(tmp_path):
     assert "data.default === 'opencode'" in dashboard.text
     assert "(agentType === 'opencode' ? 'OpenCode' : 'Claude')" in dashboard.text
     assert "var CHAT_V = '6'" in dashboard.text
+
+
+def test_minimized_window_dock_has_group_semantics_and_restores_focus(tmp_path):
+    dashboard = _client(tmp_path).get("/").text
+    assert 'id="min-dock" role="group"' in dashboard
+    assert (
+        "var returnFocus = _minimized[id] && _minimized[id].returnFocus;" in dashboard
+    )
+    assert (
+        "if (returnFocus && document.contains(returnFocus)) returnFocus.focus();"
+        in dashboard
+    )


### PR DESCRIPTION
## Summary

- address the actionable Greptile findings collected from closed PRs #85–159
- make Odoo.sh template finalization retryable and addon wiring explicit, with strict and opt-in best-effort policies
- harden scoped MCP/token handling, WebSocket validation, dependency detection, accessibility, CI concurrency, and related documentation

## Why

Several review findings remained valid on current `main`, including import retries losing staged artifacts, incomplete addon templates being reported ready, fail-open scoped access, duplicate token scans, and inactive dependency files triggering restarts. This change resolves those cases while preserving later fixes already present upstream.

## Impact

Odoo.sh imports are safer and resumable, operators can explicitly accept missing addons when needed, scoped endpoints fail closed, and unnecessary dependency restarts and CI cancellations are avoided.

## Validation

- `bash -n src/oduflow/templates/import-odoo.sh`
- Ruff on all files changed by this branch
- `mypy src/oduflow`
- 73 focused import/dashboard tests after the final rebase
- broader focused regression set previously passed (395 tests; two post-rebase locking conflicts were then resolved against upstream and retested)
