### PR TITLE
Add declarative Oduflow stacks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,20 @@
 ### Features
 
 - **OpenCode hosted agent** — OpenCode joins Claude Code and Codex as a full Agent CLI and Agent Chat runtime. The new immutable coder image includes the MIT-licensed `opencode` CLI and native ACP server; OpenCode gets generic provider authentication, an optional `provider/model` override, approval-free execution inside the existing container boundary, per-environment Agent Browser, scoped Oduflow MCP, modern ACP model selection, and isolated conversation history.
+
+- **Declarative Oduflow Stacks** — a versioned `oduflow.yaml` can now describe
+  one development environment together with its Git source, database template,
+  extra-addons repositories, required modules, auxiliary services, named
+  volumes, and text files copied into those volumes. `oduflow stack
+  validate/plan/apply/status` provide strict schema validation, read-only drift
+  previews, team-locked idempotent reconciliation, and machine-readable status;
+  `oduflow --stack ...` applies the same manifest before starting the MCP
+  server. Stack resources carry ownership/spec-hash labels, secret values can be
+  resolved from the launching process or generated environment outputs without
+  entering state files or plans, and V1 deliberately refuses replacement or
+  deletion rather than risking persisted data. See `docs/stacks.md` and
+  `specs/0046`.
+
 - **Non-interactive bundled-file upgrades** — `oduflow upgrade --force` prints
   the usual overwrite warning and affected paths but proceeds without waiting
   for terminal input, enabling unattended deployments while continuing to

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,35 @@ Shared infrastructure (Docker network, PostgreSQL, team directories) is initiali
 Configuration is loaded from `oduflow.toml` (see [Installation](installation.md#configuration-reference)).
 See [Quick Start](quick-start.md) for MCP client configuration examples for both modes.
 
+To reconcile a declarative Stack before starting the server:
+
+```bash
+oduflow --stack /path/to/oduflow.yaml --stack-team 1 --transport http
+```
+
+Startup stops with a non-zero exit if Stack validation, preflight, or apply
+fails. See [Declarative Stacks](stacks.md).
+
+## Declarative Stack Commands
+
+```bash
+# Local syntax and schema validation (does not require Docker)
+oduflow stack validate oduflow.yaml
+
+# Read-only comparison with live resources
+oduflow stack plan oduflow.yaml --team 1
+
+# Reconcile under the team's lock
+oduflow stack apply oduflow.yaml --team 1
+
+# JSON status: drift plan plus the last successful apply record
+oduflow stack status oduflow.yaml --team 1
+```
+
+Stack apply is additive and non-destructive in V1. Existing resources owned by
+someone else and environment changes that require replacement are reported as
+conflicts; no automatic deletion or pruning is performed.
+
 ## System Commands
 
 ```bash

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2642,6 +2642,194 @@ depends on it.
 
 ---
 
+# Declarative Stacks
+
+An Oduflow Stack is a versioned YAML manifest describing the complete desired
+state of one development environment and its supporting resources. It keeps the
+host-level `oduflow.toml` separate from project configuration: teams, routing,
+authentication, quotas, and backups remain operator settings, while the Stack
+file can live beside the project's code and move between Oduflow installations.
+
+## Commands
+
+```bash
+oduflow stack validate oduflow.yaml
+oduflow stack plan oduflow.yaml --team 1
+oduflow stack apply oduflow.yaml --team 1
+oduflow stack status oduflow.yaml --team 1
+```
+
+`validate` is local and does not require Docker or `oduflow.toml`. `plan` reads
+live state without changing it. `apply` validates and plans again under the
+team lock, refuses all conflicts before creating anything, and then converges
+resources in dependency order. `status` emits JSON containing the current plan
+and last successful apply record.
+
+To reconcile before the MCP server accepts clients:
+
+```bash
+oduflow --stack /etc/oduflow/acme/oduflow.yaml \
+  --stack-team 1 \
+  --transport http
+```
+
+A failed startup reconciliation exits without starting the MCP transport. Any
+resources already created before an external failure remain owned by the Stack;
+rerunning the same command safely continues from live state.
+
+## Example
+
+```yaml
+apiVersion: oduflow.dev/v1alpha1
+kind: Stack
+
+metadata:
+  name: acme-erp
+
+spec:
+  environment:
+    name: acme-dev
+    branch: "18.0"
+    repoUrl: https://github.com/acme/odoo-addons.git
+    odooImage: odoo:18.0
+    template: acme-18
+    sanitize: true
+
+    env:
+      LOG_LEVEL: info
+      PRIVATE_API_KEY:
+        fromEnv: ACME_PRIVATE_API_KEY
+
+    modules:
+      install:
+        - acme_base
+        - acme_sale
+
+  extraRepositories:
+    enterprise:
+      repoUrl: https://github.com/odoo/enterprise.git
+      branch: "18.0"
+
+    oca-web:
+      repoUrl: https://github.com/OCA/web.git
+      branch: "18.0"
+
+  volumes:
+    fs-sounds:
+      description: FreeSWITCH sounds and configuration
+
+  files:
+    - source: files/freeswitch.xml
+      volume: fs-sounds
+      path: config/freeswitch.xml
+
+  services:
+    fs:
+      image: oduist/freeswitch:1.4.0
+      port: 8080
+      hostMode: true
+
+      volumes:
+        - source: fs-sounds
+          target: /usr/share/freeswitch/sounds
+          mode: rw
+
+      env:
+        ODOO_URL:
+          environmentField: url
+        FS_WEBHOOK_TOKEN:
+          environmentField: token
+        FS_ESL_PASSWORD:
+          fromEnv: FS_ESL_PASSWORD
+```
+
+The generated JSON Schema is shipped at
+`oduflow/schemas/oduflow-stack-v1alpha1.json`. Unknown fields, duplicate YAML
+keys, undeclared volume references, invalid names, and unsafe file paths are
+rejected.
+
+## Value sources
+
+An environment variable can be a literal string:
+
+```yaml
+LOG_LEVEL: info
+```
+
+It can be read from the process starting Oduflow:
+
+```yaml
+ESL_PASSWORD:
+  fromEnv: FS_ESL_PASSWORD
+```
+
+Or a service can consume a value generated for the Stack's Odoo environment:
+
+```yaml
+ODOO_URL:
+  environmentField: url
+MCP_TOKEN:
+  environmentField: token
+```
+
+`environmentField` is deliberately unavailable under `spec.environment.env`,
+because an environment cannot depend on an output that exists only after that
+same environment has been created. Resolved values are passed directly to the
+container. They are never written to the Stack state file or printed by
+`plan`.
+
+Docker can expose container environment values to host administrators through
+`docker inspect`; Stack value sources do not change that existing Docker trust
+boundary. Configure private Git credentials separately with `setup_repo_auth`.
+
+## Reconciliation and ownership
+
+Resources created by a Stack carry these Docker labels:
+
+```text
+oduflow.stack=acme-erp
+oduflow.stack-resource=services.fs
+oduflow.stack-spec-hash=<sha256>
+```
+
+Oduflow will not silently adopt an existing environment, service, or volume
+with the same name. It reports an ownership conflict instead. Extra-addon bare
+repositories remain team-shared by design: an existing repository with the same
+name and URL is reused, while a different URL is a conflict.
+
+The V1 apply order is:
+
+1. extra-addon repositories;
+2. named volumes;
+3. the Odoo environment;
+4. text files in volumes;
+5. auxiliary services;
+6. missing Odoo modules.
+
+Module installation happens after services so an install hook can connect to a
+declared dependency. Only missing modules are installed; Stack apply never
+uninstalls a module.
+
+## Safe and replacement changes
+
+V1 can reconcile these changes in place:
+
+- Odoo image and Odoo container environment variables;
+- service image, environment, port/routes, hostname, volumes, host mode, and
+  capabilities;
+- new extra repositories, volumes, files, services, and modules.
+
+Changing an existing environment's `repoUrl`, `branch`, `template`, or
+`extraRepositories` requires replacement and is reported as a conflict. Volume
+descriptions are also immutable in V1. There is no automatic deletion or
+`prune`: removing something from YAML does not destroy persisted data.
+
+V1 supports one development environment per manifest. Production stacks,
+portable database artifacts, binary volume files, lockfiles, lifecycle shell
+hooks, dashboard controls, and OCI distribution are intentionally deferred.
+
+---
+
 # Web Dashboard & REST API
 
 ## Web Dashboard
@@ -2987,6 +3175,35 @@ Shared infrastructure (Docker network, PostgreSQL, team directories) is initiali
 
 Configuration is loaded from `oduflow.toml` (see [Installation](installation.md#configuration-reference)).
 See [Quick Start](quick-start.md) for MCP client configuration examples for both modes.
+
+To reconcile a declarative Stack before starting the server:
+
+```bash
+oduflow --stack /path/to/oduflow.yaml --stack-team 1 --transport http
+```
+
+Startup stops with a non-zero exit if Stack validation, preflight, or apply
+fails. See [Declarative Stacks](stacks.md).
+
+## Declarative Stack Commands
+
+```bash
+# Local syntax and schema validation (does not require Docker)
+oduflow stack validate oduflow.yaml
+
+# Read-only comparison with live resources
+oduflow stack plan oduflow.yaml --team 1
+
+# Reconcile under the team's lock
+oduflow stack apply oduflow.yaml --team 1
+
+# JSON status: drift plan plus the last successful apply record
+oduflow stack status oduflow.yaml --team 1
+```
+
+Stack apply is additive and non-destructive in V1. Existing resources owned by
+someone else and environment changes that require replacement are reported as
+conflicts; no automatic deletion or pruning is performed.
 
 ## System Commands
 

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -1,0 +1,186 @@
+# Declarative Stacks
+
+An Oduflow Stack is a versioned YAML manifest describing the complete desired
+state of one development environment and its supporting resources. It keeps the
+host-level `oduflow.toml` separate from project configuration: teams, routing,
+authentication, quotas, and backups remain operator settings, while the Stack
+file can live beside the project's code and move between Oduflow installations.
+
+## Commands
+
+```bash
+oduflow stack validate oduflow.yaml
+oduflow stack plan oduflow.yaml --team 1
+oduflow stack apply oduflow.yaml --team 1
+oduflow stack status oduflow.yaml --team 1
+```
+
+`validate` is local and does not require Docker or `oduflow.toml`. `plan` reads
+live state without changing it. `apply` validates and plans again under the
+team lock, refuses all conflicts before creating anything, and then converges
+resources in dependency order. `status` emits JSON containing the current plan
+and last successful apply record.
+
+To reconcile before the MCP server accepts clients:
+
+```bash
+oduflow --stack /etc/oduflow/acme/oduflow.yaml \
+  --stack-team 1 \
+  --transport http
+```
+
+A failed startup reconciliation exits without starting the MCP transport. Any
+resources already created before an external failure remain owned by the Stack;
+rerunning the same command safely continues from live state.
+
+## Example
+
+```yaml
+apiVersion: oduflow.dev/v1alpha1
+kind: Stack
+
+metadata:
+  name: acme-erp
+
+spec:
+  environment:
+    name: acme-dev
+    branch: "18.0"
+    repoUrl: https://github.com/acme/odoo-addons.git
+    odooImage: odoo:18.0
+    template: acme-18
+    sanitize: true
+
+    env:
+      LOG_LEVEL: info
+      PRIVATE_API_KEY:
+        fromEnv: ACME_PRIVATE_API_KEY
+
+    modules:
+      install:
+        - acme_base
+        - acme_sale
+
+  extraRepositories:
+    enterprise:
+      repoUrl: https://github.com/odoo/enterprise.git
+      branch: "18.0"
+
+    oca-web:
+      repoUrl: https://github.com/OCA/web.git
+      branch: "18.0"
+
+  volumes:
+    fs-sounds:
+      description: FreeSWITCH sounds and configuration
+
+  files:
+    - source: files/freeswitch.xml
+      volume: fs-sounds
+      path: config/freeswitch.xml
+
+  services:
+    fs:
+      image: oduist/freeswitch:1.4.0
+      port: 8080
+      hostMode: true
+
+      volumes:
+        - source: fs-sounds
+          target: /usr/share/freeswitch/sounds
+          mode: rw
+
+      env:
+        ODOO_URL:
+          environmentField: url
+        FS_WEBHOOK_TOKEN:
+          environmentField: token
+        FS_ESL_PASSWORD:
+          fromEnv: FS_ESL_PASSWORD
+```
+
+The generated JSON Schema is shipped at
+`oduflow/schemas/oduflow-stack-v1alpha1.json`. Unknown fields, duplicate YAML
+keys, undeclared volume references, invalid names, and unsafe file paths are
+rejected.
+
+## Value sources
+
+An environment variable can be a literal string:
+
+```yaml
+LOG_LEVEL: info
+```
+
+It can be read from the process starting Oduflow:
+
+```yaml
+ESL_PASSWORD:
+  fromEnv: FS_ESL_PASSWORD
+```
+
+Or a service can consume a value generated for the Stack's Odoo environment:
+
+```yaml
+ODOO_URL:
+  environmentField: url
+MCP_TOKEN:
+  environmentField: token
+```
+
+`environmentField` is deliberately unavailable under `spec.environment.env`,
+because an environment cannot depend on an output that exists only after that
+same environment has been created. Resolved values are passed directly to the
+container. They are never written to the Stack state file or printed by
+`plan`.
+
+Docker can expose container environment values to host administrators through
+`docker inspect`; Stack value sources do not change that existing Docker trust
+boundary. Configure private Git credentials separately with `setup_repo_auth`.
+
+## Reconciliation and ownership
+
+Resources created by a Stack carry these Docker labels:
+
+```text
+oduflow.stack=acme-erp
+oduflow.stack-resource=services.fs
+oduflow.stack-spec-hash=<sha256>
+```
+
+Oduflow will not silently adopt an existing environment, service, or volume
+with the same name. It reports an ownership conflict instead. Extra-addon bare
+repositories remain team-shared by design: an existing repository with the same
+name and URL is reused, while a different URL is a conflict.
+
+The V1 apply order is:
+
+1. extra-addon repositories;
+2. named volumes;
+3. the Odoo environment;
+4. text files in volumes;
+5. auxiliary services;
+6. missing Odoo modules.
+
+Module installation happens after services so an install hook can connect to a
+declared dependency. Only missing modules are installed; Stack apply never
+uninstalls a module.
+
+## Safe and replacement changes
+
+V1 can reconcile these changes in place:
+
+- Odoo image and Odoo container environment variables;
+- service image, environment, port/routes, hostname, volumes, host mode, and
+  capabilities;
+- new extra repositories, volumes, files, services, and modules.
+
+Changing an existing environment's `repoUrl`, `branch`, `template`, or
+`extraRepositories` requires replacement and is reported as a conflict. Volume
+descriptions are also immutable in V1. There is no automatic deletion or
+`prune`: removing something from YAML does not destroy persisted data.
+
+V1 supports one development environment per manifest. Production stacks,
+portable database artifacts, binary volume files, lockfiles, lifecycle shell
+hooks, dashboard controls, and OCI distribution are intentionally deferred.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Coding Agent: agent.md
       - Auxiliary Services: services.md
       - Extra Addons Repositories: extra-addons.md
+      - Declarative Stacks: stacks.md
   - Reference:
       - Web Dashboard & REST API: web-api.md
       - MCP Tools Reference: mcp-tools.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ keywords = ["odoo", "mcp", "docker", "development", "ci"]
 dependencies = [
     "fastmcp==2.14.3",
     "docker",
+    # Declarative Oduflow Stack manifests: typed validation + YAML input.
+    "pydantic>=2.10,<3",
+    "PyYAML>=6.0,<7",
 
     "packaging",
     "cryptography",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 fastmcp==2.14.3
 docker
+pydantic>=2.10,<3
+PyYAML>=6.0,<7
 python-dotenv
 setuptools
 fastapi

--- a/scripts/build_llms_full.py
+++ b/scripts/build_llms_full.py
@@ -24,6 +24,7 @@ SOURCES = (
     "agent.md",
     "services.md",
     "extra-addons.md",
+    "stacks.md",
     "web-api.md",
     "mcp-tools.md",
     "cli.md",

--- a/specs/0046-declarative-oduflow-stacks.md
+++ b/specs/0046-declarative-oduflow-stacks.md
@@ -1,0 +1,92 @@
+# 0046 — Declarative Oduflow Stacks
+
+**Status:** Adopted (V1)
+**Type:** Architecture — significant capability
+**First introduced:** this change (2026-08-11), branch `litnimax/declarative-oduflow-distro`
+**Key code today:** `stack_models.py` (versioned typed manifest), `stack_loader.py` (safe YAML and value sources), `stack_ops.py` (plan/apply/status reconciler), `stack_state.py` (per-team apply record), Stack CLI/startup integration in `server.py`
+
+## Context
+
+Oduflow already exposed all the individual operations needed to construct an
+Odoo solution: create an environment from a Git branch and database template,
+attach immutable extra-addons revisions, create auxiliary services and volumes,
+write configuration files, and install modules. Reproducing a complete solution
+still required an operator or agent to remember and replay a sequence of tool
+calls. Service presets covered one container but did not express dependencies
+or the Odoo environment itself.
+
+The desired unit is a portable, reviewable product definition that lives in Git
+and can bring an Oduflow installation to a known end state. It must reuse the
+existing Docker lifecycle rather than introduce a second runtime, must preserve
+team isolation and locking, and must not turn ordinary reconciliation into an
+implicit database or volume deletion mechanism.
+
+## Decision
+
+Introduce a versioned **Oduflow Stack** manifest (`oduflow.dev/v1alpha1`, kind
+`Stack`) and a built-in reconciler. A Stack V1 owns one development environment
+plus its extra repositories, named volumes, text volume files, auxiliary
+services, and required Odoo modules. `oduflow stack validate/plan/apply/status`
+are the explicit control surface; `oduflow --stack` runs the same apply before
+the server transport starts.
+
+YAML is only the authoring syntax. Pydantic models are the canonical contract
+and generate the shipped JSON Schema. The host's `oduflow.toml` remains the
+operator configuration for teams, auth, routing, quotas, and backup; a project
+manifest does not override it.
+
+V1 is intentionally additive. It creates missing resources and updates only
+configurations for which Oduflow already has a state-preserving update path.
+Environment source/template/extra-addon drift, another owner's resource, or an
+immutable volume-description change is a preflight conflict. Removal from YAML
+never deletes a live resource.
+
+## How it works
+
+The loader rejects duplicate YAML keys, unknown fields, invalid names,
+undeclared volume references, unsafe relative file paths, and non-text/oversize
+files. Values may be literals, host environment references, or a service-side
+reference to the created environment's URL/scoped MCP token. Resolved values
+are used only at apply time and never persisted in the Stack state record.
+
+The planner inspects existing label-tracked resources and classifies operations
+before mutation. Apply repeats that plan under the team's lock, refuses the
+entire run if any conflict exists, and executes repositories → volumes → Odoo →
+volume files → services → missing modules. This ordering gives service config
+access to generated Odoo outputs while ensuring module install hooks see their
+declared services. Failed external operations leave already-created resources
+in place; the next idempotent apply continues from live state.
+
+Environments, services, and volumes carry `oduflow.stack`,
+`oduflow.stack-resource`, and a per-resource spec hash. A small atomic
+`stacks/<name>.json` record stores the last manifest hash and non-secret resource
+inventory. Extra repositories remain team-shared and are reused only when name
+and sanitized remote URL agree.
+
+## Consequences
+
+- Complete development solutions can be reviewed in Git and reproduced with
+  one command or automatically at server startup.
+- The reconciler composes the existing Docker/Odoo operations, preserving their
+  tenancy, template, networking, and update semantics instead of delegating to
+  Docker Compose or another control plane.
+- Refusing adoption, replacement, deletion, and prune makes V1 conservative
+  around databases and persistent volumes, at the cost of requiring manual
+  lifecycle work for renamed or removed resources.
+- One manifest owns one development environment. Production, portable database
+  artifacts, binary files, immutable Git/image lockfiles, lifecycle hooks,
+  dashboard/MCP surfaces, and OCI packaging remain independent future steps.
+
+## Evolution
+
+A later version can add lockfiles and signed distribution artifacts without
+changing the V1 ownership or reconcile model. Production support must preserve
+the separate production database, backup, health, and rollback semantics in
+[[0035-production-hosting]] rather than treating production as a flag on the
+development resource.
+
+## History
+
+- 2026-08-11 — V1 Stack manifest, safe value sources, plan/apply/status,
+  ownership labels, and startup reconciliation introduced on
+  `litnimax/declarative-oduflow-distro`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -64,6 +64,7 @@ precursors).
 | [0043](0043-template-code-provenance-and-lineage.md) | 2026-08-08 | Templates record the commit their data was snapshotted at; environments report code/database drift at creation |
 | [0044](0044-unified-host-resource-planning.md) | 2026-08-02 | One host-wide resource plan for dev PostgreSQL, production PostgreSQL, and production Odoo |
 | [0045](0045-user-attributed-github-feedback.md) | 2026-08-11 | User-attributed GitHub feedback through prefilled, review-before-submit issue forms |
+| [0046](0046-declarative-oduflow-stacks.md) | 2026-08-11 | Declarative Oduflow Stacks: versioned YAML, plan/apply reconciliation, ownership and startup bootstrap |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1020,6 +1020,7 @@ def create_environment(
     auto_install_modules: list[str] | None = None,
     env_vars: dict[str, str] | None = None,
     local_path: str = "",
+    stack_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     env_name = env_name or branch
     from oduflow.naming import PROD_ENV_PREFIX
@@ -1148,6 +1149,8 @@ def create_environment(
         labels["oduflow.auto_install_modules"] = ",".join(auto_install_modules)
     if env_vars:
         labels["oduflow.env_vars"] = json.dumps(env_vars)
+    if stack_labels:
+        labels.update(stack_labels)
 
     labels.update(build_env_traefik_labels(settings, team, env_name))
 
@@ -2242,6 +2245,9 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                 "created_at": container.labels.get("oduflow.created_at", "")
                 or container.attrs.get("Created", ""),
                 "note": _get_note_text(env_name, team.workspaces_dir),
+                "stack": container.labels.get("oduflow.stack", ""),
+                "stack_resource": container.labels.get("oduflow.stack-resource", ""),
+                "stack_spec_hash": container.labels.get("oduflow.stack-spec-hash", ""),
             }
 
         try:
@@ -2529,6 +2535,9 @@ def get_environment_info(
             "oduflow.created_at", ""
         ) or odoo_container.attrs.get("Created", "")
         result["note"] = _get_note_text(env_name, team.workspaces_dir)
+        result["stack"] = labels.get("oduflow.stack", "")
+        result["stack_resource"] = labels.get("oduflow.stack-resource", "")
+        result["stack_spec_hash"] = labels.get("oduflow.stack-spec-hash", "")
 
         if settings.routing_mode == "traefik":
             result["url"] = (
@@ -3126,6 +3135,7 @@ def update_environment(
     extra_revision_overrides: dict[str, str] | None = None,
     pull_image: bool = True,
     install_dependencies: bool = True,
+    label_overrides: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Re-create an environment's container, preserving DB, repo and filestore.
 
@@ -3156,6 +3166,8 @@ def update_environment(
 
     # Labels
     labels = dict(container.labels)
+    if label_overrides:
+        labels.update(label_overrides)
 
     # Image (current → target). A digest-pinned recreation leaves Config.Image
     # as sha256:..., so prefer the persisted tag before falling back to it.

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -261,6 +261,7 @@ def create_service(
     cap_add: list[str] | None = None,
     privileged: bool = False,
     routes: list[dict[str, object]] | None = None,
+    stack_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     container_name = get_service_container_name(name, settings.prefix, team.team_id)
     routes = normalize_http_routes(routes)
@@ -288,6 +289,8 @@ def create_service(
         "oduflow.service": name,
         "oduflow.created_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
+    if stack_labels:
+        labels.update(stack_labels)
 
     run_kwargs: dict[str, Any] = {
         "image": image,
@@ -585,6 +588,9 @@ def _describe_service_container(
         "privileged": svc_privileged,
         "created_at": container.labels.get("oduflow.created_at", "")
         or container.attrs.get("Created", ""),
+        "stack": container.labels.get("oduflow.stack", ""),
+        "stack_resource": container.labels.get("oduflow.stack-resource", ""),
+        "stack_spec_hash": container.labels.get("oduflow.stack-spec-hash", ""),
     }
 
 
@@ -664,6 +670,7 @@ def update_service(
     cap_add_override: list[str] | None = None,
     privileged_override: bool | None = None,
     routes_override: list[dict[str, object]] | None = None,
+    stack_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Pull the latest image for a service and re-create it with the same settings.
 
@@ -798,6 +805,18 @@ def update_service(
     # brought forward by an ordinary update, even when the image digest and
     # user-controlled settings are otherwise unchanged.
     config_changed = _needs_traefik_acme_mount(settings, container)
+    persisted_stack_labels = {
+        key: value
+        for key, value in container.labels.items()
+        if key.startswith("oduflow.stack")
+    }
+    effective_stack_labels = (
+        dict(stack_labels) if stack_labels is not None else persisted_stack_labels
+    )
+    if stack_labels is not None and any(
+        container.labels.get(key) != value for key, value in stack_labels.items()
+    ):
+        config_changed = True
     if env_override is not None and env_override != (env_vars or {}):
         env_vars = env_override or None
         config_changed = True
@@ -916,6 +935,7 @@ def update_service(
         cap_add=cap_add,
         privileged=privileged,
         routes=routes,
+        stack_labels=effective_stack_labels,
     )
 
     result["image_updated"] = image_updated

--- a/src/oduflow/docker_ops/volume_ops.py
+++ b/src/oduflow/docker_ops/volume_ops.py
@@ -39,6 +39,7 @@ def create_volume(
     team: TeamSettings,
     name: str,
     description: str = "",
+    stack_labels: dict[str, str] | None = None,
 ) -> dict[str, str]:
     """Create a named Docker volume with oduflow labels."""
     if not name or not _VOLUME_NAME_RE.match(name):
@@ -63,6 +64,8 @@ def create_volume(
         "oduflow.volume": name,
         "oduflow.description": description,
     }
+    if stack_labels:
+        labels.update(stack_labels)
 
     client.volumes.create(name=docker_name, labels=labels)
     logger.info("Created volume %s", docker_name)
@@ -104,6 +107,9 @@ def list_volumes(settings: Settings, team: TeamSettings) -> list[dict[str, Any]]
                 "description": labels.get("oduflow.description", ""),
                 "created_at": vol.attrs.get("CreatedAt", ""),
                 "used_by": used_by,
+                "stack": labels.get("oduflow.stack", ""),
+                "stack_resource": labels.get("oduflow.stack-resource", ""),
+                "stack_spec_hash": labels.get("oduflow.stack-spec-hash", ""),
             }
         )
 
@@ -133,6 +139,9 @@ def inspect_volume(settings: Settings, team: TeamSettings, name: str) -> dict[st
         "driver": vol.attrs.get("Driver", ""),
         "mountpoint": vol.attrs.get("Mountpoint", ""),
         "used_by": used_by,
+        "stack": labels.get("oduflow.stack", ""),
+        "stack_resource": labels.get("oduflow.stack-resource", ""),
+        "stack_spec_hash": labels.get("oduflow.stack-spec-hash", ""),
     }
 
 

--- a/src/oduflow/schemas/oduflow-stack-v1alpha1.json
+++ b/src/oduflow/schemas/oduflow-stack-v1alpha1.json
@@ -1,0 +1,419 @@
+{
+  "$defs": {
+    "Environment": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "branch": {
+          "minLength": 1,
+          "title": "Branch",
+          "type": "string"
+        },
+        "repoUrl": {
+          "minLength": 1,
+          "title": "Repourl",
+          "type": "string"
+        },
+        "odooImage": {
+          "minLength": 1,
+          "title": "Odooimage",
+          "type": "string"
+        },
+        "template": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Template"
+        },
+        "sanitize": {
+          "default": true,
+          "title": "Sanitize",
+          "type": "boolean"
+        },
+        "env": {
+          "patternProperties": {
+            "^[A-Za-z_][A-Za-z0-9_]*$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/$defs/ValueFrom"
+                }
+              ]
+            }
+          },
+          "title": "Env",
+          "type": "object"
+        },
+        "modules": {
+          "$ref": "#/$defs/Modules"
+        }
+      },
+      "required": [
+        "name",
+        "branch",
+        "repoUrl",
+        "odooImage"
+      ],
+      "title": "Environment",
+      "type": "object"
+    },
+    "ExtraRepository": {
+      "additionalProperties": false,
+      "properties": {
+        "repoUrl": {
+          "minLength": 1,
+          "title": "Repourl",
+          "type": "string"
+        },
+        "branch": {
+          "minLength": 1,
+          "title": "Branch",
+          "type": "string"
+        },
+        "gitUser": {
+          "default": "",
+          "title": "Gituser",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repoUrl",
+        "branch"
+      ],
+      "title": "ExtraRepository",
+      "type": "object"
+    },
+    "Metadata": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$",
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Metadata",
+      "type": "object"
+    },
+    "Modules": {
+      "additionalProperties": false,
+      "properties": {
+        "install": {
+          "items": {
+            "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$",
+            "type": "string"
+          },
+          "title": "Install",
+          "type": "array"
+        }
+      },
+      "title": "Modules",
+      "type": "object"
+    },
+    "Service": {
+      "additionalProperties": false,
+      "properties": {
+        "image": {
+          "minLength": 1,
+          "title": "Image",
+          "type": "string"
+        },
+        "port": {
+          "anyOf": [
+            {
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Port"
+        },
+        "hostname": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hostname"
+        },
+        "env": {
+          "patternProperties": {
+            "^[A-Za-z_][A-Za-z0-9_]*$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/$defs/ValueFrom"
+                }
+              ]
+            }
+          },
+          "title": "Env",
+          "type": "object"
+        },
+        "hostMode": {
+          "default": false,
+          "title": "Hostmode",
+          "type": "boolean"
+        },
+        "volumes": {
+          "items": {
+            "$ref": "#/$defs/ServiceMount"
+          },
+          "title": "Volumes",
+          "type": "array"
+        },
+        "privileged": {
+          "default": false,
+          "title": "Privileged",
+          "type": "boolean"
+        },
+        "netAdmin": {
+          "default": false,
+          "title": "Netadmin",
+          "type": "boolean"
+        },
+        "routes": {
+          "items": {
+            "$ref": "#/$defs/ServiceRoute"
+          },
+          "title": "Routes",
+          "type": "array"
+        }
+      },
+      "required": [
+        "image"
+      ],
+      "title": "Service",
+      "type": "object"
+    },
+    "ServiceMount": {
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$",
+          "title": "Source",
+          "type": "string"
+        },
+        "target": {
+          "minLength": 1,
+          "title": "Target",
+          "type": "string"
+        },
+        "mode": {
+          "default": "rw",
+          "enum": [
+            "ro",
+            "rw"
+          ],
+          "title": "Mode",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "target"
+      ],
+      "title": "ServiceMount",
+      "type": "object"
+    },
+    "ServiceRoute": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "title": "Path",
+          "type": "string"
+        },
+        "port": {
+          "maximum": 65535,
+          "minimum": 1,
+          "title": "Port",
+          "type": "integer"
+        },
+        "stripPrefix": {
+          "default": false,
+          "title": "Stripprefix",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "path",
+        "port"
+      ],
+      "title": "ServiceRoute",
+      "type": "object"
+    },
+    "StackSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "environment": {
+          "$ref": "#/$defs/Environment"
+        },
+        "extraRepositories": {
+          "patternProperties": {
+            "^[A-Za-z0-9_-]{1,63}$": {
+              "$ref": "#/$defs/ExtraRepository"
+            }
+          },
+          "title": "Extrarepositories",
+          "type": "object"
+        },
+        "volumes": {
+          "patternProperties": {
+            "^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$": {
+              "$ref": "#/$defs/Volume"
+            }
+          },
+          "title": "Volumes",
+          "type": "object"
+        },
+        "files": {
+          "items": {
+            "$ref": "#/$defs/VolumeFile"
+          },
+          "title": "Files",
+          "type": "array"
+        },
+        "services": {
+          "patternProperties": {
+            "^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$": {
+              "$ref": "#/$defs/Service"
+            }
+          },
+          "title": "Services",
+          "type": "object"
+        }
+      },
+      "required": [
+        "environment"
+      ],
+      "title": "StackSpec",
+      "type": "object"
+    },
+    "ValueFrom": {
+      "additionalProperties": false,
+      "description": "A value loaded at apply time rather than persisted in the manifest.",
+      "properties": {
+        "fromEnv": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fromenv"
+        },
+        "environmentField": {
+          "anyOf": [
+            {
+              "enum": [
+                "url",
+                "token"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Environmentfield"
+        }
+      },
+      "title": "ValueFrom",
+      "type": "object"
+    },
+    "Volume": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "default": "",
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "title": "Volume",
+      "type": "object"
+    },
+    "VolumeFile": {
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "minLength": 1,
+          "title": "Source",
+          "type": "string"
+        },
+        "volume": {
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$",
+          "title": "Volume",
+          "type": "string"
+        },
+        "path": {
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source",
+        "volume",
+        "path"
+      ],
+      "title": "VolumeFile",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "properties": {
+    "apiVersion": {
+      "const": "oduflow.dev/v1alpha1",
+      "default": "oduflow.dev/v1alpha1",
+      "title": "Apiversion",
+      "type": "string"
+    },
+    "kind": {
+      "const": "Stack",
+      "default": "Stack",
+      "title": "Kind",
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    },
+    "spec": {
+      "$ref": "#/$defs/StackSpec"
+    }
+  },
+  "required": [
+    "metadata",
+    "spec"
+  ],
+  "title": "StackManifest",
+  "type": "object"
+}

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -50,6 +50,7 @@ from oduflow.errors import FlowError, NotFoundError, PrerequisiteNotMetError
 from oduflow.locking import LockManager
 from oduflow.output_cache import CachedOutput, OutputCache
 from oduflow.settings import Settings, TeamSettings, find_toml
+from oduflow.stack_loader import StackValidationError
 
 logger = logging.getLogger("oduflow")
 
@@ -5495,6 +5496,17 @@ def _run_cli() -> None:
         default="stdio",
         help="MCP transport (default: stdio)",
     )
+    parser.add_argument(
+        "--stack",
+        dest="stack_manifest",
+        default="",
+        help="reconcile this declarative Stack manifest before starting the server",
+    )
+    parser.add_argument(
+        "--stack-team",
+        default="1",
+        help="team for --stack startup reconciliation (default: 1)",
+    )
     sub = parser.add_subparsers(dest="command", title="commands", metavar="")
 
     # --- System commands ---
@@ -5682,6 +5694,21 @@ def _run_cli() -> None:
         "call_args", nargs="*", default=[], help="Tool name and arguments"
     )
 
+    # --- Declarative stacks ---
+    p_stack = sub.add_parser(
+        "stack", help="Validate, plan, apply, or inspect a declarative Stack"
+    )
+    stack_sub = p_stack.add_subparsers(
+        dest="stack_command", title="stack commands", metavar=""
+    )
+    for stack_command in ("validate", "plan", "apply", "status"):
+        p_stack_command = stack_sub.add_parser(stack_command)
+        p_stack_command.add_argument("manifest", help="Path to oduflow.yaml")
+        if stack_command != "validate":
+            p_stack_command.add_argument(
+                "--team", default="1", help="Team ID (default: 1)"
+            )
+
     # --- Systemd ---
     sub.add_parser(
         "systemd-install", help="Install and enable a systemd service for Oduflow"
@@ -5701,6 +5728,13 @@ def _run_cli() -> None:
 
     if args.command == "call":
         _run_call(args.call_args)
+        return
+
+    if args.command == "stack" and args.stack_command == "validate":
+        from oduflow.stack_loader import load_stack
+
+        manifest = load_stack(args.manifest)
+        print(f"Stack '{manifest.metadata.name}' is valid ({manifest.api_version}).")
         return
 
     if args.command == "systemd-install":
@@ -5792,6 +5826,20 @@ def _run_cli() -> None:
             migrations.run_pending(_settings)
             _ensure_initialized(_settings)
             quotas.apply_all(_settings)
+            if args.stack_manifest:
+                from oduflow.stack_loader import load_stack
+                from oduflow.stack_ops import apply_stack, format_plan
+
+                stack_team = _settings.get_team(args.stack_team)
+                stack_manifest = load_stack(args.stack_manifest)
+                applied = apply_stack(
+                    _settings,
+                    stack_team,
+                    stack_manifest,
+                    args.stack_manifest,
+                    lock_manager=_locks,
+                )
+                logger.info("Startup stack reconciliation:\n%s", format_plan(applied))
         # Record the active transport for informational purposes.
         # local_path is gated by allow_local_path in Settings.
         settings_module.TRANSPORT = args.transport
@@ -5916,6 +5964,39 @@ def _run_cli() -> None:
     if args.command == "cleanup":
         _run_cleanup(_settings, _cli_team(), dry_run=not args.force)
         return
+
+    if args.command == "stack":
+        if args.stack_command is None:
+            p_stack.print_help()
+            return
+        from oduflow.stack_loader import load_stack
+        from oduflow.stack_ops import apply_stack, build_plan, format_plan, stack_status
+
+        manifest = load_stack(args.manifest)
+        team = _cli_team()
+        if args.stack_command == "plan":
+            print(format_plan(build_plan(_settings, team, manifest, args.manifest)))
+            return
+        if args.stack_command == "apply":
+            migrations.run_pending(_settings)
+            _ensure_initialized(_settings)
+            quotas.apply_all(_settings)
+            stack_result = apply_stack(
+                _settings,
+                team,
+                manifest,
+                args.manifest,
+                lock_manager=_locks,
+            )
+            print(format_plan(stack_result))
+            return
+        if args.stack_command == "status":
+            print(
+                json.dumps(
+                    stack_status(_settings, team, manifest, args.manifest), indent=2
+                )
+            )
+            return
 
 
 def _warn_local_path_security(settings: Settings) -> None:
@@ -6185,7 +6266,10 @@ def main() -> None:
     boundary we convert it to an exit code."""
     try:
         _run_cli()
-    except PrerequisiteNotMetError as exc:
+    except FlowError as exc:
+        print(f"\n❌ {exc}", file=sys.stderr)
+        sys.exit(1)
+    except StackValidationError as exc:
         print(f"\n❌ {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/src/oduflow/stack_loader.py
+++ b/src/oduflow/stack_loader.py
@@ -1,0 +1,159 @@
+"""Load, validate, hash, and resolve declarative Stack manifests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+from pydantic import ValidationError
+
+from oduflow.stack_models import EnvValue, StackManifest, ValueFrom
+
+_MAX_MANIFEST_BYTES = 1_000_000
+_MAX_FILE_BYTES = 1_000_000
+
+
+class StackValidationError(ValueError):
+    """A manifest is malformed, invalid, or references unsafe local input."""
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):  # type: ignore[misc]
+    pass
+
+
+def _construct_mapping(
+    loader: _UniqueKeyLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise StackValidationError(
+                f"duplicate YAML key {key!r} at line {key_node.start_mark.line + 1}"
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping
+)
+
+
+def load_stack(path: str | os.PathLike[str]) -> StackManifest:
+    """Load one Stack YAML file with duplicate-key and typed validation."""
+    manifest_path = Path(path).expanduser().resolve()
+    try:
+        size = manifest_path.stat().st_size
+    except OSError as exc:
+        raise StackValidationError(f"cannot read stack manifest: {exc}") from exc
+    if size > _MAX_MANIFEST_BYTES:
+        raise StackValidationError(
+            f"stack manifest exceeds {_MAX_MANIFEST_BYTES} byte limit"
+        )
+    try:
+        raw = yaml.load(manifest_path.read_text(encoding="utf-8"), _UniqueKeyLoader)
+    except (OSError, UnicodeError, yaml.YAMLError, StackValidationError) as exc:
+        if isinstance(exc, StackValidationError):
+            raise
+        raise StackValidationError(f"invalid YAML: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise StackValidationError("stack manifest root must be a mapping")
+    try:
+        return StackManifest.model_validate(raw)
+    except ValidationError as exc:
+        raise StackValidationError(str(exc)) from exc
+
+
+def manifest_hash(manifest: StackManifest) -> str:
+    """Stable hash of declarative input; contains references, never resolved secrets."""
+    canonical = json.dumps(
+        manifest.model_dump(mode="json", by_alias=True),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def resolve_env_values(
+    values: Mapping[str, EnvValue],
+    *,
+    settings: Any = None,
+    team: Any = None,
+    env_name: str = "",
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve literal, host-env, and environment-derived values at apply time."""
+    source_env = os.environ if environ is None else environ
+    result: dict[str, str] = {}
+    for key, raw in values.items():
+        if isinstance(raw, str):
+            result[key] = raw
+            continue
+        if not isinstance(raw, ValueFrom):  # defensive for callers constructing data
+            raise StackValidationError(f"unsupported value source for '{key}'")
+        if raw.from_env is not None:
+            if raw.from_env not in source_env:
+                raise StackValidationError(
+                    f"environment variable '{raw.from_env}' required by '{key}' is not set"
+                )
+            result[key] = source_env[raw.from_env]
+            continue
+        if settings is None or team is None or not env_name:
+            raise StackValidationError(f"'{key}' requires an existing Odoo environment")
+        from oduflow.docker_ops import env_ops
+
+        if raw.environment_field == "url":
+            result[key] = env_ops.get_env_base_url(settings, team, env_name)[0]
+        elif raw.environment_field == "token":
+            token = env_ops.get_env_token(settings, team, env_name)
+            if not token:
+                raise StackValidationError(
+                    f"environment '{env_name}' has no scoped MCP token"
+                )
+            result[key] = token
+    return result
+
+
+def read_stack_file(manifest_path: str | os.PathLike[str], source: str) -> str:
+    """Read a UTF-8 source contained inside the manifest directory."""
+    base = Path(manifest_path).expanduser().resolve().parent
+    candidate = (base / source).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        raise StackValidationError(
+            f"file source '{source}' escapes the stack directory"
+        ) from exc
+    try:
+        size = candidate.stat().st_size
+    except OSError as exc:
+        raise StackValidationError(
+            f"cannot read file source '{source}': {exc}"
+        ) from exc
+    if not candidate.is_file():
+        raise StackValidationError(f"file source '{source}' is not a regular file")
+    if size > _MAX_FILE_BYTES:
+        raise StackValidationError(
+            f"file source '{source}' exceeds {_MAX_FILE_BYTES} byte limit"
+        )
+    try:
+        return candidate.read_text(encoding="utf-8")
+    except UnicodeError as exc:
+        raise StackValidationError(
+            f"file source '{source}' is not UTF-8 text; V1 supports text files only"
+        ) from exc
+
+
+def write_json_schema(path: str | os.PathLike[str]) -> None:
+    """Write the public v1alpha1 JSON Schema generated from typed models."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(StackManifest.model_json_schema(by_alias=True), indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/src/oduflow/stack_models.py
+++ b/src/oduflow/stack_models.py
@@ -1,0 +1,260 @@
+"""Typed schema for declarative Oduflow Stack manifests."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+from typing import Annotated, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from oduflow.naming import validate_env_name, validate_template_name
+
+STACK_API_VERSION = "oduflow.dev/v1alpha1"
+STACK_KIND = "Stack"
+
+ResourceName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,62}$"),
+]
+ExtraRepositoryName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[A-Za-z0-9_-]{1,63}$"),
+]
+ModuleName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$"),
+]
+EnvironmentVariableName = Annotated[
+    str,
+    StringConstraints(pattern=r"^[A-Za-z_][A-Za-z0-9_]*$"),
+]
+NonEmptyString = Annotated[str, StringConstraints(min_length=1)]
+
+
+def _to_camel(value: str) -> str:
+    head, *tail = value.split("_")
+    return head + "".join(part.capitalize() for part in tail)
+
+
+class StackModel(BaseModel):
+    """Strict base model with a YAML-friendly camelCase public shape."""
+
+    model_config = ConfigDict(
+        alias_generator=_to_camel,
+        populate_by_name=True,
+        extra="forbid",
+        str_strip_whitespace=True,
+        strict=True,
+    )
+
+
+class Metadata(StackModel):
+    name: ResourceName
+
+
+class ValueFrom(StackModel):
+    """A value loaded at apply time rather than persisted in the manifest."""
+
+    from_env: str | None = None
+    environment_field: Literal["url", "token"] | None = None
+
+    @model_validator(mode="after")
+    def exactly_one_source(self) -> ValueFrom:
+        if (self.from_env is None) == (self.environment_field is None):
+            raise ValueError("set exactly one of fromEnv or environmentField")
+        if self.from_env is not None and not re.fullmatch(
+            r"[A-Za-z_][A-Za-z0-9_]*", self.from_env
+        ):
+            raise ValueError("fromEnv must be a valid environment-variable name")
+        return self
+
+
+EnvValue = str | ValueFrom
+
+
+class ExtraRepository(StackModel):
+    repo_url: NonEmptyString
+    branch: NonEmptyString
+    git_user: str = ""
+
+
+class Modules(StackModel):
+    install: list[ModuleName] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def unique_modules(self) -> Modules:
+        if len(set(self.install)) != len(self.install):
+            raise ValueError("install must not contain duplicate module names")
+        return self
+
+
+class Environment(StackModel):
+    name: str
+    branch: NonEmptyString
+    repo_url: NonEmptyString
+    odoo_image: NonEmptyString
+    template: str | None = None
+    sanitize: bool = True
+    env: dict[EnvironmentVariableName, EnvValue] = Field(default_factory=dict)
+    modules: Modules = Field(default_factory=Modules)
+
+    @field_validator("name")
+    @classmethod
+    def valid_environment_name(cls, value: str) -> str:
+        return validate_env_name(value)
+
+    @field_validator("template", mode="before")
+    @classmethod
+    def normalize_template(cls, value: object) -> object:
+        if value in (None, "", "none"):
+            return None
+        if isinstance(value, str):
+            return validate_template_name(value)
+        return value
+
+    @model_validator(mode="after")
+    def no_self_references(self) -> Environment:
+        if any(
+            isinstance(value, ValueFrom) and value.environment_field is not None
+            for value in self.env.values()
+        ):
+            raise ValueError(
+                "environment.env cannot reference environmentField on itself"
+            )
+        return self
+
+
+class Volume(StackModel):
+    description: str = ""
+
+
+class VolumeFile(StackModel):
+    source: NonEmptyString
+    volume: ResourceName
+    path: str
+
+    @model_validator(mode="after")
+    def safe_target(self) -> VolumeFile:
+        normalized = self.path.lstrip("/")
+        if not normalized or any(
+            part in ("", ".", "..") for part in normalized.split("/")
+        ):
+            raise ValueError(
+                "path must name a file inside the volume without traversal"
+            )
+        self.path = normalized
+        return self
+
+
+class ServiceMount(StackModel):
+    source: ResourceName
+    target: NonEmptyString
+    mode: Literal["ro", "rw"] = "rw"
+
+    @model_validator(mode="after")
+    def absolute_target(self) -> ServiceMount:
+        if (
+            not self.target.startswith("/")
+            or "//" in self.target
+            or any(part in (".", "..") for part in self.target.split("/"))
+        ):
+            raise ValueError(
+                "target must be an absolute container path without dot segments"
+            )
+        self.target = posixpath.normpath(self.target)
+        return self
+
+
+class ServiceRoute(StackModel):
+    path: str
+    port: int = Field(ge=1, le=65535)
+    strip_prefix: bool = False
+
+    @field_validator("path")
+    @classmethod
+    def valid_path(cls, value: str) -> str:
+        if (
+            not value.startswith("/")
+            or "//" in value
+            or any(part in (".", "..") for part in value.split("/"))
+            or any(ch in value for ch in ("?", "#", "`"))
+            or any(ord(ch) < 32 or ch.isspace() for ch in value)
+        ):
+            raise ValueError("route path must be a safe absolute URL path")
+        return value
+
+
+class Service(StackModel):
+    image: NonEmptyString
+    port: int | None = Field(default=None, ge=1, le=65535)
+    hostname: NonEmptyString | None = None
+    env: dict[EnvironmentVariableName, EnvValue] = Field(default_factory=dict)
+    host_mode: bool = False
+    volumes: list[ServiceMount] = Field(default_factory=list)
+    privileged: bool = False
+    net_admin: bool = False
+    routes: list[ServiceRoute] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def one_exposure_mode(self) -> Service:
+        if self.privileged and self.net_admin:
+            raise ValueError("privileged and netAdmin are mutually exclusive")
+        if self.port is not None and self.routes:
+            raise ValueError("port and routes are mutually exclusive")
+        if self.port is None and not self.routes:
+            raise ValueError("set port or at least one route")
+        targets = [(mount.source, mount.target) for mount in self.volumes]
+        if len(set(targets)) != len(targets):
+            raise ValueError("volumes must not contain duplicate mounts")
+        paths = [route.path for route in self.routes]
+        if len(set(paths)) != len(paths):
+            raise ValueError("routes must not contain duplicate paths")
+        return self
+
+
+class StackSpec(StackModel):
+    environment: Environment
+    extra_repositories: dict[ExtraRepositoryName, ExtraRepository] = Field(
+        default_factory=dict
+    )
+    volumes: dict[ResourceName, Volume] = Field(default_factory=dict)
+    files: list[VolumeFile] = Field(default_factory=list)
+    services: dict[ResourceName, Service] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def references_exist(self) -> StackSpec:
+        targets: set[tuple[str, str]] = set()
+        for item in self.files:
+            if item.volume not in self.volumes:
+                raise ValueError(
+                    f"file target references undeclared volume '{item.volume}'"
+                )
+            target = (item.volume, item.path)
+            if target in targets:
+                raise ValueError(
+                    f"files contains duplicate target '{item.volume}:{item.path}'"
+                )
+            targets.add(target)
+        for service_name, service in self.services.items():
+            for mount in service.volumes:
+                if mount.source not in self.volumes:
+                    raise ValueError(
+                        f"service '{service_name}' references undeclared volume "
+                        f"'{mount.source}'"
+                    )
+        return self
+
+
+class StackManifest(StackModel):
+    api_version: Literal["oduflow.dev/v1alpha1"] = "oduflow.dev/v1alpha1"
+    kind: Literal["Stack"] = "Stack"
+    metadata: Metadata
+    spec: StackSpec

--- a/src/oduflow/stack_ops.py
+++ b/src/oduflow/stack_ops.py
@@ -1,0 +1,666 @@
+"""Plan, apply, and report declarative Oduflow Stack state."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import posixpath
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from pydantic import BaseModel
+
+from oduflow import git_ops
+from oduflow.docker_ops import (
+    env_ops,
+    odoo_ops,
+    service_ops,
+    volume_file_ops,
+    volume_ops,
+)
+from oduflow.errors import ConflictError, NotFoundError
+from oduflow.naming import sanitize_repo_url, validate_env_name
+from oduflow.settings import Settings, TeamSettings
+from oduflow.stack_loader import (
+    manifest_hash,
+    read_stack_file,
+    resolve_env_values,
+)
+from oduflow.stack_models import Service, StackManifest
+from oduflow.stack_state import load_state, save_state
+
+STACK_LABEL = "oduflow.stack"
+STACK_RESOURCE_LABEL = "oduflow.stack-resource"
+STACK_SPEC_HASH_LABEL = "oduflow.stack-spec-hash"
+
+
+@dataclass(frozen=True)
+class PlanAction:
+    operation: str
+    resource: str
+    detail: str = ""
+
+    @property
+    def conflict(self) -> bool:
+        return self.operation == "conflict"
+
+
+@dataclass(frozen=True)
+class StackPlan:
+    stack: str
+    actions: tuple[PlanAction, ...]
+
+    @property
+    def has_conflicts(self) -> bool:
+        return any(action.conflict for action in self.actions)
+
+    @property
+    def has_changes(self) -> bool:
+        return any(action.operation != "conflict" for action in self.actions)
+
+
+def _resource_hash(value: BaseModel | dict[str, Any] | list[Any]) -> str:
+    raw = (
+        value.model_dump(mode="json", by_alias=True)
+        if isinstance(value, BaseModel)
+        else value
+    )
+    encoded = json.dumps(raw, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _stack_labels(
+    stack: str, resource: str, value: BaseModel | dict[str, Any]
+) -> dict[str, str]:
+    return {
+        STACK_LABEL: stack,
+        STACK_RESOURCE_LABEL: resource,
+        STACK_SPEC_HASH_LABEL: _resource_hash(value),
+    }
+
+
+def _environment_labels(stack: str, manifest: StackManifest) -> dict[str, str]:
+    """Label only the environment-owned part of the manifest.
+
+    Module installation is reconciled independently and must not leave the
+    environment container carrying a stale hash when only that list changes.
+    """
+    value = manifest.spec.environment.model_dump(mode="json", by_alias=True)
+    value.pop("modules", None)
+    return _stack_labels(stack, "environment", value)
+
+
+def _owned_by(info: Mapping[str, Any], stack: str, resource: str) -> bool:
+    return info.get("stack") == stack and info.get("stack_resource") == resource
+
+
+def _normalized_template(value: Any) -> str:
+    return "none" if value in (None, "", "none") else str(value)
+
+
+def _desired_mounts(service: Service) -> list[dict[str, str]]:
+    return sorted(
+        [
+            {"volume": mount.source, "mount_path": mount.target, "mode": mount.mode}
+            for mount in service.volumes
+        ],
+        key=lambda item: (item["volume"], item["mount_path"], item["mode"]),
+    )
+
+
+def _desired_routes(service: Service) -> list[dict[str, object]]:
+    return [route.model_dump() for route in service.routes]
+
+
+def _actual_routes(raw: Any) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    for route in raw or []:
+        result.append(
+            {
+                "path": route.get("path"),
+                "port": route.get("port"),
+                "strip_prefix": bool(route.get("strip_prefix", False)),
+            }
+        )
+    return result
+
+
+def _actual_mounts(raw: Any) -> list[dict[str, str]]:
+    return sorted(
+        [
+            {
+                "volume": str(item.get("volume", "")),
+                "mount_path": str(item.get("mount_path", "")),
+                "mode": str(item.get("mode", "rw")),
+            }
+            for item in raw or []
+            if item.get("mount_path") != "/etc/traefik"
+        ],
+        key=lambda item: (item["volume"], item["mount_path"], item["mode"]),
+    )
+
+
+def _desired_hostname(
+    settings: Settings, team: TeamSettings, name: str, hostname: str | None
+) -> str | None:
+    if settings.routing_mode != "traefik":
+        return hostname
+    result = hostname or f"{name}.{team.hostname}"
+    if "." not in result:
+        result = f"{result}.{team.hostname}"
+    return result
+
+
+def _installed_modules(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    requested: list[str],
+) -> set[str]:
+    if not requested:
+        return set()
+    quoted = ",".join("'" + name.replace("'", "''") + "'" for name in requested)
+    result = odoo_ops.run_db_query(
+        settings,
+        team,
+        env_name,
+        "SELECT name FROM ir_module_module "
+        f"WHERE state = 'installed' AND name IN ({quoted}) ORDER BY name",
+    )
+    rows = csv.DictReader(io.StringIO(str(result.get("output", ""))))
+    return {str(row.get("name", "")) for row in rows if row.get("name")}
+
+
+def _file_matches(
+    settings: Settings,
+    team: TeamSettings,
+    volume: str,
+    path: str,
+    expected: str,
+) -> bool:
+    try:
+        result = volume_file_ops.read_file_in_volume(settings, team, volume, path)
+    except NotFoundError:
+        return False
+    return "error" not in result and result.get("output") == expected
+
+
+def build_plan(
+    settings: Settings,
+    team: TeamSettings,
+    manifest: StackManifest,
+    manifest_path: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> StackPlan:
+    """Compare the manifest with live resources without changing anything."""
+    stack = manifest.metadata.name
+    spec = manifest.spec
+    desired_env = spec.environment
+    validate_env_name(desired_env.name)
+    git_ops.validate_repo_url(desired_env.repo_url)
+    for desired_repo in spec.extra_repositories.values():
+        git_ops.validate_repo_url(desired_repo.repo_url)
+    actions: list[PlanAction] = []
+
+    # Resolve host variables during planning so a missing secret fails before
+    # any mutation. Environment-derived service values are resolved only when
+    # the environment already exists; a new service is unconditionally created.
+    desired_env_vars = resolve_env_values(desired_env.env, environ=environ)
+
+    from oduflow import extra_addons
+
+    repos = {item["name"]: item for item in extra_addons.list_extra_repos(team)}
+    for name, desired_repo in spec.extra_repositories.items():
+        actual = repos.get(name)
+        if actual is None:
+            actions.append(
+                PlanAction("create", f"extraRepositories.{name}", desired_repo.repo_url)
+            )
+        elif sanitize_repo_url(str(actual.get("repo_url", ""))) != sanitize_repo_url(
+            desired_repo.repo_url
+        ):
+            actions.append(
+                PlanAction(
+                    "conflict",
+                    f"extraRepositories.{name}",
+                    "an extra repository with this name has a different URL",
+                )
+            )
+
+    volumes = {item["name"]: item for item in volume_ops.list_volumes(settings, team)}
+    for name, desired_volume in spec.volumes.items():
+        actual = volumes.get(name)
+        resource = f"volumes.{name}"
+        if actual is None:
+            actions.append(PlanAction("create", resource, desired_volume.description))
+        elif not _owned_by(actual, stack, resource):
+            actions.append(
+                PlanAction(
+                    "conflict", resource, "existing volume is not owned by this stack"
+                )
+            )
+        elif actual.get("description", "") != desired_volume.description:
+            actions.append(
+                PlanAction(
+                    "conflict",
+                    resource,
+                    "volume descriptions are immutable in V1; replacement required",
+                )
+            )
+
+    environments = {
+        item["env_name"]: item for item in env_ops.list_environments(settings, team)
+    }
+    actual_env = environments.get(desired_env.name)
+    env_resource = "environment"
+    env_needs_create = actual_env is None
+    if actual_env is None:
+        actions.append(PlanAction("create", env_resource, desired_env.name))
+    elif not _owned_by(actual_env, stack, env_resource):
+        actions.append(
+            PlanAction(
+                "conflict",
+                env_resource,
+                "existing environment is not owned by this stack",
+            )
+        )
+    else:
+        immutable_drift: list[str] = []
+        if sanitize_repo_url(str(actual_env.get("repo_url", ""))) != sanitize_repo_url(
+            desired_env.repo_url
+        ):
+            immutable_drift.append("repoUrl")
+        if actual_env.get("git_branch") != desired_env.branch:
+            immutable_drift.append("branch")
+        if _normalized_template(
+            actual_env.get("template_name")
+        ) != _normalized_template(desired_env.template):
+            immutable_drift.append("template")
+        desired_extras = {
+            name: item.branch for name, item in spec.extra_repositories.items()
+        }
+        if actual_env.get("extra_addons", {}) != desired_extras:
+            immutable_drift.append("extraRepositories")
+        if immutable_drift:
+            actions.append(
+                PlanAction(
+                    "conflict",
+                    env_resource,
+                    "replacement required for: " + ", ".join(immutable_drift),
+                )
+            )
+        mutable_drift: list[str] = []
+        if actual_env.get("odoo_image") != desired_env.odoo_image:
+            mutable_drift.append("odooImage")
+        current_info = env_ops.get_environment_info(settings, team, desired_env.name)
+        if current_info.get("env_vars", {}) != desired_env_vars:
+            mutable_drift.append("env")
+        if mutable_drift:
+            actions.append(PlanAction("update", env_resource, ", ".join(mutable_drift)))
+
+    for item in spec.files:
+        content = read_stack_file(manifest_path, item.source)
+        resource = f"files.{item.volume}:{item.path}"
+        if item.volume not in volumes or not _file_matches(
+            settings, team, item.volume, item.path, content
+        ):
+            actions.append(PlanAction("write", resource, item.source))
+
+    services = {
+        item["name"]: item for item in service_ops.list_services(settings, team)
+    }
+    for name, desired_service in spec.services.items():
+        resource = f"services.{name}"
+        if desired_service.routes and settings.routing_mode != "traefik":
+            actions.append(
+                PlanAction(
+                    "conflict",
+                    resource,
+                    "HTTP routes require routing.mode = 'traefik'",
+                )
+            )
+            continue
+        if settings.routing_mode == "traefik" and settings.routing_tls:
+            reserved_mount = next(
+                (
+                    mount.target
+                    for mount in desired_service.volumes
+                    if posixpath.normpath(mount.target) == "/etc/traefik"
+                    or posixpath.normpath(mount.target).startswith("/etc/traefik/")
+                ),
+                None,
+            )
+            if reserved_mount is not None:
+                actions.append(
+                    PlanAction(
+                        "conflict",
+                        resource,
+                        f"mount path '{reserved_mount}' is reserved for Traefik TLS",
+                    )
+                )
+                continue
+        actual = services.get(name)
+        if actual is None:
+            # Validate host-only values now; environment values are safe to
+            # defer until after the environment create action.
+            for key, value in desired_service.env.items():
+                if getattr(value, "from_env", None) is not None:
+                    resolve_env_values({key: value}, environ=environ)
+            actions.append(PlanAction("create", resource, desired_service.image))
+            continue
+        if not _owned_by(actual, stack, resource):
+            actions.append(
+                PlanAction(
+                    "conflict", resource, "existing service is not owned by this stack"
+                )
+            )
+            continue
+        has_environment_value = any(
+            getattr(value, "environment_field", None) is not None
+            for value in desired_service.env.values()
+        )
+        if env_needs_create and has_environment_value:
+            # The environment output does not exist yet. Still validate every
+            # host-env source now; apply will resolve the generated values after
+            # creating Odoo and then update this owned service.
+            for key, value in desired_service.env.items():
+                if getattr(value, "from_env", None) is not None:
+                    resolve_env_values({key: value}, environ=environ)
+            desired_service_env: dict[str, str] | None = None
+        else:
+            desired_service_env = resolve_env_values(
+                desired_service.env,
+                settings=settings,
+                team=team,
+                env_name=desired_env.name,
+                environ=environ,
+            )
+        desired_caps = (
+            ["NET_ADMIN"]
+            if desired_service.net_admin and not desired_service.privileged
+            else []
+        )
+        drift: list[str] = []
+        comparisons = (
+            ("image", actual.get("image"), desired_service.image),
+            ("port", actual.get("port"), desired_service.port),
+            (
+                "hostname",
+                actual.get("hostname"),
+                _desired_hostname(settings, team, name, desired_service.hostname),
+            ),
+            (
+                "env",
+                actual.get("env_vars", {}),
+                desired_service_env
+                if desired_service_env is not None
+                else "<pending environment outputs>",
+            ),
+            ("hostMode", bool(actual.get("host_mode")), desired_service.host_mode),
+            (
+                "volumes",
+                _actual_mounts(actual.get("volumes")),
+                _desired_mounts(desired_service),
+            ),
+            ("capabilities", sorted(actual.get("cap_add", [])), desired_caps),
+            (
+                "privileged",
+                bool(actual.get("privileged")),
+                desired_service.privileged,
+            ),
+            (
+                "routes",
+                _actual_routes(actual.get("routes")),
+                _desired_routes(desired_service),
+            ),
+        )
+        drift.extend(
+            field for field, current, wanted in comparisons if current != wanted
+        )
+        if drift or actual.get("stack_spec_hash") != _resource_hash(desired_service):
+            actions.append(
+                PlanAction("update", resource, ", ".join(drift) or "metadata")
+            )
+
+    modules = list(desired_env.modules.install)
+    if modules:
+        installed = (
+            set()
+            if env_needs_create
+            else _installed_modules(settings, team, desired_env.name, modules)
+        )
+        missing = [module for module in modules if module not in installed]
+        if missing:
+            actions.append(PlanAction("install", "modules", ", ".join(missing)))
+
+    return StackPlan(stack=stack, actions=tuple(actions))
+
+
+def format_plan(plan: StackPlan) -> str:
+    icons = {
+        "create": "+",
+        "update": "~",
+        "write": ">",
+        "install": "+",
+        "conflict": "!",
+    }
+    lines = [f"Stack {plan.stack}:"]
+    if not plan.actions:
+        lines.append("  No changes.")
+        return "\n".join(lines)
+    for action in plan.actions:
+        detail = f" — {action.detail}" if action.detail else ""
+        lines.append(
+            f"  {icons.get(action.operation, '?')} {action.operation} "
+            f"{action.resource}{detail}"
+        )
+    return "\n".join(lines)
+
+
+def _service_kwargs(
+    settings: Settings,
+    team: TeamSettings,
+    manifest: StackManifest,
+    name: str,
+    desired: Service,
+    environ: Mapping[str, str] | None,
+) -> dict[str, Any]:
+    env_vars = resolve_env_values(
+        desired.env,
+        settings=settings,
+        team=team,
+        env_name=manifest.spec.environment.name,
+        environ=environ,
+    )
+    return {
+        "image": desired.image,
+        "port": desired.port,
+        "hostname": desired.hostname,
+        "env_vars": env_vars or None,
+        "host_mode": desired.host_mode,
+        "volumes": _desired_mounts(desired) or None,
+        "cap_add": ["NET_ADMIN"]
+        if desired.net_admin and not desired.privileged
+        else None,
+        "privileged": desired.privileged,
+        "routes": _desired_routes(desired) or None,
+        "stack_labels": _stack_labels(
+            manifest.metadata.name, f"services.{name}", desired
+        ),
+    }
+
+
+def apply_stack(
+    settings: Settings,
+    team: TeamSettings,
+    manifest: StackManifest,
+    manifest_path: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+    lock_manager: Any = None,
+) -> StackPlan:
+    """Converge live resources to a preflighted, non-destructive V1 plan."""
+    acquired = False
+    if lock_manager is not None:
+        lock_manager.acquire_team(team.team_id, operation="stack_apply")
+        acquired = True
+    try:
+        plan = build_plan(settings, team, manifest, manifest_path, environ=environ)
+        if plan.has_conflicts:
+            conflicts = "; ".join(
+                f"{item.resource}: {item.detail}"
+                for item in plan.actions
+                if item.conflict
+            )
+            raise ConflictError(f"Stack apply refused: {conflicts}")
+        operations = {(item.operation, item.resource): item for item in plan.actions}
+        stack = manifest.metadata.name
+        spec = manifest.spec
+
+        from oduflow import extra_addons
+
+        for name, desired_repo in spec.extra_repositories.items():
+            if ("create", f"extraRepositories.{name}") in operations:
+                extra_addons.clone_extra_repo(
+                    team,
+                    name,
+                    desired_repo.repo_url,
+                    git_user=desired_repo.git_user,
+                )
+
+        for name, desired_volume in spec.volumes.items():
+            resource = f"volumes.{name}"
+            if ("create", resource) in operations:
+                volume_ops.create_volume(
+                    settings,
+                    team,
+                    name,
+                    description=desired_volume.description,
+                    stack_labels=_stack_labels(stack, resource, desired_volume),
+                )
+
+        desired_env = spec.environment
+        env_vars = resolve_env_values(desired_env.env, environ=environ)
+        env_labels = _environment_labels(stack, manifest)
+        extras = {name: item.branch for name, item in spec.extra_repositories.items()}
+        if ("create", "environment") in operations:
+            env_ops.create_environment(
+                settings,
+                team,
+                desired_env.branch,
+                desired_env.repo_url,
+                desired_env.odoo_image,
+                env_name=desired_env.name,
+                template_name=desired_env.template,
+                extra_addons=extras or None,
+                sanitize=desired_env.sanitize,
+                env_vars=env_vars or None,
+                stack_labels=env_labels,
+            )
+        elif ("update", "environment") in operations:
+            env_ops.update_environment(
+                settings,
+                team,
+                desired_env.name,
+                env_override=env_vars,
+                image_override=desired_env.odoo_image,
+                label_overrides=env_labels,
+            )
+
+        for item in spec.files:
+            resource = f"files.{item.volume}:{item.path}"
+            if ("write", resource) in operations:
+                volume_file_ops.write_file_in_volume(
+                    settings,
+                    team,
+                    item.volume,
+                    item.path,
+                    read_stack_file(manifest_path, item.source),
+                )
+
+        for name, desired_service in spec.services.items():
+            resource = f"services.{name}"
+            create_service = ("create", resource) in operations
+            update_service = ("update", resource) in operations
+            if not create_service and not update_service:
+                continue
+            kwargs = _service_kwargs(
+                settings, team, manifest, name, desired_service, environ
+            )
+            if create_service:
+                service_ops.create_service(settings, team, name, **kwargs)
+            elif update_service:
+                service_ops.update_service(
+                    settings,
+                    team,
+                    name,
+                    env_override=kwargs["env_vars"] or {},
+                    image_override=kwargs["image"],
+                    port_override=kwargs["port"],
+                    hostname_override=kwargs["hostname"] or "",
+                    host_mode_override=kwargs["host_mode"],
+                    volume_override=kwargs["volumes"] or [],
+                    cap_add_override=kwargs["cap_add"] or [],
+                    privileged_override=kwargs["privileged"],
+                    routes_override=kwargs["routes"] or [],
+                    stack_labels=kwargs["stack_labels"],
+                )
+
+        module_action = operations.get(("install", "modules"))
+        if module_action:
+            modules = [item.strip() for item in module_action.detail.split(",")]
+            result = odoo_ops.install_odoo_modules(
+                settings, team, desired_env.name, *modules
+            )
+            if int(result.get("exit_code", 1)) != 0:
+                raise ConflictError(
+                    "Stack module installation failed: "
+                    + str(result.get("output", "unknown error"))
+                )
+            env_ops.restart_environment(settings, desired_env.name, team)
+
+        save_state(
+            team,
+            stack,
+            manifest_hash(manifest),
+            {
+                "environment": desired_env.name,
+                "extraRepositories": sorted(spec.extra_repositories),
+                "volumes": sorted(spec.volumes),
+                "services": sorted(spec.services),
+                "modules": list(desired_env.modules.install),
+            },
+        )
+        return plan
+    finally:
+        if acquired:
+            lock_manager.release_team(team.team_id)
+
+
+def stack_status(
+    settings: Settings,
+    team: TeamSettings,
+    manifest: StackManifest,
+    manifest_path: str,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    plan = build_plan(settings, team, manifest, manifest_path, environ=environ)
+    return {
+        "stack": manifest.metadata.name,
+        "inSync": not plan.actions,
+        "hasConflicts": plan.has_conflicts,
+        "manifestHash": manifest_hash(manifest),
+        "state": load_state(team, manifest.metadata.name),
+        "plan": [
+            {
+                "operation": item.operation,
+                "resource": item.resource,
+                "detail": item.detail,
+            }
+            for item in plan.actions
+        ],
+    }

--- a/src/oduflow/stack_state.py
+++ b/src/oduflow/stack_state.py
@@ -1,0 +1,55 @@
+"""Small atomic per-team state records for declarative stacks."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from oduflow.settings import TeamSettings
+
+STATE_API_VERSION = "oduflow.dev/state-v1"
+
+
+def state_path(team: TeamSettings, stack_name: str) -> Path:
+    return Path(team.data_dir) / "stacks" / f"{stack_name}.json"
+
+
+def load_state(team: TeamSettings, stack_name: str) -> dict[str, Any]:
+    path = state_path(team, stack_name)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_state(
+    team: TeamSettings,
+    stack_name: str,
+    manifest_digest: str,
+    resources: dict[str, Any],
+) -> dict[str, Any]:
+    """Persist non-secret apply metadata using fsync + atomic replace."""
+    data = {
+        "apiVersion": STATE_API_VERSION,
+        "stack": stack_name,
+        "manifestHash": manifest_digest,
+        "appliedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "resources": resources,
+    }
+    path = state_path(team, stack_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return data

--- a/tests/test_stack_cli.py
+++ b/tests/test_stack_cli.py
@@ -1,0 +1,70 @@
+import sys
+from unittest.mock import patch
+
+from oduflow.settings import Settings, TeamSettings
+from oduflow.stack_ops import StackPlan
+
+
+def test_stack_validate_cli(tmp_path, capsys):
+    manifest = tmp_path / "oduflow.yaml"
+    manifest.write_text(
+        """\
+apiVersion: oduflow.dev/v1alpha1
+kind: Stack
+metadata: {name: demo}
+spec:
+  environment:
+    name: demo
+    branch: main
+    repoUrl: https://github.com/acme/demo.git
+    odooImage: odoo:18.0
+""",
+        encoding="utf-8",
+    )
+    from oduflow import server
+
+    with patch.object(sys, "argv", ["oduflow", "stack", "validate", str(manifest)]):
+        server._run_cli()
+
+    assert "Stack 'demo' is valid" in capsys.readouterr().out
+
+
+def test_startup_stack_is_applied_before_server(tmp_path):
+    from oduflow import server
+
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path / "team"),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        db_password="password",
+        teams={"1": team},
+    )
+    manifest = object()
+    events = []
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["oduflow", "--stack", "/stack/oduflow.yaml", "--transport", "http"],
+        ),
+        patch.object(server, "find_toml"),
+        patch.object(server, "_get_settings", return_value=settings),
+        patch.object(server.migrations, "run_pending"),
+        patch.object(server, "_ensure_initialized"),
+        patch.object(server.quotas, "apply_all"),
+        patch("oduflow.stack_loader.load_stack", return_value=manifest),
+        patch(
+            "oduflow.stack_ops.apply_stack",
+            side_effect=lambda *a, **k: events.append("stack") or StackPlan("demo", ()),
+        ),
+        patch.object(
+            server, "_start_http", side_effect=lambda: events.append("server")
+        ),
+    ):
+        server._run_cli()
+
+    assert events == ["stack", "server"]

--- a/tests/test_stack_models.py
+++ b/tests/test_stack_models.py
@@ -1,0 +1,121 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from oduflow.stack_loader import (
+    StackValidationError,
+    load_stack,
+    read_stack_file,
+)
+from oduflow.stack_models import StackManifest
+
+VALID = """\
+apiVersion: oduflow.dev/v1alpha1
+kind: Stack
+metadata:
+  name: acme
+spec:
+  environment:
+    name: acme-dev
+    branch: main
+    repoUrl: https://github.com/acme/addons.git
+    odooImage: odoo:18.0
+    template: default
+    env:
+      LOG_LEVEL: info
+    modules:
+      install: [acme_base]
+  extraRepositories:
+    enterprise:
+      repoUrl: https://github.com/odoo/enterprise.git
+      branch: "18.0"
+  volumes:
+    fs-data:
+      description: FreeSWITCH data
+  files:
+    - source: files/fs.conf
+      volume: fs-data
+      path: config/fs.conf
+  services:
+    fs:
+      image: example/fs:1
+      port: 8080
+      env:
+        ODOO_URL:
+          environmentField: url
+        ESL_PASSWORD:
+          fromEnv: FS_ESL_PASSWORD
+      volumes:
+        - source: fs-data
+          target: /data
+"""
+
+
+def _write(tmp_path: Path, content: str = VALID) -> Path:
+    path = tmp_path / "oduflow.yaml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_load_valid_stack(tmp_path):
+    manifest = load_stack(_write(tmp_path))
+
+    assert manifest.metadata.name == "acme"
+    assert manifest.spec.environment.odoo_image == "odoo:18.0"
+    assert manifest.spec.services["fs"].env["ODOO_URL"].environment_field == "url"
+
+
+def test_duplicate_yaml_key_is_rejected(tmp_path):
+    path = _write(
+        tmp_path,
+        VALID.replace("  name: acme\n", "  name: acme\n  name: duplicate\n", 1),
+    )
+
+    with pytest.raises(StackValidationError, match="duplicate YAML key 'name'"):
+        load_stack(path)
+
+
+def test_unknown_fields_are_rejected(tmp_path):
+    path = _write(tmp_path, VALID.replace("spec:\n", "spec:\n  unsupported: true\n"))
+
+    with pytest.raises(StackValidationError, match="unsupported"):
+        load_stack(path)
+
+
+def test_undeclared_volume_reference_is_rejected(tmp_path):
+    path = _write(tmp_path, VALID.replace("volume: fs-data", "volume: missing"))
+
+    with pytest.raises(StackValidationError, match="undeclared volume 'missing'"):
+        load_stack(path)
+
+
+def test_environment_cannot_reference_its_own_token(tmp_path):
+    path = _write(
+        tmp_path,
+        VALID.replace(
+            "LOG_LEVEL: info",
+            "LOG_LEVEL:\n        environmentField: token",
+        ),
+    )
+
+    with pytest.raises(StackValidationError, match="cannot reference environmentField"):
+        load_stack(path)
+
+
+def test_stack_file_must_stay_inside_manifest_directory(tmp_path):
+    path = _write(tmp_path)
+    outside = tmp_path.parent / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+
+    with pytest.raises(StackValidationError, match="escapes the stack directory"):
+        read_stack_file(path, "../outside.txt")
+
+
+def test_shipped_json_schema_matches_models():
+    schema_path = (
+        Path(__file__).parents[1] / "src/oduflow/schemas/oduflow-stack-v1alpha1.json"
+    )
+    shipped = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    assert shipped == StackManifest.model_json_schema(by_alias=True)

--- a/tests/test_stack_ops.py
+++ b/tests/test_stack_ops.py
@@ -1,0 +1,285 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from oduflow.errors import ConflictError
+from oduflow.settings import Settings, TeamSettings
+from oduflow.stack_loader import StackValidationError, load_stack, resolve_env_values
+from oduflow.stack_models import ServiceRoute, ValueFrom
+from oduflow.stack_ops import PlanAction, StackPlan, apply_stack, build_plan
+
+MANIFEST = """\
+apiVersion: oduflow.dev/v1alpha1
+kind: Stack
+metadata:
+  name: acme
+spec:
+  environment:
+    name: acme-dev
+    branch: main
+    repoUrl: https://github.com/acme/addons.git
+    odooImage: odoo:18.0
+    template: default
+    env:
+      LOG_LEVEL: info
+    modules:
+      install: [acme_base]
+  extraRepositories:
+    enterprise:
+      repoUrl: https://github.com/odoo/enterprise.git
+      branch: "18.0"
+  volumes:
+    fs-data:
+      description: FreeSWITCH data
+  files:
+    - source: files/fs.conf
+      volume: fs-data
+      path: config/fs.conf
+  services:
+    fs:
+      image: example/fs:1
+      port: 8080
+      env:
+        ODOO_URL:
+          environmentField: url
+      volumes:
+        - source: fs-data
+          target: /data
+"""
+
+
+@pytest.fixture(autouse=True)
+def allow_example_repo_urls():
+    with patch("oduflow.stack_ops.git_ops.validate_repo_url"):
+        yield
+
+
+@pytest.fixture
+def stack_fixture(tmp_path):
+    data_dir = tmp_path / "team"
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(data_dir),
+        port_registry_path=str(data_dir / "ports.json"),
+        port_range_start=50000,
+        port_range_end=50100,
+        hostname="localhost",
+    )
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        db_user="odoo",
+        db_password="odoo",
+        teams={"1": team},
+    )
+    path = tmp_path / "oduflow.yaml"
+    path.write_text(MANIFEST, encoding="utf-8")
+    files = tmp_path / "files"
+    files.mkdir()
+    (files / "fs.conf").write_text("profile=internal\n", encoding="utf-8")
+    return settings, team, load_stack(path), str(path)
+
+
+def test_host_environment_value_is_required():
+    value = ValueFrom(fromEnv="MISSING_SECRET")
+
+    with pytest.raises(StackValidationError, match="MISSING_SECRET"):
+        resolve_env_values({"TOKEN": value}, environ={})
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.env_ops.list_environments", return_value=[])
+@patch("oduflow.stack_ops.service_ops.list_services", return_value=[])
+def test_plan_new_stack_has_dependency_ordered_actions(
+    _services, _envs, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+
+    plan = build_plan(settings, team, manifest, path)
+
+    assert [(item.operation, item.resource) for item in plan.actions] == [
+        ("create", "extraRepositories.enterprise"),
+        ("create", "volumes.fs-data"),
+        ("create", "environment"),
+        ("write", "files.fs-data:config/fs.conf"),
+        ("create", "services.fs"),
+        ("install", "modules"),
+    ]
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.env_ops.list_environments")
+def test_plan_refuses_to_adopt_existing_environment(
+    envs, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    envs.return_value = [{"env_name": "acme-dev", "stack": "", "stack_resource": ""}]
+
+    with (
+        patch("oduflow.stack_ops.service_ops.list_services", return_value=[]),
+        patch(
+            "oduflow.stack_ops.env_ops.get_environment_info",
+            return_value={"env_vars": {}},
+        ),
+        patch("oduflow.stack_ops._installed_modules", return_value=set()),
+    ):
+        plan = build_plan(settings, team, manifest, path)
+
+    conflict = next(item for item in plan.actions if item.resource == "environment")
+    assert conflict.operation == "conflict"
+    assert "not owned" in conflict.detail
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.service_ops.list_services", return_value=[])
+@patch("oduflow.stack_ops.env_ops.get_environment_info")
+@patch("oduflow.stack_ops.env_ops.list_environments")
+def test_plan_is_empty_when_owned_environment_matches(
+    envs, env_info, _services, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    manifest.spec.extra_repositories = {}
+    manifest.spec.volumes = {}
+    manifest.spec.files = []
+    manifest.spec.services = {}
+    manifest.spec.environment.modules.install = []
+    envs.return_value = [
+        {
+            "env_name": "acme-dev",
+            "stack": "acme",
+            "stack_resource": "environment",
+            "repo_url": "https://github.com/acme/addons.git",
+            "git_branch": "main",
+            "template_name": "default",
+            "extra_addons": {},
+            "odoo_image": "odoo:18.0",
+        }
+    ]
+    env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}
+
+    plan = build_plan(settings, team, manifest, path)
+
+    assert plan.actions == ()
+
+
+def test_apply_preflights_conflicts_before_mutation(stack_fixture):
+    settings, team, manifest, path = stack_fixture
+    conflict = StackPlan("acme", (PlanAction("conflict", "environment", "owned"),))
+
+    with (
+        patch("oduflow.stack_ops.build_plan", return_value=conflict),
+        patch("oduflow.stack_ops.volume_ops.create_volume") as create_volume,
+    ):
+        with pytest.raises(ConflictError, match="apply refused"):
+            apply_stack(settings, team, manifest, path)
+
+    create_volume.assert_not_called()
+
+
+def test_apply_creates_resources_and_persists_non_secret_state(stack_fixture):
+    settings, team, manifest, path = stack_fixture
+    actions = StackPlan(
+        "acme",
+        (
+            PlanAction("create", "extraRepositories.enterprise"),
+            PlanAction("create", "volumes.fs-data"),
+            PlanAction("create", "environment"),
+            PlanAction("write", "files.fs-data:config/fs.conf"),
+            PlanAction("create", "services.fs"),
+            PlanAction("install", "modules", "acme_base"),
+        ),
+    )
+    events = []
+
+    with (
+        patch("oduflow.stack_ops.build_plan", return_value=actions),
+        patch(
+            "oduflow.extra_addons.clone_extra_repo",
+            side_effect=lambda *a, **k: events.append("repo"),
+        ),
+        patch(
+            "oduflow.stack_ops.volume_ops.create_volume",
+            side_effect=lambda *a, **k: events.append("volume"),
+        ),
+        patch(
+            "oduflow.stack_ops.env_ops.create_environment",
+            side_effect=lambda *a, **k: events.append("environment"),
+        ),
+        patch(
+            "oduflow.stack_ops.volume_file_ops.write_file_in_volume",
+            side_effect=lambda *a, **k: events.append("file"),
+        ),
+        patch(
+            "oduflow.stack_ops.env_ops.get_env_base_url",
+            return_value=("http://odoo", "localhost"),
+        ),
+        patch(
+            "oduflow.stack_ops.service_ops.create_service",
+            side_effect=lambda *a, **k: events.append("service"),
+        ) as create_service,
+        patch(
+            "oduflow.stack_ops.odoo_ops.install_odoo_modules",
+            side_effect=lambda *a, **k: events.append("modules") or {"exit_code": 0},
+        ),
+        patch(
+            "oduflow.stack_ops.env_ops.restart_environment",
+            side_effect=lambda *a, **k: events.append("restart"),
+        ),
+    ):
+        result = apply_stack(settings, team, manifest, path)
+
+    assert result == actions
+    assert events == [
+        "repo",
+        "volume",
+        "environment",
+        "file",
+        "service",
+        "modules",
+        "restart",
+    ]
+    assert create_service.call_args.kwargs["env_vars"] == {"ODOO_URL": "http://odoo"}
+    state = Path(team.data_dir) / "stacks/acme.json"
+    assert state.is_file()
+    assert "http://odoo" not in state.read_text(encoding="utf-8")
+
+
+def test_apply_no_changes_is_idempotent(stack_fixture):
+    settings, team, manifest, path = stack_fixture
+    empty = StackPlan("acme", ())
+
+    with (
+        patch("oduflow.stack_ops.build_plan", return_value=empty),
+        patch("oduflow.stack_ops.env_ops.create_environment") as create_environment,
+    ):
+        result = apply_stack(settings, team, manifest, path)
+
+    assert result == empty
+    assert (Path(team.data_dir) / "stacks/acme.json").is_file()
+    create_environment.assert_not_called()
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.env_ops.list_environments", return_value=[])
+@patch("oduflow.stack_ops.service_ops.list_services", return_value=[])
+def test_plan_reports_route_mode_conflict_before_apply(
+    _services, _envs, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    manifest.spec.services["fs"].port = None
+    manifest.spec.services["fs"].routes = [ServiceRoute(path="/events", port=8080)]
+
+    plan = build_plan(settings, team, manifest, path)
+
+    assert (
+        PlanAction(
+            "conflict",
+            "services.fs",
+            "HTTP routes require routing.mode = 'traefik'",
+        )
+        in plan.actions
+    )


### PR DESCRIPTION
## What changed

- add a versioned `oduflow.dev/v1alpha1` YAML Stack manifest with strict Pydantic validation and a shipped JSON Schema
- add idempotent `validate`, `plan`, `apply`, and `status` workflows for one Odoo development environment, extra repositories, modules, volumes, files, and auxiliary services
- add Stack ownership/spec-hash labels, per-team state, safe environment value sources, and startup reconciliation through `oduflow --stack`
- extend existing environment, service, and volume operations to preserve Stack ownership metadata
- document the workflow and record the architecture decision in ADR 0046

## Why

Oduflow already exposes the individual lifecycle operations needed to assemble an Odoo solution, but reproducing the complete desired state requires manually replaying those operations. Declarative Stacks make that state reviewable in Git and safely reproducible without introducing another orchestration runtime.

V1 is intentionally non-destructive: it refuses ownership conflicts and replacement-only drift, never prunes removed resources, and never uninstalls modules.

## Impact

Operators can validate and preview Stack drift locally, reconcile a team explicitly, or converge the Stack before the MCP transport starts. Host-level tenancy, routing, authentication, quotas, backups, and production remain in `oduflow.toml` and outside the Stack contract.

## Validation

- `ruff check` on all changed Python files
- `mypy src/oduflow`
- `pytest -q -m "not integration and not heavyweight"` — 2207 passed, 15 deselected
- wheel build verified that Stack modules and JSON Schema are packaged