### PR TITLE
Fix OAuth access token type

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,15 @@
 
 ### Bug Fixes
 
+- **OAuth clients see the tools again** — in OAuth mode (Traefik routing or an
+  explicit `oauth_base_url`) every authenticated request was denied: the OAuth
+  provider handed out the MCP SDK's `AccessToken`, and FastMCP's
+  `get_access_token()` rejects that type, so the scoped-access middleware — which
+  calls it to read a token's environment scope, and fails closed — returned an
+  empty tool list on `tools/list` and refused every `tools/call`, on both `/mcp`
+  and `/mcp/<env>`. The provider now issues FastMCP's `AccessToken` on every
+  path. Deployments using static Bearer tokens were unaffected.
+
 - **A wedged Docker call can no longer take the server down silently** — startup
   runs migrations, `init_system` and quotas before the HTTP listener binds, and
   docker-py disables the socket timeout while reading exec output, so a Docker

--- a/src/oduflow/oauth_provider.py
+++ b/src/oduflow/oauth_provider.py
@@ -23,10 +23,18 @@ import re
 from typing import Any
 from urllib.parse import urlparse
 
+# FastMCP's AccessToken (a subclass of the MCP SDK's that adds ``claims``) —
+# never the SDK's own. ``fastmcp.server.dependencies.get_access_token()``, which
+# scoped_access uses to read a token's env scope, rejects a plain SDK token: it
+# tries to convert it and passes ``claims=None`` (the SDK's default) into a
+# field typed ``dict``, so validation fails and the request is denied outright.
+from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.providers.in_memory import InMemoryOAuthProvider
 from mcp.server.auth.json_response import PydanticJSONResponse
 from mcp.server.auth.provider import (
-    AccessToken,
+    AccessToken as SDKAccessToken,
+)
+from mcp.server.auth.provider import (
     AuthorizationCode,
     RefreshToken,
 )
@@ -69,6 +77,24 @@ def public_client_id(team_id: str) -> str:
     """The non-secret OAuth ``client_id`` for a team, safe to appear in the
     ``/authorize`` URL. The team's ``auth_token`` is the ``client_secret``."""
     return f"team_{team_id}"
+
+
+def _as_fastmcp_token(token: SDKAccessToken) -> AccessToken:
+    """Return ``token`` as a FastMCP ``AccessToken``.
+
+    Every token this provider hands out must be the FastMCP subclass:
+    ``fastmcp.server.dependencies.get_access_token()`` (used by
+    :mod:`oduflow.scoped_access` to read a token's env scope) raises on a plain
+    SDK token, because converting one passes the SDK's ``claims=None`` into a
+    field typed ``dict``. A raise there denies the whole request, so a token
+    that arrives from the base class's SDK-typed store is normalised here rather
+    than trusted to be the right type.
+    """
+    if isinstance(token, AccessToken):
+        return token
+    data = token.model_dump()
+    data["claims"] = data.get("claims") or {}
+    return AccessToken(**data)
 
 
 def _forwarded_scheme_host(
@@ -378,13 +404,13 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
         return await super().get_client(client_id)
 
-    async def load_access_token(  # type: ignore[override]
-        self, token: str
-    ) -> AccessToken | None:
-        # 1. Preseeded team auth_token (direct Bearer, non-expiring).
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        # 1. Preseeded team auth_token (direct Bearer, non-expiring). The base
+        # class types its store with the SDK's AccessToken, so normalise what
+        # comes back — see _as_fastmcp_token.
         existing = await super().load_access_token(token)
         if existing is not None:
-            return existing
+            return _as_fastmcp_token(existing)
         # 2. A minted OAuth access token from the persistent store. Its stored
         # client_id is the numeric team_id, so it routes like the auth_token.
         # get_access() drops the token and returns None once expired.
@@ -487,7 +513,7 @@ class OduflowOAuthProvider(InMemoryOAuthProvider):
             scope=" ".join(minted_scopes) if minted_scopes else None,
         )
 
-    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+    async def revoke_token(self, token: SDKAccessToken | RefreshToken) -> None:
         # Really delete the minted token (and its paired token) from the store.
         # The preseeded auth_token and per-env tokens are not in the store, so
         # revoking them is a no-op (rotate auth_token in oduflow.toml instead).

--- a/tests/test_oauth_provider.py
+++ b/tests/test_oauth_provider.py
@@ -507,6 +507,66 @@ class TestOduflowOAuthProvider:
         assert "evil.com" not in hdr
 
 
+class TestAccessTokenType:
+    """Every token this provider hands out must be FastMCP's ``AccessToken``.
+
+    ``fastmcp.server.dependencies.get_access_token()`` raises on a plain MCP-SDK
+    ``AccessToken`` (converting one passes the SDK's ``claims=None`` into a field
+    typed ``dict``). ``oduflow.scoped_access`` calls it on every request to read
+    a token's env scope, and a raise there fails closed — so an SDK-typed token
+    silently turns into "no tools, every call denied" for OAuth-mode servers.
+    """
+
+    def _provider(self, monkeypatch):
+        from oduflow import oauth_provider as op
+
+        mapping = {"env-secret": ("2", "feature/x"), "tok-a": ("1", None)}
+        monkeypatch.setattr(
+            op.env_tokens,
+            "resolve_token",
+            lambda settings, token: mapping.get(token),
+        )
+        return OduflowOAuthProvider(_settings())
+
+    def test_every_load_path_returns_a_fastmcp_token(self, monkeypatch):
+        from fastmcp.server.auth.auth import AccessToken as FastMCPAccessToken
+
+        provider = self._provider(monkeypatch)
+        minted = _mint(provider, scopes=["mcp"]).access_token
+
+        for label, value in (
+            ("preseeded auth_token", "tok-a"),
+            ("minted OAuth token", minted),
+            ("per-env token", "env-secret"),
+        ):
+            access = _run(provider.load_access_token(value))
+            assert access is not None, label
+            assert isinstance(access, FastMCPAccessToken), label
+            assert access.claims == {}, label
+
+    def test_fastmcp_reads_the_env_scope_off_a_live_token(self, monkeypatch):
+        # End-to-end proxy of the request path: park the token where the SDK's
+        # auth middleware would, then let scoped_access resolve the env through
+        # the real fastmcp dependency.
+        from mcp.server.auth.middleware.auth_context import auth_context_var
+        from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+
+        from oduflow import scoped_access
+
+        provider = self._provider(monkeypatch)
+        access = _run(provider.load_access_token("env-secret"))
+        assert access is not None
+        auth_context_var.set(AuthenticatedUser(access))
+        # Inside a request scoped_access re-raises instead of degrading to None,
+        # so a failure here is the deny-everything outage, not a quiet miss.
+        active = scoped_access._HTTP_REQUEST_ACTIVE.set(True)
+        try:
+            assert scoped_access.env_from_access_token() == "feature/x"
+        finally:
+            scoped_access._HTTP_REQUEST_ACTIVE.reset(active)
+            auth_context_var.set(None)
+
+
 class TestRedirectUriValidation:
     """The redirect_uri is where the authorization code is delivered, so an
     over-permissive check hands the code to an attacker."""


### PR DESCRIPTION
## Summary

- Return FastMCP `AccessToken` instances from every OAuth provider load path.
- Normalize SDK access tokens so `claims` is always a dictionary.
- Add regression coverage for team, minted OAuth, and environment-scoped tokens.
- Document the OAuth outage fix in the changelog.

## Root cause

FastMCP's request dependency rejects the MCP SDK's plain `AccessToken` when its optional `claims` value is `None`. Scoped access reads that dependency on every authenticated request and fails closed, which hid all tools and denied calls in OAuth mode.

## Impact

Authenticated OAuth clients can list and call tools again on both team-wide and environment-scoped MCP endpoints. Static bearer-token deployments are unchanged.

## Validation

- `ruff check src/oduflow/oauth_provider.py tests/test_oauth_provider.py`
- `mypy src/oduflow/oauth_provider.py`
- `pytest tests/test_oauth_provider.py tests/test_scoped_access.py -q` (95 passed)
- `pytest -m 'not integration and not heavyweight' -q` (2,237 passed, 15 deselected)