### PR TITLE
Fix declarative stack convergence

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,6 +47,14 @@
 
 ### Bug Fixes
 
+- **Declarative Stack plans now converge on the runtime they create** — apply
+  rejects unavailable database templates before creating anything and treats a
+  changed sanitization policy as replacement-only drift. Service image defaults
+  no longer look like undeclared environment variables, text files up to the
+  documented 1 MB limit compare cleanly, route paths are canonicalized before
+  duplicate checks and hashing, and `stack validate` verifies every referenced
+  local file.
+
 - **OAuth clients see the tools again** — in OAuth mode (Traefik routing or an
   explicit `oauth_base_url`) every authenticated request was denied: the OAuth
   provider handed out the MCP SDK's `AccessToken`, and FastMCP's

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -2248,6 +2248,7 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                 "stack": container.labels.get("oduflow.stack", ""),
                 "stack_resource": container.labels.get("oduflow.stack-resource", ""),
                 "stack_spec_hash": container.labels.get("oduflow.stack-spec-hash", ""),
+                "stack_sanitize": container.labels.get("oduflow.stack-sanitize", ""),
             }
 
         try:
@@ -2538,6 +2539,7 @@ def get_environment_info(
         result["stack"] = labels.get("oduflow.stack", "")
         result["stack_resource"] = labels.get("oduflow.stack-resource", "")
         result["stack_spec_hash"] = labels.get("oduflow.stack-spec-hash", "")
+        result["stack_sanitize"] = labels.get("oduflow.stack-sanitize", "")
 
         if settings.routing_mode == "traefik":
             result["url"] = (

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -495,6 +495,18 @@ def _describe_service_container(
             if key not in _SYSTEM_ENV_KEYS:
                 env_vars[key] = value
 
+    image_env_vars: dict[str, str] = {}
+    try:
+        raw_image_env = container.image.attrs.get("Config", {}).get("Env", [])
+    except Exception:
+        raw_image_env = []
+    if isinstance(raw_image_env, list):
+        for entry in raw_image_env:
+            if isinstance(entry, str) and "=" in entry:
+                key, value = entry.split("=", 1)
+                if key not in _SYSTEM_ENV_KEYS:
+                    image_env_vars[key] = value
+
     port_num: int | None = None
     url: str | None = None
     hostname: str | None = None
@@ -582,6 +594,7 @@ def _describe_service_container(
         "url": url,
         "routes": _routes_with_urls(routes, hostname),
         "env_vars": env_vars,
+        "image_env_vars": image_env_vars,
         "host_mode": is_host_mode,
         "volumes": svc_volumes,
         "cap_add": svc_cap_add,

--- a/src/oduflow/docker_ops/volume_file_ops.py
+++ b/src/oduflow/docker_ops/volume_file_ops.py
@@ -64,6 +64,8 @@ def read_file_in_volume(
     name: str,
     path: str,
     read_range: str = "",
+    *,
+    max_bytes: int = _FILE_SIZE_LIMIT,
 ) -> dict[str, Any]:
     """Read a text file or list a directory inside a Docker volume."""
     docker_name, client = _validate_volume(team, name)
@@ -90,7 +92,6 @@ def read_file_in_volume(
     else:
         read_cmd = 'cat "$FILE"'
 
-    size_limit = _FILE_SIZE_LIMIT
     quoted = shlex.quote(full_path)
     script = f"""\
 FILE={quoted}
@@ -104,7 +105,7 @@ elif [ -f "$FILE" ]; then
     if [ "$NULL_COUNT" -gt 0 ]; then
         echo "TYPE:BINARY"
         echo "SIZE:$SIZE"
-    elif [ {0 if read_range else 1} -eq 1 ] && [ "$SIZE" -gt {size_limit} ]; then
+    elif [ {0 if read_range else 1} -eq 1 ] && [ "$SIZE" -gt {max_bytes} ]; then
         echo "TYPE:TOOLARGE"
         echo "SIZE:$SIZE"
     else
@@ -155,7 +156,7 @@ fi
     if type_line == "TYPE:TOOLARGE":
         size_str = lines[1].replace("SIZE:", "").strip() if len(lines) > 1 else "?"
         size_kb = int(size_str) // 1024 if size_str.isdigit() else "?"
-        limit_kb = _FILE_SIZE_LIMIT // 1024
+        limit_kb = max_bytes // 1024
         return {
             "error": (
                 f"File is too large ({size_kb}KB, limit {limit_kb}KB). "

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -5731,9 +5731,10 @@ def _run_cli() -> None:
         return
 
     if args.command == "stack" and args.stack_command == "validate":
-        from oduflow.stack_loader import load_stack
+        from oduflow.stack_loader import load_stack, validate_stack_files
 
         manifest = load_stack(args.manifest)
+        validate_stack_files(manifest, args.manifest)
         print(f"Stack '{manifest.metadata.name}' is valid ({manifest.api_version}).")
         return
 

--- a/src/oduflow/stack_loader.py
+++ b/src/oduflow/stack_loader.py
@@ -149,6 +149,14 @@ def read_stack_file(manifest_path: str | os.PathLike[str], source: str) -> str:
         ) from exc
 
 
+def validate_stack_files(
+    manifest: StackManifest, manifest_path: str | os.PathLike[str]
+) -> None:
+    """Validate every local file referenced by a manifest without mutating state."""
+    for item in manifest.spec.files:
+        read_stack_file(manifest_path, item.source)
+
+
 def write_json_schema(path: str | os.PathLike[str]) -> None:
     """Write the public v1alpha1 JSON Schema generated from typed models."""
     target = Path(path)

--- a/src/oduflow/stack_models.py
+++ b/src/oduflow/stack_models.py
@@ -189,7 +189,7 @@ class ServiceRoute(StackModel):
             or any(ord(ch) < 32 or ch.isspace() for ch in value)
         ):
             raise ValueError("route path must be a safe absolute URL path")
-        return value
+        return value.rstrip("/") or "/"
 
 
 class Service(StackModel):

--- a/src/oduflow/stack_ops.py
+++ b/src/oduflow/stack_ops.py
@@ -17,6 +17,7 @@ from oduflow.docker_ops import (
     env_ops,
     odoo_ops,
     service_ops,
+    system_ops,
     volume_file_ops,
     volume_ops,
 )
@@ -34,6 +35,8 @@ from oduflow.stack_state import load_state, save_state
 STACK_LABEL = "oduflow.stack"
 STACK_RESOURCE_LABEL = "oduflow.stack-resource"
 STACK_SPEC_HASH_LABEL = "oduflow.stack-spec-hash"
+STACK_SANITIZE_LABEL = "oduflow.stack-sanitize"
+_STACK_FILE_LIMIT = 1_000_000
 
 
 @dataclass(frozen=True)
@@ -89,7 +92,18 @@ def _environment_labels(stack: str, manifest: StackManifest) -> dict[str, str]:
     """
     value = manifest.spec.environment.model_dump(mode="json", by_alias=True)
     value.pop("modules", None)
-    return _stack_labels(stack, "environment", value)
+    labels = _stack_labels(stack, "environment", value)
+    labels[STACK_SANITIZE_LABEL] = str(manifest.spec.environment.sanitize).lower()
+    return labels
+
+
+def _environment_hash_with_sanitize(
+    manifest: StackManifest, sanitize: bool
+) -> str:
+    value = manifest.spec.environment.model_dump(mode="json", by_alias=True)
+    value.pop("modules", None)
+    value["sanitize"] = sanitize
+    return _resource_hash(value)
 
 
 def _owned_by(info: Mapping[str, Any], stack: str, resource: str) -> bool:
@@ -181,10 +195,28 @@ def _file_matches(
     expected: str,
 ) -> bool:
     try:
-        result = volume_file_ops.read_file_in_volume(settings, team, volume, path)
+        result = volume_file_ops.read_file_in_volume(
+            settings, team, volume, path, max_bytes=_STACK_FILE_LIMIT
+        )
     except NotFoundError:
         return False
     return "error" not in result and result.get("output") == expected
+
+
+def _service_env_matches(
+    actual: Mapping[str, Any], desired: Mapping[str, str]
+) -> bool:
+    """Compare declared values while ignoring untouched image defaults."""
+    effective = actual.get("env_vars", {})
+    image_defaults = actual.get("image_env_vars", {})
+    if not isinstance(effective, dict) or not isinstance(image_defaults, dict):
+        return False
+    if any(effective.get(key) != value for key, value in desired.items()):
+        return False
+    return not any(
+        key not in desired and image_defaults.get(key) != value
+        for key, value in effective.items()
+    )
 
 
 def build_plan(
@@ -259,6 +291,20 @@ def build_plan(
     env_needs_create = actual_env is None
     if actual_env is None:
         actions.append(PlanAction("create", env_resource, desired_env.name))
+        if desired_env.template is not None:
+            templates = {
+                item["template_name"]: item
+                for item in system_ops.list_templates(settings, team)
+            }
+            template = templates.get(desired_env.template)
+            if template is None or not template.get("db_loaded", False):
+                actions.append(
+                    PlanAction(
+                        "conflict",
+                        env_resource,
+                        f"template '{desired_env.template}' is not available",
+                    )
+                )
     elif not _owned_by(actual_env, stack, env_resource):
         actions.append(
             PlanAction(
@@ -284,6 +330,17 @@ def build_plan(
         }
         if actual_env.get("extra_addons", {}) != desired_extras:
             immutable_drift.append("extraRepositories")
+        actual_sanitize = actual_env.get("stack_sanitize", "")
+        sanitize_changed = (
+            actual_sanitize in ("true", "false")
+            and (actual_sanitize == "true") != desired_env.sanitize
+        )
+        if not actual_sanitize and actual_env.get("stack_spec_hash"):
+            sanitize_changed = actual_env.get(
+                "stack_spec_hash"
+            ) == _environment_hash_with_sanitize(manifest, not desired_env.sanitize)
+        if sanitize_changed:
+            immutable_drift.append("sanitize")
         if immutable_drift:
             actions.append(
                 PlanAction(
@@ -384,6 +441,10 @@ def build_plan(
             else []
         )
         drift: list[str] = []
+        if desired_service_env is not None and not _service_env_matches(
+            actual, desired_service_env
+        ):
+            drift.append("env")
         comparisons = (
             ("image", actual.get("image"), desired_service.image),
             ("port", actual.get("port"), desired_service.port),
@@ -391,13 +452,6 @@ def build_plan(
                 "hostname",
                 actual.get("hostname"),
                 _desired_hostname(settings, team, name, desired_service.hostname),
-            ),
-            (
-                "env",
-                actual.get("env_vars", {}),
-                desired_service_env
-                if desired_service_env is not None
-                else "<pending environment outputs>",
             ),
             ("hostMode", bool(actual.get("host_mode")), desired_service.host_mode),
             (

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -488,6 +488,9 @@ class TestListServices:
         container.name = "oduflow-1-svc-redis"
         container.status = "running"
         container.image.tags = ["redis:7"]
+        container.image.attrs = {
+            "Config": {"Env": ["REDIS_VERSION=7.4", "PATH=/usr/local/bin"]}
+        }
         container.attrs = {
             "NetworkSettings": {
                 "Ports": {"6379/tcp": [{"HostIp": "0.0.0.0", "HostPort": "6379"}]}
@@ -508,6 +511,7 @@ class TestListServices:
         assert svc["url"] == "http://localhost:6379"
         # Env vars: system vars filtered out, only custom remain
         assert svc["env_vars"] == {"REDIS_PASSWORD": "secret"}
+        assert svc["image_env_vars"] == {"REDIS_VERSION": "7.4"}
 
     def test_list_with_services_traefik_mode(self, mock_docker_client):
         container = MagicMock()

--- a/tests/test_stack_cli.py
+++ b/tests/test_stack_cli.py
@@ -1,7 +1,10 @@
 import sys
 from unittest.mock import patch
 
+import pytest
+
 from oduflow.settings import Settings, TeamSettings
+from oduflow.stack_loader import StackValidationError
 from oduflow.stack_ops import StackPlan
 
 
@@ -27,6 +30,37 @@ spec:
         server._run_cli()
 
     assert "Stack 'demo' is valid" in capsys.readouterr().out
+
+
+def test_stack_validate_cli_checks_referenced_files(tmp_path):
+    manifest = tmp_path / "oduflow.yaml"
+    manifest.write_text(
+        """\
+apiVersion: oduflow.dev/v1alpha1
+kind: Stack
+metadata: {name: demo}
+spec:
+  environment:
+    name: demo
+    branch: main
+    repoUrl: https://github.com/acme/demo.git
+    odooImage: odoo:18.0
+  volumes:
+    config: {}
+  files:
+    - source: missing.conf
+      volume: config
+      path: app.conf
+""",
+        encoding="utf-8",
+    )
+    from oduflow import server
+
+    with (
+        patch.object(sys, "argv", ["oduflow", "stack", "validate", str(manifest)]),
+        pytest.raises(StackValidationError, match="cannot read file source"),
+    ):
+        server._run_cli()
 
 
 def test_startup_stack_is_applied_before_server(tmp_path):

--- a/tests/test_stack_models.py
+++ b/tests/test_stack_models.py
@@ -2,13 +2,14 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from oduflow.stack_loader import (
     StackValidationError,
     load_stack,
     read_stack_file,
 )
-from oduflow.stack_models import StackManifest
+from oduflow.stack_models import Service, ServiceRoute, StackManifest
 
 VALID = """\
 apiVersion: oduflow.dev/v1alpha1
@@ -110,6 +111,20 @@ def test_stack_file_must_stay_inside_manifest_directory(tmp_path):
 
     with pytest.raises(StackValidationError, match="escapes the stack directory"):
         read_stack_file(path, "../outside.txt")
+
+
+def test_service_route_paths_are_canonicalized_before_duplicate_validation():
+    route = ServiceRoute(path="/api/", port=8080)
+
+    assert route.path == "/api"
+    with pytest.raises(ValidationError, match="duplicate paths"):
+        Service(
+            image="example/service:1",
+            routes=[
+                ServiceRoute(path="/api", port=8080),
+                ServiceRoute(path="/api/", port=8081),
+            ],
+        )
 
 
 def test_shipped_json_schema_matches_models():

--- a/tests/test_stack_ops.py
+++ b/tests/test_stack_ops.py
@@ -7,7 +7,14 @@ from oduflow.errors import ConflictError
 from oduflow.settings import Settings, TeamSettings
 from oduflow.stack_loader import StackValidationError, load_stack, resolve_env_values
 from oduflow.stack_models import ServiceRoute, ValueFrom
-from oduflow.stack_ops import PlanAction, StackPlan, apply_stack, build_plan
+from oduflow.stack_ops import (
+    PlanAction,
+    StackPlan,
+    _file_matches,
+    _resource_hash,
+    apply_stack,
+    build_plan,
+)
 
 MANIFEST = """\
 apiVersion: oduflow.dev/v1alpha1
@@ -51,7 +58,13 @@ spec:
 
 @pytest.fixture(autouse=True)
 def allow_example_repo_urls():
-    with patch("oduflow.stack_ops.git_ops.validate_repo_url"):
+    with (
+        patch("oduflow.stack_ops.git_ops.validate_repo_url"),
+        patch(
+            "oduflow.stack_ops.system_ops.list_templates",
+            return_value=[{"template_name": "default", "db_loaded": True}],
+        ),
+    ):
         yield
 
 
@@ -110,6 +123,23 @@ def test_plan_new_stack_has_dependency_ordered_actions(
 
 @patch("oduflow.extra_addons.list_extra_repos", return_value=[])
 @patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.env_ops.list_environments", return_value=[])
+@patch("oduflow.stack_ops.service_ops.list_services", return_value=[])
+def test_plan_rejects_unavailable_template_before_apply(
+    _services, _envs, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+
+    with patch("oduflow.stack_ops.system_ops.list_templates", return_value=[]):
+        plan = build_plan(settings, team, manifest, path)
+
+    assert PlanAction(
+        "conflict", "environment", "template 'default' is not available"
+    ) in plan.actions
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
 @patch("oduflow.stack_ops.env_ops.list_environments")
 def test_plan_refuses_to_adopt_existing_environment(
     envs, _volumes, _repos, stack_fixture
@@ -156,6 +186,7 @@ def test_plan_is_empty_when_owned_environment_matches(
             "template_name": "default",
             "extra_addons": {},
             "odoo_image": "odoo:18.0",
+            "stack_sanitize": "true",
         }
     ]
     env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}
@@ -163,6 +194,111 @@ def test_plan_is_empty_when_owned_environment_matches(
     plan = build_plan(settings, team, manifest, path)
 
     assert plan.actions == ()
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.service_ops.list_services", return_value=[])
+@patch("oduflow.stack_ops.env_ops.get_environment_info")
+@patch("oduflow.stack_ops.env_ops.list_environments")
+def test_plan_treats_sanitize_change_as_immutable(
+    envs, env_info, _services, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    manifest.spec.extra_repositories = {}
+    manifest.spec.volumes = {}
+    manifest.spec.files = []
+    manifest.spec.services = {}
+    manifest.spec.environment.modules.install = []
+    envs.return_value = [
+        {
+            "env_name": "acme-dev",
+            "stack": "acme",
+            "stack_resource": "environment",
+            "repo_url": "https://github.com/acme/addons.git",
+            "git_branch": "main",
+            "template_name": "default",
+            "extra_addons": {},
+            "odoo_image": "odoo:18.0",
+            "stack_sanitize": "false",
+        }
+    ]
+    env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}
+
+    plan = build_plan(settings, team, manifest, path)
+
+    conflict = next(item for item in plan.actions if item.resource == "environment")
+    assert conflict.operation == "conflict"
+    assert "sanitize" in conflict.detail
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.env_ops.get_environment_info")
+@patch("oduflow.stack_ops.env_ops.list_environments")
+def test_plan_ignores_service_image_environment_defaults(
+    envs, env_info, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    manifest.spec.extra_repositories = {}
+    manifest.spec.volumes = {}
+    manifest.spec.files = []
+    manifest.spec.environment.modules.install = []
+    service = manifest.spec.services["fs"]
+    service.env = {"CACHE_SIZE": "256"}
+    service.volumes = []
+    envs.return_value = [
+        {
+            "env_name": "acme-dev",
+            "stack": "acme",
+            "stack_resource": "environment",
+            "repo_url": "https://github.com/acme/addons.git",
+            "git_branch": "main",
+            "template_name": "default",
+            "extra_addons": {},
+            "odoo_image": "odoo:18.0",
+            "stack_sanitize": "true",
+        }
+    ]
+    env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}
+    actual_service = {
+        "name": "fs",
+        "image": "example/fs:1",
+        "port": 8080,
+        "hostname": None,
+        "env_vars": {"CACHE_SIZE": "256", "IMAGE_VERSION": "1.0"},
+        "image_env_vars": {"IMAGE_VERSION": "1.0"},
+        "host_mode": False,
+        "volumes": [],
+        "cap_add": [],
+        "privileged": False,
+        "routes": [],
+        "stack": "acme",
+        "stack_resource": "services.fs",
+        "stack_spec_hash": _resource_hash(service),
+    }
+
+    with patch(
+        "oduflow.stack_ops.service_ops.list_services", return_value=[actual_service]
+    ):
+        plan = build_plan(settings, team, manifest, path)
+
+    assert plan.actions == ()
+
+
+def test_stack_file_comparison_uses_manifest_size_limit(stack_fixture):
+    settings, team, _manifest, _path = stack_fixture
+    content = "x" * 200_000
+
+    with patch(
+        "oduflow.stack_ops.volume_file_ops.read_file_in_volume",
+        return_value={"type": "file", "output": content},
+    ) as read_file:
+        assert _file_matches(settings, team, "fs-data", "large.conf", content)
+
+    read_file.assert_called_once_with(
+        settings, team, "fs-data", "large.conf", max_bytes=1_000_000
+    )
 
 
 def test_apply_preflights_conflicts_before_mutation(stack_fixture):


### PR DESCRIPTION
## Summary

- reject missing Stack templates and changed sanitization policy during preflight
- make service environment, volume-file, and route comparisons converge with runtime normalization
- validate every local file referenced by `oduflow stack validate`
- add regression coverage for all six review findings

## Root cause

The first Stack reconciler compared some declarative values against normalized or image-expanded Docker state, while a few creation-only inputs were not persisted or preflighted. The validation command also stopped after schema validation instead of checking local file references.

## Impact

Stack plans now refuse unsafe creation inputs before mutation and stop reporting false drift for valid service, route, and file configurations. Sanitization intent remains auditable on owned environments.

## Validation

- `pytest -m "not integration and not heavyweight" -q` — 2243 passed
- `ruff check src/oduflow tests`
- `mypy src/oduflow`
- `python scripts/build_llms_full.py --check`
- `git diff --check`
