### PR TITLE
Add structured template settings and validate module upgrades

### DIFF
--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -306,6 +306,9 @@ def _run_odoo_module_command(
             f"Environment '{env_name}' does not exist. Use create_environment first."
         )
 
+    if flag == "-u":
+        _require_upgradeable_modules(settings, team, env_name, modules)
+
     modules_str = ",".join(modules)
     cmd = f"/entrypoint.sh odoo -d {env_db} --stop-after-init --no-http {flag} {modules_str}"
 
@@ -323,6 +326,66 @@ def _run_odoo_module_command(
         "exit_code": exit_code,
         "output": output_str,
     }
+
+
+def _require_upgradeable_modules(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    modules: tuple[str, ...],
+) -> None:
+    """Fail before ``odoo -u`` when a requested module is not installed.
+
+    Odoo exits successfully when ``-u`` names an unknown or uninstalled module,
+    even though it does not upgrade it. Checking the database first prevents both
+    direct upgrades and ``pull_and_apply(upgrade=...)`` from reporting that no-op
+    as a success.
+    """
+    names = ", ".join(f"'{module}'" for module in modules)
+    result = run_db_query(
+        settings,
+        team,
+        env_name,
+        f"SELECT name, state FROM ir_module_module WHERE name IN ({names})",
+    )
+    states: dict[str, str] = {}
+    for row in result["output"].splitlines()[1:]:
+        name, separator, state = row.strip().partition(",")
+        if separator:
+            states[name] = state
+
+    unknown = [module for module in modules if module not in states]
+    if unknown:
+        module_list = ", ".join(unknown)
+        install_arg = ",".join(unknown)
+        subject = "Module" if len(unknown) == 1 else "Modules"
+        verb = "is" if len(unknown) == 1 else "are"
+        pronoun = "it is" if len(unknown) == 1 else "they are"
+        raise NotFoundError(
+            f"{subject} {module_list} {verb} unknown in environment '{env_name}' "
+            f"and cannot be upgraded. If {pronoun} new, install with "
+            "install_odoo_modules or "
+            f"pull_and_apply(install='{install_arg}')."
+        )
+
+    not_installed = [
+        f"{module} ({states[module]})"
+        for module in modules
+        if states[module] != "installed"
+    ]
+    if not_installed:
+        module_list = ", ".join(not_installed)
+        install_arg = ",".join(
+            module for module in modules if states[module] != "installed"
+        )
+        subject = "Module" if len(not_installed) == 1 else "Modules"
+        verb = "is" if len(not_installed) == 1 else "are"
+        pronoun = "it" if len(not_installed) == 1 else "them"
+        raise PrerequisiteNotMetError(
+            f"{subject} {module_list} {verb} not installed and cannot be upgraded. "
+            f"Install {pronoun} first with install_odoo_modules or "
+            f"pull_and_apply(install='{install_arg}')."
+        )
 
 
 def upgrade_odoo_modules(

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1875,7 +1875,10 @@ def upgrade_odoo_modules(
     env_name: str, modules: str, ctx: Context | None = None
 ) -> str:
     """
-    Upgrade Odoo modules in an environment.
+    Upgrade installed Odoo modules in an environment.
+
+    Unknown or uninstalled modules are rejected with a suggestion to use
+    install_odoo_modules or pull_and_apply(install=...) instead.
 
     Args:
         env_name: The name of the environment.

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -595,6 +595,27 @@
     line-height: 1.5;
     tab-size: 2;
   }
+  #tset-extra-addons { max-height: 190px; }
+  #template-settings-form .tag {
+    display: inline-block;
+    padding: 1px 7px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    font-size: var(--text-2xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+  }
+  .meta-facts {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 4px 14px;
+    margin: 0;
+    font-size: var(--text-xs);
+  }
+  .meta-facts dt { color: var(--text-dim); }
+  .meta-facts dd { margin: 0; color: var(--text); overflow-wrap: anywhere; }
   /* Unified large modal size (chat / terminals) — almost fullscreen, with margins */
   .modal-terminal, .modal-chat { width: 92vw; max-width: 92vw; height: 90vh; max-height: 90vh; }
   /* --- ACP chat (chat.js) — Engineer's Console tokens only (DESIGN.md) --- */
@@ -1171,6 +1192,12 @@
   .check-list { max-height: 120px; overflow-y: auto; padding: 4px 0; }
   .check-item { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: var(--text-sm); cursor: pointer; }
   .branch-input { width: 100px; font-size: var(--text-xs); padding: 2px 6px; margin-left: auto; }
+  /* Checkbox rows live inside a .form-group, whose label rule would otherwise
+     turn them into full-width blocks and stretch the branch input. */
+  .form-group .check-item { display: flex; margin-bottom: 0; font-weight: 400; }
+  .form-group input.branch-input { width: 120px; flex: 0 0 auto; padding: 2px 6px; font-size: var(--text-xs); }
+  /* Long repo URLs truncate instead of scrolling the row sideways. */
+  .form-group .check-item > .hint { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .section-subtitle { font-size: var(--text-md); font-weight: 600; margin-bottom: 10px; color: var(--text-dim); }
   .modal-note { font-size: var(--text-sm); color: var(--text-dim); margin-bottom: 16px; }
   .modal-note a { color: var(--accent); }
@@ -1798,12 +1825,59 @@
     </div>
     <div class="modal-body">
       <div class="form-error" id="template-settings-error"></div>
-      <div class="form-group">
+      <div class="hint" id="template-settings-loading">Loading metadata.json...</div>
+      <div id="template-settings-form" style="display:none;">
+        <div class="form-group">
+          <label for="tset-image">Odoo image</label>
+          <input type="text" id="tset-image" placeholder="e.g. odoo:19.0">
+        </div>
+        <div class="form-group">
+          <label for="tset-repo">Repository URL</label>
+          <input type="text" id="tset-repo" placeholder="https://github.com/owner/repo.git">
+        </div>
+        <div class="form-group">
+          <label for="tset-local-path">Live-mount path</label>
+          <input type="text" id="tset-local-path" placeholder="/path/to/local/checkout">
+          <div class="hint">Used instead of a repository URL when local live-mounts are enabled. Leave empty to drop the setting.</div>
+        </div>
+        <div class="form-group">
+          <label for="tset-git-user">Git credential</label>
+          <select id="tset-git-user">
+            <option value="">— None —</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Extra addons repos</label>
+          <div id="tset-extra-addons" class="check-list"></div>
+          <div class="hint">Checked repos are mounted into environments created from this template. Each one needs a branch.</div>
+        </div>
+        <div class="form-group">
+          <label for="tset-auto-install">Auto-install modules</label>
+          <input type="text" id="tset-auto-install" placeholder="e.g. sale,purchase,stock">
+          <div class="hint">Comma-separated list of modules to install after provisioning</div>
+        </div>
+        <div class="form-group">
+          <label for="tset-overlay">Filestore mode</label>
+          <select id="tset-overlay">
+            <option value="auto">Auto — decide from filestore size</option>
+            <option value="overlay">Overlay (fuse-overlayfs)</option>
+            <option value="copy">Copy</option>
+          </select>
+          <div class="hint">How environments created from this template get their filestore.</div>
+        </div>
+        <div class="form-group" id="tset-facts-group" style="display:none;">
+          <label>Provenance</label>
+          <dl class="meta-facts" id="tset-facts"></dl>
+          <div class="hint">Recorded when the template was created. Read-only here; edit it in raw JSON if needed.</div>
+        </div>
+      </div>
+      <div class="form-group" id="template-settings-raw-group" style="display:none;">
         <label for="template-metadata-editor">metadata.json</label>
         <textarea id="template-metadata-editor" rows="18" spellcheck="false" autocomplete="off" aria-describedby="template-metadata-hint" disabled></textarea>
         <div class="hint" id="template-metadata-hint">This is the complete template metadata file. Changes affect environments created from this template.</div>
       </div>
       <div class="form-actions">
+        <button class="btn" id="template-settings-mode" style="margin-right:auto;" onclick="toggleTemplateSettingsMode()" disabled>Edit raw JSON</button>
         <button class="btn" onclick="closeTemplateSettingsModal()">Cancel</button>
         <button class="btn-create" id="template-settings-submit" onclick="submitTemplateSettings()" disabled>Save settings</button>
       </div>
@@ -2745,6 +2819,16 @@ function escAttr(s) {
     .replace(/>/g, '&gt;');
 }
 
+// Safe for plain double-quoted HTML attributes. Unlike escAttr, this does not
+// add JavaScript-string backslashes, so form values round-trip unchanged.
+function escHtmlAttr(s) {
+  return String(s || '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function isAmbiguousGatewayStatus(status) {
   return [408, 502, 503, 504, 524].indexOf(status) !== -1;
 }
@@ -3425,41 +3509,273 @@ var _renameTplName = '';
 var _templateSettingsName = '';
 var _templateSettingsRevision = '';
 var _templateSettingsLoadToken = 0;
+// Parsed metadata.json as loaded/last applied. Saving merges the form fields
+// into this object so keys the form does not know about survive a round-trip.
+var _templateSettingsMeta = {};
+var _templateSettingsRawMode = false;
+
+// Provenance and size keys: recorded by the import/snapshot code, not editable
+// in the form (raw JSON mode can still change them).
+var TSET_FACTS = [
+  ['source', 'Source'],
+  ['source_url', 'Source URL'],
+  ['source_db', 'Source database'],
+  ['source_repository', 'Source repository'],
+  ['source_revision', 'Source revision'],
+  ['source_branch', 'Source branch'],
+  ['source_commit', 'Source commit'],
+  ['snapshot_at', 'Snapshot at'],
+  ['backup_datetime_utc', 'Backup (UTC)'],
+  ['odoo_version', 'Odoo version'],
+  ['pg_version', 'PostgreSQL version'],
+  ['includes_filestore', 'Includes filestore'],
+  ['filestore_size_mb', 'Filestore size (MB)'],
+  ['dump_size_mb', 'Dump size (MB)']
+];
+
+function _tsetNormalizeExtras(raw) {
+  // Mirrors _normalize_extra_addons on the server: only the {name: branch}
+  // dict form carries branch information; the legacy list form is dropped.
+  var extras = Object.create(null);
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return extras;
+  Object.keys(raw).forEach(function(name) {
+    var branch = raw[name];
+    extras[name] = (typeof branch === 'string') ? branch : '';
+  });
+  return extras;
+}
+
+function _tsetBranchOptions(branches) {
+  var seen = Object.create(null);
+  var out = [];
+  (branches || []).forEach(function(b) {
+    var name = (b || '').indexOf('origin/') === 0 ? b.slice(7) : b;
+    if (!name || name === 'HEAD' || seen[name]) return;
+    seen[name] = true;
+    out.push(name);
+  });
+  return out;
+}
+
+function _tsetExtraRow(name, repoUrl, branches, extras, idx, missing) {
+  var checked = Object.prototype.hasOwnProperty.call(extras, name);
+  var branch = checked ? (extras[name] || '') : '';
+  var listId = 'tset-branches-' + idx;
+  var options = _tsetBranchOptions(branches);
+  var note = missing
+    ? ' <span class="tag tag-missing" title="Referenced by this template but not registered as an extra repo">missing</span>'
+    : (repoUrl ? ' <span class="hint" style="margin-top:0;">(' + esc(repoUrl) + ')</span>' : '');
+  return '<label class="check-item">' +
+    '<input type="checkbox" class="tset-extra-cb" value="' + escHtmlAttr(name) + '"' + (checked ? ' checked' : '') + '>' +
+    esc(name) + note +
+    '<input type="text" class="tset-extra-branch branch-input" data-repo="' + escHtmlAttr(name) + '"' +
+      ' placeholder="branch" list="' + listId + '" value="' + escHtmlAttr(branch) + '">' +
+    (options.length
+      ? '<datalist id="' + listId + '">' + options.map(function(b) {
+          return '<option value="' + escHtmlAttr(b) + '"></option>';
+        }).join('') + '</datalist>'
+      : '') +
+  '</label>';
+}
+
+function _tsetRenderExtraAddons(extras) {
+  var container = document.getElementById('tset-extra-addons');
+  var repos = cachedExtraRepos || [];
+  var known = Object.create(null);
+  var rows = repos.map(function(r, i) {
+    known[r.name] = true;
+    return _tsetExtraRow(r.name, r.repo_url, r.branches, extras, i, false);
+  });
+  Object.keys(extras).forEach(function(name, i) {
+    if (!known[name]) rows.push(_tsetExtraRow(name, '', [], extras, 'x' + i, true));
+  });
+  container.innerHTML = rows.length
+    ? rows.join('')
+    : '<span class="hint" style="margin-top:0;">No extra repos available</span>';
+}
+
+function _tsetRenderCredentials(current) {
+  var sel = document.getElementById('tset-git-user');
+  var html = '<option value="">— None —</option>';
+  var found = false;
+  (cachedCredentials || []).forEach(function(c) {
+    if (c.username === current) found = true;
+    html += '<option value="' + escHtmlAttr(c.username) + '">' + esc(c.username) + ' (' + esc(c.host) + ')</option>';
+  });
+  if (current && !found) {
+    html += '<option value="' + escHtmlAttr(current) + '">' + esc(current) + ' (not configured)</option>';
+  }
+  sel.innerHTML = html;
+  sel.value = current || '';
+}
+
+function _tsetRenderFacts(meta) {
+  var rows = [];
+  TSET_FACTS.forEach(function(entry) {
+    var key = entry[0];
+    if (!(key in meta)) return;
+    var value = meta[key];
+    if (value === null || value === '' || typeof value === 'object') return;
+    rows.push('<dt>' + esc(entry[1]) + '</dt><dd>' + esc(String(value)) + '</dd>');
+  });
+  var modules = meta.modules;
+  if (modules && typeof modules === 'object') {
+    var count = Array.isArray(modules) ? modules.length : Object.keys(modules).length;
+    rows.push('<dt>Installed modules</dt><dd>' + count + '</dd>');
+  }
+  document.getElementById('tset-facts').innerHTML = rows.join('');
+  document.getElementById('tset-facts-group').style.display = rows.length ? '' : 'none';
+}
+
+function _tsetFillForm(meta) {
+  document.getElementById('tset-image').value = meta.odoo_image || '';
+  document.getElementById('tset-repo').value = meta.repo_url || '';
+  document.getElementById('tset-local-path').value = meta.local_path || '';
+  document.getElementById('tset-auto-install').value = meta.auto_install_modules || '';
+  var overlay = meta.use_overlay;
+  document.getElementById('tset-overlay').value =
+    overlay === true ? 'overlay' : (overlay === false ? 'copy' : 'auto');
+  _tsetRenderCredentials(meta.git_user || '');
+  _tsetRenderExtraAddons(_tsetNormalizeExtras(meta.extra_addons));
+  _tsetRenderFacts(meta);
+}
+
+// Merge the form back into the loaded metadata. Returns null (and shows the
+// error) when a checked extra repo has no branch.
+function _tsetCollectForm() {
+  var errEl = document.getElementById('template-settings-error');
+  var extras = Object.create(null);
+  var missingBranch = [];
+  document.querySelectorAll('.tset-extra-cb:checked').forEach(function(cb) {
+    var repoName = cb.value;
+    var input = document.querySelector('.tset-extra-branch[data-repo="' + repoName + '"]');
+    var branch = input ? input.value.trim() : '';
+    if (!branch) { missingBranch.push(repoName); }
+    else { extras[repoName] = branch; }
+  });
+  if (missingBranch.length) {
+    errEl.textContent = 'Branch is required for extra addon(s): ' + missingBranch.join(', ') + '.';
+    errEl.style.display = 'block';
+    return null;
+  }
+
+  var meta = Object.assign(Object.create(null), _templateSettingsMeta);
+  meta.odoo_image = document.getElementById('tset-image').value.trim();
+  meta.repo_url = document.getElementById('tset-repo').value.trim();
+  meta.git_user = document.getElementById('tset-git-user').value;
+  meta.auto_install_modules = document.getElementById('tset-auto-install').value.trim();
+  meta.extra_addons = extras;
+  var localPath = document.getElementById('tset-local-path').value.trim();
+  if (localPath) { meta.local_path = localPath; }
+  else { delete meta.local_path; }
+  var overlay = document.getElementById('tset-overlay').value;
+  meta.use_overlay = overlay === 'overlay' ? true : (overlay === 'copy' ? false : null);
+  errEl.style.display = 'none';
+  return meta;
+}
+
+function _tsetSetMode(rawMode) {
+  _templateSettingsRawMode = rawMode;
+  document.getElementById('template-settings-form').style.display = rawMode ? 'none' : '';
+  document.getElementById('template-settings-raw-group').style.display = rawMode ? '' : 'none';
+  document.getElementById('template-settings-mode').textContent =
+    rawMode ? 'Back to form' : 'Edit raw JSON';
+}
+
+function toggleTemplateSettingsMode() {
+  var editor = document.getElementById('template-metadata-editor');
+  var errEl = document.getElementById('template-settings-error');
+  if (!_templateSettingsRawMode) {
+    var collected = _tsetCollectForm();
+    if (!collected) return;
+    editor.value = JSON.stringify(collected, null, 2) + '\n';
+    _tsetSetMode(true);
+    editor.focus();
+    return;
+  }
+  var parsed;
+  try {
+    parsed = JSON.parse(editor.value);
+  } catch (e) {
+    errEl.textContent = 'Invalid JSON: ' + e.message;
+    errEl.style.display = 'block';
+    editor.focus();
+    return;
+  }
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+    errEl.textContent = 'Template metadata must be a JSON object.';
+    errEl.style.display = 'block';
+    editor.focus();
+    return;
+  }
+  errEl.style.display = 'none';
+  _templateSettingsMeta = parsed;
+  _tsetFillForm(parsed);
+  _tsetSetMode(false);
+}
 
 async function openTemplateSettingsModal(name) {
   _templateSettingsName = name;
   _templateSettingsRevision = '';
+  _templateSettingsMeta = {};
   var token = ++_templateSettingsLoadToken;
   var editor = document.getElementById('template-metadata-editor');
   var errEl = document.getElementById('template-settings-error');
   var btn = document.getElementById('template-settings-submit');
+  var modeBtn = document.getElementById('template-settings-mode');
   document.getElementById('template-settings-title').textContent = 'Template settings — ' + name;
-  editor.value = 'Loading metadata.json...';
+  document.getElementById('template-settings-loading').style.display = '';
+  document.getElementById('template-settings-form').style.display = 'none';
+  document.getElementById('template-settings-raw-group').style.display = 'none';
+  editor.value = '';
   editor.disabled = true;
   btn.disabled = true;
   btn.textContent = 'Save settings';
+  modeBtn.disabled = true;
+  _templateSettingsRawMode = false;
   errEl.style.display = 'none';
   errEl.textContent = '';
   showModal('template-settings-modal');
 
+  // The pickers need the same lists the create-environment modal uses.
+  var lists = Promise.all([loadExtraRepos(), loadCredentials()]);
   try {
     var r = await fetch(API_TEMPLATES + '/' + encodeURIComponent(name) + '/metadata');
     var data = await readResult(r);
+    await lists;
     if (token !== _templateSettingsLoadToken) return;
-    if (data.ok) {
-      editor.value = data.content;
-      _templateSettingsRevision = data.revision;
-      editor.disabled = false;
-      btn.disabled = false;
-      editor.focus();
-    } else {
-      editor.value = '';
+    document.getElementById('template-settings-loading').style.display = 'none';
+    if (!data.ok) {
       errEl.textContent = data.error || 'Failed to load template settings';
       errEl.style.display = 'block';
+      return;
     }
+    _templateSettingsRevision = data.revision;
+    editor.value = data.content;
+    editor.disabled = false;
+    btn.disabled = false;
+    modeBtn.disabled = false;
+    var parsed = null;
+    try {
+      parsed = JSON.parse(data.content);
+    } catch (e) {
+      parsed = null;
+    }
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+      // Broken metadata: open the raw editor so it can be repaired.
+      _tsetSetMode(true);
+      errEl.textContent = 'metadata.json is not a valid JSON object. Repair it here, then switch back to the form.';
+      errEl.style.display = 'block';
+      editor.focus();
+      return;
+    }
+    _templateSettingsMeta = parsed;
+    _tsetFillForm(parsed);
+    _tsetSetMode(false);
+    document.getElementById('tset-image').focus();
   } catch (e) {
     if (token !== _templateSettingsLoadToken) return;
-    editor.value = '';
+    document.getElementById('template-settings-loading').style.display = 'none';
     errEl.textContent = 'Connection error: ' + e.message;
     errEl.style.display = 'block';
   }
@@ -3478,17 +3794,24 @@ async function submitTemplateSettings() {
   var name = _templateSettingsName;
   var revision = _templateSettingsRevision;
   var token = _templateSettingsLoadToken;
-  var content = editor.value;
-  try {
-    var parsed = JSON.parse(content);
-    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
-      throw new Error('Template metadata must be a JSON object.');
+  var content;
+  if (_templateSettingsRawMode) {
+    content = editor.value;
+    try {
+      var parsed = JSON.parse(content);
+      if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+        throw new Error('Template metadata must be a JSON object.');
+      }
+    } catch (e) {
+      errEl.textContent = 'Invalid JSON: ' + e.message;
+      errEl.style.display = 'block';
+      editor.focus();
+      return;
     }
-  } catch (e) {
-    errEl.textContent = 'Invalid JSON: ' + e.message;
-    errEl.style.display = 'block';
-    editor.focus();
-    return;
+  } else {
+    var collected = _tsetCollectForm();
+    if (!collected) return;
+    content = JSON.stringify(collected, null, 2) + '\n';
   }
 
   errEl.style.display = 'none';
@@ -3508,6 +3831,11 @@ async function submitTemplateSettings() {
     if (data.ok) {
       editor.value = data.content;
       _templateSettingsRevision = data.revision;
+      try {
+        _templateSettingsMeta = JSON.parse(data.content);
+      } catch (e) {
+        _templateSettingsMeta = {};
+      }
       showToast('Template "' + name + '" settings saved');
       closeTemplateSettingsModal();
       await loadTemplates();

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3648,7 +3648,8 @@ function _tsetCollectForm() {
   var missingBranch = [];
   document.querySelectorAll('.tset-extra-cb:checked').forEach(function(cb) {
     var repoName = cb.value;
-    var input = document.querySelector('.tset-extra-branch[data-repo="' + repoName + '"]');
+    var row = cb.closest('.check-item');
+    var input = row ? row.querySelector('.tset-extra-branch') : null;
     var branch = input ? input.value.trim() : '';
     if (!branch) { missingBranch.push(repoName); }
     else { extras[repoName] = branch; }

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1733,7 +1733,11 @@ class TestInstallModules:
 
 
 class TestUpgradeModules:
-    def test_upgrade(self, mock_docker_client):
+    @patch(
+        "oduflow.docker_ops.odoo_ops.run_db_query",
+        return_value={"exit_code": 0, "output": "name,state\nsale,installed\n"},
+    )
+    def test_upgrade(self, mock_query, mock_docker_client):
         container = MagicMock()
         container.exec_run.return_value = (0, b"OK")
         mock_docker_client.containers.get.return_value = container
@@ -1744,6 +1748,36 @@ class TestUpgradeModules:
         args = container.exec_run.call_args[0][0]
         assert "-d oduflow_1_main" in args
         assert "-u sale" in args
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.run_db_query",
+        return_value={"exit_code": 0, "output": "name,state\nwebsite,uninstalled\n"},
+    )
+    def test_uninstalled_module_is_refused(self, mock_query, mock_docker_client):
+        container = MagicMock()
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(
+            PrerequisiteNotMetError, match="not installed.*install_odoo_modules"
+        ):
+            odoo_ops.upgrade_odoo_modules(TEST_SETTINGS, TEST_TEAM, "main", "website")
+
+        container.exec_run.assert_not_called()
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.run_db_query",
+        return_value={"exit_code": 0, "output": "name,state\n"},
+    )
+    def test_unknown_module_is_refused(self, mock_query, mock_docker_client):
+        container = MagicMock()
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(NotFoundError, match="unknown.*install_odoo_modules"):
+            odoo_ops.upgrade_odoo_modules(
+                TEST_SETTINGS, TEST_TEAM, "main", "not_a_module"
+            )
+
+        container.exec_run.assert_not_called()
 
 
 class TestRunEnvironmentTests:
@@ -2232,6 +2266,28 @@ class TestApplyActionsConf:
         container.restart.assert_called_once()
         assert result["action"] == "upgrade"
         assert "Reapplied odoo.conf." in result["message"]
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.upgrade_odoo_modules",
+        side_effect=PrerequisiteNotMetError("module is not installed"),
+    )
+    def test_rejected_upgrade_does_not_restart(self, mock_upgrade):
+        client, container = self._client_with_container()
+
+        with pytest.raises(PrerequisiteNotMetError, match="not installed"):
+            env_ops._apply_actions(
+                client,
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "feature/x",
+                "oduflow-1-feature-x-odoo",
+                to_install=[],
+                to_upgrade=["website"],
+                do_restart=False,
+                changed_files=[],
+            )
+
+        container.restart.assert_not_called()
 
 
 class TestApplyActionsDeps:

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -185,9 +185,32 @@ var fields = {
   'tset-local-path': {value: ''},
   'tset-overlay': {value: 'auto'}
 };
+function checkbox(value, branch) {
+  return {
+    value: value,
+    closest: function (selector) {
+      if (selector !== '.check-item') throw new Error('Unexpected row selector');
+      return {
+        querySelector: function (inputSelector) {
+          if (inputSelector !== '.tset-extra-branch') {
+            throw new Error('Unexpected input selector');
+          }
+          return {value: branch};
+        }
+      };
+    }
+  };
+}
 global.document = {
-  querySelectorAll: function () { return [{value: '__proto__'}]; },
-  querySelector: function () { return {value: "feature'quote"}; },
+  querySelectorAll: function () {
+    return [
+      checkbox('__proto__', "feature'quote"),
+      checkbox('missing"repo\\name', 'release\\candidate')
+    ];
+  },
+  querySelector: function () {
+    throw new Error('Repository names must not be interpolated into selectors');
+  },
   getElementById: function (id) { return fields[id]; }
 };
 var _templateSettingsMeta = JSON.parse(
@@ -215,7 +238,10 @@ process.stdout.write(JSON.stringify({
             "repo_url": "https://example.test/addons.git",
             "git_user": "O'Reilly",
             "auto_install_modules": "",
-            "extra_addons": {"__proto__": "feature'quote"},
+            "extra_addons": {
+                "__proto__": "feature'quote",
+                'missing"repo\\name': "release\\candidate",
+            },
             "use_overlay": None,
         },
     }

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -2,14 +2,49 @@
 
 from __future__ import annotations
 
+import json
 import re
+import shutil
+import subprocess
+from pathlib import Path
 
+import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import mount_web_ui
+
+_DASHBOARD = (
+    Path(__file__).parents[1] / "src" / "oduflow" / "templates" / "dashboard.html"
+)
+
+
+def _js_function(source: str, name: str) -> str:
+    """Extract one top-level dashboard function for a focused Node harness."""
+    start = source.index(f"function {name}(")
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JavaScript function {name}")
+
+
+def _run_node(source: str) -> dict[str, object]:
+    result = subprocess.run(
+        ["node", "-"],
+        input=source,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
 
 
 def _client(tmp_path) -> TestClient:
@@ -129,3 +164,55 @@ def test_odoo_sh_import_exposes_best_effort_addon_policy(tmp_path):
         "addon_error_policy: document.getElementById('import-best-effort').checked "
         "? 'best_effort' : 'strict'" in dashboard
     )
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_template_settings_form_round_trips_attribute_and_prototype_key_values():
+    dashboard = _DASHBOARD.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _js_function(dashboard, name)
+        for name in ("escHtmlAttr", "_tsetNormalizeExtras", "_tsetCollectForm")
+    )
+    harness = functions + r"""
+var fields = {
+  'template-settings-error': {style: {}},
+  'tset-image': {value: 'odoo:19.0'},
+  'tset-repo': {value: 'https://example.test/addons.git'},
+  'tset-git-user': {value: "O'Reilly"},
+  'tset-auto-install': {value: ''},
+  'tset-local-path': {value: ''},
+  'tset-overlay': {value: 'auto'}
+};
+global.document = {
+  querySelectorAll: function () { return [{value: '__proto__'}]; },
+  querySelector: function () { return {value: "feature'quote"}; },
+  getElementById: function (id) { return fields[id]; }
+};
+var _templateSettingsMeta = JSON.parse(
+  '{"__proto__":{"keep":true},"custom":{"preserved":true}}'
+);
+var normalized = _tsetNormalizeExtras(JSON.parse(
+  '{"__proto__":"main","constructor":"stable"}'
+));
+var collected = _tsetCollectForm();
+process.stdout.write(JSON.stringify({
+  escaped: escHtmlAttr("feature'quote&\"<>"),
+  normalized: normalized,
+  collected: collected
+}));
+"""
+
+    assert _run_node(harness) == {
+        "escaped": "feature'quote&amp;&quot;&lt;&gt;",
+        "normalized": {"__proto__": "main", "constructor": "stable"},
+        "collected": {
+            "__proto__": {"keep": True},
+            "custom": {"preserved": True},
+            "odoo_image": "odoo:19.0",
+            "repo_url": "https://example.test/addons.git",
+            "git_user": "O'Reilly",
+            "auto_install_modules": "",
+            "extra_addons": {"__proto__": "feature'quote"},
+            "use_overlay": None,
+        },
+    }

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -173,7 +173,9 @@ def test_template_settings_form_round_trips_attribute_and_prototype_key_values()
         _js_function(dashboard, name)
         for name in ("escHtmlAttr", "_tsetNormalizeExtras", "_tsetCollectForm")
     )
-    harness = functions + r"""
+    harness = (
+        functions
+        + r"""
 var fields = {
   'template-settings-error': {style: {}},
   'tset-image': {value: 'odoo:19.0'},
@@ -201,6 +203,7 @@ process.stdout.write(JSON.stringify({
   collected: collected
 }));
 """
+    )
 
     assert _run_node(harness) == {
         "escaped": "feature'quote&amp;&quot;&lt;&gt;",


### PR DESCRIPTION
## Summary

- replace the raw-JSON-only template settings flow with a structured form
- preserve unknown metadata fields and retain raw JSON editing for advanced repairs
- safely handle repository names containing quotes, backslashes, apostrophes, or JavaScript prototype keys
- reject unknown or uninstalled modules before `upgrade_odoo_modules` or `pull_and_apply(upgrade=...)` can report a false success

## Why

Operators need a safer way to edit common template metadata without losing advanced fields. During review, repository names containing JavaScript-sensitive characters also exposed a selector construction bug.

Separately, Odoo exits with code 0 when `-u` targets an unknown or uninstalled module, even though no upgrade occurs. Oduflow previously treated that no-op as a successful upgrade.

## Impact

Template settings can be edited through structured controls while provenance and advanced raw metadata remain available. Module upgrades now validate database state first: installed modules proceed, while unknown or uninstalled modules fail with an installation hint and do not restart the environment.

## Validation

- `ruff format --check src/oduflow tests`
- `ruff check src/oduflow tests`
- `mypy src/oduflow`
- `pytest -m 'not integration and not heavyweight'` (2,248 passed, 15 deselected)
- live Odoo 19 comparison of installed, uninstalled, and unknown module upgrade behavior
