### PR TITLE
Harden legacy Stack sanitization drift

### DIFF
--- a/src/oduflow/stack_ops.py
+++ b/src/oduflow/stack_ops.py
@@ -97,9 +97,7 @@ def _environment_labels(stack: str, manifest: StackManifest) -> dict[str, str]:
     return labels
 
 
-def _environment_hash_with_sanitize(
-    manifest: StackManifest, sanitize: bool
-) -> str:
+def _environment_hash_with_sanitize(manifest: StackManifest, sanitize: bool) -> str:
     value = manifest.spec.environment.model_dump(mode="json", by_alias=True)
     value.pop("modules", None)
     value["sanitize"] = sanitize
@@ -203,9 +201,7 @@ def _file_matches(
     return "error" not in result and result.get("output") == expected
 
 
-def _service_env_matches(
-    actual: Mapping[str, Any], desired: Mapping[str, str]
-) -> bool:
+def _service_env_matches(actual: Mapping[str, Any], desired: Mapping[str, str]) -> bool:
     """Compare declared values while ignoring untouched image defaults."""
     effective = actual.get("env_vars", {})
     image_defaults = actual.get("image_env_vars", {})
@@ -331,14 +327,16 @@ def build_plan(
         if actual_env.get("extra_addons", {}) != desired_extras:
             immutable_drift.append("extraRepositories")
         actual_sanitize = actual_env.get("stack_sanitize", "")
-        sanitize_changed = (
-            actual_sanitize in ("true", "false")
-            and (actual_sanitize == "true") != desired_env.sanitize
-        )
-        if not actual_sanitize and actual_env.get("stack_spec_hash"):
+        if actual_sanitize in ("true", "false"):
+            sanitize_changed = (actual_sanitize == "true") != desired_env.sanitize
+        else:
+            # Older Stack environments predate the explicit policy label. Their
+            # spec hash can prove the current manifest has the same policy, but
+            # any other mismatch is ambiguous: sanitization happens only during
+            # creation, so never stamp a policy through an ordinary update.
             sanitize_changed = actual_env.get(
                 "stack_spec_hash"
-            ) == _environment_hash_with_sanitize(manifest, not desired_env.sanitize)
+            ) != _environment_hash_with_sanitize(manifest, desired_env.sanitize)
         if sanitize_changed:
             immutable_drift.append("sanitize")
         if immutable_drift:

--- a/tests/test_stack_ops.py
+++ b/tests/test_stack_ops.py
@@ -10,6 +10,7 @@ from oduflow.stack_models import ServiceRoute, ValueFrom
 from oduflow.stack_ops import (
     PlanAction,
     StackPlan,
+    _environment_hash_with_sanitize,
     _file_matches,
     _resource_hash,
     apply_stack,
@@ -133,9 +134,10 @@ def test_plan_rejects_unavailable_template_before_apply(
     with patch("oduflow.stack_ops.system_ops.list_templates", return_value=[]):
         plan = build_plan(settings, team, manifest, path)
 
-    assert PlanAction(
-        "conflict", "environment", "template 'default' is not available"
-    ) in plan.actions
+    assert (
+        PlanAction("conflict", "environment", "template 'default' is not available")
+        in plan.actions
+    )
 
 
 @patch("oduflow.extra_addons.list_extra_repos", return_value=[])
@@ -221,6 +223,44 @@ def test_plan_treats_sanitize_change_as_immutable(
             "extra_addons": {},
             "odoo_image": "odoo:18.0",
             "stack_sanitize": "false",
+        }
+    ]
+    env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}
+
+    plan = build_plan(settings, team, manifest, path)
+
+    conflict = next(item for item in plan.actions if item.resource == "environment")
+    assert conflict.operation == "conflict"
+    assert "sanitize" in conflict.detail
+
+
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.service_ops.list_services", return_value=[])
+@patch("oduflow.stack_ops.env_ops.get_environment_info")
+@patch("oduflow.stack_ops.env_ops.list_environments")
+def test_plan_refuses_ambiguous_legacy_sanitize_drift(
+    envs, env_info, _services, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    manifest.spec.extra_repositories = {}
+    manifest.spec.volumes = {}
+    manifest.spec.files = []
+    manifest.spec.services = {}
+    manifest.spec.environment.modules.install = []
+    legacy = manifest.model_copy(deep=True)
+    legacy.spec.environment.odoo_image = "odoo:17.0"
+    envs.return_value = [
+        {
+            "env_name": "acme-dev",
+            "stack": "acme",
+            "stack_resource": "environment",
+            "stack_spec_hash": _environment_hash_with_sanitize(legacy, True),
+            "repo_url": "https://github.com/acme/addons.git",
+            "git_branch": "main",
+            "template_name": "default",
+            "extra_addons": {},
+            "odoo_image": "odoo:17.0",
         }
     ]
     env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}


### PR DESCRIPTION
## Summary

- refuse ambiguous sanitization policy drift on legacy Stack environments
- add regression coverage for simultaneous legacy image and sanitization drift
- apply the Ruff formatting required by the lint job on the already-merged #185

## Root cause

Environments created by the initial Stack implementation have a spec hash but no explicit `oduflow.stack-sanitize` label. If another hashed field changed alongside `sanitize`, neither policy hash matched and the planner previously inferred that sanitization had not changed. An ordinary environment update could then stamp the new policy even though sanitization only runs during creation.

## Impact

A legacy environment is now accepted only when its old spec hash proves the current sanitization policy. Any ambiguous mismatch is replacement-only drift, preventing an unsanitized database from being reported as converged under `sanitize: true`.

## Validation

- `pytest -m "not integration and not heavyweight" -q` — 2244 passed
- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow tests`
- `mypy src/oduflow`
- `python scripts/build_llms_full.py --check`
- `git diff --check`
