### PR TITLE
Fix flaky chunkstore incremental backup test

### DIFF
--- a/tests/test_chunkstore.py
+++ b/tests/test_chunkstore.py
@@ -193,7 +193,7 @@ class TestBackupRestore:
         src = tmp_path / "src"
         _make_tree(str(src), spec)
 
-        chunkstore.backup(str(src), small_config_storage, "erp")
+        first = chunkstore.backup(str(src), small_config_storage, "erp")
 
         counting = CountingStorage(small_config_storage)
         # Change ONE file.
@@ -202,9 +202,12 @@ class TestBackupRestore:
         result = chunkstore.backup(str(src), counting, "erp")
         assert result.revision == 2
         assert result.unchanged_files == 9
-        # Only the changed file's chunks + metadata chunks are uploaded.
-        assert result.new_chunks <= 8
-        assert counting.counts["put"] <= 10  # chunks + revision file
+        # Only the changed file's chunks + metadata chunks are uploaded — a
+        # small fraction of the full backup's ~50 KB of incompressible data.
+        # Chunk *counts* are seed-dependent (the store seed is random and
+        # file mtimes shift metadata chunk boundaries), so assert on bytes.
+        assert result.uploaded_bytes < first.uploaded_bytes / 3
+        assert counting.counts["put"] == result.new_chunks + 1  # + revision file
 
         # Both revisions restore correctly.
         dst = tmp_path / "dst"


### PR DESCRIPTION
## Problem

`tests/test_chunkstore.py::TestBackupRestore::test_incremental_skips_unchanged` fails intermittently in CI:

```
assert result.new_chunks <= 8
AssertionError: assert 9 <= 8
```

The test asserted on exact chunk counts, which are not deterministic:

1. `ensure_config` generates a random chunker seed per store (`secrets.token_bytes(32)`), so CDC chunk boundaries differ on every run.
2. File mtimes are part of the metadata JSON, so metadata chunk boundaries shift too — even a fixed seed would not make the counts stable.

Observed `new_chunks` across repeated runs: 4–9. CI failed on the runs that drew 9.

## Fix

Replace the count-based assertions with invariants that hold for any seed:

- `result.uploaded_bytes < first.uploaded_bytes / 3` — the incremental backup uploads ~5.6–6.3 KB against a ~17 KB threshold, while a dedup regression would re-upload the full ~51 KB.
- `counting.counts["put"] == result.new_chunks + 1` — exact equality (one `put` per new chunk in `backup.py:84`, plus the revision file in `backup.py:423`), stricter than the old `put <= 10` upper bound.

`revision == 2`, `unchanged_files == 9` and the restore check are unchanged. The random seed is kept deliberately: it fuzzes the chunker for free now that the assertions are seed-independent.

## Verification

- `pytest tests/test_chunkstore.py` — 104 passed
- 60 repeated runs of the previously flaky test (fresh random seed each run) — 0 failures
- Full unit suite — 2248 passed
- `ruff check src/oduflow tests` and `ruff format --check` clean