### PR TITLE
Report a translation verdict instead of raw catalogues

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3051,7 +3051,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
 | `upgrade_odoo_modules` | ✓ | Upgrade Odoo modules (`-u`) |
 | `export_module_translations` | ✓ | Export a module's `.pot`/`.po` with Odoo's own exporter, write it into the module's `i18n/`, and return a summary plus an HTTP download URL or local temporary path |
-| `translation_status` | ✓ | Compare a module's terms, database translations and committed `.po` files, including the sibling-POT metadata merge Odoo performs before import |
+| `translation_status` | ✓ | Verdict per language (OK, PARTIAL, NOT LOADED, NOT TRANSLATED, IMPORT SILENTLY DROPPED, IMPORT ABORTS, NO FILE, NOT ACTIVATED) from the module's terms, the database and the committed `.po` files, including the sibling-POT metadata merge Odoo performs before import, plus the call that fixes it |
 | `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `test_tags` narrows the run to one class or method, `upgrade=False` skips the `-u` for a fast re-run (collects `post_install` tests only and requires module-scoped positive tags) |
 | `get_environment_logs` | | Retrieve recent container logs |
 | `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -20,7 +20,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
 | `upgrade_odoo_modules` | ✓ | Upgrade Odoo modules (`-u`) |
 | `export_module_translations` | ✓ | Export a module's `.pot`/`.po` with Odoo's own exporter, write it into the module's `i18n/`, and return a summary plus an HTTP download URL or local temporary path |
-| `translation_status` | ✓ | Compare a module's terms, database translations and committed `.po` files, including the sibling-POT metadata merge Odoo performs before import |
+| `translation_status` | ✓ | Verdict per language (OK, PARTIAL, NOT LOADED, NOT TRANSLATED, IMPORT SILENTLY DROPPED, IMPORT ABORTS, NO FILE, NOT ACTIVATED) from the module's terms, the database and the committed `.po` files, including the sibling-POT metadata merge Odoo performs before import, plus the call that fixes it |
 | `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `test_tags` narrows the run to one class or method, `upgrade=False` skips the `-u` for a fast re-run (collects `post_install` tests only and requires module-scoped positive tags) |
 | `get_environment_logs` | | Retrieve recent container logs |
 | `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |

--- a/specs/0042-translation-tooling.md
+++ b/specs/0042-translation-tooling.md
@@ -3,7 +3,7 @@
 **Status:** Adopted
 **Type:** MCP capability
 **First introduced:** this change (2026-07-27)
-**Key code today:** `po_tools.py` (`parse_po`, `summarize`, `merge_with_template`, `compare`), `docker_ops/odoo_ops.py` (`export_module_translations`, `translation_status`, `_export_po`, `_export_command`, `_i18n_basename`), `server.py` (both tools, `_artifact_url`), `artifact_tokens.py`, `web_ui.py` (`/oduflow-artifact`), `scoped_access.py` (allowlist)
+**Key code today:** `po_tools.py` (`parse_po`, `summarize`, `merge_with_template`, `compare`, `diagnose`), `docker_ops/odoo_ops.py` (`export_module_translations`, `translation_status`, `_export_po`, `_export_command`, `_i18n_basename`), `server.py` (both tools, `_artifact_url`), `artifact_tokens.py`, `web_ui.py` (`/oduflow-artifact`), `scoped_access.py` (allowlist)
 
 ## Context
 
@@ -135,6 +135,34 @@ private bounded temporary file owned by the Oduflow process.
   its own layout is per-module; mixing modules into one catalogue would produce
   something no module could ship.
 
+## Evolution
+
+**Status reports a verdict, not three catalogues (2026-08-13).** The first
+version printed what it measured: the term counts, the database counts, the file
+counts, and the raw missing/stale msgid lists behind a preview cap. On a module
+whose Russian catalogue covered 3 of 442 terms that came back as ~450 lines —
+fifteen multi-line view bodies and a `... and 424 more` — to say something the
+first two numbers had already said. The client was left to reconcile three
+catalogues and infer the conclusion, which is work the server was in a better
+position to do: it holds all three sources, and the inference is mechanical.
+
+So the same data now yields a judgement. `po_tools.diagnose` classifies each
+language (`OK`, `PARTIAL`, `NOT LOADED`, `NOT TRANSLATED`, `IMPORT SILENTLY
+DROPPED`, `IMPORT ABORTS`, `NO FILE`, `NOT ACTIVATED`) from the numbers alone,
+ordered so that the failures which mask each other are reported in the order
+they must be fixed; the report adds coverage against the module's own term count
+and the one call that moves that language forward. The distinction that matters
+most is between a catalogue Odoo read and discarded and one it never read — the
+counts look alike, the fixes do not.
+
+Two supporting changes follow from that. Terms are identified by their `#:`
+reference rather than by msgid, because the reference names the field or view to
+open while a report's msgid is a page of markup; and a diff is listed only when
+it is short enough to act on, since a truncated alphabetical slice of 439 terms
+is not a to-do list and the exported catalogue holds them all anyway. Verdicts
+live in `po_tools` with the rest of the pure logic, so they stay unit-testable
+and every caller reads the same conclusion.
+
 ## History
 
 - Motivated by a field report on translating an Odoo 15 module under Oduflow
@@ -145,3 +173,6 @@ private bounded temporary file owned by the Oduflow process.
   rule.
 - Corrected status to model Odoo's sibling-POT merge and hardened catalogue I/O
   and artifact egress after review, 2026-08-11.
+- Turned the status report into a per-language verdict with a prescribed next
+  step after a real call returned ~450 lines of term dump for an untranslated
+  language, 2026-08-13.

--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -1560,6 +1560,7 @@ def translation_status(
         po_tools.parse_po(pot_content) if pot_content is not None else None
     )
 
+    template = po_tools.summarize(template_entries)
     per_lang: list[dict[str, Any]] = []
     for lang in targets:
         entry: dict[str, Any] = {"lang": lang, "active": lang in active}
@@ -1588,12 +1589,22 @@ def translation_status(
                 pot_path if committed_template is not None else ""
             )
             entry["diff"] = po_tools.compare(template_entries, file_entries)
+        # The caller wants a conclusion, not three catalogues to reconcile, so
+        # the verdict is reached here where all three are already in hand.
+        entry["status"] = po_tools.diagnose(
+            template,
+            active=entry["active"],
+            database=entry.get("database"),
+            file=entry.get("file"),
+            effective=entry.get("import_effective"),
+            missing=len(entry["diff"]["missing"]) if "diff" in entry else 0,
+        )
         per_lang.append(entry)
 
     return {
         "module": module,
         "module_dir": module_dir,
-        "template": po_tools.summarize(template_entries),
+        "template": template,
         "active_langs": active,
         "langs": per_lang,
     }

--- a/src/oduflow/po_tools.py
+++ b/src/oduflow/po_tools.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 from dataclasses import dataclass, field
+from functools import partial
 
 # The reference kinds Odoo derives a translation's type from. ``model_terms``
 # must be tested before ``model`` — it is a longer prefix of the same shape.
@@ -200,8 +201,10 @@ class PoSummary:
     no_reference: int
     #: Entries with no ``#. module:`` comment — these abort the import.
     no_module_comment: int
-    #: msgids with an empty msgstr, in file order.
-    untranslated_msgids: list[str]
+    #: Entries with an empty msgstr, in file order. Whole entries rather than
+    #: bare msgids: a term is identified by *where* it lives, and a report's
+    #: msgid can be a page of markup.
+    untranslated_terms: list[PoEntry]
 
 
 def summarize(entries: list[PoEntry]) -> PoSummary:
@@ -209,7 +212,7 @@ def summarize(entries: list[PoEntry]) -> PoSummary:
     by_type: Counter[str] = Counter()
     no_reference = 0
     no_module = 0
-    untranslated: list[str] = []
+    untranslated: list[PoEntry] = []
 
     for entry in entries:
         ref_types = entry.ref_types
@@ -219,7 +222,7 @@ def summarize(entries: list[PoEntry]) -> PoSummary:
         if not entry.module:
             no_module += 1
         if not entry.msgstr:
-            untranslated.append(entry.msgid)
+            untranslated.append(entry)
 
     return PoSummary(
         entries=len(entries),
@@ -228,7 +231,7 @@ def summarize(entries: list[PoEntry]) -> PoSummary:
         by_type={name: by_type[name] for name in TYPE_ORDER if by_type[name]},
         no_reference=no_reference,
         no_module_comment=no_module,
-        untranslated_msgids=untranslated,
+        untranslated_terms=untranslated,
     )
 
 
@@ -264,19 +267,140 @@ def merge_with_template(
     return merged
 
 
+def _absent_from(entries: list[PoEntry], other: set[str]) -> list[PoEntry]:
+    """Entries whose msgid is not in *other*, one per msgid, sorted by msgid."""
+    seen: set[str] = set()
+    picked: list[PoEntry] = []
+    for entry in entries:
+        if entry.msgid in other or entry.msgid in seen:
+            continue
+        seen.add(entry.msgid)
+        picked.append(entry)
+    return sorted(picked, key=lambda entry: entry.msgid)
+
+
 def compare(
     template: list[PoEntry], translation: list[PoEntry]
-) -> dict[str, list[str]]:
+) -> dict[str, list[PoEntry]]:
     """Diff a ``.pot`` against a ``.po`` by msgid.
 
     ``missing`` are terms the module exposes but the file never mentions — new
     strings someone forgot. ``stale`` are the reverse: entries left over after
     the source string changed or stopped being translatable, which is how dead
     translations survive unnoticed.
+
+    Whole entries come back rather than msgids, because the useful handle on a
+    term is its ``#:`` reference: it names the field or view to fix and stays
+    short, while the msgid of a report term can be a screenful of markup.
     """
     template_ids = {entry.msgid for entry in template}
     translation_ids = {entry.msgid for entry in translation}
     return {
-        "missing": sorted(template_ids - translation_ids),
-        "stale": sorted(translation_ids - template_ids),
+        "missing": _absent_from(template, translation_ids),
+        "stale": _absent_from(translation, template_ids),
     }
+
+
+# -- Verdicts -----------------------------------------------------------------
+#
+# The three catalogues are only raw material; what a caller wants to know is
+# whether the translation landed and what to do next. That judgement is made
+# here, from the numbers alone, so every caller reads the same conclusion.
+
+#: The language is not activated, so nothing can load into the database at all.
+NOT_ACTIVATED = "not_activated"
+#: The module ships no catalogue for this language.
+NO_FILE = "no_file"
+#: Entries lack ``#. module:`` — Odoo's reader raises instead of importing.
+IMPORT_ABORTS = "import_aborts"
+#: Entries lack ``#:`` — Odoo reads them and stores nothing, without a warning.
+IMPORT_DROPPED = "import_dropped"
+#: A catalogue exists but barely covers the module: nobody translated this yet.
+NOT_TRANSLATED = "not_translated"
+#: The file is fine and the database is empty — it was never loaded.
+NOT_LOADED = "not_loaded"
+#: Loaded, with terms still missing or not applied.
+PARTIAL = "partial"
+#: File, database and module agree.
+OK = "ok"
+
+# A defect this widespread is the headline; a handful of bad entries in an
+# otherwise good file is reported as a warning beside the real verdict.
+_DEFECT_SHARE = 0.5
+# Below this share of the module's terms, listing what is missing is the same
+# statement as "this language was never translated", only much longer.
+_COVERED_SHARE = 0.1
+# What did reach the database, as a share of what the file offers.
+_LOADED_SHARE = 0.1
+# Terms may legitimately resist translation (identifiers, symbols), so the
+# database is never expected to match the module term for term.
+_COMPLETE_SHARE = 0.95
+
+
+@dataclass(frozen=True)
+class LangStatus:
+    """What became of one language, and the numbers behind that conclusion."""
+
+    code: str
+    #: Translatable terms the module exposes — the denominator for everything.
+    template_terms: int
+    #: Module terms the committed file actually carries.
+    covered_terms: int
+    #: Module terms the database holds a translation for.
+    db_terms: int
+    #: Translated file entries with no counterpart in the database.
+    not_applied: int
+
+    @property
+    def coverage(self) -> float:
+        """Share of the module's terms translated in the database."""
+        if not self.template_terms:
+            return 0.0
+        return self.db_terms / self.template_terms
+
+
+def diagnose(
+    template: PoSummary,
+    *,
+    active: bool,
+    database: PoSummary | None = None,
+    file: PoSummary | None = None,
+    effective: PoSummary | None = None,
+    missing: int = 0,
+) -> LangStatus:
+    """Judge one language from the three catalogues.
+
+    *effective* is the file as Odoo would import it (after the sibling-POT
+    merge, when there is one); *missing* is how many of the module's terms the
+    file never mentions. The order of the checks is the order in which the
+    failures mask each other: an inactive language hides a broken file, and a
+    broken file hides an empty translation.
+    """
+    db_terms = database.translated if database else 0
+    in_file = file.translated if file else 0
+    # With no file there is no diff to subtract, and "all terms covered" is the
+    # one thing that must not be reported for a catalogue that does not exist.
+    covered = max(template.entries - missing, 0) if file else 0
+    status = partial(
+        LangStatus,
+        template_terms=template.entries,
+        covered_terms=covered,
+        db_terms=db_terms,
+        not_applied=max(in_file - db_terms, 0),
+    )
+
+    if not active:
+        return status(NOT_ACTIVATED)
+    if file is None or effective is None:
+        return status(NO_FILE)
+    if effective.no_module_comment >= max(effective.entries * _DEFECT_SHARE, 1):
+        return status(IMPORT_ABORTS)
+    if effective.no_reference >= max(effective.entries * _DEFECT_SHARE, 1):
+        return status(IMPORT_DROPPED)
+    if template.entries and covered <= template.entries * _COVERED_SHARE:
+        return status(NOT_TRANSLATED)
+    if in_file and db_terms <= in_file * _LOADED_SHARE:
+        return status(NOT_LOADED)
+    if not missing and db_terms >= template.entries * _COMPLETE_SHARE:
+        return status(OK)
+    return status(PARTIAL)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -30,6 +30,7 @@ from oduflow import (
     artifact_tokens,
     git_ops,
     migrations,
+    po_tools,
     production_registry,
     quotas,
     reaper,
@@ -49,6 +50,7 @@ from oduflow.docker_ops import (
 from oduflow.errors import FlowError, NotFoundError, PrerequisiteNotMetError
 from oduflow.locking import LockManager
 from oduflow.output_cache import CachedOutput, OutputCache
+from oduflow.po_tools import PoEntry
 from oduflow.settings import Settings, TeamSettings, find_toml
 from oduflow.stack_loader import StackValidationError
 
@@ -1911,8 +1913,12 @@ _TERM_KINDS = {
     "code": "Python _() / _lt(), JS _t()",
     "other": "unrecognised reference kind",
 }
-# Long lists of terms belong in the cached output, not in the headline report.
-_TERM_PREVIEW = 15
+# A list this short is a to-do list; a longer one is a statement about the file
+# as a whole, which the counts already make. The full set is in the exported
+# catalogue either way, so nothing is lost by not printing it.
+_TERM_LIST_MAX = 20
+# Enough of the source string to recognise the term next to its reference.
+_TERM_SNIPPET = 60
 
 
 def _format_term_counts(by_type: dict[str, int]) -> list[str]:
@@ -1922,16 +1928,82 @@ def _format_term_counts(by_type: dict[str, int]) -> list[str]:
     ]
 
 
-def _format_term_list(label: str, msgids: list[str]) -> list[str]:
-    """A capped bullet list, nested one level under its own label's indent."""
-    if not msgids:
+def _format_term(entry: PoEntry) -> str:
+    """One term on one line: where it lives, then what it says.
+
+    A ``model_terms`` msgid is a whole view or report body, newlines included,
+    so printing it verbatim buries the report. The ``#:`` reference is the part
+    that says which field or view to open.
+    """
+    text = " ".join(entry.msgid.split())
+    if len(text) > _TERM_SNIPPET:
+        text = text[: _TERM_SNIPPET - 1].rstrip() + "…"
+    reference = entry.occurrences[0] if entry.occurrences else ""
+    return f'{reference}  "{text}"' if reference else f'"{text}"'
+
+
+_VERDICT_LABEL = {
+    po_tools.OK: "OK",
+    po_tools.PARTIAL: "PARTIAL",
+    po_tools.NOT_LOADED: "NOT LOADED",
+    po_tools.NOT_TRANSLATED: "NOT TRANSLATED",
+    po_tools.IMPORT_DROPPED: "IMPORT SILENTLY DROPPED",
+    po_tools.IMPORT_ABORTS: "IMPORT ABORTS",
+    po_tools.NO_FILE: "NO FILE",
+    po_tools.NOT_ACTIVATED: "NOT ACTIVATED",
+}
+
+
+def _format_next_step(
+    status: po_tools.LangStatus, env_name: str, module: str, lang: str
+) -> list[str]:
+    """The one action that moves this language forward, as a callable line.
+
+    The verdict is only half an answer; the caller ran this tool to find out
+    what to do, and the fix differs per failure — a catalogue that was never
+    loaded and one that Odoo read and discarded look identical in the counts.
+    """
+    export = f'export_module_translations("{env_name}", "{module}", "{lang}")'
+    export_pot = f'export_module_translations("{env_name}", "{module}")'
+    upgrade = f'upgrade_odoo_modules("{env_name}", "{module}")'
+    fill_in = f"Next: {export}, fill in the msgstr values, then {upgrade}."
+
+    if status.code == po_tools.OK:
+        return []
+    if status.code == po_tools.NOT_ACTIVATED:
+        return [
+            f"Next: activate {lang} in Odoo (Settings → Translations → "
+            f"Languages), then {upgrade}."
+        ]
+    if status.code in (po_tools.NO_FILE, po_tools.NOT_TRANSLATED):
+        return [fill_in]
+    if status.code in (po_tools.IMPORT_DROPPED, po_tools.IMPORT_ABORTS):
+        return [
+            f"Next: {export_pot} writes the sibling .pot that Odoo merges for "
+            f"this metadata — commit it beside the .po, then {upgrade}.",
+        ]
+    if status.code == po_tools.NOT_LOADED:
+        return [f"Next: {upgrade} loads the file into the database."]
+    if status.not_applied:
+        return [f"Next: {upgrade} re-reads the file into the database."]
+    return [f"Next: {export} merges the module's new terms into the file."]
+
+
+def _format_term_list(label: str, terms: list[PoEntry]) -> list[str]:
+    """A bullet list, nested one level under its own label's indent.
+
+    Beyond :data:`_TERM_LIST_MAX` only the count is printed: a truncated list of
+    alphabetically-first terms is not a to-do list, and the reader still has to
+    export the catalogue to act on it.
+    """
+    if not terms:
         return []
     indent = " " * (len(label) - len(label.lstrip()) + 2)
-    lines = [f"{label} ({len(msgids)}):"]
-    lines += [f"{indent}- {m}" for m in msgids[:_TERM_PREVIEW]]
-    if len(msgids) > _TERM_PREVIEW:
-        lines.append(f"{indent}... and {len(msgids) - _TERM_PREVIEW} more")
-    return lines
+    if len(terms) > _TERM_LIST_MAX:
+        return [f"{label} ({len(terms)}) — too many to list; export the catalogue."]
+    return [f"{label} ({len(terms)}):"] + [
+        f"{indent}- {_format_term(term)}" for term in terms
+    ]
 
 
 @mcp.tool()
@@ -1980,7 +2052,7 @@ def export_module_translations(
             f"Translated: {summary.translated} / {summary.entries} "
             f"({summary.untranslated} missing)"
         )
-        lines += [""] + _format_term_list("Untranslated", summary.untranslated_msgids)
+        lines += [""] + _format_term_list("Untranslated", summary.untranslated_terms)
     if not summary.by_type.get("code"):
         # The exporter finds these by walking addons_path and reading the
         # module's sources, so an empty count usually means the module's
@@ -2038,20 +2110,24 @@ def translation_status(
     env_name: str, module: str, langs: str = "", ctx: Context | None = None
 ) -> str:
     """
-    Report what a module's translations look like across all three places they live.
+    Report whether a module's translations actually landed, and what to do next.
 
     Compares the term template Odoo derives from the module, the translations
-    actually stored in the database, and the committed `i18n/<lang>.po` files.
-    Use this after loading translations: Odoo's importer is silent about the two
-    ways a `.po` fails, and this is what makes them visible.
+    actually stored in the database, and the committed `i18n/<lang>.po` files,
+    and returns a verdict per language rather than three catalogues to
+    reconcile. Use this after loading translations: Odoo's importer is silent
+    about the two ways a `.po` fails, and this is what makes them visible.
 
     - Entries with no `#:` reference line import as ZERO translations, with no
       warning at all, unless a sibling `<module>.pot` supplies the metadata.
     - Entries with no `#. module:` comment abort the import outright unless that
       sibling template supplies it.
 
-    It also reports terms present in the module but missing from the file, and
-    stale entries left in the file after a source string changed.
+    Each language gets a verdict (OK, PARTIAL, NOT LOADED, NOT TRANSLATED,
+    IMPORT SILENTLY DROPPED, IMPORT ABORTS, NO FILE, NOT ACTIVATED), the
+    coverage behind it, and the call that fixes it. Terms missing from the file
+    or left stale in it are listed only when few enough to act on — otherwise
+    export the catalogue, which holds them all.
 
     Args:
         env_name: The name of the environment.
@@ -2080,41 +2156,49 @@ def translation_status(
         ]
 
     for entry in result["langs"]:
-        lines += ["", f"--- {entry['lang']} ---"]
+        status = entry["status"]
+        lines += ["", f"--- {entry['lang']} ---  {_VERDICT_LABEL[status.code]}"]
+        lines.append(
+            f"Coverage:  file {status.covered_terms}/{status.template_terms} "
+            f"module terms, database {status.db_terms}/{status.template_terms} "
+            f"translated ({status.coverage:.0%})."
+        )
         if not entry["active"]:
             lines.append(
                 "Language is NOT activated in this database, so translations "
                 "have nowhere to load. Activate it first."
             )
+        elif entry["file_path"]:
+            po = entry["file"]
+            effective = entry.get("import_effective", po)
+            lines.append(f"File:      {entry['file_path']} — {po.entries} entries")
+            if entry.get("metadata_template_path"):
+                lines.append(
+                    f"  Import metadata: merged from {entry['metadata_template_path']}"
+                )
+            if effective.no_reference:
+                lines.append(
+                    f"  ! {effective.no_reference} entries have no '#:' reference — "
+                    "Odoo imports these as ZERO translations, silently."
+                )
+            if effective.no_module_comment:
+                lines.append(
+                    f"  ! {effective.no_module_comment} entries have no '#. module:' "
+                    "comment — these abort the import with an error."
+                )
+            if status.not_applied:
+                lines.append(
+                    f"  ! {status.not_applied} translated entries in the file are "
+                    "not in the database."
+                )
+            diff = entry["diff"]
+            lines += _format_term_list("  Missing from the file", diff["missing"])
+            lines += _format_term_list(
+                "  Stale (no longer in the module)", diff["stale"]
+            )
         else:
-            db = entry["database"]
-            counts = ", ".join(f"{k} {v}" for k, v in db.by_type.items())
-            lines.append(f"In database:  {db.translated} translated ({counts})")
-
-        if not entry["file_path"]:
-            lines.append(f"No i18n/{entry['lang']}.po in the module.")
-            continue
-
-        po = entry["file"]
-        effective = entry.get("import_effective", po)
-        lines.append(f"In {entry['file_path']}: {po.entries} entries")
-        if entry.get("metadata_template_path"):
-            lines.append(
-                f"  Import metadata: merged from {entry['metadata_template_path']}"
-            )
-        if effective.no_reference:
-            lines.append(
-                f"  ! {effective.no_reference} entries have no '#:' reference — Odoo "
-                "imports these as ZERO translations, silently."
-            )
-        if effective.no_module_comment:
-            lines.append(
-                f"  ! {effective.no_module_comment} entries have no '#. module:' "
-                "comment — these abort the import with an error."
-            )
-        diff = entry["diff"]
-        lines += _format_term_list("  Missing from the file", diff["missing"])
-        lines += _format_term_list("  Stale (no longer in the module)", diff["stale"])
+            lines.append(f"File:      no i18n/{entry['lang']}.po in the module.")
+        lines += _format_next_step(status, env_name, module, entry["lang"])
 
     header = f"{woke}Translation status for {module} in environment '{env_name}'."
     return _maybe_cache(

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -84,7 +84,7 @@ In live-mount mode, you as the agent must track the intent of your own edits. If
 | Tool | When to use |
 |---|---|
 | `export_module_translations(env_name, module, lang?)` | Export the module's catalogue with Odoo's own exporter. No `lang` → the `.pot` template (all translatable terms, including `_()` messages from Python). With `lang` → a `.po` filled from the database. Writes into the module's `i18n/` and returns a **summary plus a one-time download URL** over HTTP or a temporary host path under stdio, never the file body. |
-| `translation_status(env_name, module, langs?)` | Compare the module's terms, the database, and the committed `i18n/*.po`. **Run this after loading translations** — Odoo is silent about both ways a `.po` fails. |
+| `translation_status(env_name, module, langs?)` | Compare the module's terms, the database, and the committed `i18n/*.po`. **Run this after loading translations** — Odoo is silent about both ways a `.po` fails. Answers with a verdict per language (`OK`, `PARTIAL`, `NOT LOADED`, `NOT TRANSLATED`, `IMPORT SILENTLY DROPPED`, `IMPORT ABORTS`, `NO FILE`, `NOT ACTIVATED`), the coverage behind it, and the `Next:` call that fixes it — follow that line rather than re-deriving the state from the numbers. Terms missing from a file are listed only when few enough to act on; past that, export the catalogue. |
 
 > **Odoo does not warn you when translations fail to load.** A `.po` entry with
 > no `#:` reference line is read and discarded — a whole valid file can import as

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -8,6 +8,7 @@ from urllib.parse import urlsplit
 import pytest
 
 import docker
+from oduflow import po_tools
 from oduflow.docker_ops import env_ops, odoo_ops, system_ops
 from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
 from oduflow.settings import DEFAULT_AGENT_IMAGE, Settings, TeamSettings
@@ -3399,11 +3400,14 @@ class TestTranslationStatus:
         assert entry["database"].entries == 0
         assert entry["file"].entries == 1
         assert entry["file"].no_reference == 1
-        assert entry["diff"]["missing"] == [
+        assert [e.msgid for e in entry["diff"]["missing"]] == [
             "Only a dispatch manager may accept deals.",
             "Publish",
         ]
         assert result["template"].entries == 3
+        # The backend reaches the verdict, so every caller reads the same one.
+        assert entry["status"].code == po_tools.IMPORT_DROPPED
+        assert entry["status"].covered_terms == 1
 
     @patch("oduflow.docker_ops.odoo_ops.run_db_query")
     def test_inactive_language_is_reported_not_silently_empty(

--- a/tests/test_po_tools.py
+++ b/tests/test_po_tools.py
@@ -1,6 +1,14 @@
 """Unit tests for the pure .po reader in oduflow.po_tools (no Docker needed)."""
 
-from oduflow.po_tools import compare, merge_with_template, parse_po, summarize
+from oduflow import po_tools
+from oduflow.po_tools import (
+    PoSummary,
+    compare,
+    diagnose,
+    merge_with_template,
+    parse_po,
+    summarize,
+)
 
 HEADER = """msgid ""
 msgstr ""
@@ -128,9 +136,15 @@ class TestSummarize:
         assert summary.entries == 3
         assert summary.by_type == {"model": 1, "model_terms": 1, "code": 1}
         assert summary.translated == 2
-        assert summary.untranslated_msgids == [
+        assert [e.msgid for e in summary.untranslated_terms] == [
             "Only a dispatch manager may accept deals."
         ]
+
+    def test_untranslated_terms_keep_their_reference(self):
+        # The reference is what a caller needs to find the term; the msgid of a
+        # view term can be a whole page of markup.
+        (term,) = summarize(parse_po(WELL_FORMED)).untranslated_terms
+        assert term.occurrences == ("code:addons/transeu_bridge/models/freight.py:0",)
 
     def test_entries_without_reference_are_flagged(self):
         # A valid gettext file that Odoo imports as *zero* translations: with no
@@ -193,11 +207,22 @@ msgstr "Usługa Trans.eu jest niedostępna: %s"
 """
         )
         diff = compare(template, translation)
-        assert diff["missing"] == [
+        assert [e.msgid for e in diff["missing"]] == [
             "Only a dispatch manager may accept deals.",
             "Publish",
         ]
-        assert diff["stale"] == ["The Trans.eu service is unreachable: %s"]
+        assert [e.msgid for e in diff["stale"]] == [
+            "The Trans.eu service is unreachable: %s"
+        ]
+
+    def test_diff_entries_carry_the_reference_that_locates_them(self):
+        template = parse_po(WELL_FORMED)
+        (publish,) = [
+            e for e in compare(template, [])["missing"] if e.msgid == "Publish"
+        ]
+        assert publish.occurrences == (
+            "model_terms:ir.ui.view,arch_db:transeu_bridge.view_freight_form",
+        )
 
     def test_identical_files_have_no_diff(self):
         entries = parse_po(WELL_FORMED)
@@ -236,3 +261,134 @@ msgstr "Stary tekst"
 
         assert merged
         assert "Old string" not in {entry.msgid for entry in merged}
+
+
+def _summary(entries: int, translated: int, **overrides) -> PoSummary:
+    """A PoSummary with only the numbers a verdict is made of."""
+    base = dict(
+        entries=entries,
+        translated=translated,
+        untranslated=entries - translated,
+        by_type={},
+        no_reference=0,
+        no_module_comment=0,
+        untranslated_terms=[],
+    )
+    base.update(overrides)
+    return PoSummary(**base)  # type: ignore[arg-type]
+
+
+class TestDiagnose:
+    """The verdict is the answer callers came for; these are its edges."""
+
+    TEMPLATE = _summary(442, 442)
+
+    def test_an_inactive_language_hides_every_other_problem(self):
+        # Nothing can load, so a broken file is not the thing to report.
+        status = diagnose(
+            self.TEMPLATE,
+            active=False,
+            file=_summary(435, 435, no_reference=435),
+            effective=_summary(435, 435, no_reference=435),
+        )
+        assert status.code == po_tools.NOT_ACTIVATED
+
+    def test_no_file_at_all(self):
+        status = diagnose(self.TEMPLATE, active=True, database=_summary(442, 0))
+        assert status.code == po_tools.NO_FILE
+
+    def test_a_file_odoo_reads_and_discards(self):
+        # 311 valid-looking entries, none with a "#:" line: the silent case.
+        broken = _summary(311, 311, no_reference=311)
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 0),
+            file=broken,
+            effective=broken,
+            missing=131,
+        )
+        assert status.code == po_tools.IMPORT_DROPPED
+
+    def test_a_missing_module_comment_outranks_a_missing_reference(self):
+        # Both are present, but this one aborts the import outright.
+        broken = _summary(311, 311, no_reference=311, no_module_comment=311)
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 0),
+            file=broken,
+            effective=broken,
+        )
+        assert status.code == po_tools.IMPORT_ABORTS
+
+    def test_a_handful_of_bad_entries_is_not_the_headline(self):
+        # Four bad entries in an otherwise loaded file: still a warning, but the
+        # verdict describes the file as a whole.
+        file = _summary(442, 442, no_reference=4)
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 438),
+            file=file,
+            effective=file,
+        )
+        assert status.code == po_tools.OK
+
+    def test_a_file_covering_almost_nothing_reads_as_untranslated(self):
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 20),
+            file=_summary(3, 3),
+            effective=_summary(3, 3),
+            missing=439,
+        )
+        assert status.code == po_tools.NOT_TRANSLATED
+        assert status.covered_terms == 3
+        assert status.coverage == 20 / 442
+
+    def test_a_good_file_that_never_reached_the_database(self):
+        file = _summary(435, 435)
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 0),
+            file=file,
+            effective=file,
+            missing=7,
+        )
+        assert status.code == po_tools.NOT_LOADED
+
+    def test_loaded_but_incomplete_counts_what_did_not_apply(self):
+        file = _summary(435, 435)
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 379),
+            file=file,
+            effective=file,
+            missing=7,
+        )
+        assert status.code == po_tools.PARTIAL
+        assert status.not_applied == 56
+        assert status.covered_terms == 435
+
+    def test_complete_translation_is_ok(self):
+        file = _summary(442, 442)
+        status = diagnose(
+            self.TEMPLATE,
+            active=True,
+            database=_summary(442, 442),
+            file=file,
+            effective=file,
+        )
+        assert status.code == po_tools.OK
+        assert status.not_applied == 0
+
+    def test_a_module_with_no_terms_does_not_divide_by_zero(self):
+        empty = _summary(0, 0)
+        status = diagnose(
+            empty, active=True, database=empty, file=empty, effective=empty
+        )
+        assert status.coverage == 0.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from oduflow.po_tools import PoSummary
+from oduflow import po_tools
+from oduflow.po_tools import PoEntry, PoSummary
 from oduflow.settings import Settings, TeamSettings
 
 TEST_TEAM = TeamSettings(
@@ -1585,6 +1586,15 @@ class TestResetAdminPasswordDropsSessions:
         assert ("1", "main", "") not in odoo_rpc._SESSIONS
 
 
+def _po_entry(msgid: str, reference: str = "") -> PoEntry:
+    return PoEntry(
+        msgid=msgid,
+        msgstr="",
+        module="mymod",
+        occurrences=(reference,) if reference else (),
+    )
+
+
 class TestTranslationTools:
     """The two i18n tools, at the layer that turns backend data into a report."""
 
@@ -1595,8 +1605,33 @@ class TestTranslationTools:
         by_type={"model": 161, "model_terms": 82, "code": 68},
         no_reference=0,
         no_module_comment=0,
-        untranslated_msgids=["Active", "Company"],
+        untranslated_terms=[_po_entry("Active"), _po_entry("Company")],
     )
+
+    def _lang(self, lang="pl_PL", *, active=True, missing=(), stale=(), **entry):
+        """One backend language record, verdict included as the backend adds it."""
+        record = {"lang": lang, "active": active, "file_path": "", **entry}
+        if record["file_path"]:
+            record["diff"] = {"missing": list(missing), "stale": list(stale)}
+            record.setdefault("metadata_template_path", "")
+        record["status"] = po_tools.diagnose(
+            self._SUMMARY,
+            active=active,
+            database=record.get("database"),
+            file=record.get("file"),
+            effective=record.get("import_effective"),
+            missing=len(missing),
+        )
+        return record
+
+    def _status_result(self, *langs):
+        return {
+            "module": "mymod",
+            "module_dir": "/mnt/extra-addons/mymod",
+            "template": self._SUMMARY,
+            "active_langs": ["en_US", "pl_PL"],
+            "langs": list(langs),
+        }
 
     def _export_result(self, **overrides):
         base = {
@@ -1760,34 +1795,29 @@ class TestTranslationTools:
             by_type={},
             no_reference=311,
             no_module_comment=4,
-            untranslated_msgids=[],
+            untranslated_terms=[],
         )
-        mock_status.return_value = {
-            "module": "mymod",
-            "module_dir": "/mnt/extra-addons/mymod",
-            "template": self._SUMMARY,
-            "active_langs": ["en_US", "pl_PL"],
-            "langs": [
-                {
-                    "lang": "pl_PL",
-                    "active": True,
-                    "database": empty,
-                    "file_path": "/mnt/extra-addons/mymod/i18n/pl_PL.po",
-                    "file": broken,
-                    "import_effective": broken,
-                    "metadata_template_path": "",
-                    "diff": {"missing": ["Active"], "stale": ["Old string"]},
-                }
-            ],
-        }
+        mock_status.return_value = self._status_result(
+            self._lang(
+                database=empty,
+                file_path="/mnt/extra-addons/mymod/i18n/pl_PL.po",
+                file=broken,
+                import_effective=broken,
+                missing=[_po_entry("Active")],
+                stale=[_po_entry("Old string")],
+            )
+        )
         result = _get_tool_fn("translation_status")(env_name="main", module="mymod")
 
+        assert "IMPORT SILENTLY DROPPED" in result
         assert "311 entries have no '#:' reference" in result
         assert "ZERO translations" in result
         assert "4 entries have no '#. module:' comment" in result
-        assert "In database:  0 translated" in result
+        assert "database 0/311 translated (0%)" in result
         assert "Active" in result
         assert "Old string" in result
+        # The fix is the sibling template, not another upgrade on its own.
+        assert 'Next: export_module_translations("main", "mymod") writes' in result
         mock_status.assert_called_once_with(
             TEST_SETTINGS, TEST_TEAM, "main", "mymod", None
         )
@@ -1797,56 +1827,131 @@ class TestTranslationTools:
     def test_status_does_not_warn_when_sibling_pot_supplies_metadata(
         self, mock_status, mock_ensure
     ):
-        empty = PoSummary(0, 0, 0, {}, 0, 0, [])
-        raw = PoSummary(1, 1, 0, {}, 1, 1, [])
-        effective = PoSummary(1, 1, 0, {"model": 1}, 0, 0, [])
-        mock_status.return_value = {
-            "module": "mymod",
-            "module_dir": "/mnt/extra-addons/mymod",
-            "template": self._SUMMARY,
-            "active_langs": ["en_US", "pl_PL"],
-            "langs": [
-                {
-                    "lang": "pl_PL",
-                    "active": True,
-                    "database": empty,
-                    "file_path": "/mnt/extra-addons/mymod/i18n/pl.po",
-                    "file": raw,
-                    "import_effective": effective,
-                    "metadata_template_path": (
-                        "/mnt/extra-addons/mymod/i18n/mymod.pot"
-                    ),
-                    "diff": {"missing": [], "stale": []},
-                }
-            ],
-        }
+        raw = PoSummary(311, 311, 0, {}, 311, 311, [])
+        effective = PoSummary(311, 311, 0, {"model": 311}, 0, 0, [])
+        mock_status.return_value = self._status_result(
+            self._lang(
+                database=PoSummary(311, 311, 0, {"model": 311}, 0, 0, []),
+                file_path="/mnt/extra-addons/mymod/i18n/pl.po",
+                file=raw,
+                import_effective=effective,
+                metadata_template_path="/mnt/extra-addons/mymod/i18n/mymod.pot",
+            )
+        )
 
         result = _get_tool_fn("translation_status")(env_name="main", module="mymod")
 
         assert "Import metadata: merged from" in result
         assert "imports these as ZERO" not in result
         assert "abort the import" not in result
+        # Nothing left to do, so nothing is prescribed.
+        assert "--- pl_PL ---  OK" in result
+        assert "Next:" not in result
 
     @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
     @patch("oduflow.docker_ops.odoo_ops.translation_status")
     def test_status_says_so_when_a_language_is_not_activated(
         self, mock_status, mock_ensure
     ):
-        mock_status.return_value = {
-            "module": "mymod",
-            "module_dir": "/mnt/extra-addons/mymod",
-            "template": self._SUMMARY,
-            "active_langs": ["en_US"],
-            "langs": [{"lang": "ru_RU", "active": False, "file_path": ""}],
-        }
+        mock_status.return_value = self._status_result(
+            self._lang("ru_RU", active=False)
+        )
         result = _get_tool_fn("translation_status")(
             env_name="main", module="mymod", langs="ru_RU"
         )
 
         assert "NOT activated" in result
+        assert "Next: activate ru_RU in Odoo" in result
+        # A language with no catalogue must never be counted as fully covered.
+        assert "file 0/311 module terms" in result
         mock_status.assert_called_once_with(
             TEST_SETTINGS, TEST_TEAM, "main", "mymod", ["ru_RU"]
         )
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_ops.translation_status")
+    def test_status_answers_an_untranslated_language_in_a_few_lines(
+        self, mock_status, mock_ensure
+    ):
+        # A file covering 3 of 311 terms says "nobody translated this", and the
+        # other 308 msgids say it again, at 100x the length.
+        tiny = PoSummary(3, 3, 0, {}, 0, 0, [])
+        mock_status.return_value = self._status_result(
+            self._lang(
+                database=PoSummary(311, 20, 291, {}, 0, 0, []),
+                file_path="/mnt/extra-addons/mymod/i18n/ru.po",
+                file=tiny,
+                import_effective=tiny,
+                missing=[_po_entry(f"Term {i}") for i in range(308)],
+            )
+        )
+
+        result = _get_tool_fn("translation_status")(env_name="main", module="mymod")
+
+        assert "NOT TRANSLATED" in result
+        assert "file 3/311 module terms, database 20/311 translated (6%)" in result
+        assert "Missing from the file (308) — too many to list" in result
+        assert "Term 42" not in result
+        assert "and 293 more" not in result
+        assert "Next: export_module_translations" in result
+        # The whole language fits well inside what the old preview alone cost.
+        assert len(result.splitlines()) < 20
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_ops.translation_status")
+    def test_status_lists_a_short_diff_by_reference_on_one_line(
+        self, mock_status, mock_ensure
+    ):
+        # A report term's msgid is a page of markup; the "#:" reference is the
+        # part that names the view to open.
+        arch = _po_entry(
+            "Place / Place\n     On / On\n     Signature and stamp of the "
+            "consignee, plus a great deal more boilerplate",
+            "model_terms:ir.ui.view,arch_db:mymod.report_cmr",
+        )
+        loaded = PoSummary(310, 310, 0, {}, 0, 0, [])
+        mock_status.return_value = self._status_result(
+            self._lang(
+                database=PoSummary(311, 310, 1, {}, 0, 0, []),
+                file_path="/mnt/extra-addons/mymod/i18n/pl.po",
+                file=loaded,
+                import_effective=loaded,
+                missing=[arch],
+            )
+        )
+
+        result = _get_tool_fn("translation_status")(env_name="main", module="mymod")
+
+        (line,) = [ln for ln in result.splitlines() if "report_cmr" in ln]
+        assert line.startswith("    - model_terms:ir.ui.view,arch_db:mymod.report_cmr")
+        # One line, a readable snippet, and the rest of the markup left behind.
+        assert line.endswith('…"')
+        assert "boilerplate" not in result
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_ops.translation_status")
+    def test_status_counts_what_the_file_holds_but_the_database_does_not(
+        self, mock_status, mock_ensure
+    ):
+        # The gap between a good file and the database is the whole reason to
+        # run this tool a second time; it must not be left for the reader to
+        # subtract.
+        file = PoSummary(304, 304, 0, {}, 0, 0, [])
+        mock_status.return_value = self._status_result(
+            self._lang(
+                database=PoSummary(311, 248, 63, {}, 0, 0, []),
+                file_path="/mnt/extra-addons/mymod/i18n/pl.po",
+                file=file,
+                import_effective=file,
+                missing=[_po_entry(f"Term {i}") for i in range(7)],
+            )
+        )
+
+        result = _get_tool_fn("translation_status")(env_name="main", module="mymod")
+
+        assert "--- pl_PL ---  PARTIAL" in result
+        assert "! 56 translated entries in the file are not in the database." in result
+        assert 'Next: upgrade_odoo_modules("main", "mymod") re-reads' in result
 
     def test_translation_tools_in_scoped_allowlist(self):
         from oduflow.scoped_access import SCOPED_ALLOWLIST


### PR DESCRIPTION
## Problem

`translation_status` printed what it measured — template, database and file counts plus a capped list of missing/stale msgids. On a module whose Russian catalogue covered 3 of 442 terms, that came back as ~450 lines of multi-line view bodies to restate what the first two numbers already said, leaving the caller to reconcile three catalogues and infer the conclusion.

## Change

The server holds all three sources and the inference is mechanical, so it makes the judgement now.

- `po_tools.diagnose` classifies each language (`OK`, `PARTIAL`, `NOT LOADED`, `NOT TRANSLATED`, `IMPORT SILENTLY DROPPED`, `IMPORT ABORTS`, `NO FILE`, `NOT ACTIVATED`) from the numbers alone, ordered so failures that mask each other are reported in the order they must be fixed.
- The report adds coverage against the module's own term count and the one call that moves that language forward. The distinction that matters most is between a catalogue Odoo read and discarded and one it never read — the counts look alike, the fixes do not.
- `compare`/`summarize` return whole entries, so a term is shown by its `#:` reference (the field or view to open) rather than by a msgid that can be a page of markup.
- A diff is listed only when short enough to act on: beyond 20 terms only the count is printed, since a truncated alphabetical slice is not a to-do list and the exported catalogue holds them all.

Decision record `specs/0042-translation-tooling.md` gets an Evolution section; `docs/mcp-tools.md` and the agent guide are updated.

## Testing

`ruff check`, `ruff format --check`, `mypy` clean; `pytest -m "not integration and not heavyweight"` → 2263 passed.