### PR TITLE
Fix translation export into missing i18n directories

### DIFF
--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -691,7 +691,42 @@ def write_file_in_environment(
         )
 
     parent = path.rsplit("/", 1)[0] if "/" in path else "/"
-    container.exec_run(["mkdir", "-p", parent], user=user)
+    mkdir_code, mkdir_output = container.exec_run(["mkdir", "-p", parent], user=user)
+    if mkdir_code != 0:
+        # Source checkouts are mounted root-owned, so the requested user may be
+        # unable to create the first missing directory (commonly ``i18n``).
+        # Find the highest missing directory and chown only the tree that this
+        # operation creates; existing repository content must keep its owner.
+        missing_root: str | None = None
+        candidate = parent
+        while candidate and candidate != "/":
+            exists_code, _ = container.exec_run(["test", "-d", candidate], user="root")
+            if exists_code == 0:
+                break
+            missing_root = candidate
+            candidate = (
+                candidate.rsplit("/", 1)[0] if "/" in candidate else "/"
+            ) or "/"
+
+        if missing_root is None:
+            raise ExternalCommandError("mkdir -p", mkdir_code, _decode(mkdir_output))
+
+        root_mkdir_code, root_mkdir_output = container.exec_run(
+            ["mkdir", "-p", parent], user="root"
+        )
+        if root_mkdir_code != 0:
+            raise ExternalCommandError(
+                "mkdir -p", root_mkdir_code, _decode(root_mkdir_output)
+            )
+
+        if user != "root":
+            chown_code, chown_output = container.exec_run(
+                ["chown", "-R", user, missing_root], user="root"
+            )
+            if chown_code != 0:
+                raise ExternalCommandError(
+                    "chown created directory", chown_code, _decode(chown_output)
+                )
 
     data = content.encode("utf-8")
     tar_stream = io.BytesIO()
@@ -701,10 +736,24 @@ def write_file_in_environment(
         info.size = len(data)
         tar.addfile(info, io.BytesIO(data))
     tar_stream.seek(0)
-    container.put_archive(parent, tar_stream)
+    try:
+        container.put_archive(parent, tar_stream)
+    except docker.errors.APIError as exc:
+        raise ExternalCommandError(
+            "write file archive",
+            1,
+            f"Could not write '{path}' inside the container. "
+            f"Verify that parent directory '{parent}' exists and is writable: {exc}",
+        ) from exc
 
     if user != "root":
-        container.exec_run(["chown", user, path], user="root")
+        chown_code, chown_output = container.exec_run(
+            ["chown", user, path], user="root"
+        )
+        if chown_code != 0:
+            raise ExternalCommandError(
+                "chown written file", chown_code, _decode(chown_output)
+            )
 
     logger.info(
         "File written in environment",

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -3,6 +3,7 @@ import os
 import re
 import tarfile
 from unittest.mock import MagicMock, patch
+from unittest.mock import call as mock_call
 from urllib.parse import urlsplit
 
 import pytest
@@ -3109,6 +3110,7 @@ class TestExportModuleTranslations:
         self, mock_docker_client
     ):
         container = MagicMock()
+        container.exec_run.return_value = (0, b"")
         mock_docker_client.containers.get.return_value = container
         content = "x" * 1_500_000
 
@@ -3123,6 +3125,93 @@ class TestExportModuleTranslations:
 
         assert result["size"] == len(content)
         container.put_archive.assert_called_once()
+
+    def test_write_creates_missing_parent_as_root_without_chowning_checkout(
+        self, mock_docker_client
+    ):
+        container = MagicMock()
+        parent = "/mnt/extra-addons/mymod/i18n"
+        path = f"{parent}/pl.po"
+        container.exec_run.side_effect = [
+            (1, b"Permission denied"),  # mkdir as odoo
+            (1, b""),  # i18n does not exist
+            (0, b""),  # module directory exists
+            (0, b""),  # mkdir as root
+            (0, b""),  # chown new i18n directory
+            (0, b""),  # chown written file
+        ]
+        mock_docker_client.containers.get.return_value = container
+
+        result = odoo_ops.write_file_in_environment(
+            TEST_SETTINGS, TEST_TEAM, "main", path, 'msgid ""\n'
+        )
+
+        assert result == {"path": path, "size": 9}
+        assert container.exec_run.call_args_list == [
+            mock_call(["mkdir", "-p", parent], user="odoo"),
+            mock_call(["test", "-d", parent], user="root"),
+            mock_call(["test", "-d", "/mnt/extra-addons/mymod"], user="root"),
+            mock_call(["mkdir", "-p", parent], user="root"),
+            mock_call(["chown", "-R", "odoo", parent], user="root"),
+            mock_call(["chown", "odoo", path], user="root"),
+        ]
+        container.put_archive.assert_called_once()
+
+    def test_write_reports_root_mkdir_failure(self, mock_docker_client):
+        container = MagicMock()
+        parent = "/mnt/extra-addons/mymod/i18n"
+        container.exec_run.side_effect = [
+            (1, b"Permission denied"),
+            (1, b""),
+            (0, b""),
+            (1, b"Read-only file system"),
+        ]
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(
+            odoo_ops.ExternalCommandError, match="Read-only file system"
+        ):
+            odoo_ops.write_file_in_environment(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "main",
+                f"{parent}/pl.po",
+                "content",
+            )
+
+        container.put_archive.assert_not_called()
+
+    def test_write_wraps_docker_archive_error(self, mock_docker_client):
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"")
+        container.put_archive.side_effect = docker.errors.NotFound(
+            "parent directory not found"
+        )
+        mock_docker_client.containers.get.return_value = container
+        path = "/mnt/extra-addons/mymod/i18n/pl.po"
+
+        with pytest.raises(
+            odoo_ops.ExternalCommandError,
+            match=r"Could not write '.*/i18n/pl\.po'.*parent directory",
+        ):
+            odoo_ops.write_file_in_environment(
+                TEST_SETTINGS, TEST_TEAM, "main", path, "content"
+            )
+
+    def test_write_reports_chown_failure(self, mock_docker_client):
+        container = MagicMock()
+        container.exec_run.side_effect = [
+            (0, b""),
+            (1, b"Operation not permitted"),
+        ]
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(
+            odoo_ops.ExternalCommandError, match="Operation not permitted"
+        ):
+            odoo_ops.write_file_in_environment(
+                TEST_SETTINGS, TEST_TEAM, "main", "/tmp/output.txt", "content"
+            )
 
     def test_public_write_limit_remains_one_mb(self, mock_docker_client):
         with pytest.raises(odoo_ops.ExternalCommandError, match="1000000 byte limit"):


### PR DESCRIPTION
## Summary

- detect failed parent-directory creation when writing files into an Odoo environment
- create only the missing directory tree as root, then transfer ownership of that new tree to the requested user
- convert Docker archive and ownership failures into actionable `ExternalCommandError` responses
- add regression coverage for missing `i18n` directories and each failure path

## Root cause

Translation export writes generated catalogues through `write_file_in_environment`. When a module had no `i18n` directory, `mkdir -p` ran as the unprivileged Odoo user against a root-owned source checkout and failed silently. The following Docker archive upload then returned a raw 404 because its destination directory did not exist.

## Impact

Modules can now export their first PO/POT catalogue into a previously absent `i18n` directory. Failures are returned as normal Oduflow tool errors instead of leaking Docker tracebacks.

## Validation

- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow tests`
- `mypy src/oduflow`
- `pytest -m "not integration and not heavyweight"` (2,267 passed, 15 deselected)
