### PR TITLE
Require branch push before environment creation

### DIFF
--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1033,6 +1033,17 @@ def get_agent_instructions(ctx: Context | None = None) -> str:
                 "---\n\n"
             )
 
+        if not envs:
+            return (
+                "## Current Code Delivery Mode\n\n"
+                "No environment was detected yet. Choose the delivery mode "
+                "before calling `create_environment`. For `repo_url`, first "
+                "publish the current branch with `git push -u origin HEAD`; "
+                "Oduflow cannot clone a local-only branch. For `local_path`, "
+                "pass the absolute checkout path and do not push.\n\n"
+                "---\n\n"
+            )
+
         return (
             "## Current Code Delivery Mode\n\n"
             "No live-mount/local_path environment was detected. Use the "

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1036,7 +1036,10 @@ def get_agent_instructions(ctx: Context | None = None) -> str:
         return (
             "## Current Code Delivery Mode\n\n"
             "No live-mount/local_path environment was detected. Use the "
-            "`repo_url` workflow: edit locally, commit, push, then call "
+            "`repo_url` workflow. Before the first `create_environment` for "
+            "the current branch, publish that branch with "
+            "`git push -u origin HEAD`; Oduflow cannot clone a local-only "
+            "branch. Then edit locally, commit, push, and call "
             "`pull_and_apply`.\n\n"
             "---\n\n"
         )

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 5
+Version: 6
 
 ## Purpose
 
@@ -21,21 +21,32 @@ version (15–19).
   what Oduflow applies.
 
 Use `list_environments` before creating anything. Reuse the environment for
-the current branch when it exists; otherwise call `create_environment` with
-the branch, correct Odoo image, and either `repo_url` or `local_path`. Show the
-returned URL to the user.
+the current branch when it exists. If none exists, prepare the selected
+delivery mode before calling `create_environment`:
+
+- **`repo_url`: first run `git push -u origin HEAD`** so the current branch
+  exists in the remote repository, then create the environment. Oduflow can
+  clone only pushed commits; it cannot see a local-only branch or uncommitted
+  changes.
+- **`local_path`:** create the environment from the absolute checkout path;
+  no push is required.
+
+Call `create_environment` with the branch, correct Odoo image, and either
+`repo_url` or `local_path`. Show the returned URL to the user.
 
 ## Core workflow
 
 ```text
-1. list_environments; create_environment only if needed
-2. get_odoo_development_guide before module code changes
-3. edit code locally
-4. repo_url: commit + push; local_path: no delivery step
-5. pull_and_apply with the action required by the edit
-6. read that response; if it failed, fix and repeat from step 3
-7. run_odoo_tests for the changed modules
-8. delete_environment when the task is done or cancelled and nobody still
+1. list_environments
+2. if creation is needed: repo_url must git push -u origin HEAD first;
+   local_path needs no push; then call create_environment
+3. get_odoo_development_guide before module code changes
+4. edit code locally
+5. repo_url: commit + push; local_path: no delivery step
+6. pull_and_apply with the action required by the edit
+7. read that response; if it failed, fix and repeat from step 4
+8. run_odoo_tests for the changed modules
+9. delete_environment when the task is done or cancelled and nobody still
    needs the URL or its test data
 ```
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -406,6 +406,9 @@ class TestAgentInstructionsTool:
 
         assert len(guide) < 16_000
         assert "Per-environment Odoo configuration" in guide
+        assert "Version: 6" in guide
+        assert "git push -u origin HEAD" in guide
+        assert "cannot see a local-only branch" in guide
         assert "db_maxconn" in guide
         assert "max_cron_threads" in guide
         assert "workers" in guide
@@ -439,7 +442,10 @@ class TestAgentInstructionsTool:
 
         assert result.startswith("## Current Code Delivery Mode")
         assert "No live-mount/local_path environment was detected" in result
-        assert "commit, push, then call `pull_and_apply`" in result
+        assert "Before the first `create_environment`" in result
+        assert "git push -u origin HEAD" in result
+        assert "cannot clone a local-only branch" in result
+        assert "commit, push, and call `pull_and_apply`" in result
 
 
 class TestInfoTool:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -436,7 +436,7 @@ class TestAgentInstructionsTool:
 
     @patch("oduflow.docker_ops.env_ops.list_environments")
     def test_instructions_preface_repo_url_mode(self, mock_list):
-        mock_list.return_value = []
+        mock_list.return_value = [{"env_name": "test-git", "local_path": None}]
 
         result = _call_tool("get_agent_instructions")
 
@@ -446,6 +446,20 @@ class TestAgentInstructionsTool:
         assert "git push -u origin HEAD" in result
         assert "cannot clone a local-only branch" in result
         assert "commit, push, and call `pull_and_apply`" in result
+
+    @patch("oduflow.docker_ops.env_ops.list_environments")
+    def test_instructions_preface_before_first_environment(self, mock_list):
+        mock_list.return_value = []
+
+        result = _call_tool("get_agent_instructions")
+
+        assert result.startswith("## Current Code Delivery Mode")
+        assert "No environment was detected yet" in result
+        assert "Choose the delivery mode" in result
+        assert "For `repo_url`" in result
+        assert "git push -u origin HEAD" in result
+        assert "For `local_path`" in result
+        assert "do not push" in result
 
 
 class TestInfoTool:


### PR DESCRIPTION
## What changed

- require agents using `repo_url` mode to publish the current branch with `git push -u origin HEAD` before the first `create_environment`
- keep `local_path` mode explicitly exempt from the push requirement
- bump the bundled agent guide to version 6 and add regression coverage

## Why

Agents could call `create_environment` for a branch that existed only in their local Conductor workspace. Oduflow then failed while cloning because the remote server could not see that branch or any uncommitted changes.

## Impact

New agent sessions receive the requirement both in the mode preface and in the core workflow, before environment creation is attempted.

## Validation

- `pytest tests/test_server.py -q` — 124 passed
- `ruff check src/oduflow/server.py tests/test_server.py`
- `git diff --check`