### PR TITLE
[codex] Handle containers removed during listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 keywords = ["odoo", "mcp", "docker", "development", "ci"]
 dependencies = [
     "fastmcp==2.14.3",
-    "docker",
+    "docker>=3.3.0",
     # Declarative Oduflow Stack manifests: typed validation + YAML input.
     "pydantic>=2.10,<3",
     "PyYAML>=6.0,<7",

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -2206,7 +2206,11 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
             f"{settings.team_label}={team.team_id}",
         ]
     }
-    containers = client.containers.list(all=True, filters=filters)
+    containers = client.containers.list(
+        all=True,
+        filters=filters,
+        ignore_removed=True,
+    )
 
     envs: dict[str, dict[str, Any]] = {}
     for container in containers:

--- a/src/oduflow/docker_ops/stats.py
+++ b/src/oduflow/docker_ops/stats.py
@@ -83,6 +83,7 @@ def get_container_stats(settings: Settings, team: TeamSettings) -> list[dict[str
                     f"{settings.team_label}={team.team_id}",
                 ]
             },
+            ignore_removed=True,
         )
         if c.name.startswith(settings.prefix)
     ]

--- a/tests/test_container_listing_race.py
+++ b/tests/test_container_listing_race.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+from oduflow.docker_ops import env_ops, stats
+from oduflow.settings import Settings, TeamSettings
+
+
+def _settings_and_team(tmp_path):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+    settings = Settings(teams={"1": team})
+    return settings, team
+
+
+def test_list_environments_ignores_containers_removed_during_listing(tmp_path):
+    settings, team = _settings_and_team(tmp_path)
+    client = MagicMock()
+    client.containers.list.return_value = []
+
+    with patch.object(env_ops, "get_client", return_value=client):
+        assert env_ops.list_environments(settings, team) == []
+
+    client.containers.list.assert_called_once_with(
+        all=True,
+        filters={
+            "label": [
+                f"{settings.managed_label}=true",
+                f"{settings.team_label}={team.team_id}",
+            ]
+        },
+        ignore_removed=True,
+    )
+
+
+def test_container_stats_ignores_containers_removed_during_listing(tmp_path):
+    settings, team = _settings_and_team(tmp_path)
+    client = MagicMock()
+    client.containers.list.return_value = []
+
+    with patch.object(stats, "get_client", return_value=client):
+        assert stats.get_container_stats(settings, team) == []
+
+    client.containers.list.assert_called_once_with(
+        all=True,
+        filters={
+            "label": [
+                f"{settings.managed_label}=true",
+                f"{settings.team_label}={team.team_id}",
+            ]
+        },
+        ignore_removed=True,
+    )


### PR DESCRIPTION
## What changed

- Ignore containers deleted between Docker list and inspect calls when listing environments and collecting stats.
- Require Docker SDK 3.3.0 or newer, where `ignore_removed` is supported.
- Add regression coverage for both listing paths.

## Why

Docker SDK expands a container list by inspecting each result. If a container is removed during that window, the default behavior raises `NotFound` and breaks environment or dashboard statistics listing.

## Impact

Concurrent environment deletion no longer makes the environment list or container statistics endpoint fail. Existing installations with an older Docker SDK are upgraded to a compatible version.

## Validation

- `pytest -q tests/test_container_listing_race.py` (2 passed)
- `pytest -q -m "not integration and not heavyweight"` (2271 passed, 15 deselected)
- `ruff check src/oduflow/docker_ops/env_ops.py src/oduflow/docker_ops/stats.py tests/test_container_listing_race.py`
- `mypy src/oduflow/docker_ops/env_ops.py src/oduflow/docker_ops/stats.py`
- `git diff --check`