### PR TITLE
[codex] Preserve local changes during bundled upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ MCP Clients (Cursor, Claude, etc.)
         ├── locking.py ── LockManager with per-branch, per-team, system locks
         ├── git_ops.py ── Clone, credentials, manifest parsing
         ├── git_analysis.py ── Classify changed files → action (install/upgrade/restart/nothing)
+        ├── bundled_upgrade.py ── Three-way merge deployed bundle files with persistent baselines
         ├── naming.py ── Pure functions: slugify, DB names, paths
         ├── extra_addons.py ── Extra addon repo management (bare clones + worktrees)
         ├── port_registry.py ── Stable port allocation (ports.json)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,10 +19,16 @@
   deletion rather than risking persisted data. See `docs/stacks.md` and
   `specs/0046`.
 
-- **Non-interactive bundled-file upgrades** — `oduflow upgrade --force` prints
-  the usual overwrite warning and affected paths but proceeds without waiting
-  for terminal input, enabling unattended deployments while continuing to
-  preserve files marked with `# KEEP`.
+- **Three-way bundled-file upgrades** — `oduflow upgrade` no longer compares
+  only file sizes and overwrites every differing deployed copy. Each team's
+  `odoo.conf`, agent guides, and sanitize script now keep a pristine bundled
+  baseline and merge local and upstream changes through `git merge-file`, with
+  an atomic pre-update backup. Conflicts never put markers into a live config:
+  they create `*.oduflow-merge`, preserve the old baseline, and exit non-zero.
+  Existing customized installations without a baseline receive a conservative
+  one-time `*.oduflow-new` sidecar. `--force` remains automation-friendly but
+  skips only confirmation, `# KEEP` remains a complete opt-out, and generated
+  `postgresql.conf` is now exclusively managed by `retune-postgres`.
 
 - **Structured Odoo ORM tools** — six new MCP tools give agents the semantics of
   standard Odoo XML-RPC `execute_kw` without writing Python: `odoo_search_read`,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,10 +65,10 @@ conflicts; no automatic deletion or pruning is performed.
 # Destroy all shared infrastructure (requires no active environments)
 oduflow destroy
 
-# Refresh deployed files bundled with the installed Oduflow version
+# Three-way merge deployed files with the installed bundled versions
 oduflow upgrade
 
-# Refresh non-interactively (for scripts and automated deployments)
+# Skip the confirmation prompt (conflicts still fail safely)
 oduflow upgrade --force
 
 # Preview the unified host resource plan and managed config diffs
@@ -85,14 +85,24 @@ then lists every PostgreSQL and Odoo container that should be restarted. It
 refuses to replace a custom PostgreSQL config unless `--apply --force` is
 given. See [PostgreSQL resource planning](installation.md#configuration-file-overrides).
 
-`oduflow upgrade` compares and interactively refreshes the system
-`postgresql.conf` plus each team's `odoo.conf`, agent guides, and bundled
-sanitize script. It prints the affected paths and asks for confirmation before
-overwriting them. A deployed file whose first line is exactly `# KEEP` is left
-unchanged. This command is separate from upgrading the Python package (for
-example, `uv tool upgrade oduflow`). Pass `--force` to accept the listed
-overwrites without reading from the terminal; the warning and affected-file
-list are still printed, and `# KEEP` files are still preserved.
+`oduflow upgrade` reconciles each team's `odoo.conf`, agent guides, and bundled
+sanitize script against a stored pristine baseline. It compares complete file
+contents, updates an untouched file, preserves local-only changes, and uses
+`git merge-file` when both the local and bundled versions changed. Before a live
+update, the previous file is saved under
+`<team-data>/.bundled_upgrade/backups/`.
+
+On a clean merge the live file and baseline advance together. On conflict the
+live file and accepted baseline stay untouched; the merge result is written to
+`*.oduflow-merge`. Existing customized installations with no baseline receive
+`*.oduflow-new` for a one-time manual reconciliation. Resolve/install the
+sidecar and remove it; until then the command exits with status 1. `--force`
+only skips the confirmation prompt and never overwrites a conflict. A first-line
+`# KEEP` remains an unconditional opt-out.
+
+This command is separate from upgrading the Python package (for example,
+`uv tool upgrade oduflow`). It does not manage `postgresql.conf`; use
+`oduflow retune-postgres` for PostgreSQL planning and updates.
 
 ## Template Commands
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -103,26 +103,40 @@ oduflow upgrade --force
 ```
 
 The first command upgrades the Python package. The second is a separate,
-interactive migration of deployed bundled files: it shows the files that would
-be replaced and waits for confirmation before updating agent guides,
-`postgresql.conf`, sanitize scripts, and per-team `odoo.conf` files. Package
-upgrade alone does not overwrite those deployed copies.
+interactive reconciliation of each team's deployed `odoo.conf`, agent guides,
+and bundled sanitize script. Package upgrade alone does not update those
+deployed copies. `postgresql.conf` is intentionally separate: preview and apply
+resource-tuning changes with `oduflow retune-postgres [--apply]`.
 
-For unattended upgrades, pass `--force`. Oduflow still prints the warning and
-affected paths but proceeds without reading from stdin. Files protected by
-`# KEEP` remain untouched.
+Oduflow keeps the previous pristine bundle under
+`<team-data>/.bundled_upgrade/baselines/` and performs a three-way merge. An
+unmodified deployed file receives the new bundle directly; local-only changes
+stay untouched; disjoint local and upstream changes are merged. The pre-update
+live file is retained under `.bundled_upgrade/backups/`.
 
-If you have customized any of these files and want to prevent `oduflow upgrade`
-from overwriting it, add `# KEEP` as the **very first line** of the file:
+For an installation created before baselines existed, the first upgrade keeps
+the live file and writes the new bundle beside it as `*.oduflow-new`. Merge that
+file manually into the live file, then delete the sidecar. A true merge conflict
+similarly leaves the live file untouched and writes `*.oduflow-merge`; resolve
+that file, install the resolved content as the live file, and remove the
+sidecar. Until the sidecar is resolved, `oduflow upgrade` exits non-zero.
+
+For unattended upgrades, pass `--force`. It skips only the stdin confirmation:
+legacy files and conflicts are still preserved and still produce a non-zero
+exit code.
+
+Automatic merging is the default. To opt a file out of all bundled changes,
+add `# KEEP` as the **very first line**:
 
 ```conf
 # KEEP
-# My custom postgresql.conf
-listen_addresses = '*'
+[options]
+# Keep this odoo.conf entirely operator-managed.
 ...
 ```
 
-Files marked with `# KEEP` will be skipped during upgrade and listed as `(kept)` in the upgrade output.
+Files marked with `# KEEP` are skipped and listed as `(kept)` in the upgrade
+output.
 
 ## Configuration Reference
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -69,6 +69,7 @@ src/oduflow/
   locking.py           # LockManager with per-branch, per-team, and system locks
   git_ops.py           # Git clone, pull, credential management, manifest parsing
   git_analysis.py      # Classify changed files → install / upgrade / restart / refresh
+  bundled_upgrade.py   # Three-way merge bundled files using persistent baselines
   port_registry.py     # Stable port allocation with JSON persistence
   web_ui.py            # Starlette dashboard, REST/WS API, session+Basic auth middleware
   extra_addons.py      # Extra addon repo management (clone, worktree, odoo.conf generation)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -96,11 +96,14 @@ oduflow upgrade
 oduflow upgrade --force
 ```
 
-Package upgrade and deployed-file refresh are separate. `oduflow upgrade` lists
-bundled config/guides/sanitize files that changed and asks before overwriting;
-add `# KEEP` as the first line of a customized deployed file to preserve it.
-Pass `--force` to skip the stdin confirmation in unattended automation; the
-warning is still printed and `# KEEP` files are still preserved.
+Package upgrade and deployed-file reconciliation are separate. `oduflow
+upgrade` three-way merges each team's bundled `odoo.conf`, agent guides, and
+sanitize script against a stored pristine baseline. Conflicts preserve the live
+file and create `*.oduflow-merge`; pre-baseline installations create
+`*.oduflow-new` for one-time manual reconciliation. Both cases exit non-zero
+until the sidecar is resolved and removed. `--force` skips only the stdin
+confirmation. A first-line `# KEEP` opts a file out entirely. PostgreSQL config
+changes use `oduflow retune-postgres`, not `oduflow upgrade`.
 
 ### Set up a template
 
@@ -654,26 +657,40 @@ oduflow upgrade --force
 ```
 
 The first command upgrades the Python package. The second is a separate,
-interactive migration of deployed bundled files: it shows the files that would
-be replaced and waits for confirmation before updating agent guides,
-`postgresql.conf`, sanitize scripts, and per-team `odoo.conf` files. Package
-upgrade alone does not overwrite those deployed copies.
+interactive reconciliation of each team's deployed `odoo.conf`, agent guides,
+and bundled sanitize script. Package upgrade alone does not update those
+deployed copies. `postgresql.conf` is intentionally separate: preview and apply
+resource-tuning changes with `oduflow retune-postgres [--apply]`.
 
-For unattended upgrades, pass `--force`. Oduflow still prints the warning and
-affected paths but proceeds without reading from stdin. Files protected by
-`# KEEP` remain untouched.
+Oduflow keeps the previous pristine bundle under
+`<team-data>/.bundled_upgrade/baselines/` and performs a three-way merge. An
+unmodified deployed file receives the new bundle directly; local-only changes
+stay untouched; disjoint local and upstream changes are merged. The pre-update
+live file is retained under `.bundled_upgrade/backups/`.
 
-If you have customized any of these files and want to prevent `oduflow upgrade`
-from overwriting it, add `# KEEP` as the **very first line** of the file:
+For an installation created before baselines existed, the first upgrade keeps
+the live file and writes the new bundle beside it as `*.oduflow-new`. Merge that
+file manually into the live file, then delete the sidecar. A true merge conflict
+similarly leaves the live file untouched and writes `*.oduflow-merge`; resolve
+that file, install the resolved content as the live file, and remove the
+sidecar. Until the sidecar is resolved, `oduflow upgrade` exits non-zero.
+
+For unattended upgrades, pass `--force`. It skips only the stdin confirmation:
+legacy files and conflicts are still preserved and still produce a non-zero
+exit code.
+
+Automatic merging is the default. To opt a file out of all bundled changes,
+add `# KEEP` as the **very first line**:
 
 ```conf
 # KEEP
-# My custom postgresql.conf
-listen_addresses = '*'
+[options]
+# Keep this odoo.conf entirely operator-managed.
 ...
 ```
 
-Files marked with `# KEEP` will be skipped during upgrade and listed as `(kept)` in the upgrade output.
+Files marked with `# KEEP` are skipped and listed as `(kept)` in the upgrade
+output.
 
 ## Configuration Reference
 
@@ -3211,10 +3228,10 @@ conflicts; no automatic deletion or pruning is performed.
 # Destroy all shared infrastructure (requires no active environments)
 oduflow destroy
 
-# Refresh deployed files bundled with the installed Oduflow version
+# Three-way merge deployed files with the installed bundled versions
 oduflow upgrade
 
-# Refresh non-interactively (for scripts and automated deployments)
+# Skip the confirmation prompt (conflicts still fail safely)
 oduflow upgrade --force
 
 # Preview the unified host resource plan and managed config diffs
@@ -3231,14 +3248,24 @@ then lists every PostgreSQL and Odoo container that should be restarted. It
 refuses to replace a custom PostgreSQL config unless `--apply --force` is
 given. See [PostgreSQL resource planning](installation.md#configuration-file-overrides).
 
-`oduflow upgrade` compares and interactively refreshes the system
-`postgresql.conf` plus each team's `odoo.conf`, agent guides, and bundled
-sanitize script. It prints the affected paths and asks for confirmation before
-overwriting them. A deployed file whose first line is exactly `# KEEP` is left
-unchanged. This command is separate from upgrading the Python package (for
-example, `uv tool upgrade oduflow`). Pass `--force` to accept the listed
-overwrites without reading from the terminal; the warning and affected-file
-list are still printed, and `# KEEP` files are still preserved.
+`oduflow upgrade` reconciles each team's `odoo.conf`, agent guides, and bundled
+sanitize script against a stored pristine baseline. It compares complete file
+contents, updates an untouched file, preserves local-only changes, and uses
+`git merge-file` when both the local and bundled versions changed. Before a live
+update, the previous file is saved under
+`<team-data>/.bundled_upgrade/backups/`.
+
+On a clean merge the live file and baseline advance together. On conflict the
+live file and accepted baseline stay untouched; the merge result is written to
+`*.oduflow-merge`. Existing customized installations with no baseline receive
+`*.oduflow-new` for a one-time manual reconciliation. Resolve/install the
+sidecar and remove it; until then the command exits with status 1. `--force`
+only skips the confirmation prompt and never overwrites a conflict. A first-line
+`# KEEP` remains an unconditional opt-out.
+
+This command is separate from upgrading the Python package (for example,
+`uv tool upgrade oduflow`). It does not manage `postgresql.conf`; use
+`oduflow retune-postgres` for PostgreSQL planning and updates.
 
 ## Template Commands
 
@@ -4135,6 +4162,7 @@ src/oduflow/
   locking.py           # LockManager with per-branch, per-team, and system locks
   git_ops.py           # Git clone, pull, credential management, manifest parsing
   git_analysis.py      # Classify changed files → install / upgrade / restart / refresh
+  bundled_upgrade.py   # Three-way merge bundled files using persistent baselines
   port_registry.py     # Stable port allocation with JSON persistence
   web_ui.py            # Starlette dashboard, REST/WS API, session+Basic auth middleware
   extra_addons.py      # Extra addon repo management (clone, worktree, odoo.conf generation)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -96,11 +96,14 @@ oduflow upgrade
 oduflow upgrade --force
 ```
 
-Package upgrade and deployed-file refresh are separate. `oduflow upgrade` lists
-bundled config/guides/sanitize files that changed and asks before overwriting;
-add `# KEEP` as the first line of a customized deployed file to preserve it.
-Pass `--force` to skip the stdin confirmation in unattended automation; the
-warning is still printed and `# KEEP` files are still preserved.
+Package upgrade and deployed-file reconciliation are separate. `oduflow
+upgrade` three-way merges each team's bundled `odoo.conf`, agent guides, and
+sanitize script against a stored pristine baseline. Conflicts preserve the live
+file and create `*.oduflow-merge`; pre-baseline installations create
+`*.oduflow-new` for one-time manual reconciliation. Both cases exit non-zero
+until the sidecar is resolved and removed. `--force` skips only the stdin
+confirmation. A first-line `# KEEP` opts a file out entirely. PostgreSQL config
+changes use `oduflow retune-postgres`, not `oduflow upgrade`.
 
 ### Set up a template
 

--- a/specs/0006-git-driven-change-classification.md
+++ b/specs/0006-git-driven-change-classification.md
@@ -65,9 +65,9 @@ The rules, refined incrementally from real misfires:
   request looks like an *under*-action (a missing install/upgrade/restart),
   leaving the agent in charge.
 - **`# KEEP` protection.** A file whose first line is `# KEEP` is never
-  overwritten by `oduflow upgrade`; it is reported as `(kept)` instead. This lets
-  generated/hand-tuned files (e.g. a locally edited `odoo.conf`,
-  `postgresql.conf`) survive a sync.
+  changed by `oduflow upgrade`; it is reported as `(kept)` instead. The later
+  bundled-file reconciler ([[0047-three-way-bundled-upgrades]]) preserves this
+  complete opt-out alongside automatic merging for ordinary local edits.
 - **Trace logging.** `ODUFLOW_TRACE=1` emits a per-file decision trace through
   the classify/sync pipeline, for debugging why an action was (or wasn't) chosen.
 

--- a/specs/0016-configuration-model.md
+++ b/specs/0016-configuration-model.md
@@ -72,8 +72,10 @@ aggressively rather than expose knobs.
   conservative fallbacks, never raising), and `generate_postgresql_conf()`
   produces a lean, SSD-oriented config sized for "one host running many
   lightweight single-user Odoo envs". The generated file is written with a
-  `# KEEP` marker so [[0006-git-driven-change-classification]]'s upgrade never
-  overwrites a hand-edited copy. No new TOML settings were added for it.
+  `# KEEP` marker and is outside the bundled-file upgrade path; explicit
+  resource-plan changes go through `retune-postgres`
+  ([[0044-unified-host-resource-planning]]). No new TOML settings were added for
+  it.
 
 ## Consequences
 

--- a/specs/0047-three-way-bundled-upgrades.md
+++ b/specs/0047-three-way-bundled-upgrades.md
@@ -1,0 +1,90 @@
+# 0047 — Three-way upgrades for deployed bundled files
+
+**Status:** Adopted
+**Type:** Architecture — configuration delivery model
+**First introduced:** this change (2026-08-14), branch `litnimax/merge-local-upgrades`
+**Key code today:** `bundled_upgrade.py` (baseline state machine, merge, atomic writes), `server.py` (`_ensure_initialized`, `oduflow upgrade` CLI)
+
+## Context
+
+Auto-init seeds a per-team `odoo.conf`, sanitization script, and agent guides
+from package templates ([[0018-onboarding-stdio-default-auto-init]]). Operators
+are expected to customize those deployed copies. The original upgrade command
+could not distinguish an operator edit from a new package version: it compared
+only file sizes and copied the new bundle over every different-size file. An
+edit of the same size was missed entirely, while a detected edit was lost
+unless the operator had added the all-or-nothing `# KEEP` marker.
+
+Merging requires three versions: the operator's live file, the new bundle, and
+the previous pristine bundle they share as an ancestor. Existing installations
+do not have that ancestor, so their first reconciliation cannot be automated
+without guessing which release supplied the file. A conflict must also never
+put `<<<<<<<` markers into a live `odoo.conf` or agent instruction file.
+
+## Decision
+
+Treat deployed bundled files as three-way-managed configuration. Each team
+stores the last accepted pristine bundle under
+`.bundled_upgrade/baselines/`, mirroring the deployed relative paths. Auto-init
+creates the live file and baseline together; it may adopt an existing file only
+when its bytes exactly match the current bundle.
+
+`oduflow upgrade` compares complete content and classifies each file before
+writing:
+
+- untouched local file: install the new bundle;
+- local-only change: leave it untouched;
+- both sides changed: merge with `git merge-file` using the stored baseline;
+- first-line `# KEEP`: skip unconditionally.
+
+Before replacing a live file, keep its previous bytes under
+`.bundled_upgrade/backups/`. Live writes and state writes use temporary files
+plus atomic replacement. `--force` controls only interactive confirmation; it
+does not weaken preservation or conflict handling.
+
+PostgreSQL configuration is not part of this mechanism. It is generated from
+host resources and changes through the explicit preview/apply boundary in
+`retune-postgres` ([[0044-unified-host-resource-planning]]).
+
+## How it works (macro)
+
+A clean diff3 result atomically replaces the live file and advances the
+baseline to the new pristine bundle. A conflicting result is written beside
+the live file as `*.oduflow-merge`; the live file and accepted baseline remain
+unchanged. The candidate new baseline is held separately under
+`.bundled_upgrade/pending/`. The operator resolves and installs the sidecar,
+then removes it; that removal acknowledges the pending bundle as the new merge
+base on the next run. Until resolution, the CLI exits non-zero and refreshes
+the conflict against the accepted baseline.
+
+For a customized pre-baseline installation, Oduflow cannot reconstruct the
+ancestor safely. It therefore leaves the live file byte-for-byte intact, writes
+the current bundle as `*.oduflow-new`, and records it as pending rather than
+accepted. The operator performs this one-time manual reconciliation and removes
+the sidecar. From then on, later package changes have a real ancestor and merge
+automatically.
+
+If the merge engine is unavailable or fails, the live file and baseline remain
+unchanged and the new bundle is exposed as `*.oduflow-error-new`. Planning also
+records the bytes it inspected; apply refuses to proceed if the source, live
+file, or merge base changed while the confirmation prompt was open.
+
+## Consequences
+
+- Ordinary local customization no longer blocks upstream improvements or gets
+  overwritten by them; disjoint changes merge automatically.
+- Conflicts are explicit, script-detectable, and safe for parsers and agents
+  because markers never enter the live file.
+- Existing customized installations require one honest manual reconciliation;
+  the system does not infer an unknowable historical base from file similarity
+  or package tags.
+- Per-team baseline, pending, and rolling backup copies consume a small amount
+  of quota-accounted storage and become part of the team's persistent state.
+- Git remains the merge implementation, consistent with Oduflow's Git-driven
+  development model; its absence degrades to a non-destructive error artifact.
+
+## History
+
+- 2026-08-14 — persistent baselines, safe legacy migration, diff3 merge,
+  conflict sidecars, atomic backups, and PostgreSQL exclusion introduced on
+  `litnimax/merge-local-upgrades`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -65,6 +65,7 @@ precursors).
 | [0044](0044-unified-host-resource-planning.md) | 2026-08-02 | One host-wide resource plan for dev PostgreSQL, production PostgreSQL, and production Odoo |
 | [0045](0045-user-attributed-github-feedback.md) | 2026-08-11 | User-attributed GitHub feedback through prefilled, review-before-submit issue forms |
 | [0046](0046-declarative-oduflow-stacks.md) | 2026-08-11 | Declarative Oduflow Stacks: versioned YAML, plan/apply reconciliation, ownership and startup bootstrap |
+| [0047](0047-three-way-bundled-upgrades.md) | 2026-08-14 | Three-way upgrades for deployed bundled files with persistent baselines and safe conflict sidecars |
 
 ## Design docs
 

--- a/src/oduflow/bundled_upgrade.py
+++ b/src/oduflow/bundled_upgrade.py
@@ -1,0 +1,533 @@
+"""Safely reconcile deployed files with newer bundled versions.
+
+Each managed file keeps the pristine bundled content last seen by Oduflow as
+its baseline.  That gives upgrades the three inputs required for a real merge:
+the previous bundle, the operator's live file, and the new bundle.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+ActionKind = Literal[
+    "up-to-date",
+    "adopt",
+    "create",
+    "update",
+    "local-only",
+    "resolved",
+    "merge",
+    "keep",
+    "legacy",
+    "legacy-pending",
+    "conflict",
+    "error",
+]
+
+
+class BundledUpgradeError(RuntimeError):
+    """Raised when an upgrade plan can no longer be applied safely."""
+
+
+@dataclass(frozen=True)
+class ManagedFile:
+    """One bundled source and its deployed, baseline, and backup locations."""
+
+    label: str
+    source: Path
+    destination: Path
+    state_root: Path
+    relative_path: Path
+
+    @property
+    def baseline_path(self) -> Path:
+        return self.state_root / "baselines" / self.relative_path
+
+    @property
+    def backup_path(self) -> Path:
+        return self.state_root / "backups" / self.relative_path
+
+    @property
+    def pending_path(self) -> Path:
+        return self.state_root / "pending" / self.relative_path
+
+    @property
+    def new_path(self) -> Path:
+        return Path(f"{self.destination}.oduflow-new")
+
+    @property
+    def merge_path(self) -> Path:
+        return Path(f"{self.destination}.oduflow-merge")
+
+    @property
+    def error_path(self) -> Path:
+        return Path(f"{self.destination}.oduflow-error-new")
+
+
+@dataclass(frozen=True)
+class ReconcilePlan:
+    """A side-effect-free decision for one managed file."""
+
+    managed: ManagedFile
+    kind: ActionKind
+    source_content: bytes
+    local_content: bytes | None = None
+    baseline_content: bytes | None = None
+    result_content: bytes | None = None
+    error: str = ""
+    base_path: Path | None = None
+    pending_acknowledged: bool = False
+
+    @property
+    def needs_confirmation(self) -> bool:
+        return self.kind in {
+            "create",
+            "update",
+            "merge",
+            "legacy",
+            "legacy-pending",
+            "conflict",
+            "error",
+        }
+
+    @property
+    def needs_attention(self) -> bool:
+        return self.kind in {"legacy", "legacy-pending", "conflict", "error"}
+
+
+def seed_managed_file(managed: ManagedFile) -> bool:
+    """Create a missing deployed file and its baseline.
+
+    Existing custom files are never adopted as a baseline.  An existing file
+    is safe to adopt only when it is byte-for-byte equal to the current bundle.
+    Returns True when the deployed file itself was created.
+    """
+    source_content = managed.source.read_bytes()
+    try:
+        local_content = managed.destination.read_bytes()
+    except FileNotFoundError:
+        _atomic_write(managed.destination, source_content, reference=managed.source)
+        _atomic_write(managed.baseline_path, source_content, reference=managed.source)
+        return True
+
+    if local_content == source_content:
+        try:
+            baseline_content = managed.baseline_path.read_bytes()
+        except FileNotFoundError:
+            baseline_content = None
+        if baseline_content != source_content:
+            _atomic_write(
+                managed.baseline_path, source_content, reference=managed.source
+            )
+    return False
+
+
+def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
+    """Classify one file without changing the filesystem."""
+    source_content = managed.source.read_bytes()
+    try:
+        local_content = managed.destination.read_bytes()
+    except FileNotFoundError:
+        return ReconcilePlan(managed, "create", source_content)
+
+    if _has_keep_marker(local_content):
+        return ReconcilePlan(
+            managed, "keep", source_content, local_content=local_content
+        )
+
+    try:
+        baseline_content = managed.baseline_path.read_bytes()
+    except FileNotFoundError:
+        baseline_content = None
+
+    if local_content == source_content:
+        sidecars_exist = (
+            managed.new_path.exists()
+            or managed.merge_path.exists()
+            or managed.error_path.exists()
+            or managed.pending_path.exists()
+        )
+        kind: ActionKind = (
+            "up-to-date"
+            if baseline_content == source_content and not sidecars_exist
+            else "adopt"
+        )
+        return ReconcilePlan(
+            managed,
+            kind,
+            source_content,
+            local_content=local_content,
+            baseline_content=baseline_content,
+        )
+
+    # Sidecars are explicit gates. Keep refreshing them from the last accepted
+    # baseline until the operator reconciles the live file and removes them.
+    if managed.new_path.exists():
+        return ReconcilePlan(
+            managed,
+            "legacy-pending",
+            source_content,
+            local_content=local_content,
+            baseline_content=baseline_content,
+            result_content=source_content,
+        )
+
+    if managed.merge_path.exists():
+        if baseline_content is None:
+            return ReconcilePlan(
+                managed,
+                "error",
+                source_content,
+                local_content=local_content,
+                result_content=source_content,
+                error="conflict sidecar exists but its accepted baseline is missing",
+            )
+        merged_content, error, conflicted = _merge_file(managed, managed.baseline_path)
+        if error:
+            return ReconcilePlan(
+                managed,
+                "error",
+                source_content,
+                local_content=local_content,
+                baseline_content=baseline_content,
+                result_content=source_content,
+                error=error,
+                base_path=managed.baseline_path,
+            )
+        return ReconcilePlan(
+            managed,
+            "conflict" if conflicted else "merge",
+            source_content,
+            local_content=local_content,
+            baseline_content=baseline_content,
+            result_content=merged_content,
+            base_path=managed.baseline_path,
+        )
+
+    pending_acknowledged = False
+    base_path = managed.baseline_path
+    try:
+        pending_content = managed.pending_path.read_bytes()
+    except FileNotFoundError:
+        pending_content = None
+    else:
+        # Removing the visible sidecar acknowledges that the operator resolved
+        # it. The pending bundle becomes the accepted base for this run.
+        baseline_content = pending_content
+        base_path = managed.pending_path
+        pending_acknowledged = True
+
+    if baseline_content is None:
+        return ReconcilePlan(
+            managed,
+            "legacy",
+            source_content,
+            local_content=local_content,
+            result_content=source_content,
+        )
+
+    if local_content == baseline_content:
+        return ReconcilePlan(
+            managed,
+            "update",
+            source_content,
+            local_content=local_content,
+            baseline_content=baseline_content,
+            result_content=source_content,
+            base_path=base_path,
+            pending_acknowledged=pending_acknowledged,
+        )
+
+    if source_content == baseline_content:
+        if pending_acknowledged:
+            return ReconcilePlan(
+                managed,
+                "resolved",
+                source_content,
+                local_content=local_content,
+                baseline_content=baseline_content,
+                base_path=base_path,
+                pending_acknowledged=True,
+            )
+        return ReconcilePlan(
+            managed,
+            "local-only",
+            source_content,
+            local_content=local_content,
+            baseline_content=baseline_content,
+            base_path=base_path,
+        )
+
+    merged_content, error, conflicted = _merge_file(managed, base_path)
+    if error:
+        return ReconcilePlan(
+            managed,
+            "error",
+            source_content,
+            local_content=local_content,
+            baseline_content=baseline_content,
+            result_content=source_content,
+            error=error,
+            base_path=base_path,
+            pending_acknowledged=pending_acknowledged,
+        )
+    return ReconcilePlan(
+        managed,
+        "conflict" if conflicted else "merge",
+        source_content,
+        local_content=local_content,
+        baseline_content=baseline_content,
+        result_content=merged_content,
+        base_path=base_path,
+        pending_acknowledged=pending_acknowledged,
+    )
+
+
+def apply_reconcile(plan: ReconcilePlan) -> None:
+    """Apply a previously computed plan with atomic writes and drift checks."""
+    managed = plan.managed
+    _assert_unchanged(managed.source, plan.source_content, "bundled source")
+
+    if plan.local_content is None:
+        if managed.destination.exists():
+            raise BundledUpgradeError(
+                f"{managed.destination} appeared after the upgrade was planned"
+            )
+    else:
+        _assert_unchanged(managed.destination, plan.local_content, "deployed file")
+    if plan.base_path is not None and plan.baseline_content is not None:
+        _assert_unchanged(plan.base_path, plan.baseline_content, "merge baseline")
+
+    if plan.kind in {"up-to-date", "local-only", "keep"}:
+        return
+
+    if plan.kind == "adopt":
+        _write_baseline(plan)
+        _unlink_if_exists(managed.pending_path)
+        _remove_generated_sidecars(managed)
+        return
+
+    if plan.kind == "resolved":
+        if plan.baseline_content is None:
+            raise BundledUpgradeError("Resolved plan has no accepted baseline")
+        _write_baseline_content(managed, plan.baseline_content)
+        _unlink_if_exists(managed.pending_path)
+        _remove_generated_sidecars(managed)
+        return
+
+    if plan.kind == "create":
+        _atomic_write(
+            managed.destination,
+            plan.source_content,
+            reference=managed.source,
+        )
+        _write_baseline(plan)
+        _unlink_if_exists(managed.pending_path)
+        _remove_generated_sidecars(managed)
+        return
+
+    if plan.kind in {"update", "merge"}:
+        if plan.local_content is None or plan.result_content is None:
+            raise BundledUpgradeError(f"Incomplete {plan.kind} plan")
+        _atomic_write(
+            managed.backup_path,
+            plan.local_content,
+            reference=managed.destination,
+        )
+        _atomic_write(
+            managed.destination,
+            plan.result_content,
+            reference=managed.destination,
+        )
+        _write_baseline(plan)
+        _unlink_if_exists(managed.pending_path)
+        _remove_generated_sidecars(managed)
+        return
+
+    if plan.kind in {"legacy", "legacy-pending"}:
+        _atomic_write(
+            managed.new_path,
+            plan.source_content,
+            reference=managed.source,
+        )
+        _atomic_write(
+            managed.pending_path,
+            plan.source_content,
+            reference=managed.source,
+        )
+        _unlink_if_exists(managed.merge_path)
+        _unlink_if_exists(managed.error_path)
+        return
+
+    if plan.kind == "conflict":
+        if plan.result_content is None:
+            raise BundledUpgradeError("Conflict plan has no merge artifact")
+        _atomic_write(
+            managed.merge_path,
+            plan.result_content,
+            reference=managed.destination,
+        )
+        if plan.pending_acknowledged:
+            if plan.baseline_content is None:
+                raise BundledUpgradeError("Conflict plan has no accepted baseline")
+            _write_baseline_content(managed, plan.baseline_content)
+        _atomic_write(
+            managed.pending_path,
+            plan.source_content,
+            reference=managed.source,
+        )
+        _unlink_if_exists(managed.new_path)
+        _unlink_if_exists(managed.error_path)
+        return
+
+    if plan.kind == "error":
+        if plan.pending_acknowledged:
+            if plan.baseline_content is None:
+                raise BundledUpgradeError("Error plan has no accepted baseline")
+            _write_baseline_content(managed, plan.baseline_content)
+            _unlink_if_exists(managed.pending_path)
+        _atomic_write(
+            managed.error_path,
+            plan.source_content,
+            reference=managed.source,
+        )
+        return
+
+    raise BundledUpgradeError(f"Unknown reconcile action: {plan.kind}")
+
+
+def _merge_file(
+    managed: ManagedFile, base_path: Path
+) -> tuple[bytes | None, str, bool]:
+    """Run git's diff3 merge without modifying any input file."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "merge-file",
+                "-p",
+                "-L",
+                str(managed.destination),
+                "-L",
+                "previous bundled version",
+                "-L",
+                "new bundled version",
+                str(managed.destination),
+                str(base_path),
+                str(managed.source),
+            ],
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        return None, f"git merge-file could not run: {exc}", False
+
+    if result.returncode == 0:
+        return result.stdout, "", False
+    if result.returncode == 1:
+        return result.stdout, "", True
+    stderr = result.stderr.decode("utf-8", errors="replace").strip()
+    detail = stderr or f"exit code {result.returncode}"
+    return None, f"git merge-file failed: {detail}", False
+
+
+def _has_keep_marker(content: bytes) -> bool:
+    lines = content.splitlines()
+    return bool(lines and lines[0].strip() == b"# KEEP")
+
+
+def _write_baseline(plan: ReconcilePlan) -> None:
+    _write_baseline_content(plan.managed, plan.source_content)
+
+
+def _write_baseline_content(managed: ManagedFile, content: bytes) -> None:
+    _atomic_write(
+        managed.baseline_path,
+        content,
+        reference=managed.source,
+    )
+
+
+def _assert_unchanged(path: Path, expected: bytes, description: str) -> None:
+    try:
+        current = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise BundledUpgradeError(
+            f"{description} disappeared after the upgrade was planned: {path}"
+        ) from exc
+    if current != expected:
+        raise BundledUpgradeError(
+            f"{description} changed after the upgrade was planned: {path}"
+        )
+
+
+def _remove_generated_sidecars(managed: ManagedFile) -> None:
+    _unlink_if_exists(managed.new_path)
+    _unlink_if_exists(managed.merge_path)
+    _unlink_if_exists(managed.error_path)
+
+
+def _unlink_if_exists(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _atomic_write(path: Path, content: bytes, *, reference: Path | None) -> None:
+    """Write bytes with fsync + replace while retaining useful metadata."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as tmp:
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+
+        mode = 0o644
+        owner: tuple[int, int] | None = None
+        if reference is not None:
+            try:
+                reference_stat = reference.stat()
+            except FileNotFoundError:
+                pass
+            else:
+                mode = stat.S_IMODE(reference_stat.st_mode)
+                owner = (reference_stat.st_uid, reference_stat.st_gid)
+        os.chmod(tmp_path, mode)
+        if owner is not None:
+            try:
+                os.chown(tmp_path, *owner)
+            except PermissionError:
+                pass
+
+        os.replace(tmp_path, path)
+        _fsync_directory(path.parent)
+    finally:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -28,6 +28,7 @@ from fastmcp.exceptions import ToolError
 from oduflow import (
     activity,
     artifact_tokens,
+    bundled_upgrade,
     git_ops,
     migrations,
     po_tools,
@@ -4498,6 +4499,41 @@ def delete_production(
 # =============================================================================
 
 
+def _managed_bundled_files(
+    bundled_dir: pathlib.Path, team_id: str, team: TeamSettings
+) -> list[bundled_upgrade.ManagedFile]:
+    """Return the bundled files reconciled for one team."""
+    label = f"[team.{team_id}]"
+    state_root = pathlib.Path(team.data_dir) / ".bundled_upgrade"
+    entries: list[tuple[pathlib.Path, pathlib.Path]] = [
+        (bundled_dir / "odoo.conf", pathlib.Path("odoo.conf")),
+        (
+            bundled_dir / "01_disable_mail.sql",
+            pathlib.Path("odoo_sanitize") / "01_disable_mail.sql",
+        ),
+    ]
+
+    guides_dir = bundled_dir / "agent_guides"
+    if guides_dir.is_dir():
+        entries.extend(
+            (guide, pathlib.Path("agent_guides") / guide.name)
+            for guide in sorted(guides_dir.iterdir())
+            if guide.is_file() and guide.suffix == ".md"
+        )
+
+    return [
+        bundled_upgrade.ManagedFile(
+            label=label,
+            source=source,
+            destination=pathlib.Path(team.data_dir) / relative,
+            state_root=state_root,
+            relative_path=relative,
+        )
+        for source, relative in entries
+        if source.is_file()
+    ]
+
+
 def _apply_agent_feedback(settings: Settings) -> None:
     """Expose ``submit_agent_feedback`` only while the hidden option is on.
 
@@ -4530,9 +4566,6 @@ def _ensure_initialized(settings: Settings) -> None:
 
     backup_ops.register_pre_update_hook()
 
-    import pathlib
-    import shutil
-
     bundled_dir = pathlib.Path(__file__).resolve().parent / "templates"
 
     for team_id, team in settings.teams.items():
@@ -4546,34 +4579,11 @@ def _ensure_initialized(settings: Settings) -> None:
             with open(presets_path, "w") as f:
                 f.write("{}\n")
 
-        # Copy bundled odoo.conf to team data dir
-        odoo_conf_dest = os.path.join(team.data_dir, "odoo.conf")
-        if not os.path.isfile(odoo_conf_dest):
-            bundled_odoo_conf = bundled_dir / "odoo.conf"
-            if bundled_odoo_conf.is_file():
-                shutil.copy2(str(bundled_odoo_conf), odoo_conf_dest)
-                logger.info("[team.%s] Config: %s", team_id, odoo_conf_dest)
-
-        # Seed team-level sanitization scripts
-        sanitize_dest = os.path.join(team.data_dir, "odoo_sanitize")
-        os.makedirs(sanitize_dest, exist_ok=True)
-        bundled_sql = bundled_dir / "01_disable_mail.sql"
-        dest_sql = os.path.join(sanitize_dest, "01_disable_mail.sql")
-        if not os.path.isfile(dest_sql) and bundled_sql.is_file():
-            shutil.copy2(str(bundled_sql), dest_sql)
-            logger.info("[team.%s] Sanitize script: %s", team_id, dest_sql)
-
-        # Copy bundled agent guides
-        agent_guides_dest = os.path.join(team.data_dir, "agent_guides")
-        os.makedirs(agent_guides_dest, exist_ok=True)
-        bundled_guides_dir = bundled_dir / "agent_guides"
-        if bundled_guides_dir.is_dir():
-            for guide_file in bundled_guides_dir.iterdir():
-                if guide_file.is_file() and guide_file.suffix == ".md":
-                    dest_file = os.path.join(agent_guides_dest, guide_file.name)
-                    if not os.path.isfile(dest_file):
-                        shutil.copy2(str(guide_file), dest_file)
-                        logger.info("[team.%s] Agent guide: %s", team_id, dest_file)
+        os.makedirs(os.path.join(team.data_dir, "odoo_sanitize"), exist_ok=True)
+        os.makedirs(os.path.join(team.data_dir, "agent_guides"), exist_ok=True)
+        for managed in _managed_bundled_files(bundled_dir, team_id, team):
+            if bundled_upgrade.seed_managed_file(managed):
+                logger.info("[team.%s] Bundled file: %s", team_id, managed.destination)
 
         logger.info(
             "Team %s initialized (workspaces=%s, templates=%s)",
@@ -4590,99 +4600,53 @@ def _ensure_initialized(settings: Settings) -> None:
     )
 
 
-def _run_upgrade(settings: Settings, *, force: bool = False) -> None:
-    """Overwrite bundled files, optionally without an interactive prompt."""
-    import pathlib
-    import shutil
-
+def _run_upgrade(settings: Settings, *, force: bool = False) -> bool:
+    """Three-way merge deployed bundled files with the current package."""
     bundled_dir = pathlib.Path(__file__).resolve().parent / "templates"
-    bundled_guides_dir = bundled_dir / "agent_guides"
-    etc_dir = pathlib.Path(settings.etc_dir)
-
-    # --- Collect files that will be written ---
-    files_to_write: list[tuple[str, str, str]] = []  # (label, src, dest)
-
-    # System-level: postgresql.conf
-    pg_conf_src = bundled_dir / "postgresql.conf"
-    pg_conf_dest = etc_dir / "postgresql.conf"
-    if pg_conf_src.is_file():
-        files_to_write.append(("[system]", str(pg_conf_src), str(pg_conf_dest)))
-
-    # Per-team files
+    managed_files: list[bundled_upgrade.ManagedFile] = []
     for team_id, team in settings.teams.items():
-        label = f"[team.{team_id}]"
+        managed_files.extend(_managed_bundled_files(bundled_dir, team_id, team))
 
-        # odoo.conf
-        bundled_odoo_conf = bundled_dir / "odoo.conf"
-        if bundled_odoo_conf.is_file():
-            dest = os.path.join(team.data_dir, "odoo.conf")
-            files_to_write.append((label, str(bundled_odoo_conf), dest))
-
-        # Agent guides
-        agent_guides_dest = os.path.join(team.data_dir, "agent_guides")
-        if bundled_guides_dir.is_dir():
-            for guide_file in sorted(bundled_guides_dir.iterdir()):
-                if guide_file.is_file() and guide_file.suffix == ".md":
-                    dest = os.path.join(agent_guides_dest, guide_file.name)
-                    files_to_write.append((label, str(guide_file), dest))
-
-        # Sanitize scripts
-        bundled_sql = bundled_dir / "01_disable_mail.sql"
-        if bundled_sql.is_file():
-            dest = os.path.join(team.data_dir, "odoo_sanitize", "01_disable_mail.sql")
-            files_to_write.append((label, str(bundled_sql), dest))
-
-    if not files_to_write:
+    if not managed_files:
         print("Nothing to upgrade — no bundled files found.")
-        return
+        return True
 
-    # --- Filter to only new or changed files (compare by size) ---
-    files_to_update: list[tuple[str, str, str, str]] = []  # (label, src, dest, tag)
-    files_kept: list[tuple[str, str]] = []  # (label, dest)
-    for label, src, dest in files_to_write:
-        if not os.path.isfile(dest):
-            files_to_update.append((label, src, dest, "new"))
-        elif os.path.getsize(src) != os.path.getsize(dest):
-            # Check if the deployed file is marked with # KEEP on the first line
-            try:
-                with open(dest, "r", encoding="utf-8", errors="replace") as f:
-                    first_line = f.readline().strip()
-                if first_line == "# KEEP":
-                    files_kept.append((label, dest))
-                    continue
-            except OSError:
-                pass
-            files_to_update.append((label, src, dest, "changed"))
+    plans = [bundled_upgrade.plan_reconcile(managed) for managed in managed_files]
+    actionable = [plan for plan in plans if plan.needs_confirmation]
+    kept = [plan for plan in plans if plan.kind == "keep"]
 
-    if not files_to_update and not files_kept:
-        print("\nAll bundled files are already up to date. Nothing to do.")
-        return
+    if not actionable:
+        success = _apply_upgrade_plans(plans)
+        if not success:
+            return False
+        if not kept:
+            print("\nAll bundled files are already up to date. Nothing to do.")
+            return True
+        print("\nNo bundled files require reconciliation.")
+        print("Files marked with # KEEP remain untouched:")
+        for plan in kept:
+            print(f"  {plan.managed.label} {plan.managed.destination} (kept)")
+        return True
 
-    if not files_to_update and files_kept:
-        print("\nAll changed files are marked with # KEEP. Nothing to overwrite.")
-        for label, dest in files_kept:
-            print(f"  {label} {dest} (kept)")
-        return
-
-    # --- Warning banner ---
     print()
     print("=" * 70)
-    print("  WARNING: The following files will be OVERWRITTEN")
-    print("  with bundled versions from this Oduflow release.")
+    print("  The following bundled files will be reconciled.")
+    print("  Local changes are preserved through three-way merge.")
     print("=" * 70)
     print()
-    for label, _src, dest, tag in files_to_update:
-        print(f"  {label} {dest} ({tag})")
-    if files_kept:
-        print()
+    for plan in actionable:
         print(
-            "  The following files are marked with # KEEP and will NOT be overwritten:"
+            f"  {plan.managed.label} {plan.managed.destination} "
+            f"({_upgrade_plan_description(plan)})"
         )
-        for label, dest in files_kept:
-            print(f"  {label} {dest} (kept)")
+    if kept:
+        print()
+        print("  Files marked with # KEEP will remain untouched:")
+        for plan in kept:
+            print(f"  {plan.managed.label} {plan.managed.destination} (kept)")
     print()
-    print("  If you have made custom changes to any of these files,")
-    print("  press Ctrl+C NOW and back them up before proceeding.")
+    print("  Conflicts and legacy files keep the live file unchanged and create")
+    print("  a sidecar for manual resolution.")
     print()
 
     if not force:
@@ -4690,17 +4654,73 @@ def _run_upgrade(settings: Settings, *, force: bool = False) -> None:
             input("  Press Enter to continue or Ctrl+C to abort... ")
         except KeyboardInterrupt:
             print("\n\nAborted. No files were changed.")
-            return
+            return True
 
-    # --- Overwrite ---
-    count = 0
-    for label, src, dest, tag in files_to_update:
-        os.makedirs(os.path.dirname(dest), exist_ok=True)
-        shutil.copy2(src, dest)
-        count += 1
-        print(f"  Updated: {dest}")
+    success = _apply_upgrade_plans(plans)
+    if success:
+        changed = sum(plan.kind in {"create", "update", "merge"} for plan in plans)
+        print(
+            f"\nDone. Reconciled {changed} file(s) across "
+            f"{len(settings.teams)} team(s)."
+        )
+    else:
+        print(
+            "\nUpgrade needs attention. Live files with conflicts or legacy "
+            "state were not overwritten."
+        )
+    return success
 
-    print(f"\nDone. Updated {count} file(s) across {len(settings.teams)} team(s).")
+
+def _upgrade_plan_description(plan: bundled_upgrade.ReconcilePlan) -> str:
+    descriptions = {
+        "create": "new",
+        "update": "upstream update",
+        "merge": "clean merge",
+        "legacy": f"legacy; review {plan.managed.new_path}",
+        "legacy-pending": f"pending review; update {plan.managed.new_path}",
+        "conflict": f"conflict; resolve {plan.managed.merge_path}",
+        "error": f"merge unavailable; review {plan.managed.error_path}",
+    }
+    return descriptions.get(plan.kind, plan.kind)
+
+
+def _apply_upgrade_plans(plans: list[bundled_upgrade.ReconcilePlan]) -> bool:
+    success = True
+    for plan in plans:
+        try:
+            bundled_upgrade.apply_reconcile(plan)
+        except bundled_upgrade.BundledUpgradeError as exc:
+            print(f"  ERROR: {plan.managed.destination}: {exc}")
+            success = False
+            continue
+
+        destination = plan.managed.destination
+        if plan.kind == "create":
+            print(f"  Created: {destination}")
+        elif plan.kind == "update":
+            print(f"  Updated: {destination}")
+        elif plan.kind == "merge":
+            print(f"  Merged: {destination}")
+        elif plan.kind in {"legacy", "legacy-pending"}:
+            print(
+                f"  REVIEW: {destination} kept; merge {plan.managed.new_path} "
+                "manually, then delete the sidecar"
+            )
+            success = False
+        elif plan.kind == "conflict":
+            print(
+                f"  CONFLICT: {destination} kept; resolve "
+                f"{plan.managed.merge_path}, install it as the live file, "
+                "then remove the sidecar"
+            )
+            success = False
+        elif plan.kind == "error":
+            print(
+                f"  ERROR: {destination} kept; {plan.error}; "
+                f"new bundle saved to {plan.managed.error_path}"
+            )
+            success = False
+    return success
 
 
 def _copy_bundled_configs() -> None:
@@ -5612,12 +5632,12 @@ def _run_cli() -> None:
     sub.add_parser("destroy", help="Destroy all shared infrastructure")
     p_upgrade = sub.add_parser(
         "upgrade",
-        help="Overwrite bundled agent guides and sanitize scripts with the latest version",
+        help="Merge bundled configs, agent guides, and sanitize scripts",
     )
     p_upgrade.add_argument(
         "--force",
         action="store_true",
-        help="overwrite changed bundled files without prompting",
+        help="reconcile changed bundled files without prompting",
     )
     p_retune = sub.add_parser(
         "retune-postgres",
@@ -5954,7 +5974,8 @@ def _run_cli() -> None:
         return
 
     if args.command == "upgrade":
-        _run_upgrade(_settings, force=args.force)
+        if not _run_upgrade(_settings, force=args.force):
+            sys.exit(1)
         return
 
     if args.command == "retune-postgres":

--- a/tests/test_bundled_upgrade.py
+++ b/tests/test_bundled_upgrade.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from oduflow import bundled_upgrade
+
+
+def _managed(
+    tmp_path: Path,
+    *,
+    source: bytes,
+    local: bytes | None,
+    baseline: bytes | None,
+) -> bundled_upgrade.ManagedFile:
+    source_path = tmp_path / "package" / "guide.md"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_bytes(source)
+
+    destination = tmp_path / "team" / "agent_guides" / "guide.md"
+    if local is not None:
+        destination.parent.mkdir(parents=True)
+        destination.write_bytes(local)
+
+    managed = bundled_upgrade.ManagedFile(
+        label="[team.1]",
+        source=source_path,
+        destination=destination,
+        state_root=tmp_path / "team" / ".bundled_upgrade",
+        relative_path=Path("agent_guides/guide.md"),
+    )
+    if baseline is not None:
+        managed.baseline_path.parent.mkdir(parents=True)
+        managed.baseline_path.write_bytes(baseline)
+    return managed
+
+
+def test_seed_creates_deployed_file_and_baseline(tmp_path: Path):
+    managed = _managed(tmp_path, source=b"bundled\n", local=None, baseline=None)
+
+    assert bundled_upgrade.seed_managed_file(managed) is True
+
+    assert managed.destination.read_bytes() == b"bundled\n"
+    assert managed.baseline_path.read_bytes() == b"bundled\n"
+
+
+def test_seed_adopts_only_an_identical_existing_file(tmp_path: Path):
+    identical = _managed(
+        tmp_path / "identical",
+        source=b"bundled\n",
+        local=b"bundled\n",
+        baseline=None,
+    )
+    custom = _managed(
+        tmp_path / "custom",
+        source=b"bundled\n",
+        local=b"custom\n",
+        baseline=None,
+    )
+
+    assert bundled_upgrade.seed_managed_file(identical) is False
+    assert identical.baseline_path.read_bytes() == b"bundled\n"
+    assert bundled_upgrade.seed_managed_file(custom) is False
+    assert not custom.baseline_path.exists()
+
+
+def test_same_size_local_edit_is_preserved(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"value=old\n",
+        local=b"value=new\n",
+        baseline=b"value=old\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "local-only"
+    assert managed.destination.read_bytes() == b"value=new\n"
+
+
+def test_upstream_only_change_updates_and_backs_up(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"bundled v1\n",
+        baseline=b"bundled v1\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "update"
+    assert managed.destination.read_bytes() == b"bundled v2\n"
+    assert managed.baseline_path.read_bytes() == b"bundled v2\n"
+    assert managed.backup_path.read_bytes() == b"bundled v1\n"
+
+
+def test_disjoint_changes_merge_cleanly(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"alpha=1\nunchanged one\nunchanged two\nbeta=2\n",
+        local=b"alpha=2\nunchanged one\nunchanged two\nbeta=1\n",
+        baseline=b"alpha=1\nunchanged one\nunchanged two\nbeta=1\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "merge"
+    assert managed.destination.read_bytes() == (
+        b"alpha=2\nunchanged one\nunchanged two\nbeta=2\n"
+    )
+    assert managed.baseline_path.read_bytes() == (
+        b"alpha=1\nunchanged one\nunchanged two\nbeta=2\n"
+    )
+    assert managed.backup_path.read_bytes() == (
+        b"alpha=2\nunchanged one\nunchanged two\nbeta=1\n"
+    )
+
+
+def test_conflict_keeps_live_file_and_baseline(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"value=upstream\n",
+        local=b"value=local\n",
+        baseline=b"value=base\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "conflict"
+    assert managed.destination.read_bytes() == b"value=local\n"
+    assert managed.baseline_path.read_bytes() == b"value=base\n"
+    assert managed.pending_path.read_bytes() == b"value=upstream\n"
+    artifact = managed.merge_path.read_text(encoding="utf-8")
+    assert "<<<<<<<" in artifact
+    assert "value=local" in artifact
+    assert "value=upstream" in artifact
+
+
+def test_keep_marker_is_an_unconditional_opt_out(tmp_path: Path):
+    local = b"# KEEP\nvalue=local\n"
+    managed = _managed(
+        tmp_path,
+        source=b"value=upstream\n",
+        local=local,
+        baseline=b"value=base\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "keep"
+    assert managed.destination.read_bytes() == local
+    assert managed.baseline_path.read_bytes() == b"value=base\n"
+
+
+def test_legacy_file_is_preserved_behind_review_sidecar(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"custom legacy\n",
+        baseline=None,
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "legacy"
+    assert plan.needs_attention is True
+    assert managed.destination.read_bytes() == b"custom legacy\n"
+    assert managed.new_path.read_bytes() == b"bundled v2\n"
+    assert not managed.baseline_path.exists()
+    assert managed.pending_path.read_bytes() == b"bundled v2\n"
+    assert bundled_upgrade.plan_reconcile(managed).kind == "legacy-pending"
+
+
+def test_pending_legacy_sidecar_tracks_latest_bundle(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"custom legacy\n",
+        baseline=None,
+    )
+    bundled_upgrade.apply_reconcile(bundled_upgrade.plan_reconcile(managed))
+    managed.source.write_bytes(b"bundled v3\n")
+
+    pending = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(pending)
+
+    assert pending.kind == "legacy-pending"
+    assert managed.destination.read_bytes() == b"custom legacy\n"
+    assert managed.new_path.read_bytes() == b"bundled v3\n"
+    assert not managed.baseline_path.exists()
+    assert managed.pending_path.read_bytes() == b"bundled v3\n"
+
+
+def test_deleting_legacy_sidecar_accepts_pending_bundle_as_baseline(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"custom plus bundled v2\n",
+        baseline=None,
+    )
+    bundled_upgrade.apply_reconcile(bundled_upgrade.plan_reconcile(managed))
+    managed.new_path.unlink()
+
+    resolved = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(resolved)
+
+    assert resolved.kind == "resolved"
+    assert managed.destination.read_bytes() == b"custom plus bundled v2\n"
+    assert managed.baseline_path.read_bytes() == b"bundled v2\n"
+    assert not managed.pending_path.exists()
+
+
+def test_resolved_conflict_advances_baseline_after_sidecar_is_removed(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"value=upstream\n",
+        local=b"value=local\n",
+        baseline=b"value=base\n",
+    )
+    bundled_upgrade.apply_reconcile(bundled_upgrade.plan_reconcile(managed))
+    managed.destination.write_bytes(b"value=manually-resolved\n")
+    managed.merge_path.unlink()
+
+    resolved = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(resolved)
+
+    assert resolved.kind == "resolved"
+    assert managed.destination.read_bytes() == b"value=manually-resolved\n"
+    assert managed.baseline_path.read_bytes() == b"value=upstream\n"
+    assert not managed.pending_path.exists()
+
+
+def test_missing_git_fails_safe_and_exposes_new_bundle(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"alpha=1\nbeta=2\n",
+        local=b"alpha=2\nbeta=1\n",
+        baseline=b"alpha=1\nbeta=1\n",
+    )
+
+    with patch(
+        "oduflow.bundled_upgrade.subprocess.run",
+        side_effect=FileNotFoundError("git not found"),
+    ):
+        plan = bundled_upgrade.plan_reconcile(managed)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "error"
+    assert managed.destination.read_bytes() == b"alpha=2\nbeta=1\n"
+    assert managed.baseline_path.read_bytes() == b"alpha=1\nbeta=1\n"
+    assert managed.error_path.read_bytes() == b"alpha=1\nbeta=2\n"
+
+
+def test_apply_refuses_a_file_changed_after_planning(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"bundled v1\n",
+        baseline=b"bundled v1\n",
+    )
+    plan = bundled_upgrade.plan_reconcile(managed)
+    managed.destination.write_bytes(b"changed during prompt\n")
+
+    with pytest.raises(bundled_upgrade.BundledUpgradeError):
+        bundled_upgrade.apply_reconcile(plan)
+
+    assert managed.destination.read_bytes() == b"changed during prompt\n"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -104,6 +104,19 @@ class TestCLIInitDestroy:
 
         mock_upgrade.assert_called_once_with(TEST_SETTINGS, force=True)
 
+    def test_cli_upgrade_exits_nonzero_when_attention_is_required(self):
+        from oduflow import server
+
+        with (
+            patch.object(sys, "argv", ["oduflow", "upgrade", "--force"]),
+            patch.object(server, "_get_settings", return_value=TEST_SETTINGS),
+            patch.object(server, "_run_upgrade", return_value=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            server._run_cli()
+
+        assert exc_info.value.code == 1
+
 
 class TestCLIUpgrade:
     @staticmethod
@@ -113,14 +126,19 @@ class TestCLIUpgrade:
         package_dir = tmp_path / "package"
         bundled_guides = package_dir / "templates" / "agent_guides"
         bundled_guides.mkdir(parents=True)
-        (bundled_guides / "guide.md").write_text("bundled\n", encoding="utf-8")
+        (bundled_guides / "guide.md").write_text("bundled v2\n", encoding="utf-8")
         monkeypatch.setattr(server, "__file__", str(package_dir / "server.py"))
 
         team_dir = tmp_path / "team"
         deployed_guides = team_dir / "agent_guides"
         deployed_guides.mkdir(parents=True)
         deployed_guide = deployed_guides / "guide.md"
-        deployed_guide.write_text("custom content\n", encoding="utf-8")
+        deployed_guide.write_text("bundled v1\n", encoding="utf-8")
+        baseline = (
+            team_dir / ".bundled_upgrade" / "baselines" / "agent_guides" / "guide.md"
+        )
+        baseline.parent.mkdir(parents=True)
+        baseline.write_text("bundled v1\n", encoding="utf-8")
         team = replace(
             TEST_TEAM,
             data_dir=str(team_dir),
@@ -146,7 +164,7 @@ class TestCLIUpgrade:
         mock_input.assert_called_once_with(
             "  Press Enter to continue or Ctrl+C to abort... "
         )
-        assert deployed_guide.read_text(encoding="utf-8") == "bundled\n"
+        assert deployed_guide.read_text(encoding="utf-8") == "bundled v2\n"
 
     def test_upgrade_force_skips_prompt(self, tmp_path, monkeypatch):
         server, settings, deployed_guide = self._settings_with_changed_guide(
@@ -156,7 +174,54 @@ class TestCLIUpgrade:
         with patch("builtins.input", side_effect=AssertionError("unexpected prompt")):
             server._run_upgrade(settings, force=True)
 
-        assert deployed_guide.read_text(encoding="utf-8") == "bundled\n"
+        assert deployed_guide.read_text(encoding="utf-8") == "bundled v2\n"
+
+    def test_upgrade_legacy_file_requires_review_without_overwriting(
+        self, tmp_path, monkeypatch
+    ):
+        server, settings, deployed_guide = self._settings_with_changed_guide(
+            tmp_path, monkeypatch
+        )
+        baseline = (
+            Path(settings.teams["1"].data_dir)
+            / ".bundled_upgrade"
+            / "baselines"
+            / "agent_guides"
+            / "guide.md"
+        )
+        baseline.unlink()
+        deployed_guide.write_text("custom legacy\n", encoding="utf-8")
+
+        assert server._run_upgrade(settings, force=True) is False
+
+        assert deployed_guide.read_text(encoding="utf-8") == "custom legacy\n"
+        assert (
+            Path(f"{deployed_guide}.oduflow-new").read_text(encoding="utf-8")
+            == "bundled v2\n"
+        )
+
+    def test_upgrade_does_not_manage_postgresql_conf(self, tmp_path, monkeypatch):
+        from oduflow import server
+
+        package_dir = tmp_path / "package"
+        templates = package_dir / "templates"
+        templates.mkdir(parents=True)
+        (templates / "postgresql.conf").write_text("bundled\n", encoding="utf-8")
+        monkeypatch.setattr(server, "__file__", str(package_dir / "server.py"))
+
+        conf_dir = tmp_path / "conf"
+        conf_dir.mkdir()
+        deployed = conf_dir / "postgresql.conf"
+        deployed.write_text("custom\n", encoding="utf-8")
+        settings = replace(
+            TEST_SETTINGS,
+            base_data_dir=str(tmp_path),
+            etc_dir=str(conf_dir),
+            teams={},
+        )
+
+        assert server._run_upgrade(settings, force=True) is True
+        assert deployed.read_text(encoding="utf-8") == "custom\n"
 
 
 class TestImportTemplateFromOdoo:


### PR DESCRIPTION
## What changed

- Replace size-based bundled-file overwrites with persistent baselines, atomic backups, and three-way `git merge-file` reconciliation for per-team configs, agent guides, and sanitize scripts.
- Preserve live files on conflicts or pre-baseline installations, expose explicit resolution sidecars, return a non-zero status while attention is required, and keep `--force` limited to skipping confirmation.
- Remove `postgresql.conf` from the bundled upgrade path in favor of `retune-postgres`, and document the architecture in ADR 0047 plus the CLI, installation, changelog, internals, and agent guidance.
- Validate the behavior with dedicated merge-state tests and the full suite: 2,292 passed, 7 deselected, with Ruff, formatting, MyPy, documentation sync, and diff checks also passing.
