### PR TITLE
[codex] Verify Odoo module installations

### DIFF
--- a/src/oduflow/docker_ops/odoo_ops.py
+++ b/src/oduflow/docker_ops/odoo_ops.py
@@ -321,11 +321,73 @@ def _run_odoo_module_command(
     exit_code, output = container.exec_run(cmd)
     output_str = output.decode("utf-8") if isinstance(output, bytes) else str(output)
 
+    if flag == "-i" and exit_code == 0:
+        _require_installed_modules(settings, team, env_name, modules)
+
     return {
         "modules": list(modules),
         "exit_code": exit_code,
         "output": output_str,
     }
+
+
+def _get_module_states(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    modules: tuple[str, ...],
+) -> dict[str, str]:
+    names = ", ".join(f"'{module}'" for module in modules)
+    # This is a fixed, validated SELECT, so legacy environments may safely use
+    # the cluster credential that their Odoo container already runs with.
+    result = _execute_db_query(
+        settings,
+        team,
+        env_name,
+        f"SELECT name, state FROM ir_module_module WHERE name IN ({names})",
+        allow_fallback=True,
+    )
+    states: dict[str, str] = {}
+    for row in result["output"].splitlines()[1:]:
+        name, separator, state = row.strip().partition(",")
+        if separator:
+            states[name] = state
+    return states
+
+
+def _require_installed_modules(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    modules: tuple[str, ...],
+) -> None:
+    """Verify that an exit-code-0 ``odoo -i`` actually installed every module."""
+    states = _get_module_states(settings, team, env_name, modules)
+
+    unknown = [module for module in modules if module not in states]
+    if unknown:
+        module_list = ", ".join(unknown)
+        subject = "Module" if len(unknown) == 1 else "Modules"
+        verb = "was" if len(unknown) == 1 else "were"
+        raise NotFoundError(
+            f"{subject} {module_list} {verb} not found in environment '{env_name}' "
+            "after Odoo reported a successful installation. Check the module "
+            "name, addons path, and manifest validity."
+        )
+
+    not_installed = [
+        f"{module} ({states[module]})"
+        for module in modules
+        if states[module] != "installed"
+    ]
+    if not_installed:
+        module_list = ", ".join(not_installed)
+        subject = "Module" if len(not_installed) == 1 else "Modules"
+        verb = "is" if len(not_installed) == 1 else "are"
+        raise PrerequisiteNotMetError(
+            f"{subject} {module_list} {verb} not installed in environment "
+            f"'{env_name}' after Odoo reported a successful installation."
+        )
 
 
 def _require_upgradeable_modules(
@@ -341,18 +403,7 @@ def _require_upgradeable_modules(
     direct upgrades and ``pull_and_apply(upgrade=...)`` from reporting that no-op
     as a success.
     """
-    names = ", ".join(f"'{module}'" for module in modules)
-    result = run_db_query(
-        settings,
-        team,
-        env_name,
-        f"SELECT name, state FROM ir_module_module WHERE name IN ({names})",
-    )
-    states: dict[str, str] = {}
-    for row in result["output"].splitlines()[1:]:
-        name, separator, state = row.strip().partition(",")
-        if separator:
-            states[name] = state
+    states = _get_module_states(settings, team, env_name, modules)
 
     unknown = [module for module in modules if module not in states]
     if unknown:
@@ -610,13 +661,16 @@ def reset_admin_password(
     return {"status": "ok", "login": "admin", "psql_output": output_str}
 
 
-def run_db_query(
+def _execute_db_query(
     settings: Settings,
     team: TeamSettings,
     env_name: str,
     query: str,
     output_format: str = "csv",
+    *,
+    allow_fallback: bool,
 ) -> dict[str, Any]:
+    """Execute SQL; legacy fallback is only safe for fixed internal queries."""
     client = get_client()
     env_db = get_db_name(env_name, team.team_id)
 
@@ -633,7 +687,7 @@ def run_db_query(
         team.workspaces_dir,
         settings.db_user,
         settings.db_password,
-        allow_fallback=False,
+        allow_fallback=allow_fallback,
     )
     if output_format == "human":
         cmd = ["psql", "-U", creds["pg_user"], "-d", env_db, "-c", query]
@@ -654,6 +708,24 @@ def run_db_query(
         "exit_code": exit_code,
         "output": output_str,
     }
+
+
+def run_db_query(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    query: str,
+    output_format: str = "csv",
+) -> dict[str, Any]:
+    """Run arbitrary SQL using only the environment's scoped credentials."""
+    return _execute_db_query(
+        settings,
+        team,
+        env_name,
+        query,
+        output_format,
+        allow_fallback=False,
+    )
 
 
 _WRITE_FILE_LIMIT = 1_000_000  # 1 MB

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1718,8 +1718,31 @@ class TestGetEnvironmentInfo:
         assert result["local_path"] == "/Users/dev/addons"
 
 
+class TestRunDbQuery:
+    def test_arbitrary_query_rejects_legacy_db_credentials(
+        self, tmp_path, mock_docker_client
+    ):
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path))
+        db_container = MagicMock()
+        mock_docker_client.containers.get.return_value = db_container
+
+        with pytest.raises(
+            PrerequisiteNotMetError, match="no scoped database credentials"
+        ):
+            odoo_ops.run_db_query(TEST_SETTINGS, team, "main", "SELECT 1")
+
+        db_container.exec_run.assert_not_called()
+
+
 class TestInstallModules:
-    def test_install(self, mock_docker_client):
+    @patch(
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
+        return_value={
+            "exit_code": 0,
+            "output": "name,state\nsale,installed\ncrm,installed\n",
+        },
+    )
+    def test_install(self, mock_query, mock_docker_client):
         container = MagicMock()
         container.exec_run.return_value = (0, b"OK")
         mock_docker_client.containers.get.return_value = container
@@ -1733,10 +1756,116 @@ class TestInstallModules:
         assert "-d oduflow_1_main" in args
         assert "-i sale,crm" in args
 
+    def test_install_verification_allows_legacy_db_credentials(
+        self, tmp_path, mock_docker_client
+    ):
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path))
+        odoo_container = MagicMock()
+        odoo_container.exec_run.return_value = (0, b"OK")
+        db_container = MagicMock()
+        db_container.exec_run.return_value = (
+            0,
+            b"name,state\nsale,installed\n",
+        )
+
+        def get_container(name):
+            if name == TEST_SETTINGS.shared_db_container:
+                return db_container
+            return odoo_container
+
+        mock_docker_client.containers.get.side_effect = get_container
+
+        result = odoo_ops.install_odoo_modules(TEST_SETTINGS, team, "main", "sale")
+
+        assert result["exit_code"] == 0
+        query_cmd = db_container.exec_run.call_args.args[0]
+        assert query_cmd[:6] == [
+            "psql",
+            "-U",
+            TEST_SETTINGS.db_user,
+            "-d",
+            "oduflow_1_main",
+            "--csv",
+        ]
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
+        return_value={"exit_code": 0, "output": "name,state\n"},
+    )
+    def test_unknown_module_after_success_exit_is_refused(
+        self, mock_query, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.return_value = (
+            0,
+            b"WARNING invalid module names, ignored: prt_email_from",
+        )
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(NotFoundError, match="not found.*successful installation"):
+            odoo_ops.install_odoo_modules(
+                TEST_SETTINGS, TEST_TEAM, "main", "prt_email_from"
+            )
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
+        return_value={
+            "exit_code": 0,
+            "output": "name,state\nwebsite,uninstalled\n",
+        },
+    )
+    def test_uninstalled_module_after_success_exit_is_refused(
+        self, mock_query, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"install command completed")
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(
+            PrerequisiteNotMetError,
+            match=r"website \(uninstalled\).*successful installation",
+        ):
+            odoo_ops.install_odoo_modules(TEST_SETTINGS, TEST_TEAM, "main", "website")
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
+        return_value={
+            "exit_code": 0,
+            "output": "name,state\nsale,installed\ncrm,uninstalled\n",
+        },
+    )
+    def test_partial_install_after_success_exit_is_refused(
+        self, mock_query, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.return_value = (0, b"install command completed")
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(PrerequisiteNotMetError, match=r"crm \(uninstalled\)"):
+            odoo_ops.install_odoo_modules(
+                TEST_SETTINGS, TEST_TEAM, "main", "sale", "crm"
+            )
+
+    @patch("oduflow.docker_ops.odoo_ops._execute_db_query")
+    def test_failed_command_is_not_masked_by_state_verification(
+        self, mock_query, mock_docker_client
+    ):
+        container = MagicMock()
+        container.exec_run.return_value = (1, b"manifest parse error")
+        mock_docker_client.containers.get.return_value = container
+
+        result = odoo_ops.install_odoo_modules(
+            TEST_SETTINGS, TEST_TEAM, "main", "broken_module"
+        )
+
+        assert result["exit_code"] == 1
+        assert result["output"] == "manifest parse error"
+        mock_query.assert_not_called()
+
 
 class TestUpgradeModules:
     @patch(
-        "oduflow.docker_ops.odoo_ops.run_db_query",
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
         return_value={"exit_code": 0, "output": "name,state\nsale,installed\n"},
     )
     def test_upgrade(self, mock_query, mock_docker_client):
@@ -1752,7 +1881,7 @@ class TestUpgradeModules:
         assert "-u sale" in args
 
     @patch(
-        "oduflow.docker_ops.odoo_ops.run_db_query",
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
         return_value={"exit_code": 0, "output": "name,state\nwebsite,uninstalled\n"},
     )
     def test_uninstalled_module_is_refused(self, mock_query, mock_docker_client):
@@ -1767,7 +1896,7 @@ class TestUpgradeModules:
         container.exec_run.assert_not_called()
 
     @patch(
-        "oduflow.docker_ops.odoo_ops.run_db_query",
+        "oduflow.docker_ops.odoo_ops._execute_db_query",
         return_value={"exit_code": 0, "output": "name,state\n"},
     )
     def test_unknown_module_is_refused(self, mock_query, mock_docker_client):
@@ -2285,6 +2414,28 @@ class TestApplyActionsConf:
                 "oduflow-1-feature-x-odoo",
                 to_install=[],
                 to_upgrade=["website"],
+                do_restart=False,
+                changed_files=[],
+            )
+
+        container.restart.assert_not_called()
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.install_odoo_modules",
+        side_effect=NotFoundError("module was not found after installation"),
+    )
+    def test_rejected_install_does_not_restart(self, mock_install):
+        client, container = self._client_with_container()
+
+        with pytest.raises(NotFoundError, match="not found after installation"):
+            env_ops._apply_actions(
+                client,
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "feature/x",
+                "oduflow-1-feature-x-odoo",
+                to_install=["missing_module"],
+                to_upgrade=[],
                 do_restart=False,
                 changed_files=[],
             )


### PR DESCRIPTION
## What changed

Verify successful `odoo -i` runs against `ir_module_module` so unknown, uninstallable, and partially installed module sets no longer report success.
Reuse the shared state lookup for upgrade validation and allow the documented legacy database credential fallback only for this fixed, validated query; arbitrary `run_db_query` calls remain scoped.
Add coverage for rejected installs, restart behavior, legacy credentials, and the arbitrary-SQL security boundary.

## Validation

- `pytest -m "not integration and not heavyweight" -q` (`2276 passed`, `15 deselected`)
- `ruff check src/oduflow tests`
- `ruff format --check src/oduflow tests`
- `mypy src/oduflow`
