### PR TITLE
Disk space admission control for environment creation

### DIFF
--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -26,9 +26,12 @@ from oduflow.docker_ops.system_ops import (
     _exec_sql,
     _resolve_instance_conf,
     check_db_quota,
+    check_disk_space,
     drop_signaling_sequences,
     ensure_team_network,
     ensure_team_tablespace,
+    estimate_new_db_bytes,
+    pg_clone_strategy_clause,
     reassign_db_ownership,
 )
 from oduflow.env_credentials import create_credentials, load_credentials
@@ -1095,7 +1098,17 @@ def create_environment(
                 "that does not normalise to the same database."
             )
 
-    check_db_quota(client, settings, team)
+    est_db_bytes = estimate_new_db_bytes(client, settings, team, template_name)
+    check_db_quota(client, settings, team, estimated_new_db_bytes=est_db_bytes)
+    check_disk_space(
+        client,
+        settings,
+        team,
+        template_name,
+        estimated_db_bytes=est_db_bytes,
+        local_mount=bool(local_path),
+        env_name=env_name,
+    )
     ensure_team_network(client, settings, team)
 
     _cleanup_old_environment(client, settings, team, env_name)
@@ -1217,10 +1230,15 @@ def create_environment(
     ts_name = ensure_team_tablespace(client, settings, team)
     if template_name is not None:
         tpl_db = get_template_db_name(template_name, team.team_id)
+        # PG 15+ defaults to STRATEGY WAL_LOG, which writes the entire clone
+        # through WAL — a large template transiently doubles its disk cost and
+        # can fill PGDATA mid-clone. FILE_COPY keeps transient WAL small.
+        strategy = pg_clone_strategy_clause(client, settings)
         _exec_sql(
             client,
             settings,
-            f'CREATE DATABASE "{env_db}" TEMPLATE "{tpl_db}" TABLESPACE "{ts_name}";',
+            f'CREATE DATABASE "{env_db}" TEMPLATE "{tpl_db}"{strategy} '
+            f'TABLESPACE "{ts_name}";',
         )
     else:
         _exec_sql(

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import stat
 import subprocess
+import sys
 import tarfile
 import time
 import uuid
@@ -811,26 +812,301 @@ def get_team_db_usage_bytes(
 
 
 def check_db_quota(
-    client: DockerClient, settings: Settings, team: TeamSettings
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    estimated_new_db_bytes: int = 0,
 ) -> None:
     """Raise if the team's PostgreSQL usage is at or over its ``db_quota_gb``.
 
     Called before operations that create a *new* database (environment or
     template); replacement operations (refresh/reload) are not gated so a
     team at its quota can still shrink or refresh what it has. 0 disables
-    the quota.
+    the quota. ``estimated_new_db_bytes`` (the predicted size of the database
+    about to be created) makes the check predictive: a clone that would land
+    over the quota is refused before CREATE DATABASE starts, not after it
+    fails halfway.
     """
     if team.db_quota_gb <= 0:
         return
     used = get_team_db_usage_bytes(client, settings, team.team_id)
     quota = team.db_quota_gb * 1024**3
-    if used >= quota:
+    projected = used + max(estimated_new_db_bytes, 0)
+    if projected >= quota:
         raise PrerequisiteNotMetError(
             f"Team '{team.team_id}' database quota exceeded: "
-            f"{used / 1024**3:.1f} GB of {team.db_quota_gb} GB used "
+            f"{used / 1024**3:.1f} GB used plus an estimated "
+            f"{max(estimated_new_db_bytes, 0) / 1024**3:.1f} GB for the new "
+            f"database exceeds the {team.db_quota_gb} GB quota "
             "(db_quota_gb in oduflow.toml). Delete unused environments or "
             "templates, or raise the quota."
         )
+
+
+# Disk admission control for environment creation: refuse to start when a
+# target filesystem would be left without breathing room. Deliberately
+# constants, not TOML options — the reserve exists so PostgreSQL never hits
+# 0 bytes free (at which point even deleting environments fails).
+_DISK_MIN_FREE_GB = 5.0  # absolute floor that must remain free
+_DISK_MIN_FREE_PERCENT = 5.0  # relative floor for small disks
+_DISK_RESERVE_CAP_GB = 10.0  # cap on the percent leg (large/dev-machine disks)
+_DISK_ESTIMATE_MARGIN = 1.2  # safety multiplier on the write estimate
+_CLONE_BUDGET_BYTES = 512 * 1024**2  # remote git checkout allowance
+_OVERLAY_HEADROOM_BYTES = 512 * 1024**2  # upper/work layer of an overlay
+_GREENFIELD_DB_BYTES = 1024**3  # `-i base` init without a template
+
+
+def estimate_new_db_bytes(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str | None,
+) -> int:
+    """Predicted on-disk size of the environment database about to be created.
+
+    ``CREATE DATABASE ... TEMPLATE`` physically copies the template, so
+    ``pg_database_size()`` of the template DB is the exact answer. Estimation
+    failures fall back to the greenfield budget rather than blocking creation.
+    """
+    if template_name is None:
+        return _GREENFIELD_DB_BYTES
+    tpl_db = get_template_db_name(template_name, team.team_id)
+    try:
+        return int(_exec_sql(client, settings, f"SELECT pg_database_size('{tpl_db}');"))
+    except Exception:
+        logger.warning("Could not measure template DB '%s' size", tpl_db, exc_info=True)
+        return _GREENFIELD_DB_BYTES
+
+
+def _estimate_template_filestore_bytes(
+    settings: Settings, team: TeamSettings, template_name: str
+) -> int:
+    """Bytes the new environment's filestore will occupy on the host.
+
+    Mirrors the mode selection in ``env_ops._mount_filestore``: an overlay
+    mount (Linux only) does not copy the lower layer and needs only headroom
+    for the upper/work dirs; a plain copy needs the full template size.
+    """
+    fs_path = team.get_template_filestore_path(template_name)
+    if not os.path.isdir(fs_path):
+        return 0
+    metadata: dict[str, Any] = {}
+    metadata_path = team.get_template_metadata_path(template_name)
+    if os.path.isfile(metadata_path):
+        try:
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            metadata = {}
+    fs_size_mb = metadata.get("filestore_size_mb")
+    if not isinstance(fs_size_mb, (int, float)):
+        from oduflow.docker_ops.env_ops import _dir_size_mb
+
+        logger.info(
+            "Template '%s' metadata lacks filestore_size_mb; scanning filestore",
+            template_name,
+        )
+        fs_size_mb = _dir_size_mb(fs_path)
+    use_overlay = metadata.get("use_overlay")
+    if use_overlay is None:
+        use_overlay = fs_size_mb >= settings.overlay_threshold_mb
+    if use_overlay and sys.platform.startswith("linux"):
+        return _OVERLAY_HEADROOM_BYTES
+    return int(fs_size_mb * 1024**2)
+
+
+def _existing_anchor(path: str) -> str | None:
+    """Nearest existing ancestor of ``path`` (which may not exist yet)."""
+    p = os.path.realpath(path)
+    while p and not os.path.exists(p):
+        parent = os.path.dirname(p)
+        if parent == p:
+            return None
+        p = parent
+    return p or None
+
+
+def _reserve_bytes(total: int) -> int:
+    """max(5 GiB, min(5% of the disk, 10 GiB)) — the percent leg is capped so
+    a large disk (e.g. a 1 TB dev machine) is not held to a ~50 GiB reserve."""
+    percent_leg = min(
+        total * _DISK_MIN_FREE_PERCENT / 100, _DISK_RESERVE_CAP_GB * 1024**3
+    )
+    return int(max(_DISK_MIN_FREE_GB * 1024**3, percent_leg))
+
+
+def _pgdata_usage_via_df(
+    client: DockerClient, settings: Settings
+) -> tuple[int, int] | None:
+    """(total, free) bytes of PGDATA measured inside the shared DB container.
+
+    Fallback for hosts where the named volume's mountpoint is not visible
+    (macOS / Docker Desktop). Returns None when the container or df is
+    unavailable — the check is then skipped, never fatal.
+    """
+    try:
+        container = client.containers.get(settings.shared_db_container)
+        exit_code, output = container.exec_run(
+            ["df", "-Pk", "/var/lib/postgresql/data"]
+        )
+        if exit_code != 0:
+            return None
+        text = output.decode("utf-8") if isinstance(output, bytes) else str(output)
+        fields = text.strip().splitlines()[-1].split()
+        # POSIX df -Pk: Filesystem 1024-blocks Used Available Capacity Mounted
+        return int(fields[1]) * 1024, int(fields[3]) * 1024
+    except Exception:
+        logger.warning("Could not measure PGDATA disk usage via df", exc_info=True)
+        return None
+
+
+def check_disk_space(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    template_name: str | None,
+    *,
+    estimated_db_bytes: int,
+    local_mount: bool = False,
+    env_name: str = "",
+) -> None:
+    """Refuse environment creation when a target filesystem lacks room.
+
+    Estimates the bytes each target directory will receive (database
+    tablespace, workspace filestore + checkout), groups targets that share a
+    device via ``st_dev``, and requires ``free - estimate*margin`` to stay
+    above ``max(5 GiB, min(5%, 10 GiB))`` on every device. The PGDATA volume (WAL +
+    catalogs live there, not in the tablespace) is held to the same floor.
+    Like ``check_db_quota``, only new creation is gated — delete/cleanup paths
+    stay available so a full disk can always be recovered.
+    """
+    fs_bytes = (
+        _estimate_template_filestore_bytes(settings, team, template_name)
+        if template_name is not None
+        else 0
+    )
+    clone_bytes = 0 if local_mount else _CLONE_BUDGET_BYTES
+    targets: list[tuple[str, str, int]] = [
+        (
+            "database tablespace",
+            os.path.join(_pg_tablespaces_host_dir(settings), f"team_{team.team_id}"),
+            max(estimated_db_bytes, 0),
+        ),
+        (
+            "workspace (filestore + checkout)",
+            team.workspaces_dir,
+            fs_bytes + clone_bytes,
+        ),
+    ]
+
+    pgdata_df: tuple[int, int] | None = None
+    mountpoint = ""
+    try:
+        volume = client.volumes.get(settings.shared_db_volume)
+        attrs = volume.attrs if isinstance(volume.attrs, dict) else {}
+        raw = attrs.get("Mountpoint", "")
+        mountpoint = raw if isinstance(raw, str) else ""
+    except Exception:
+        logger.warning("Could not inspect shared DB volume", exc_info=True)
+    if mountpoint and os.path.isdir(mountpoint):
+        targets.append(("PostgreSQL data (WAL)", mountpoint, 0))
+    else:
+        pgdata_df = _pgdata_usage_via_df(client, settings)
+
+    groups: dict[int, dict[str, Any]] = {}
+    for label, path, nbytes in targets:
+        anchor = _existing_anchor(path)
+        if anchor is None:
+            logger.warning("Disk check: no existing ancestor for %s (%s)", path, label)
+            continue
+        try:
+            dev = os.stat(anchor).st_dev
+        except OSError:
+            logger.warning("Disk check: cannot stat %s (%s)", anchor, label)
+            continue
+        group = groups.setdefault(dev, {"anchor": anchor, "bytes": 0, "labels": []})
+        group["bytes"] += nbytes
+        group["labels"].append(label)
+
+    problems: list[str] = []
+    checked: list[dict[str, Any]] = []
+    for group in groups.values():
+        try:
+            usage = shutil.disk_usage(group["anchor"])
+        except OSError:
+            logger.warning("Disk check: disk_usage failed for %s", group["anchor"])
+            continue
+        required = int(group["bytes"] * _DISK_ESTIMATE_MARGIN)
+        reserve = _reserve_bytes(usage.total)
+        checked.append(
+            {
+                "anchor": group["anchor"],
+                "components": group["labels"],
+                "free_gb": round(usage.free / 1024**3, 1),
+                "required_gb": round(required / 1024**3, 1),
+                "reserve_gb": round(reserve / 1024**3, 1),
+            }
+        )
+        if usage.free - required < reserve:
+            problems.append(
+                f"{' + '.join(group['labels'])} on '{group['anchor']}': "
+                f"{usage.free / 1024**3:.1f} GiB free, creation needs "
+                f"~{required / 1024**3:.1f} GiB and {reserve / 1024**3:.1f} GiB "
+                "must stay free"
+            )
+    if pgdata_df is not None:
+        total, free = pgdata_df
+        reserve = _reserve_bytes(total)
+        checked.append(
+            {
+                "anchor": "PGDATA (in-container)",
+                "components": ["PostgreSQL data (WAL)"],
+                "free_gb": round(free / 1024**3, 1),
+                "required_gb": 0.0,
+                "reserve_gb": round(reserve / 1024**3, 1),
+            }
+        )
+        if free < reserve:
+            problems.append(
+                f"PostgreSQL data volume '{settings.shared_db_volume}': "
+                f"{free / 1024**3:.1f} GiB free, {reserve / 1024**3:.1f} GiB "
+                "must stay free"
+            )
+
+    logger.info(
+        "Disk space check for environment creation",
+        extra={
+            "env_name": env_name,
+            "template": template_name or "none",
+            "estimated_db_bytes": estimated_db_bytes,
+            "estimated_filestore_bytes": fs_bytes,
+            "clone_budget_bytes": clone_bytes,
+            "filesystems": checked,
+            "problems": len(problems),
+        },
+    )
+    if problems:
+        raise PrerequisiteNotMetError(
+            f"Not enough free disk space to create environment '{env_name}'. "
+            + "; ".join(problems)
+            + ". Delete unused environments or templates and retry."
+        )
+
+
+def pg_clone_strategy_clause(client: DockerClient, settings: Settings) -> str:
+    """`` STRATEGY FILE_COPY`` when the server supports it (PG 15+), else "".
+
+    PG 15 changed the CREATE DATABASE default to WAL_LOG, which writes the
+    whole template clone through WAL — a large template can transiently double
+    its disk cost and fill PGDATA mid-clone. FILE_COPY copies at file level
+    and keeps WAL small.
+    """
+    try:
+        version = int(_exec_sql(client, settings, "SHOW server_version_num;"))
+    except Exception:
+        logger.warning("Could not determine PostgreSQL version", exc_info=True)
+        return ""
+    return " STRATEGY FILE_COPY" if version >= 150000 else ""
 
 
 def _create_pg_role(

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -520,6 +520,15 @@ def _parse_extra_addons(raw: str) -> dict[str, str]:
     return result
 
 
+def _parse_env_vars(raw: str) -> dict[str, str]:
+    """Parse env assignments without treating commas inside values as separators."""
+    items = re.split(
+        r"\r?\n|,(?=\s*[A-Za-z_][A-Za-z0-9_]*=)",
+        raw,
+    )
+    return dict(item.strip().split("=", 1) for item in items if "=" in item)
+
+
 # =============================================================================
 # MCP Tools — Environments
 # =============================================================================
@@ -3238,7 +3247,7 @@ def create_service(
         image: Docker image with tag (e.g. "redis:7", "getmeili/meilisearch:v1.6").
         port: Catch-all exposure mode: forward every path to this one container port. Required outside Traefik. Mutually exclusive with routes.
         hostname: Custom hostname for traefik routing (optional, traefik mode only).
-        env_vars: Comma-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production").
+        env_vars: Comma- or newline-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Commas inside values are preserved, so "CONNECT_MCP_TOOL_GROUPS=write,collaboration,documents" is one variable.
         host_mode: Run the container in host network mode instead of the shared Docker network. Use when the service needs direct host network access. Traefik routing still works.
         volumes: Comma-separated volume mounts (e.g. "mydata:/data,config:/etc/app:ro"). Each entry is volume_name:/container/path[:ro|rw]. Volumes must be created first via create_volume. In Traefik TLS mode the system ACME volume is mounted automatically at /etc/traefik:ro; do not include it here.
         privileged: Run the container in privileged mode (full host access). Use with care — implies all Linux capabilities. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
@@ -3249,9 +3258,7 @@ def create_service(
     team = _resolve_team(ctx)
     parsed_env = None
     if env_vars:
-        parsed_env = dict(
-            item.split("=", 1) for item in env_vars.split(",") if "=" in item
-        )
+        parsed_env = _parse_env_vars(env_vars)
     parsed_volumes = volume_ops.parse_volume_mounts(volumes) if volumes else None
     cap_add = ["NET_ADMIN"] if net_admin else None
     result = service_ops.create_service(
@@ -3318,7 +3325,7 @@ def update_service(
 
     Args:
         name: The name of the service to update (e.g. "redis", "meilisearch").
-        env_vars: Comma-separated KEY=VALUE pairs that fully replace existing env vars (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Leave empty to keep current env vars.
+        env_vars: Comma- or newline-separated KEY=VALUE pairs that fully replace existing env vars (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Commas inside values are preserved. Leave empty to keep current env vars.
         image: New Docker image with tag (e.g. "redis:8"). Leave empty to keep current image.
         port: New container port. Pass 0 to keep current port.
         hostname: New hostname for traefik routing. Leave empty to keep current hostname.
@@ -3334,9 +3341,7 @@ def update_service(
     # Parse optional overrides
     parsed_env = None
     if env_vars:
-        parsed_env = dict(
-            item.split("=", 1) for item in env_vars.split(",") if "=" in item
-        )
+        parsed_env = _parse_env_vars(env_vars)
 
     parsed_volumes = None
     if volumes:

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2019,7 +2019,7 @@
       </div>
       <div class="form-actions">
         <button class="btn" onclick="closeConnect()">Close</button>
-        <button class="btn btn-connect" id="connect-submit" onclick="submitConnect()">Connect</button>
+        <button class="btn-create" id="connect-submit" onclick="submitConnect()">Connect</button>
       </div>
     </div>
   </div>
@@ -2593,7 +2593,9 @@ function renderEnvironments(envs, force) {
             (env.protected ? ' disabled title="Protected environments are excluded from bulk actions"' : '') +
             ' onclick="envSelectClick(event, \'' + escAttr(env.branch) + '\', ' + idx + ')"' +
             ' aria-label="Select ' + esc(env.branch) + '"></label>' +
-          '<span class="branch-name">' + esc(env.branch) + '</span>' +
+          '<span class="branch-name copy-db" role="button" tabindex="0" ' +
+            'title="Copy environment name" aria-label="Copy environment name" ' +
+            'onclick="copyToClipboard(\'' + escAttr(env.branch) + '\')">' + esc(env.branch) + '</span>' +
           (env.git_branch && env.git_branch !== env.branch ? '<span class="git-branch">⎇ ' + esc(env.git_branch) + '</span>' : '') +
           repoLinksHtml +
           '<span class="badge ' + badgeClass(env.status) + '"' +
@@ -5884,7 +5886,7 @@ var MODAL_CLOSERS = {
 };
 
 document.addEventListener('keydown', function(e) {
-  // Enter/Space activate non-native role="button" elements (db name, note, guide cards)
+  // Enter/Space activate non-native role="button" elements (copyable names, notes, guides).
   if ((e.key === 'Enter' || e.key === ' ') && e.target.getAttribute &&
       e.target.getAttribute('role') === 'button' && e.target.tagName !== 'BUTTON') {
     e.preventDefault();

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1023,6 +1023,25 @@ def _build_routes(
             env_vars = json.loads(labels.get("oduflow.env_vars", "{}")) or None
             local_path = labels.get("oduflow.local_path", "")
 
+            # Check disk space BEFORE deleting the old environment: refusing
+            # here loses nothing, while failing after delete_environment would
+            # destroy a working environment. Conservative on purpose — the old
+            # environment's own space is not yet freed at measurement time.
+            from oduflow.docker_ops import system_ops
+
+            est_db_bytes = system_ops.estimate_new_db_bytes(
+                client, settings, team, template_name
+            )
+            system_ops.check_disk_space(
+                client,
+                settings,
+                team,
+                template_name,
+                estimated_db_bytes=est_db_bytes,
+                local_mount=bool(local_path),
+                env_name=branch,
+            )
+
             env_ops.delete_environment(settings, team, branch)
             result = env_ops.create_environment(
                 settings,

--- a/tests/test_disk_space.py
+++ b/tests/test_disk_space.py
@@ -1,0 +1,371 @@
+"""Disk admission control for environment creation.
+
+Creation must be refused while the disk still has room to recover — once
+PostgreSQL hits 0 bytes free even deleting environments fails. The check
+estimates the bytes each target filesystem will receive (template DB size via
+pg_database_size, filestore copy vs overlay, git clone budget), groups targets
+sharing a device, and keeps a max(5 GiB, min(5%, 10 GiB)) reserve free on
+every device.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import namedtuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow.docker_ops import system_ops
+from oduflow.docker_ops.system_ops import (
+    _CLONE_BUDGET_BYTES,
+    _GREENFIELD_DB_BYTES,
+    _OVERLAY_HEADROOM_BYTES,
+    _estimate_template_filestore_bytes,
+    _existing_anchor,
+    _reserve_bytes,
+    check_db_quota,
+    check_disk_space,
+    estimate_new_db_bytes,
+    pg_clone_strategy_clause,
+)
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+GB = 1024**3
+MB = 1024**2
+
+_usage = namedtuple("_usage", "total used free")
+
+
+def _make_env(tmp_path):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    os.makedirs(team.workspaces_dir, exist_ok=True)
+    return settings, team
+
+
+def _client_without_pgdata():
+    """Docker client whose volume/container lookups fail: the PGDATA leg of
+    the check degrades to a logged skip, isolating the host-path assertions."""
+    client = MagicMock()
+    client.volumes.get.side_effect = RuntimeError("no docker")
+    client.containers.get.side_effect = RuntimeError("no docker")
+    return client
+
+
+def _write_template(team, name, metadata, *, filestore=True):
+    tpl_dir = team.get_template_dir(name)
+    os.makedirs(tpl_dir, exist_ok=True)
+    if filestore:
+        os.makedirs(os.path.join(tpl_dir, "filestore"), exist_ok=True)
+    with open(team.get_template_metadata_path(name), "w") as f:
+        json.dump(metadata, f)
+
+
+# --- estimate_new_db_bytes -------------------------------------------------
+
+
+class TestEstimateNewDbBytes:
+    def test_template_uses_pg_database_size(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        with patch.object(system_ops, "_exec_sql", return_value=str(3 * GB)) as sql:
+            assert estimate_new_db_bytes(None, settings, team, "prod") == 3 * GB
+        assert "pg_database_size('oduflow_template_1_prod')" in sql.call_args.args[2]
+
+    def test_no_template_uses_greenfield_budget(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        with patch.object(system_ops, "_exec_sql") as sql:
+            assert estimate_new_db_bytes(None, settings, team, None) == (
+                _GREENFIELD_DB_BYTES
+            )
+        sql.assert_not_called()
+
+    def test_measurement_failure_falls_back(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        with patch.object(system_ops, "_exec_sql", side_effect=RuntimeError("down")):
+            assert estimate_new_db_bytes(None, settings, team, "prod") == (
+                _GREENFIELD_DB_BYTES
+            )
+
+
+# --- filestore estimate ----------------------------------------------------
+
+
+class TestFilestoreEstimate:
+    def test_overlay_on_linux_needs_only_headroom(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "t", {"use_overlay": True, "filestore_size_mb": 4096})
+        with patch.object(system_ops.sys, "platform", "linux"):
+            assert _estimate_template_filestore_bytes(settings, team, "t") == (
+                _OVERLAY_HEADROOM_BYTES
+            )
+
+    def test_copy_mode_needs_full_size(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "t", {"use_overlay": False, "filestore_size_mb": 4096})
+        assert _estimate_template_filestore_bytes(settings, team, "t") == 4096 * MB
+
+    def test_overlay_falls_back_to_copy_off_linux(self, tmp_path):
+        # _mount_filestore forces a plain copy on non-Linux platforms; the
+        # estimate must budget the full size there too.
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "t", {"use_overlay": True, "filestore_size_mb": 4096})
+        with patch.object(system_ops.sys, "platform", "darwin"):
+            assert _estimate_template_filestore_bytes(settings, team, "t") == 4096 * MB
+
+    def test_missing_metadata_scans_filestore(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "t", {})
+        with (
+            patch("oduflow.docker_ops.env_ops._dir_size_mb", return_value=10.0) as scan,
+            patch.object(system_ops.sys, "platform", "linux"),
+        ):
+            # 10 MB is under the overlay threshold (50), so copy mode: 10 MB.
+            assert _estimate_template_filestore_bytes(settings, team, "t") == 10 * MB
+        scan.assert_called_once()
+
+    def test_no_filestore_dir_is_zero(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "t", {"filestore_size_mb": 4096}, filestore=False)
+        assert _estimate_template_filestore_bytes(settings, team, "t") == 0
+
+
+# --- anchor resolution -----------------------------------------------------
+
+
+def test_anchor_climbs_to_existing_parent(tmp_path):
+    missing = tmp_path / "a" / "b" / "c"
+    assert _existing_anchor(str(missing)) == str(tmp_path)
+
+
+# --- reserve formula -------------------------------------------------------
+
+
+def test_reserve_is_capped_on_large_disks():
+    assert _reserve_bytes(60 * GB) == 5 * GB  # 5% = 3 GB, floor wins
+    assert _reserve_bytes(100 * GB) == 5 * GB  # 5% = floor
+    assert _reserve_bytes(1000 * GB) == 10 * GB  # 5% = 50 GB, cap wins
+
+
+# --- check_disk_space ------------------------------------------------------
+
+
+class TestCheckDiskSpace:
+    def _check(self, settings, team, template_name, db_bytes, usage, **kwargs):
+        with patch.object(system_ops.shutil, "disk_usage", return_value=usage):
+            check_disk_space(
+                _client_without_pgdata(),
+                settings,
+                team,
+                template_name,
+                estimated_db_bytes=db_bytes,
+                env_name="feature-x",
+                **kwargs,
+            )
+
+    def test_enough_space_passes(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        self._check(settings, team, None, 2 * GB, _usage(100 * GB, 90 * GB, 10 * GB))
+
+    def test_insufficient_space_raises(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        with pytest.raises(PrerequisiteNotMetError, match="Not enough free disk"):
+            self._check(settings, team, None, 2 * GB, _usage(100 * GB, 96 * GB, 4 * GB))
+
+    def test_reserve_cannot_be_consumed(self, tmp_path):
+        # free (6 GB) covers the estimate (2 GB * 1.2 + clone budget) but the
+        # remainder dips under the 5 GiB floor: refuse.
+        settings, team = _make_env(tmp_path)
+        with pytest.raises(PrerequisiteNotMetError, match="must stay free"):
+            self._check(settings, team, None, 2 * GB, _usage(100 * GB, 94 * GB, 6 * GB))
+
+    def test_same_device_requirements_are_summed(self, tmp_path):
+        # DB (4 GB) or filestore copy (4 GB) alone fits in 11 GB free with the
+        # 5 GiB reserve; together (8 GB * 1.2 margin) they do not.
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "t", {"use_overlay": False, "filestore_size_mb": 4096})
+        with pytest.raises(PrerequisiteNotMetError, match="Not enough free disk"):
+            self._check(settings, team, "t", 4 * GB, _usage(100 * GB, 89 * GB, 11 * GB))
+
+    def test_local_mount_skips_clone_budget(self, tmp_path):
+        # 2 GB * 1.2 = 2.4 GB; free 7.5 GB leaves 5.1 GB > 5 GiB reserve only
+        # because no clone budget is added for a live-mount.
+        settings, team = _make_env(tmp_path)
+        self._check(
+            settings,
+            team,
+            None,
+            2 * GB,
+            _usage(100 * GB, int(92.5 * GB), int(7.5 * GB)),
+            local_mount=True,
+        )
+        clone_extra = _CLONE_BUDGET_BYTES * 1.2 / GB
+        assert clone_extra > 0.1  # the same free space fails with the budget
+        with pytest.raises(PrerequisiteNotMetError):
+            self._check(
+                settings,
+                team,
+                None,
+                2 * GB,
+                _usage(100 * GB, int(92.5 * GB), int(7.5 * GB)),
+            )
+
+    def test_separate_devices_checked_independently(self, tmp_path):
+        # Workspace disk is huge; the tablespace disk alone is too full. The
+        # refusal must name the database tablespace component.
+        settings, team = _make_env(tmp_path)
+        tablespace_root = str(tmp_path / "pg_tablespaces")
+        os.makedirs(tablespace_root, exist_ok=True)
+        real_stat = os.stat
+
+        def fake_stat(path, *args, **kwargs):
+            result = real_stat(path, *args, **kwargs)
+            if str(path).startswith(tablespace_root):
+                return _FakeStat(st_dev=result.st_dev + 1)
+            return result
+
+        def fake_usage(path):
+            if str(path).startswith(tablespace_root):
+                return _usage(100 * GB, 97 * GB, 3 * GB)
+            return _usage(100 * GB, 10 * GB, 90 * GB)
+
+        with (
+            patch.object(system_ops.os, "stat", side_effect=fake_stat),
+            patch.object(system_ops.shutil, "disk_usage", side_effect=fake_usage),
+        ):
+            with pytest.raises(PrerequisiteNotMetError, match="database tablespace"):
+                check_disk_space(
+                    _client_without_pgdata(),
+                    settings,
+                    team,
+                    None,
+                    estimated_db_bytes=1 * GB,
+                    env_name="feature-x",
+                )
+
+    def test_measurement_errors_never_block_creation(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        with patch.object(system_ops.shutil, "disk_usage", side_effect=OSError("gone")):
+            check_disk_space(
+                _client_without_pgdata(),
+                settings,
+                team,
+                None,
+                estimated_db_bytes=1 * GB,
+                env_name="feature-x",
+            )
+
+    def test_pgdata_df_fallback_enforces_reserve(self, tmp_path):
+        settings, team = _make_env(tmp_path)
+        client = MagicMock()
+        client.volumes.get.side_effect = RuntimeError("no mountpoint")
+        df_output = (
+            "Filesystem 1024-blocks Used Available Capacity Mounted on\n"
+            f"overlay {100 * GB // 1024} {98 * GB // 1024} {2 * GB // 1024} 98% "
+            "/var/lib/postgresql/data\n"
+        )
+        client.containers.get.return_value.exec_run.return_value = (
+            0,
+            df_output.encode(),
+        )
+        with patch.object(
+            system_ops.shutil,
+            "disk_usage",
+            return_value=_usage(100 * GB, 10 * GB, 90 * GB),
+        ):
+            with pytest.raises(PrerequisiteNotMetError, match="data volume"):
+                check_disk_space(
+                    client,
+                    settings,
+                    team,
+                    None,
+                    estimated_db_bytes=1 * GB,
+                    env_name="feature-x",
+                )
+
+
+class _FakeStat:
+    def __init__(self, st_dev):
+        self.st_dev = st_dev
+
+
+# --- predictive db quota ---------------------------------------------------
+
+
+class TestPredictiveDbQuota:
+    _ROWS = f"oduflow_1_main|{6 * GB}"
+
+    def _team(self, quota_gb):
+        return TeamSettings(team_id="1", db_quota_gb=quota_gb)
+
+    def test_projected_over_quota_raises(self):
+        with patch.object(system_ops, "_exec_sql", return_value=self._ROWS):
+            with pytest.raises(PrerequisiteNotMetError, match="quota exceeded"):
+                check_db_quota(
+                    None, Settings(), self._team(8), estimated_new_db_bytes=3 * GB
+                )
+
+    def test_projected_under_quota_passes(self):
+        with patch.object(system_ops, "_exec_sql", return_value=self._ROWS):
+            check_db_quota(
+                None, Settings(), self._team(10), estimated_new_db_bytes=3 * GB
+            )
+
+
+# --- CREATE DATABASE strategy ----------------------------------------------
+
+
+class TestCloneStrategy:
+    def test_pg15_uses_file_copy(self):
+        with patch.object(system_ops, "_exec_sql", return_value="150004"):
+            assert pg_clone_strategy_clause(None, Settings()) == " STRATEGY FILE_COPY"
+
+    def test_pg14_uses_default(self):
+        with patch.object(system_ops, "_exec_sql", return_value="140007"):
+            assert pg_clone_strategy_clause(None, Settings()) == ""
+
+    def test_version_probe_failure_is_safe(self):
+        with patch.object(system_ops, "_exec_sql", side_effect=RuntimeError("down")):
+            assert pg_clone_strategy_clause(None, Settings()) == ""
+
+
+# --- recreate checks before deleting ---------------------------------------
+
+
+class TestRecreateChecksFirst:
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    @patch("oduflow.docker_ops.env_ops.delete_environment")
+    @patch("oduflow.docker_ops.client.get_client")
+    def test_recreate_refuses_before_delete(
+        self, mock_client, mock_delete, mock_create, tmp_path
+    ):
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        from oduflow.locking import LockManager
+        from oduflow.web_ui import mount_web_ui
+
+        settings, team = _make_env(tmp_path)
+        container = MagicMock()
+        container.labels = {
+            settings.repo_label: "https://github.com/x/y.git",
+            settings.image_label: "odoo:19.0",
+            "oduflow.template": "none",
+        }
+        mock_client.return_value.containers.get.return_value = container
+
+        app = Starlette()
+        mount_web_ui(app, lambda: settings, LockManager())
+        with patch.object(
+            system_ops,
+            "check_disk_space",
+            side_effect=PrerequisiteNotMetError("Not enough free disk space"),
+        ):
+            resp = TestClient(app).post("/api/environments/main/recreate")
+
+        assert resp.status_code == 400
+        assert "Not enough free disk space" in resp.json()["error"]
+        mock_delete.assert_not_called()
+        mock_create.assert_not_called()

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -41,6 +41,16 @@ def _no_db_quota(monkeypatch):
     monkeypatch.setattr(
         "oduflow.docker_ops.env_ops.check_db_quota", lambda *a, **kw: None
     )
+    # Disk admission is covered by tests/test_disk_space.py.
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.estimate_new_db_bytes", lambda *a, **kw: 0
+    )
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.check_disk_space", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(
+        "oduflow.docker_ops.env_ops.pg_clone_strategy_clause", lambda *a, **kw: ""
+    )
     # Tablespace provisioning is covered by tests/test_tablespaces.py.
     monkeypatch.setattr(
         "oduflow.docker_ops.env_ops.ensure_team_tablespace",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -721,6 +721,29 @@ class TestCreateServiceTool:
         assert parsed_env == {"MEILI_MASTER_KEY": "abc", "MEILI_ENV": "production"}
 
     @patch("oduflow.docker_ops.service_ops.create_service")
+    def test_create_preserves_commas_inside_env_value(self, mock_create):
+        mock_create.return_value = {
+            "name": "connect-mcp-server",
+            "container_name": "oduflow-1-svc-connect-mcp-server",
+            "url": "http://localhost:8080",
+            "image": "example/connect-mcp-server:latest",
+        }
+
+        _get_tool_fn("create_service")(
+            name="connect-mcp-server",
+            image="example/connect-mcp-server:latest",
+            port=8080,
+            env_vars=(
+                "CONNECT_MCP_TOOL_GROUPS=write,collaboration,documents,LOG_LEVEL=info"
+            ),
+        )
+
+        assert mock_create.call_args.kwargs["env_vars"] == {
+            "CONNECT_MCP_TOOL_GROUPS": "write,collaboration,documents",
+            "LOG_LEVEL": "info",
+        }
+
+    @patch("oduflow.docker_ops.service_ops.create_service")
     def test_create_empty_env_vars(self, mock_create):
         mock_create.return_value = {
             "name": "redis",
@@ -798,6 +821,26 @@ class TestUpdateServiceTool:
             "Internal hostname: host network — reach it via host.docker.internal"
             in result
         )
+
+    @patch("oduflow.docker_ops.service_ops.update_service")
+    def test_update_preserves_commas_inside_env_value(self, mock_update):
+        mock_update.return_value = {
+            "name": "connect-mcp-server",
+            "container_name": "oduflow-1-svc-connect-mcp-server",
+            "url": "http://localhost:8080",
+            "image": "example/connect-mcp-server:latest",
+            "image_updated": False,
+            "config_updated": True,
+        }
+
+        _get_tool_fn("update_service")(
+            name="connect-mcp-server",
+            env_vars="CONNECT_MCP_TOOL_GROUPS=write,collaboration,documents",
+        )
+
+        assert mock_update.call_args.kwargs["env_override"] == {
+            "CONNECT_MCP_TOOL_GROUPS": "write,collaboration,documents"
+        }
 
     @patch("oduflow.docker_ops.service_ops.update_service")
     def test_update_routes_mapping(self, mock_update):

--- a/tests/test_template_local_path.py
+++ b/tests/test_template_local_path.py
@@ -220,11 +220,13 @@ class TestWebUILiveMountTemplate:
         assert resp.status_code == 400
         assert "live-mounted environment" in resp.json()["error"]
 
+    @patch("oduflow.docker_ops.system_ops.check_disk_space")
+    @patch("oduflow.docker_ops.system_ops.estimate_new_db_bytes", return_value=0)
     @patch("oduflow.docker_ops.env_ops.create_environment")
     @patch("oduflow.docker_ops.env_ops.delete_environment")
     @patch("oduflow.docker_ops.client.get_client")
     def test_recreate_passes_local_path(
-        self, mock_client, mock_delete, mock_create, tmp_path
+        self, mock_client, mock_delete, mock_create, mock_est, mock_disk, tmp_path
     ):
         from starlette.testclient import TestClient
 

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -96,7 +96,10 @@ def test_environment_name_is_copyable(tmp_path):
     dashboard = _client(tmp_path).get("/")
 
     assert dashboard.status_code == 200
-    assert '<span class="branch-name copy-db" role="button" tabindex="0" ' in dashboard.text
+    assert (
+        '<span class="branch-name copy-db" role="button" tabindex="0" '
+        in dashboard.text
+    )
     assert (
         'title="Copy environment name" aria-label="Copy environment name" '
         in dashboard.text
@@ -108,7 +111,9 @@ def test_connect_modal_emphasizes_primary_action(tmp_path):
     dashboard = _client(tmp_path).get("/")
 
     assert dashboard.status_code == 200
-    assert '<button class="btn" onclick="closeConnect()">Close</button>' in dashboard.text
+    assert (
+        '<button class="btn" onclick="closeConnect()">Close</button>' in dashboard.text
+    )
     assert (
         '<button class="btn-create" id="connect-submit" '
         'onclick="submitConnect()">Connect</button>' in dashboard.text

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -92,6 +92,29 @@ def test_environment_metadata_shows_live_mount_path(tmp_path):
     assert "env.local_path ? '<span>Live-mount:" in dashboard.text
 
 
+def test_environment_name_is_copyable(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert '<span class="branch-name copy-db" role="button" tabindex="0" ' in dashboard.text
+    assert (
+        'title="Copy environment name" aria-label="Copy environment name" '
+        in dashboard.text
+    )
+    assert "copyToClipboard(\\'' + escAttr(env.branch)" in dashboard.text
+
+
+def test_connect_modal_emphasizes_primary_action(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert '<button class="btn" onclick="closeConnect()">Close</button>' in dashboard.text
+    assert (
+        '<button class="btn-create" id="connect-submit" '
+        'onclick="submitConnect()">Connect</button>' in dashboard.text
+    )
+
+
 def test_dashboard_uses_safe_json_response_reader(tmp_path):
     dashboard = _client(tmp_path).get("/")
 


### PR DESCRIPTION
## Summary

- **Disk admission before `create_environment`**: estimates what creation will write (exact `pg_database_size()` of the template DB, filestore copy vs overlay headroom from template metadata, 512 MiB remote-clone budget), groups target directories by `st_dev` (tablespace dir, workspaces dir, and the PGDATA volume where WAL/catalogs live), and refuses with a clear `PrerequisiteNotMetError` unless `free − estimate×1.2` stays above `max(5 GiB, min(5 %, 10 GiB))` on every device. Built-in constants, no new config. Only creation is gated — delete/cleanup stay available so a full disk can always be recovered, and measurement failures never block.
- **Predictive `check_db_quota`**: `used + estimated_new_db` is checked before `CREATE DATABASE`, not after it fails halfway.
- **Recreate checks before deleting**: the dashboard recreate endpoint runs the disk check before `delete_environment`, so a refusal never destroys a working environment.
- **`STRATEGY FILE_COPY` on PG 15+ template clones**: the WAL_LOG default writes the whole clone through WAL and can transiently double its disk cost; version probed at runtime via `SHOW server_version_num`.
- **Dashboard**: environment name in the list is click-to-copy (keyboard accessible); Connect dialog uses the primary button style.
- **Service env vars**: commas inside values are preserved (`KEY=a,b,c` stays one variable; split only on newlines or commas followed by a new `KEY=`).

## Testing

- New `tests/test_disk_space.py` (24 tests): same-device summing, independent devices, reserve floor/cap, overlay vs copy vs non-Linux fallback, PGDATA df fallback, predictive quota, FILE_COPY clause, recreate-refuses-before-delete.
- Full unit suite: 2322 passed; `ruff check`, `ruff format --check`, `mypy` clean.