### PR TITLE
[codex] Add reusable environment and service slots

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,18 @@
 
 ### Features
 
+- **Reusable environment hostname slots** — Traefik teams can set
+  `environment_slots = N` to decouple public routing from branch names and
+  number the team hostname prefix: `dev.example.com` becomes the fixed pool
+  `dev1.example.com` through `devN.example.com`. Assignments are concurrency-safe,
+  persist across stops and container updates, and return to the pool on deletion,
+  bounding normal Let's Encrypt certificate issuance to the configured pool.
+  `create_environment(hostname="qa")` requests `qa.example.com` while still
+  consuming one team slot. The default is 20 environment slots. Teams also
+  receive a separate `service_slots = 10` cap for managed auxiliary
+  services; deleting an unused service immediately frees its slot, and either
+  limit can be disabled with `0`.
+
 - **OpenCode hosted agent** — OpenCode joins Claude Code and Codex as a full Agent CLI and Agent Chat runtime. The new immutable coder image includes the MIT-licensed `opencode` CLI and native ACP server; OpenCode gets generic provider authentication, an optional `provider/model` override, approval-free execution inside the existing container boundary, per-environment Agent Browser, scoped Oduflow MCP, modern ACP model selection, and isolated conversation history.
 
 - **Declarative Oduflow Stacks** — a versioned `oduflow.yaml` can now describe

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -14,11 +14,22 @@ oduflow call create_environment feature-login "" none https://github.com/owner/r
 # Create with JSON arguments (more explicit)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0"}'
 
+# Override the numbered Traefik prefix (dev.example.com -> qa.example.com)
+oduflow call create_environment '{"branch":"feature-login","hostname":"qa","template_name":"myproject"}'
+
 # Inject container environment variables (comma-separated KEY=VALUE)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","env_vars":"WORKERS=2,LIMIT_TIME_CPU=600"}'
 ```
 
 `env_vars` are added on top of the database connection variables (`HOST`/`USER`/`PASSWORD`). They are stored on the container and can later be replaced with [`update_environment`](#lifecycle-management).
+
+In Traefik mode, a team with `environment_slots = N` numbers the first label of
+its hostname. For `dev.example.com`, the reusable pool is `dev1.example.com`
+through `devN.example.com`. The assignment survives stops and container updates
+and is released only when the environment is deleted. Pass `hostname` to replace
+the numbered prefix: `hostname="qa"` produces `qa.example.com`. The default is
+20 concurrent environment slots; set `environment_slots = 0` to retain legacy
+branch-derived hostnames.
 
 When creating an environment, Oduflow:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -246,6 +246,8 @@ auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 di
 
 [team.1]
 hostname = "localhost"               # port mode: http://{hostname}:{port}, traefik mode: https://{slug}.{hostname}
+environment_slots = 20               # traefik: dev.example.com + N => dev1.example.com..devN.example.com; 0 = legacy hostnames
+service_slots = 10                   # maximum managed auxiliary services; 0 = unlimited
 auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Bearer token
 ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
@@ -352,6 +354,8 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | Key | Default | Description |
 |---|---|---|
 | `hostname` | `localhost` | Team hostname. In port mode: `http://{hostname}:{port}`. In traefik mode: `https://{slug}.{hostname}` |
+| `environment_slots` | `20` | Traefik reusable hostname pool and concurrent environment cap. `0` keeps branch-derived hostnames; with `dev.example.com`, `N` allocates `dev1.example.com` through `devN.example.com` |
+| `service_slots` | `10` | Maximum number of managed auxiliary services for the team. Stopped services count; deleting a service frees its slot. `0` disables the cap |
 | `auth_token` | *(generated in fresh config)* | Bearer token for MCP HTTP auth and OAuth client secret. Empty disables MCP auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
@@ -361,6 +365,10 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
 | `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
 
+`environment_slots > 0` requires a hostname with a distinct host prefix and
+parent domain, such as `dev.example.com`. A bare registrable domain such as
+`example.com` has no prefix to number and is rejected.
+
 Team data is stored at `{data_dir}/team_{ID}/`:
 
 ```
@@ -369,6 +377,7 @@ team_{ID}/
 ├── templates/            # Reusable database snapshots
 ├── shared_repos/         # Extra addon repositories (bare clones)
 ├── ports.json            # Port registry
+├── hostnames.json        # Reusable Traefik hostname reservations
 ├── .git-credentials      # Git credentials for this team
 └── agent_guides/         # AI agent guides (markdown)
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -800,6 +800,8 @@ auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 di
 
 [team.1]
 hostname = "localhost"               # port mode: http://{hostname}:{port}, traefik mode: https://{slug}.{hostname}
+environment_slots = 20               # traefik: dev.example.com + N => dev1.example.com..devN.example.com; 0 = legacy hostnames
+service_slots = 10                   # maximum managed auxiliary services; 0 = unlimited
 auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Bearer token
 ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
 port_range = [50000, 50100]          # port range for Odoo containers [start, end)
@@ -906,6 +908,8 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | Key | Default | Description |
 |---|---|---|
 | `hostname` | `localhost` | Team hostname. In port mode: `http://{hostname}:{port}`. In traefik mode: `https://{slug}.{hostname}` |
+| `environment_slots` | `20` | Traefik reusable hostname pool and concurrent environment cap. `0` keeps branch-derived hostnames; with `dev.example.com`, `N` allocates `dev1.example.com` through `devN.example.com` |
+| `service_slots` | `10` | Maximum number of managed auxiliary services for the team. Stopped services count; deleting a service frees its slot. `0` disables the cap |
 | `auth_token` | *(generated in fresh config)* | Bearer token for MCP HTTP auth and OAuth client secret. Empty disables MCP auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `port_range` | `[50000, 50100]` | Port range for Odoo containers `[start, end)` — supports up to 100 concurrent environments |
@@ -915,6 +919,10 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
 | `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
 
+`environment_slots > 0` requires a hostname with a distinct host prefix and
+parent domain, such as `dev.example.com`. A bare registrable domain such as
+`example.com` has no prefix to number and is rejected.
+
 Team data is stored at `{data_dir}/team_{ID}/`:
 
 ```
@@ -923,6 +931,7 @@ team_{ID}/
 ├── templates/            # Reusable database snapshots
 ├── shared_repos/         # Extra addon repositories (bare clones)
 ├── ports.json            # Port registry
+├── hostnames.json        # Reusable Traefik hostname reservations
 ├── .git-credentials      # Git credentials for this team
 └── agent_guides/         # AI agent guides (markdown)
 ```
@@ -1564,11 +1573,22 @@ oduflow call create_environment feature-login "" none https://github.com/owner/r
 # Create with JSON arguments (more explicit)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0"}'
 
+# Override the numbered Traefik prefix (dev.example.com -> qa.example.com)
+oduflow call create_environment '{"branch":"feature-login","hostname":"qa","template_name":"myproject"}'
+
 # Inject container environment variables (comma-separated KEY=VALUE)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","env_vars":"WORKERS=2,LIMIT_TIME_CPU=600"}'
 ```
 
 `env_vars` are added on top of the database connection variables (`HOST`/`USER`/`PASSWORD`). They are stored on the container and can later be replaced with [`update_environment`](#lifecycle-management).
+
+In Traefik mode, a team with `environment_slots = N` numbers the first label of
+its hostname. For `dev.example.com`, the reusable pool is `dev1.example.com`
+through `devN.example.com`. The assignment survives stops and container updates
+and is released only when the environment is deleted. Pass `hostname` to replace
+the numbered prefix: `hostname="qa"` produces `qa.example.com`. The default is
+20 concurrent environment slots; set `environment_slots = 0` to retain legacy
+branch-derived hostnames.
 
 When creating an environment, Oduflow:
 
@@ -2389,6 +2409,11 @@ Services are:
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
 - Always created from a freshly pulled image — `create_service` and `restore_service` explicitly pull before running, so mutable tags like `:latest` get the current published version instead of a stale local cache
 
+Each team has `service_slots = 10` by default. The cap includes running and
+stopped managed services; updating or restarting an existing service does not
+consume another slot. Delete an unused service to free capacity, or set
+`service_slots = 0` to disable the cap.
+
 ### Connecting from Odoo
 
 Inside the team's Docker network the service is reachable by its **container
@@ -2706,6 +2731,7 @@ metadata:
 spec:
   environment:
     name: acme-dev
+    hostname: qa                # optional; dev.example.com -> qa.example.com
     branch: "18.0"
     repoUrl: https://github.com/acme/odoo-addons.git
     odooImage: odoo:18.0
@@ -2891,7 +2917,7 @@ than a JSON API. Production routes are registered only when
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/environments` | List environments |
-| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user` |
+| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `hostname`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user` |
 | `POST` | `/api/environments/{branch}/start` | Start an environment |
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
@@ -3055,7 +3081,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `env_vars` injects container environment variables |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
@@ -3408,18 +3434,28 @@ For production-like access with HTTPS, Oduflow can deploy a **Traefik** reverse 
 
    [team.1]
    hostname = "dev.example.com"
+   environment_slots = 20
    ```
 
 3. **Start (or restart) Oduflow.** On startup, Oduflow will create a Traefik v3 container that:
    - Listens on ports 80 and 443
    - Automatically redirects HTTP to HTTPS
-   - Obtains a separate TLS certificate from Let's Encrypt for each environment subdomain via HTTP-01 challenge
+   - Obtains a separate TLS certificate from Let's Encrypt for each reusable environment hostname via HTTP-01 challenge
    - Routes requests to the correct Odoo container based on the subdomain
    - Also routes the Oduflow server itself via the team `hostname`
 
 ## How certificates work
 
-Traefik requests a **per-subdomain certificate** from Let's Encrypt each time a new environment is created. This works out of the box with any DNS provider since it uses HTTP-01 validation (Traefik responds to the ACME challenge on port 80).
+With `hostname = "dev.example.com"` and `environment_slots = 20`, Oduflow
+allocates `dev1.example.com` through `dev20.example.com`: it removes the first
+hostname label, adds the slot number to it, and keeps the parent domain.
+Deleting an environment returns its hostname to the pool, so later environments
+reuse the same certificates from Traefik's persistent ACME store instead of
+continuously issuing certificates for branch names.
+`create_environment(hostname="qa")` requests `qa.example.com`. Set
+`environment_slots = 0` to retain the legacy branch-derived hostname behavior.
+The configured hostname must include a distinct prefix (`dev.example.com`, not
+bare `example.com`) so Oduflow has a label to number.
 
 Wildcard certificates (`*.dev.example.com`) via DNS-01 validation are also possible but require additional Traefik configuration with a provider-specific plugin.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -7,7 +7,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `env_vars` injects container environment variables |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |

--- a/docs/services.md
+++ b/docs/services.md
@@ -41,6 +41,11 @@ Services are:
 - Labeled for management (`oduflow.managed=true`, `oduflow.service=<name>`)
 - Always created from a freshly pulled image — `create_service` and `restore_service` explicitly pull before running, so mutable tags like `:latest` get the current published version instead of a stale local cache
 
+Each team has `service_slots = 10` by default. The cap includes running and
+stopped managed services; updating or restarting an existing service does not
+consume another slot. Delete an unused service to free capacity, or set
+`service_slots = 0` to disable the cap.
+
 ### Connecting from Odoo
 
 Inside the team's Docker network the service is reachable by its **container

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -45,6 +45,7 @@ metadata:
 spec:
   environment:
     name: acme-dev
+    hostname: qa                # optional; dev.example.com -> qa.example.com
     branch: "18.0"
     repoUrl: https://github.com/acme/odoo-addons.git
     odooImage: odoo:18.0
@@ -183,4 +184,3 @@ descriptions are also immutable in V1. There is no automatic deletion or
 V1 supports one development environment per manifest. Production stacks,
 portable database artifacts, binary volume files, lockfiles, lifecycle shell
 hooks, dashboard controls, and OCI distribution are intentionally deferred.
-

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -23,18 +23,28 @@ For production-like access with HTTPS, Oduflow can deploy a **Traefik** reverse 
 
    [team.1]
    hostname = "dev.example.com"
+   environment_slots = 20
    ```
 
 3. **Start (or restart) Oduflow.** On startup, Oduflow will create a Traefik v3 container that:
    - Listens on ports 80 and 443
    - Automatically redirects HTTP to HTTPS
-   - Obtains a separate TLS certificate from Let's Encrypt for each environment subdomain via HTTP-01 challenge
+   - Obtains a separate TLS certificate from Let's Encrypt for each reusable environment hostname via HTTP-01 challenge
    - Routes requests to the correct Odoo container based on the subdomain
    - Also routes the Oduflow server itself via the team `hostname`
 
 ## How certificates work
 
-Traefik requests a **per-subdomain certificate** from Let's Encrypt each time a new environment is created. This works out of the box with any DNS provider since it uses HTTP-01 validation (Traefik responds to the ACME challenge on port 80).
+With `hostname = "dev.example.com"` and `environment_slots = 20`, Oduflow
+allocates `dev1.example.com` through `dev20.example.com`: it removes the first
+hostname label, adds the slot number to it, and keeps the parent domain.
+Deleting an environment returns its hostname to the pool, so later environments
+reuse the same certificates from Traefik's persistent ACME store instead of
+continuously issuing certificates for branch names.
+`create_environment(hostname="qa")` requests `qa.example.com`. Set
+`environment_slots = 0` to retain the legacy branch-derived hostname behavior.
+The configured hostname must include a distinct prefix (`dev.example.com`, not
+bare `example.com`) so Oduflow has a label to number.
 
 Wildcard certificates (`*.dev.example.com`) via DNS-01 validation are also possible but require additional Traefik configuration with a provider-specific plugin.
 

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -42,7 +42,7 @@ than a JSON API. Production routes are registered only when
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/environments` | List environments |
-| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user` |
+| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `hostname`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user` |
 | `POST` | `/api/environments/{branch}/start` | Start an environment |
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |

--- a/specs/0048-reusable-environment-hostname-slots.md
+++ b/specs/0048-reusable-environment-hostname-slots.md
@@ -1,0 +1,75 @@
+# 0048 — Reusable environment hostname slots
+
+**Status:** Adopted
+**Type:** Routing / Capacity
+**First introduced:** `litnimax/reusable-hostname-slots` branch (2026-08-16)
+**Key code today:** `hostname_registry.py`, `docker_ops/env_ops.py`, `settings.py`, `naming.py`
+
+## Context
+
+[[0004-stable-addressing-port-registry-and-traefik]] originally derived every
+Traefik hostname from the environment name. That made URLs descriptive, but
+ephemeral branch environments continually introduced new DNS names. With
+Traefik's HTTP-01 ACME integration, each new name required a new Let's Encrypt
+certificate and sufficiently active teams could reach certificate issuance
+rate limits even though they never needed an unbounded set of simultaneous
+addresses.
+
+The environment name still matters for source, database, workspace and agent
+identity. It does not need to be the public routing identity.
+
+## Decision
+
+Make the public environment hostname an independently persisted, reusable team
+resource. A team can configure `environment_slots = N`; Oduflow then numbers
+the first label of the team hostname. For `dev.example.com`, the reusable pool
+is `dev1.example.com` through `devN.example.com` instead of unbounded
+branch-derived names.
+
+`create_environment` also accepts an explicit short `hostname` that replaces
+the numbered prefix: `hostname="qa"` under `dev.example.com` produces
+`qa.example.com`. Explicit names are useful for controlled integrations but
+still consume one of the team's configured concurrent environment slots. The
+configured default is 20 slots; a zero slot count preserves the legacy
+branch-derived behavior for compatibility.
+
+## How it works (macro)
+
+- A per-team `hostnames.json` registry maps environment identity to its short
+  routing hostname. Read-modify-write operations use a thread mutex, process
+  `flock`, and atomic replacement, matching the concurrency requirements of the
+  persistent port registry.
+- Automatic allocation splits the team hostname into a reusable prefix and
+  parent domain, then selects the first unused numbered prefix (`dev1`, `dev2`,
+  ...). Active legacy environments and in-flight reservations both count toward
+  capacity, so two parallel creates cannot receive the same hostname or exceed
+  the configured team limit.
+- The short hostname is stored on the Odoo container as an `oduflow.hostname`
+  label. URL reporting, Traefik rules, browser login handoff and container
+  updates read that label instead of recomputing the route from the branch.
+- Stops and updates preserve the reservation. Deletion releases it. A failed
+  create releases a reservation when no serving container was created.
+- Existing unlabeled environments keep their branch-derived hostname until an
+  update migrates them into the configured pool, avoiding a surprise URL change
+  merely from restarting the Oduflow server.
+
+## Consequences
+
+- Certificate cardinality is bounded by the configured numbered hostname pool
+  during normal automatic operation; once the pool has been issued, later
+  environments reuse the same Traefik ACME certificates.
+- Environment identity and public address are no longer the same concept. All
+  routing consumers must use the persisted hostname label, while database,
+  workspace and locking code continues to use the environment name.
+- A positive slot count is also a hard cap on concurrent development
+  environments for the team. Capacity exhaustion is reported before
+  provisioning starts.
+- Explicit custom hostnames can still create additional certificate names over
+  time; that is an intentional operator override rather than the automatic
+  lifecycle default.
+
+## History
+
+- `litnimax/reusable-hostname-slots` (2026-08-16) — reusable per-team hostname
+  pool, explicit short hostname override, persisted routing identity and
+  lifecycle integration.

--- a/specs/README.md
+++ b/specs/README.md
@@ -66,6 +66,7 @@ precursors).
 | [0045](0045-user-attributed-github-feedback.md) | 2026-08-11 | User-attributed GitHub feedback through prefilled, review-before-submit issue forms |
 | [0046](0046-declarative-oduflow-stacks.md) | 2026-08-11 | Declarative Oduflow Stacks: versioned YAML, plan/apply reconciliation, ownership and startup bootstrap |
 | [0047](0047-three-way-bundled-upgrades.md) | 2026-08-14 | Three-way upgrades for deployed bundled files with persistent baselines and safe conflict sidecars |
+| [0048](0048-reusable-environment-hostname-slots.md) | 2026-08-16 | Reusable environment hostname slots decouple public routing from branch identity |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -44,6 +45,7 @@ from oduflow.errors import (
     ProtectedError,
 )
 from oduflow.git_ops import RepoAuthError, git_env_for_team
+from oduflow.hostname_registry import allocate_hostname, release_hostname
 from oduflow.naming import (
     get_agent_checkout_dir,
     get_agent_container_name,
@@ -52,6 +54,7 @@ from oduflow.naming import (
     get_agent_workspace_volume_name,
     get_db_name,
     get_env_hostname,
+    get_env_short_hostname,
     get_filestore_paths,
     get_repo_path,
     get_resource_name,
@@ -61,6 +64,8 @@ from oduflow.naming import (
     redact_url_credentials,
     sanitize_repo_url,
     slugify_branch,
+    split_team_hostname,
+    validate_env_hostname,
 )
 from oduflow.port_registry import allocate_port, release_port
 from oduflow.settings import Settings, TeamSettings
@@ -69,6 +74,15 @@ logger = logging.getLogger("oduflow")
 
 AGENT_USER = "agent"
 AGENT_HOME = "/home/agent"
+ENV_HOSTNAME_LABEL = "oduflow.hostname"
+
+
+def _hostname_registry_path(team: TeamSettings) -> str:
+    if team.hostname_registry_path:
+        return team.hostname_registry_path
+    if team.data_dir:
+        return os.path.join(team.data_dir, "hostnames.json")
+    raise ValueError("Team data_dir is required for environment hostname allocation.")
 
 
 def _trace(msg: str, *args: object) -> None:
@@ -200,6 +214,51 @@ def _get_used_ports(
                     except (KeyError, ValueError, TypeError):
                         pass
     return used
+
+
+def _environment_hostname_usage(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    *,
+    exclude_env: str = "",
+) -> tuple[set[str], set[str]]:
+    """Return active environment names and their short routing hostnames."""
+    active_envs: set[str] = set()
+    used_hostnames: set[str] = set()
+    _hostname_prefix, parent_domain = split_team_hostname(team.hostname)
+    suffix = f".{parent_domain}"
+    for configured_team in settings.teams.values():
+        if configured_team.hostname.endswith(suffix):
+            used_hostnames.add(configured_team.hostname[: -len(suffix)])
+    for route in settings.extra_routes:
+        if route.host.endswith(suffix):
+            used_hostnames.add(route.host[: -len(suffix)])
+    filters = {
+        "label": [
+            f"{settings.managed_label}=true",
+            f"{settings.team_label}={team.team_id}",
+        ]
+    }
+    for container in client.containers.list(all=True, filters=filters):
+        env_name = container.labels.get(settings.branch_label, "")
+        if env_name == exclude_env:
+            continue
+        for key, value in container.labels.items():
+            if not key.startswith("traefik.http.routers.") or not key.endswith(".rule"):
+                continue
+            for fqdn in re.findall(r"Host\(`([^`]+)`\)", value):
+                if fqdn.endswith(suffix):
+                    used_hostnames.add(fqdn[: -len(suffix)])
+        if not env_name:
+            continue
+        active_envs.add(env_name)
+        used_hostnames.add(
+            get_env_short_hostname(
+                env_name, container.labels.get(ENV_HOSTNAME_LABEL, "")
+            )
+        )
+    return active_envs, used_hostnames
 
 
 def _ensure_system_ready(
@@ -976,7 +1035,10 @@ def _clone_repo(
 
 
 def build_env_traefik_labels(
-    settings: Settings, team: TeamSettings, env_name: str
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    route_hostname: str = "",
 ) -> dict[str, str]:
     """Traefik docker-provider routing labels for an environment's Odoo container.
 
@@ -991,7 +1053,7 @@ def build_env_traefik_labels(
         return {}
     slug = slugify_branch(env_name)
     router = f"oduflow-{team.team_id}-{slug}"
-    host = get_env_hostname(env_name, team.hostname)
+    host = get_env_hostname(env_name, team.hostname, route_hostname)
     labels: dict[str, str] = {
         "traefik.enable": "true",
         f"traefik.http.routers.{router}.rule": f"Host(`{host}`)",
@@ -1024,6 +1086,95 @@ def create_environment(
     env_vars: dict[str, str] | None = None,
     local_path: str = "",
     stack_labels: dict[str, str] | None = None,
+    hostname: str = "",
+) -> dict[str, Any]:
+    """Allocate routing state, then provision the environment itself."""
+    resolved_env_name = env_name or branch
+    requested_hostname = validate_env_hostname(hostname) if hostname else ""
+    if requested_hostname and settings.routing_mode != "traefik":
+        raise ValueError("hostname is supported only when routing.mode = 'traefik'.")
+
+    assigned_hostname = ""
+    if settings.routing_mode == "traefik" and (
+        requested_hostname or team.environment_slots > 0
+    ):
+        hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
+        try:
+            client = get_client()
+        except Exception as exc:
+            raise PrerequisiteNotMetError(
+                f"Failed to connect to Docker daemon: {exc}. Ensure Docker is running."
+            ) from exc
+        container_name = get_resource_name(
+            resolved_env_name, "odoo", settings.prefix, team.team_id
+        )
+        try:
+            client.containers.get(container_name)
+        except docker.errors.NotFound:
+            active_envs, used_hostnames = _environment_hostname_usage(
+                client, settings, team, exclude_env=resolved_env_name
+            )
+            assigned_hostname = allocate_hostname(
+                _hostname_registry_path(team),
+                resolved_env_name,
+                team.environment_slots,
+                requested_hostname=requested_hostname,
+                hostname_prefix=hostname_prefix,
+                active_envs=active_envs,
+                used_hostnames=used_hostnames,
+            )
+
+    try:
+        return _create_environment_impl(
+            settings,
+            team,
+            branch,
+            repo_url,
+            odoo_image,
+            env_name=env_name,
+            template_name=template_name,
+            extra_addons=extra_addons,
+            git_user=git_user,
+            sanitize=sanitize,
+            auto_install_modules=auto_install_modules,
+            env_vars=env_vars,
+            local_path=local_path,
+            stack_labels=stack_labels,
+            hostname=assigned_hostname,
+        )
+    except Exception:
+        if assigned_hostname:
+            try:
+                get_client().containers.get(
+                    get_resource_name(
+                        resolved_env_name, "odoo", settings.prefix, team.team_id
+                    )
+                )
+            except docker.errors.NotFound:
+                release_hostname(_hostname_registry_path(team), resolved_env_name)
+            except Exception:
+                # Keep the reservation when Docker state cannot be checked; a
+                # later retry of the same environment will reuse it safely.
+                pass
+        raise
+
+
+def _create_environment_impl(
+    settings: Settings,
+    team: TeamSettings,
+    branch: str,
+    repo_url: str,
+    odoo_image: str,
+    env_name: str = "",
+    template_name: str | None = None,
+    extra_addons: dict[str, str] | None = None,
+    git_user: str = "",
+    sanitize: bool = True,
+    auto_install_modules: list[str] | None = None,
+    env_vars: dict[str, str] | None = None,
+    local_path: str = "",
+    stack_labels: dict[str, str] | None = None,
+    hostname: str = "",
 ) -> dict[str, Any]:
     env_name = env_name or branch
     from oduflow.naming import PROD_ENV_PREFIX
@@ -1060,7 +1211,7 @@ def create_environment(
         if existing.status == "running":
             existing.reload()
             if settings.routing_mode == "traefik":
-                url = f"https://{get_env_hostname(env_name, team.hostname)}"
+                url = f"https://{get_env_hostname(env_name, team.hostname, existing.labels.get(ENV_HOSTNAME_LABEL, ''))}"
             else:
                 ports = existing.ports.get("8069/tcp")
                 existing_port = ports[0]["HostPort"] if ports else "?"
@@ -1164,8 +1315,10 @@ def create_environment(
         labels["oduflow.env_vars"] = json.dumps(env_vars)
     if stack_labels:
         labels.update(stack_labels)
+    if hostname:
+        labels[ENV_HOSTNAME_LABEL] = hostname
 
-    labels.update(build_env_traefik_labels(settings, team, env_name))
+    labels.update(build_env_traefik_labels(settings, team, env_name, hostname))
 
     logger.info(
         "Creating environment",
@@ -1176,7 +1329,7 @@ def create_environment(
             "image": odoo_image,
             "prefix": settings.prefix,
             "routing_mode": settings.routing_mode,
-            "hostname": team.hostname,
+            "hostname": hostname or get_env_short_hostname(env_name),
             "workspaces_dir": team.workspaces_dir,
         },
     )
@@ -1466,7 +1619,7 @@ def create_environment(
         container.restart()
 
     if settings.routing_mode == "traefik":
-        url = f"https://{get_env_hostname(env_name, team.hostname)}"
+        url = f"https://{get_env_hostname(env_name, team.hostname, hostname)}"
     else:
         url = f"http://{team.hostname}:{host_port}"
     logger.info(
@@ -1489,6 +1642,7 @@ def create_environment(
 
     result: dict[str, Any] = {
         "url": url,
+        "hostname": hostname or get_env_short_hostname(env_name),
         "odoo_container": odoo_container_name,
         "database": env_db,
         "workspace": workspace_path,
@@ -2168,6 +2322,8 @@ def delete_environment(
 
     if settings.routing_mode == "port":
         release_port(team.port_registry_path, env_name)
+    if team.hostname_registry_path or team.data_dir:
+        release_hostname(_hostname_registry_path(team), env_name)
 
     if container_exists:
         try:
@@ -2271,6 +2427,9 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                 "stack_resource": container.labels.get("oduflow.stack-resource", ""),
                 "stack_spec_hash": container.labels.get("oduflow.stack-spec-hash", ""),
                 "stack_sanitize": container.labels.get("oduflow.stack-sanitize", ""),
+                "hostname": get_env_short_hostname(
+                    env_name, container.labels.get(ENV_HOSTNAME_LABEL, "")
+                ),
             }
 
         try:
@@ -2287,7 +2446,7 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
         if "-odoo" in container.name:
             if settings.routing_mode == "traefik":
                 envs[env_name]["url"] = (
-                    f"https://{get_env_hostname(env_name, team.hostname)}/web?debug=1"
+                    f"https://{get_env_hostname(env_name, team.hostname, container.labels.get(ENV_HOSTNAME_LABEL, ''))}/web?debug=1"
                 )
             else:
                 ports = container.attrs.get("NetworkSettings", {}).get("Ports", {})
@@ -2485,7 +2644,19 @@ def get_env_base_url(
     actually send.
     """
     if settings.routing_mode == "traefik":
-        host = get_env_hostname(env_name, team.hostname)
+        if container is None:
+            client = get_client()
+            try:
+                container = client.containers.get(
+                    get_resource_name(env_name, "odoo", settings.prefix, team.team_id)
+                )
+            except docker.errors.NotFound:
+                raise NotFoundError(
+                    f"Environment '{env_name}' does not exist. Use create_environment first."
+                )
+        host = get_env_hostname(
+            env_name, team.hostname, container.labels.get(ENV_HOSTNAME_LABEL, "")
+        )
         return f"https://{host}", host
 
     # Port routing: read the container's published 8069 port. Cookies are not
@@ -2562,10 +2733,13 @@ def get_environment_info(
         result["stack_resource"] = labels.get("oduflow.stack-resource", "")
         result["stack_spec_hash"] = labels.get("oduflow.stack-spec-hash", "")
         result["stack_sanitize"] = labels.get("oduflow.stack-sanitize", "")
+        result["hostname"] = get_env_short_hostname(
+            env_name, labels.get(ENV_HOSTNAME_LABEL, "")
+        )
 
         if settings.routing_mode == "traefik":
             result["url"] = (
-                f"https://{get_env_hostname(env_name, team.hostname)}/web?debug=1"
+                f"https://{get_env_hostname(env_name, team.hostname, labels.get(ENV_HOSTNAME_LABEL, ''))}/web?debug=1"
             )
         else:
             ports = odoo_container.attrs.get("NetworkSettings", {}).get("Ports", {})
@@ -3279,6 +3453,24 @@ def update_environment(
                     "locally; leaving the existing environment untouched."
                 ) from exc
 
+    if (
+        settings.routing_mode == "traefik"
+        and team.environment_slots > 0
+        and not labels.get(ENV_HOSTNAME_LABEL)
+    ):
+        hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
+        active_envs, used_hostnames = _environment_hostname_usage(
+            client, settings, team, exclude_env=env_name
+        )
+        labels[ENV_HOSTNAME_LABEL] = allocate_hostname(
+            _hostname_registry_path(team),
+            env_name,
+            team.environment_slots,
+            hostname_prefix=hostname_prefix,
+            active_envs=active_envs,
+            used_hostnames=used_hostnames,
+        )
+
     logger.info(
         "Updating environment – stopping old container",
         extra={"env_name": env_name, "container": odoo_container_name},
@@ -3357,7 +3549,8 @@ def update_environment(
     # update_environment. Strip every stale ``traefik.*`` key first so a
     # traefik→port switch drops them and a renamed router does not linger.
     labels = {k: v for k, v in labels.items() if not k.startswith("traefik.")}
-    labels.update(build_env_traefik_labels(settings, team, env_name))
+    route_hostname = labels.get(ENV_HOSTNAME_LABEL, "")
+    labels.update(build_env_traefik_labels(settings, team, env_name, route_hostname))
     if settings.routing_mode == "traefik":
         # No published port in traefik mode; drop any stale reservation left from
         # a previous port-mode life so the slot is reusable.
@@ -3450,7 +3643,7 @@ def update_environment(
     # 6. Build URL and return result
     # ------------------------------------------------------------------
     if settings.routing_mode == "traefik":
-        url = f"https://{get_env_hostname(env_name, team.hostname)}"
+        url = f"https://{get_env_hostname(env_name, team.hostname, route_hostname)}"
     else:
         url = f"http://{team.hostname}:{host_port}"
 
@@ -3463,6 +3656,7 @@ def update_environment(
 
     return {
         "url": url,
+        "hostname": get_env_short_hostname(env_name, route_hostname),
         "odoo_container": odoo_container_name,
         "database": env_db,
         "workspace": workspace,

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -10,7 +10,12 @@ from typing import Any
 import docker
 from oduflow.docker_ops import service_presets, volume_ops
 from oduflow.docker_ops.client import get_client
-from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
+from oduflow.errors import (
+    ConflictError,
+    FlowError,
+    NotFoundError,
+    PrerequisiteNotMetError,
+)
 from oduflow.naming import get_service_container_name
 from oduflow.settings import Settings, TeamSettings
 
@@ -268,20 +273,38 @@ def create_service(
     _validate_service_exposure(settings, port, routes)
     client = get_client()
 
+    # Check for existing container
+    is_new_service = False
+    try:
+        existing = client.containers.get(container_name)
+        if existing.status == "running":
+            raise ConflictError(f"Service '{name}' already exists and is running.")
+    except docker.errors.NotFound:
+        is_new_service = True
+
+    if is_new_service and team.service_slots > 0:
+        services = client.containers.list(
+            all=True,
+            filters={
+                "label": [
+                    f"{settings.managed_label}=true",
+                    f"{settings.team_label}={team.team_id}",
+                    "oduflow.service",
+                ]
+            },
+        )
+        if len(services) >= team.service_slots:
+            raise FlowError(
+                f"No free service slots (configured: {team.service_slots}). "
+                "Delete an unused service to free a slot."
+            )
+
     # Services join the team's isolated network (not needed for host mode).
     team_network = ""
     if not host_mode:
         from oduflow.docker_ops.system_ops import ensure_team_network
 
         team_network = ensure_team_network(client, settings, team)
-
-    # Check for existing container
-    try:
-        existing = client.containers.get(container_name)
-        if existing.status == "running":
-            raise ConflictError(f"Service '{name}' already exists and is running.")
-    except docker.errors.NotFound:
-        pass
 
     labels = {
         "oduflow.managed": "true",

--- a/src/oduflow/hostname_registry.py
+++ b/src/oduflow/hostname_registry.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+import threading
+from contextlib import contextmanager
+from typing import Iterator
+
+from oduflow.errors import ConflictError, FlowError
+
+logger = logging.getLogger("oduflow")
+
+_locks_guard = threading.Lock()
+_path_locks: dict[str, threading.Lock] = {}
+
+
+def _thread_lock(registry_path: str) -> threading.Lock:
+    with _locks_guard:
+        lock = _path_locks.get(registry_path)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[registry_path] = lock
+        return lock
+
+
+@contextmanager
+def _registry_lock(registry_path: str) -> Iterator[None]:
+    """Serialize hostname reservations across threads and server processes."""
+    with _thread_lock(registry_path):
+        os.makedirs(os.path.dirname(registry_path) or ".", exist_ok=True)
+        fd = os.open(registry_path + ".lock", os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+
+def _load_registry(registry_path: str) -> dict[str, str]:
+    if not os.path.isfile(registry_path):
+        return {}
+    try:
+        with open(registry_path) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            logger.warning("Ignoring malformed hostname registry %s", registry_path)
+            return {}
+        return {str(key): str(value) for key, value in data.items() if value}
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as exc:
+        logger.warning("Could not load hostname registry %s: %s", registry_path, exc)
+        return {}
+
+
+def _save_registry(registry_path: str, registry: dict[str, str]) -> None:
+    directory = os.path.dirname(registry_path) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix="hostnames.", suffix=".tmp", dir=directory)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(registry, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o644)
+        os.replace(tmp_path, registry_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def allocate_hostname(
+    registry_path: str,
+    env_name: str,
+    slot_count: int,
+    *,
+    requested_hostname: str = "",
+    hostname_prefix: str,
+    active_envs: set[str] | None = None,
+    used_hostnames: set[str] | None = None,
+) -> str:
+    """Reserve a stable short hostname for one environment.
+
+    Automatic reservations append a number to ``hostname_prefix``. An explicitly
+    requested hostname still consumes one of the team's configured environment
+    slots, so the setting remains a hard cap on concurrent environments.
+    """
+    active_envs = active_envs or set()
+    used_hostnames = used_hostnames or set()
+
+    with _registry_lock(registry_path):
+        registry = _load_registry(registry_path)
+        current = registry.get(env_name, "")
+        occupied_envs = (set(registry) | active_envs) - {env_name}
+        if slot_count > 0 and len(occupied_envs) >= slot_count:
+            raise FlowError(
+                f"No free environment slots (configured: {slot_count}). "
+                "Delete an unused environment to free a slot."
+            )
+
+        occupied_hostnames = {
+            value for key, value in registry.items() if key != env_name
+        } | used_hostnames
+
+        if requested_hostname:
+            if requested_hostname in occupied_hostnames:
+                raise ConflictError(
+                    f"Hostname '{requested_hostname}' is already used by another "
+                    "environment."
+                )
+            if current != requested_hostname:
+                registry[env_name] = requested_hostname
+                _save_registry(registry_path, registry)
+            return requested_hostname
+
+        if current and current not in occupied_hostnames:
+            return current
+        if slot_count <= 0:
+            raise FlowError(
+                "Automatic hostname allocation requires environment_slots > 0."
+            )
+
+        for number in range(1, slot_count + 1):
+            candidate = f"{hostname_prefix}{number}"
+            if candidate not in occupied_hostnames:
+                registry[env_name] = candidate
+                _save_registry(registry_path, registry)
+                logger.info(
+                    "Allocated hostname %s for environment '%s'", candidate, env_name
+                )
+                return candidate
+
+    raise FlowError(
+        f"No free environment hostnames in {hostname_prefix}1-"
+        f"{hostname_prefix}{slot_count}. "
+        "Delete an unused environment to free a slot."
+    )
+
+
+def release_hostname(registry_path: str, env_name: str) -> None:
+    with _registry_lock(registry_path):
+        registry = _load_registry(registry_path)
+        hostname = registry.pop(env_name, None)
+        if hostname is not None:
+            _save_registry(registry_path, registry)
+            logger.info("Released hostname %s for environment '%s'", hostname, env_name)
+
+
+def get_hostname(registry_path: str, env_name: str) -> str | None:
+    return _load_registry(registry_path).get(env_name)

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -232,10 +232,49 @@ def get_repo_path(env_name: str, workspaces_dir: str) -> str:
     return os.path.join(get_workspace_path(env_name, workspaces_dir), "repo")
 
 
-def get_env_hostname(env_name: str, hostname: str) -> str:
-    slug = slugify_branch(env_name).replace("_", "-")
+def get_env_short_hostname(env_name: str, route_hostname: str = "") -> str:
+    slug = slugify_branch(route_hostname or env_name).replace("_", "-")
     slug = re.sub(r"-+", "-", slug).strip("-")
-    return f"{slug}.{hostname}"
+    return slug
+
+
+def split_team_hostname(hostname: str) -> tuple[str, str]:
+    """Split ``dev.example.com`` into the reusable prefix and parent domain."""
+    value = hostname.strip().lower().rstrip(".")
+    prefix, separator, parent_domain = value.partition(".")
+    if not separator or not prefix or not parent_domain:
+        raise ValueError(
+            f"Team hostname '{hostname}' must contain a host prefix and parent "
+            "domain, for example 'dev.example.com'."
+        )
+    try:
+        validate_env_hostname(prefix)
+        validate_domain(parent_domain)
+    except ValueError as exc:
+        raise ValueError(
+            f"Team hostname '{hostname}' must contain a host prefix and parent "
+            "domain, for example 'dev.example.com'."
+        ) from exc
+    return prefix, parent_domain
+
+
+def get_env_hostname(env_name: str, hostname: str, route_hostname: str = "") -> str:
+    short_hostname = get_env_short_hostname(env_name, route_hostname)
+    if not route_hostname:
+        return f"{short_hostname}.{hostname}"
+    _prefix, parent_domain = split_team_hostname(hostname)
+    return f"{short_hostname}.{parent_domain}"
+
+
+def validate_env_hostname(hostname: str) -> str:
+    """Validate a short environment hostname such as ``dev1`` or ``qa``."""
+    value = hostname.strip().lower()
+    if not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", value):
+        raise ValueError(
+            f"Invalid environment hostname '{hostname}': expected one DNS label "
+            "such as 'dev1' (letters, digits and internal hyphens only)."
+        )
+    return value
 
 
 def get_team_network_name(team_id: str, prefix: str = "oduflow-") -> str:

--- a/src/oduflow/schemas/oduflow-stack-v1alpha1.json
+++ b/src/oduflow/schemas/oduflow-stack-v1alpha1.json
@@ -7,6 +7,18 @@
           "title": "Name",
           "type": "string"
         },
+        "hostname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hostname"
+        },
         "branch": {
           "minLength": 1,
           "title": "Branch",

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -547,6 +547,7 @@ def create_environment(
     auto_install_modules: str = "",
     env_vars: str = "",
     local_path: str = "",
+    hostname: str = "",
     ctx: Context | None = None,
 ) -> str:
     """
@@ -555,6 +556,7 @@ def create_environment(
     Args:
         branch: The git branch to clone (e.g. "19.0", "feature/my-feature").
         env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="19.0").
+        hostname: Optional short Traefik hostname (for example "qa"). If omitted and the team configures environment_slots, Oduflow numbers the team hostname prefix: dev.example.com produces dev1.example.com through devN.example.com. An explicit value replaces that prefix, so hostname="qa" produces qa.example.com.
         template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden). A template saved from a live-mounted environment supplies local_path instead of repo_url and recreates the live-mount when allow_local_path is enabled.
         repo_url: URL of the git repository to clone. Optional when template_name is specified (loaded from template metadata).
         odoo_image: Full Docker image name with tag (e.g. "odoo:19.0"). Optional when template_name is specified (loaded from template metadata).
@@ -683,6 +685,7 @@ def create_environment(
             auto_install_modules=auto_install_list or None,
             env_vars=parsed_env,
             local_path=local_path,
+            hostname=hostname,
         )
 
         from oduflow.telemetry import record_env_created
@@ -698,6 +701,7 @@ def create_environment(
             "Environment provisioned successfully!",
             f"Environment: {resolved_env_name}",
             f"URL: {result['url']}",
+            f"Hostname: {result.get('hostname', '')}",
             f"Odoo Container: {result['odoo_container']}",
             f"Database: {result['database']}",
             f"Workspace: {result['workspace']}",
@@ -1518,6 +1522,7 @@ def update_environment(
     lines = [
         "Environment updated successfully!",
         f"URL: {result['url']}",
+        f"Hostname: {result.get('hostname', '')}",
         f"Odoo Container: {result['odoo_container']}",
         f"Database: {result['database']}",
         f"Workspace: {result['workspace']}",
@@ -1563,6 +1568,8 @@ def get_environment_info(env_name: str, ctx: Context | None = None) -> str:
     lines.append(f"Database: {info['db_name']}")
     if info.get("url"):
         lines.append(f"URL: {info['url']}")
+    if info.get("hostname"):
+        lines.append(f"Hostname: {info['hostname']}")
     if info.get("repo_url") and not info.get("local_path"):
         lines.append(f"Repo: {info['repo_url']}")
     if info.get("local_path"):

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -50,6 +50,13 @@ class TeamSettings:
     port_range_end: int = 50100
     data_dir: str = ""
     port_registry_path: str = ""
+    hostname_registry_path: str = ""
+    # Traefik-only reusable hostname pool. 0 keeps legacy branch-derived
+    # hostnames; for dev.example.com a positive value allocates
+    # dev1.example.com..devN.example.com and caps active environments.
+    environment_slots: int = 20
+    # Hard cap on managed auxiliary service containers. 0 disables the cap.
+    service_slots: int = 10
     # Quotas; 0 disables. db_quota_gb caps the combined size of the team's
     # PostgreSQL databases (environments + templates) and is checked before
     # operations that create a new database. disk_quota_gb caps the team's
@@ -367,6 +374,25 @@ class Settings:
                 raise ValueError(
                     f"Team '{team.team_id}': quotas must be >= 0 (0 disables)"
                 )
+            if team.environment_slots < 0:
+                raise ValueError(
+                    f"Team '{team.team_id}': environment_slots must be >= 0 "
+                    "(0 disables)"
+                )
+            if team.service_slots < 0:
+                raise ValueError(
+                    f"Team '{team.team_id}': service_slots must be >= 0 (0 disables)"
+                )
+            if self.routing_mode == "traefik" and team.environment_slots > 0:
+                from oduflow.naming import split_team_hostname
+
+                try:
+                    split_team_hostname(team.hostname)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Team '{team.team_id}': environment_slots requires a "
+                        "hostname such as 'dev.example.com'"
+                    ) from exc
 
         # Validate static extra routes ([route.*]). They only make sense in
         # traefik mode (port mode has no shared reverse proxy) and must forward
@@ -540,6 +566,9 @@ class Settings:
                 port_range_end=port_end,
                 data_dir=team_data_dir,
                 port_registry_path=os.path.join(team_data_dir, "ports.json"),
+                hostname_registry_path=os.path.join(team_data_dir, "hostnames.json"),
+                environment_slots=int(team_cfg.get("environment_slots", 20)),
+                service_slots=int(team_cfg.get("service_slots", 10)),
                 db_quota_gb=int(team_cfg.get("db_quota_gb", 50)),
                 disk_quota_gb=int(team_cfg.get("disk_quota_gb", 0)),
                 agent_enabled=bool(team_cfg.get("agent_enabled", False)),

--- a/src/oduflow/stack_models.py
+++ b/src/oduflow/stack_models.py
@@ -15,7 +15,11 @@ from pydantic import (
     model_validator,
 )
 
-from oduflow.naming import validate_env_name, validate_template_name
+from oduflow.naming import (
+    validate_env_hostname,
+    validate_env_name,
+    validate_template_name,
+)
 
 STACK_API_VERSION = "oduflow.dev/v1alpha1"
 STACK_KIND = "Stack"
@@ -98,6 +102,7 @@ class Modules(StackModel):
 
 class Environment(StackModel):
     name: str
+    hostname: str | None = None
     branch: NonEmptyString
     repo_url: NonEmptyString
     odoo_image: NonEmptyString
@@ -110,6 +115,11 @@ class Environment(StackModel):
     @classmethod
     def valid_environment_name(cls, value: str) -> str:
         return validate_env_name(value)
+
+    @field_validator("hostname")
+    @classmethod
+    def valid_environment_hostname(cls, value: str | None) -> str | None:
+        return validate_env_hostname(value) if value else None
 
     @field_validator("template", mode="before")
     @classmethod

--- a/src/oduflow/stack_ops.py
+++ b/src/oduflow/stack_ops.py
@@ -317,6 +317,8 @@ def build_plan(
             immutable_drift.append("repoUrl")
         if actual_env.get("git_branch") != desired_env.branch:
             immutable_drift.append("branch")
+        if desired_env.hostname and actual_env.get("hostname") != desired_env.hostname:
+            immutable_drift.append("hostname")
         if _normalized_template(
             actual_env.get("template_name")
         ) != _normalized_template(desired_env.template):
@@ -611,6 +613,7 @@ def apply_stack(
                 sanitize=desired_env.sanitize,
                 env_vars=env_vars or None,
                 stack_labels=env_labels,
+                hostname=desired_env.hostname or "",
             )
         elif ("update", "environment") in operations:
             env_ops.update_environment(

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1424,6 +1424,11 @@
         <input type="text" id="cr-branch" placeholder="e.g. feature/my-branch">
       </div>
       <div class="form-group">
+        <label for="cr-hostname">Hostname</label>
+        <input type="text" id="cr-hostname" placeholder="Auto (dev1, dev2, ...)">
+        <div class="hint">Optional prefix override; for dev.example.com, "qa" becomes qa.example.com</div>
+      </div>
+      <div class="form-group">
         <label for="cr-repo">Repository URL</label>
         <input type="text" id="cr-repo" placeholder="https://github.com/owner/repo.git">
       </div>
@@ -2558,9 +2563,10 @@ function renderEnvironments(envs, force) {
       '</span>';
     })();
 
-    const metaHtml = (env.odoo_image || env.repo_url || env.local_path || env.db_name || env.template_name)
+    const metaHtml = (env.odoo_image || env.repo_url || env.local_path || env.db_name || env.template_name || env.hostname)
       ? '<div class="env-meta">' +
           (env.db_name ? '<span>DB: <strong class="copy-db" role="button" tabindex="0" title="Copy database name" aria-label="Copy database name" onclick="copyToClipboard(\'' + esc(env.db_name).replace(/'/g, "\\'") + '\')">' + esc(env.db_name) + '</strong></span>' : '') +
+          (env.hostname ? '<span>Host: <strong>' + esc(env.hostname) + '</strong></span>' : '') +
           (env.template_name && env.template_name !== 'none' ? '<span>Template: <strong>' + esc(env.template_name) + '</strong></span>' : '') +
           (env.odoo_image ? '<span>Image: <strong>' + esc(env.odoo_image) + '</strong></span>' : '') +
           (env.repo_url && !env.local_path ? '<span>Repo: <strong>' + esc(env.repo_url) + '</strong></span>' : '') +
@@ -4089,6 +4095,7 @@ function populateTemplateSelect() {
 function openCreateFromTemplate(templateName) {
   var tpl = cachedTemplates.find(function(t) { return t.template_name === templateName; });
   document.getElementById('cr-branch').value = '';
+  document.getElementById('cr-hostname').value = '';
   document.getElementById('cr-repo').value = tpl && tpl.repo_url ? tpl.repo_url : '';
   document.getElementById('cr-image').value = tpl && tpl.odoo_image ? tpl.odoo_image : '';
   document.getElementById('cr-auto-install').value = tpl && tpl.auto_install_modules ? tpl.auto_install_modules : '';
@@ -4133,6 +4140,7 @@ function openCreateFromTemplate(templateName) {
 
 function openCreateModal() {
   document.getElementById('cr-branch').value = '';
+  document.getElementById('cr-hostname').value = '';
   document.getElementById('cr-repo').value = '';
   document.getElementById('cr-image').value = '';
   document.getElementById('cr-auto-install').value = '';
@@ -4239,6 +4247,7 @@ async function submitFeedback() {
 
 async function submitCreate() {
   var branch = document.getElementById('cr-branch').value.trim();
+  var hostname = document.getElementById('cr-hostname').value.trim();
   var repo = document.getElementById('cr-repo').value.trim();
   var image = document.getElementById('cr-image').value.trim();
   var template = document.getElementById('cr-template').value;
@@ -4277,6 +4286,7 @@ async function submitCreate() {
     }
     var payload = {
       env_name: branch,
+      hostname: hostname,
       repo_url: repo,
       odoo_image: image,
       template_name: template,

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -113,6 +113,8 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 
 [team.1]
 hostname = "localhost"            # port: http://{hostname}:{port}, traefik: https://{slug}.{hostname}
+environment_slots = 20            # traefik: dev.example.com + N => dev1.example.com..devN.example.com; 0 = legacy hostnames
+service_slots = 10                # maximum managed auxiliary services; 0 = unlimited
 auth_token = ""                   # MCP bearer token / OAuth client_id+secret (auto-generated on first run; HTTP refuses to start if empty)
 ui_password = ""                  # Web UI password (auto-generated on first run; HTTP refuses to start if empty unless allow_insecure_http)
 port_range = [50000, 50100]       # port range for Odoo containers

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1022,6 +1022,7 @@ def _build_routes(
             git_user = labels.get("oduflow.git_user", "")
             env_vars = json.loads(labels.get("oduflow.env_vars", "{}")) or None
             local_path = labels.get("oduflow.local_path", "")
+            hostname = labels.get(env_ops.ENV_HOSTNAME_LABEL, "")
 
             # Check disk space BEFORE deleting the old environment: refusing
             # here loses nothing, while failing after delete_environment would
@@ -1054,6 +1055,7 @@ def _build_routes(
                 git_user=git_user,
                 env_vars=env_vars,
                 local_path=local_path,
+                hostname=hostname,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
@@ -1144,6 +1146,7 @@ def _build_routes(
         extra_addons_raw = body.get("extra_addons")
         auto_install_raw = (body.get("auto_install_modules") or "").strip()
         env_vars_raw = (body.get("env_vars") or "").strip()
+        hostname = (body.get("hostname") or "").strip()
         env_vars = None
         if env_vars_raw:
             import re
@@ -1257,6 +1260,7 @@ def _build_routes(
                 auto_install_modules=auto_install_list or None,
                 env_vars=env_vars,
                 local_path=local_path_from_meta,
+                hostname=hostname,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:

--- a/tests/test_hostname_registry.py
+++ b/tests/test_hostname_registry.py
@@ -1,0 +1,207 @@
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import docker
+from oduflow.docker_ops import env_ops
+from oduflow.errors import ConflictError, FlowError
+from oduflow.hostname_registry import (
+    allocate_hostname,
+    get_hostname,
+    release_hostname,
+)
+from oduflow.settings import Settings, TeamSettings
+
+
+def _path(tmp_path):
+    return str(tmp_path / "hostnames.json")
+
+
+def test_automatic_slots_are_stable_and_reusable(tmp_path):
+    path = _path(tmp_path)
+
+    assert allocate_hostname(path, "feature-a", 2, hostname_prefix="dev") == "dev1"
+    assert allocate_hostname(path, "feature-b", 2, hostname_prefix="dev") == "dev2"
+    assert allocate_hostname(path, "feature-a", 2, hostname_prefix="dev") == "dev1"
+
+    release_hostname(path, "feature-a")
+    assert get_hostname(path, "feature-a") is None
+    assert allocate_hostname(path, "feature-c", 2, hostname_prefix="dev") == "dev1"
+
+
+def test_explicit_hostname_consumes_capacity_and_cannot_collide(tmp_path):
+    path = _path(tmp_path)
+
+    assert (
+        allocate_hostname(
+            path,
+            "feature-a",
+            2,
+            requested_hostname="preview",
+            hostname_prefix="dev",
+        )
+        == "preview"
+    )
+    with pytest.raises(ConflictError, match="already used"):
+        allocate_hostname(
+            path,
+            "feature-b",
+            2,
+            requested_hostname="preview",
+            hostname_prefix="dev",
+        )
+
+    assert allocate_hostname(path, "feature-b", 2, hostname_prefix="dev") == "dev1"
+    with pytest.raises(FlowError, match="No free environment slots"):
+        allocate_hostname(path, "feature-c", 2, hostname_prefix="dev")
+
+
+def test_active_legacy_environments_count_toward_capacity(tmp_path):
+    with pytest.raises(FlowError, match="configured: 2"):
+        allocate_hostname(
+            _path(tmp_path),
+            "feature-c",
+            2,
+            active_envs={"feature-a", "feature-b"},
+            used_hostnames={"feature-a", "feature-b"},
+            hostname_prefix="dev",
+        )
+
+
+def test_parallel_allocations_never_share_a_slot(tmp_path):
+    path = _path(tmp_path)
+    envs = [f"feature-{number}" for number in range(20)]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        hostnames = list(
+            pool.map(
+                lambda env: allocate_hostname(
+                    path, env, len(envs), hostname_prefix="dev"
+                ),
+                envs,
+            )
+        )
+
+    assert len(set(hostnames)) == len(envs)
+    assert set(hostnames) == {f"dev{number}" for number in range(1, 21)}
+
+
+def _traefik_settings(tmp_path, slots=2):
+    data_dir = tmp_path / "team_1"
+    team = TeamSettings(
+        team_id="1",
+        hostname="dev.example.com",
+        data_dir=str(data_dir),
+        hostname_registry_path=str(data_dir / "hostnames.json"),
+        environment_slots=slots,
+    )
+    return Settings(
+        routing_mode="traefik",
+        routing_tls=False,
+        teams={"1": team},
+    ), team
+
+
+def test_create_wrapper_assigns_short_hostname(tmp_path):
+    settings, team = _traefik_settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    client.containers.list.return_value = []
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.env_ops._create_environment_impl",
+            return_value={"url": "https://dev1.example.com"},
+        ) as provision,
+    ):
+        result = env_ops.create_environment(
+            settings, team, "feature-a", "repo", "odoo:19.0"
+        )
+
+    assert result["url"] == "https://dev1.example.com"
+    assert provision.call_args.kwargs["hostname"] == "dev1"
+    assert get_hostname(team.hostname_registry_path, "feature-a") == "dev1"
+
+
+def test_create_wrapper_accepts_explicit_parent_domain_prefix(tmp_path):
+    settings, team = _traefik_settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    client.containers.list.return_value = []
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.env_ops._create_environment_impl",
+            return_value={"url": "https://qa.example.com"},
+        ) as provision,
+    ):
+        env_ops.create_environment(
+            settings,
+            team,
+            "feature-a",
+            "repo",
+            "odoo:19.0",
+            hostname="qa",
+        )
+
+    assert provision.call_args.kwargs["hostname"] == "qa"
+    assert get_hostname(team.hostname_registry_path, "feature-a") == "qa"
+
+
+def test_automatic_allocation_skips_hostname_used_by_service(tmp_path):
+    settings, team = _traefik_settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    service = MagicMock()
+    service.labels = {
+        "oduflow.managed": "true",
+        "oduflow.team": "1",
+        "traefik.http.routers.oduflow-1-service-dev1.rule": (
+            "Host(`dev1.example.com`)"
+        ),
+    }
+    client.containers.list.return_value = [service]
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.env_ops._create_environment_impl",
+            return_value={"url": "https://dev2.example.com"},
+        ) as provision,
+    ):
+        env_ops.create_environment(settings, team, "feature-a", "repo", "odoo:19.0")
+
+    assert provision.call_args.kwargs["hostname"] == "dev2"
+
+
+def test_failed_create_releases_hostname_before_container_exists(tmp_path):
+    settings, team = _traefik_settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    client.containers.list.return_value = []
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.env_ops._create_environment_impl",
+            side_effect=RuntimeError("boom"),
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        env_ops.create_environment(settings, team, "feature-a", "repo", "odoo:19.0")
+
+    assert get_hostname(team.hostname_registry_path, "feature-a") is None
+
+
+def test_base_url_reads_persisted_short_hostname(tmp_path):
+    settings, team = _traefik_settings(tmp_path)
+    container = MagicMock()
+    container.labels = {env_ops.ENV_HOSTNAME_LABEL: "dev2"}
+
+    assert env_ops.get_env_base_url(settings, team, "feature-a", container) == (
+        "https://dev2.example.com",
+        "dev2.example.com",
+    )

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -2,6 +2,7 @@ import pytest
 
 from oduflow.naming import (
     get_db_name,
+    get_env_hostname,
     get_filestore_paths,
     get_repo_path,
     get_resource_name,
@@ -9,9 +10,43 @@ from oduflow.naming import (
     get_template_db_name,
     get_workspace_path,
     slugify_branch,
+    split_team_hostname,
+    validate_env_hostname,
     validate_service_name,
     validate_template_name,
 )
+
+
+class TestEnvironmentHostname:
+    def test_short_hostname_is_normalized(self):
+        assert validate_env_hostname("  Env-12 ") == "env-12"
+
+    @pytest.mark.parametrize("value", ["", "env.example.com", "-env", "env-", "env_1"])
+    def test_invalid_short_hostname_is_rejected(self, value):
+        with pytest.raises(ValueError, match="Invalid environment hostname"):
+            validate_env_hostname(value)
+
+    def test_numbered_hostname_replaces_team_prefix(self):
+        assert (
+            get_env_hostname("feature-a", "dev.example.com", "dev3")
+            == "dev3.example.com"
+        )
+
+    def test_legacy_hostname_still_uses_branch_subdomain(self):
+        assert (
+            get_env_hostname("feature-a", "dev.example.com")
+            == "feature-a.dev.example.com"
+        )
+
+    def test_team_hostname_splits_first_label(self):
+        assert split_team_hostname("odoo.dev.example.com") == (
+            "odoo",
+            "dev.example.com",
+        )
+
+    def test_team_hostname_requires_parent_domain(self):
+        with pytest.raises(ValueError, match="host prefix and parent domain"):
+            split_team_hostname("localhost")
 
 
 class TestSlugifyBranch:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -335,6 +335,28 @@ class TestCreateEnvironmentTool:
         )
         assert mock_create.call_args.kwargs["env_vars"] is None
 
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_create_with_short_hostname(self, mock_create):
+        mock_create.return_value = {
+            "url": "https://dev3.example.com",
+            "hostname": "dev3",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+        }
+
+        result = _call_tool(
+            "create_environment",
+            branch="main",
+            hostname="dev3",
+            template_name="none",
+            repo_url="https://8.8.8.8/repo.git",
+            odoo_image="odoo:17.0",
+        )
+
+        assert mock_create.call_args.kwargs["hostname"] == "dev3"
+        assert "Hostname: dev3" in result
+
 
 class TestUpdateEnvironmentTool:
     @patch("oduflow.docker_ops.env_ops.update_environment")

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -6,6 +6,7 @@ import docker
 from oduflow.docker_ops import service_ops, system_ops
 from oduflow.errors import (
     ConflictError,
+    FlowError,
     NotFoundError,
     PrerequisiteNotMetError,
 )
@@ -71,6 +72,52 @@ def mock_docker_client():
 
 
 class TestCreateService:
+    def test_service_slot_limit_rejects_new_service(self, mock_docker_client):
+        team = TeamSettings(team_id="1", service_slots=2)
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.list.return_value = [MagicMock(), MagicMock()]
+
+        with pytest.raises(FlowError) as exc_info:
+            service_ops.create_service(
+                TEST_SETTINGS,
+                team,
+                "third",
+                "redis:7",
+                6379,
+            )
+
+        assert str(exc_info.value) == (
+            "No free service slots (configured: 2). "
+            "Delete an unused service to free a slot."
+        )
+        mock_docker_client.containers.list.assert_called_once_with(
+            all=True,
+            filters={
+                "label": [
+                    "oduflow.managed=true",
+                    "oduflow.team=1",
+                    "oduflow.service",
+                ]
+            },
+        )
+        mock_docker_client.images.pull.assert_not_called()
+        mock_docker_client.containers.run.assert_not_called()
+
+    def test_zero_service_slots_disables_limit(self, mock_docker_client):
+        team = TeamSettings(team_id="1", service_slots=0)
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        service_ops.create_service(
+            TEST_SETTINGS,
+            team,
+            "redis",
+            "redis:7",
+            6379,
+        )
+
+        mock_docker_client.containers.list.assert_not_called()
+
     def test_missing_image_returns_safe_not_found(self, mock_docker_client):
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
         mock_docker_client.images.pull.side_effect = docker.errors.NotFound(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -119,6 +119,54 @@ class TestSettings:
         with pytest.raises(ValueError, match="invalid port range"):
             s.validate()
 
+    def test_team_slots_from_toml(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[routing]\nmode = "traefik"\ntls = false\n'
+            '[team.1]\nhostname = "dev.example.com"\n'
+            "environment_slots = 7\nservice_slots = 3\n"
+        )
+
+        team = Settings.from_toml(str(toml)).get_team("1")
+
+        assert team.environment_slots == 7
+        assert team.service_slots == 3
+        assert team.hostname_registry_path.endswith("team_1/hostnames.json")
+
+    def test_team_slot_defaults(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text("[team.1]\n")
+
+        team = Settings.from_toml(str(toml)).get_team("1")
+
+        assert team.environment_slots == 20
+        assert team.service_slots == 10
+
+    def test_negative_environment_slots_rejected(self):
+        team = TeamSettings(team_id="1", environment_slots=-1)
+        settings = Settings(teams={"1": team})
+
+        with pytest.raises(ValueError, match="environment_slots"):
+            settings.validate()
+
+    def test_negative_service_slots_rejected(self):
+        team = TeamSettings(team_id="1", service_slots=-1)
+        settings = Settings(teams={"1": team})
+
+        with pytest.raises(ValueError, match="service_slots"):
+            settings.validate()
+
+    def test_environment_slots_require_prefixed_domain(self):
+        team = TeamSettings(team_id="1", hostname="localhost", environment_slots=2)
+        settings = Settings(
+            routing_mode="traefik",
+            routing_tls=False,
+            teams={"1": team},
+        )
+
+        with pytest.raises(ValueError, match="dev.example.com"):
+            settings.validate()
+
     def test_validate_overlapping_port_ranges(self):
         # Two teams left on the default (identical) range would draw host ports
         # from the same pool — issue #46.

--- a/tests/test_traefik_tls.py
+++ b/tests/test_traefik_tls.py
@@ -273,3 +273,14 @@ class TestBuildEnvTraefikLabels:
             labels[f"traefik.http.routers.{self.ROUTER}.tls.certresolver"]
             == "letsencrypt"
         )
+
+    def test_reusable_short_hostname_replaces_branch_slug(self):
+        settings = _env_settings("traefik", True)
+        labels = build_env_traefik_labels(
+            settings, settings.teams["1"], self.ENV, "dev3"
+        )
+
+        assert (
+            labels[f"traefik.http.routers.{self.ROUTER}.rule"]
+            == "Host(`dev3.example.com`)"
+        )

--- a/tests/test_web_ui_create_lock.py
+++ b/tests/test_web_ui_create_lock.py
@@ -69,3 +69,27 @@ def test_api_create_invalid_json_no_lock_error(tmp_path):
     )
     assert resp.status_code == 400
     assert resp.json()["ok"] is False
+
+
+def test_api_create_passes_short_hostname(tmp_path):
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    with patch(
+        "oduflow.web_ui.env_ops.create_environment",
+        return_value={"url": "https://dev2.example.com"},
+    ) as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "env_name": "main",
+                "hostname": "dev2",
+                "repo_url": "r",
+                "odoo_image": "i",
+            },
+        )
+
+    assert resp.json()["ok"] is True
+    assert create.call_args.kwargs["hostname"] == "dev2"


### PR DESCRIPTION
## What changed

- add concurrency-safe reusable Traefik hostname slots for development environments
- derive numbered hosts from the team prefix, with explicit hostname overrides
- add per-team environment and auxiliary-service capacity limits with defaults of 20 and 10
- expose environment hostname overrides through MCP, REST, dashboard, and declarative stacks
- document the routing decision and lifecycle behavior

## Why

Reusing a bounded set of environment hostnames prevents ephemeral environments from continuously requesting new Let's Encrypt certificates and hitting issuance rate limits. Service slots provide the same predictable per-team capacity boundary for auxiliary containers.

## Validation

- ruff check src/oduflow tests
- mypy src/oduflow
- pytest -m "not integration and not heavyweight" (2351 passed, 15 deselected)
- documentation synchronization and git diff checks

Docker integration and heavyweight suites were not run.