### PR TITLE
Environment reuse: switch_branch moves an environment onto another branch

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -183,6 +183,56 @@ oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odo
 oduflow call delete_environment feature-login
 ```
 
+### Reusing an Environment for the Next Branch
+
+An environment is not tied for life to the branch it was created from. When a
+branch is finished — PR merged, worktree gone — point the same environment at the
+next branch instead of deleting it and provisioning a new one:
+
+```bash
+# Same environment, next branch. The branch must already exist on origin.
+oduflow call switch_branch '{"env_name": "dev1", "branch": "feature/next-task"}'
+```
+
+Everything except the code stays: the environment name, its database and
+filestore, its hostname and URL, its ports, its database credentials and its
+scoped MCP endpoint and token. This matters twice over — provisioning is skipped
+(no fresh clone, no template database copy), and the MCP client you already
+pointed at `/mcp/dev1` keeps working, because the address never changed.
+
+After the switch, Oduflow diffs the two branch tips and applies the same logic
+as [Smart Pull](#smart-pull--intelligent-change-detection). Pass
+`install` / `upgrade` / `restart` when you know what changed, or leave them empty
+to let Oduflow classify the difference:
+
+```bash
+oduflow call switch_branch '{"env_name": "dev1", "branch": "feature/next-task", "upgrade": "sale_custom"}'
+```
+
+Since the database is kept, it can outlive the code that created it. If the
+target branch never carried a module that is installed in this database, the
+response says so, and `strict: true` refuses the switch instead of warning:
+
+```bash
+oduflow call switch_branch '{"env_name": "dev1", "branch": "hotfix/19.0", "strict": true}'
+```
+
+Two limits are worth knowing:
+
+- **The branch must be pushed.** Oduflow switches its own managed clone, which
+  can only fetch from origin. A branch that exists only on your machine fails
+  with a "push it first" message and changes nothing.
+- **Live-mounted environments are rejected.** With `local_path` the checkout is
+  yours, not Oduflow's; switch the branch there and call `pull_and_apply`.
+
+On the dashboard the branch chip (`⎇ branch`) on each environment card is also
+the control: click it to switch. Extra addon repositories can move along with
+the main repo by passing `extra_addons` (`"enterprise:19.0"`).
+
+Reuse and recreate answer different questions: switch the branch when the
+database is still a reasonable starting point, and **Recreate** (below) when you
+want it replaced from the template.
+
 ### Recreating Environments
 
 The **Recreate** action (available via the Web Dashboard and REST API) deletes an environment and immediately creates a fresh one using the same parameters (repo URL, Odoo image, template, extra addons). This is useful when you want a clean slate without manually re-entering all environment settings.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1742,6 +1742,56 @@ oduflow call update_environment feature-login "WORKERS=4,LIMIT_TIME_CPU=900" odo
 oduflow call delete_environment feature-login
 ```
 
+### Reusing an Environment for the Next Branch
+
+An environment is not tied for life to the branch it was created from. When a
+branch is finished — PR merged, worktree gone — point the same environment at the
+next branch instead of deleting it and provisioning a new one:
+
+```bash
+# Same environment, next branch. The branch must already exist on origin.
+oduflow call switch_branch '{"env_name": "dev1", "branch": "feature/next-task"}'
+```
+
+Everything except the code stays: the environment name, its database and
+filestore, its hostname and URL, its ports, its database credentials and its
+scoped MCP endpoint and token. This matters twice over — provisioning is skipped
+(no fresh clone, no template database copy), and the MCP client you already
+pointed at `/mcp/dev1` keeps working, because the address never changed.
+
+After the switch, Oduflow diffs the two branch tips and applies the same logic
+as [Smart Pull](#smart-pull--intelligent-change-detection). Pass
+`install` / `upgrade` / `restart` when you know what changed, or leave them empty
+to let Oduflow classify the difference:
+
+```bash
+oduflow call switch_branch '{"env_name": "dev1", "branch": "feature/next-task", "upgrade": "sale_custom"}'
+```
+
+Since the database is kept, it can outlive the code that created it. If the
+target branch never carried a module that is installed in this database, the
+response says so, and `strict: true` refuses the switch instead of warning:
+
+```bash
+oduflow call switch_branch '{"env_name": "dev1", "branch": "hotfix/19.0", "strict": true}'
+```
+
+Two limits are worth knowing:
+
+- **The branch must be pushed.** Oduflow switches its own managed clone, which
+  can only fetch from origin. A branch that exists only on your machine fails
+  with a "push it first" message and changes nothing.
+- **Live-mounted environments are rejected.** With `local_path` the checkout is
+  yours, not Oduflow's; switch the branch there and call `pull_and_apply`.
+
+On the dashboard the branch chip (`⎇ branch`) on each environment card is also
+the control: click it to switch. Extra addon repositories can move along with
+the main repo by passing `extra_addons` (`"enterprise:19.0"`).
+
+Reuse and recreate answer different questions: switch the branch when the
+database is still a reasonable starting point, and **Recreate** (below) when you
+want it replaced from the template.
+
 ### Recreating Environments
 
 The **Recreate** action (available via the Web Dashboard and REST API) deletes an environment and immediately creates a fresh one using the same parameters (repo URL, Odoo image, template, extra addons). This is useful when you want a clean slate without manually re-entering all environment settings.
@@ -2922,6 +2972,7 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
+| `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch` |
 | `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars`, `odoo_image` |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |
@@ -3089,6 +3140,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
+| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -15,6 +15,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
+| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -47,6 +47,7 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
+| `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch` |
 | `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars`, `odoo_image` |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |

--- a/specs/0049-environment-reuse-by-branch-switch.md
+++ b/specs/0049-environment-reuse-by-branch-switch.md
@@ -1,0 +1,100 @@
+# 0049 — Environment reuse by branch switch
+
+**Status:** Adopted
+**Type:** Lifecycle / Capacity
+**First introduced:** `litnimax/bangkok` branch (2026-08-17)
+**Key code today:** `docker_ops/env_ops.py` (`switch_environment_branch`),
+`git_ops.py` (`fetch_branch`, `checkout_branch`, `tree_modules`), `server.py`
+(`switch_branch`), `web_ui.py`, `templates/dashboard.html`
+
+## Context
+
+[[0001-mcp-orchestrated-ephemeral-per-branch-environments]] made an environment
+per branch, created and destroyed with the branch. In practice the unit of work
+is not a branch but a *developer's slot*: the same person, agent or client works
+one task at a time, and each task happens to have a new branch name.
+
+The per-branch lifecycle charges the full provisioning cost at every task
+boundary — a fresh clone and a template database copy — and it charges it again
+in ceremony. The old environment has to be deleted by hand or waited out through
+the idle reaper, and every downstream address changes with the name: the URL, the
+scoped `/mcp/<env>` endpoint and its token, the agent's checkout directory. A
+merged branch's environment is, by then, an almost perfect starting point for the
+next branch: the same repository, the same image, and a database whose schema
+already contains the merged work.
+
+[[0048-reusable-environment-hostname-slots]] had already separated one identity
+from the environment name — the public hostname became a pooled, reusable team
+resource. The remaining coupling was the code: the branch was recorded once, at
+creation, and never moved.
+
+## Decision
+
+Make the branch a mutable property of an existing environment. One operation,
+`switch_branch`, points an environment at another git branch and brings its
+running Odoo up to date with the difference. Everything that constitutes the
+environment's identity is preserved: name, database, filestore, hostname and URL,
+ports, PostgreSQL credentials, and the scoped MCP endpoint and token.
+
+Deliberately **not** part of this decision: renaming an environment to match the
+new branch. The name is the key from which the database name, workspace path,
+container name, port and hostname registry keys, credential file and agent
+checkout directory are all derived, and no transaction spans a rename of an
+`ALTER DATABASE`, a fuse-overlayfs remount, a `docker rename` and three
+registries — a half-renamed environment is a worse failure than a name that no
+longer echoes the branch. Instead the branch is displayed as a first-class,
+always-visible property of the card, and the environment name becomes what it
+already effectively was: a stable slot label.
+
+## How it works (macro)
+
+- The branch already lived in a Docker label (`oduflow.git_branch`), read by
+  every pull. Switching therefore means flipping that label and moving the
+  managed clone, in that order — reversed, a lost label flip would leave a
+  switched tree that the next pull silently resets back to the old branch. Labels are
+  frozen at container creation, so the flip recreates the container, reusing the
+  same path that already switches immutable extra-addons mounts mid-pull.
+- The target branch is fetched *before* anything is mutated. A branch that only
+  exists on the developer's machine is the common case, and it fails there with
+  "push it first" and no side effects.
+- Applying the difference reuses the ordinary sync path. The checkout is moved
+  first and the resulting `(old_head, changed_files)` is handed to
+  `pull_environment`, so classification, the guardrail, extra-addons resolution
+  and install/upgrade/restart have exactly one implementation. The file list is a
+  *tree* diff between the two tips, which is what keeps squash-merged histories
+  behaving.
+- Reuse introduces one failure mode a fresh environment cannot have: the
+  database outlives the code. A preflight compares the modules the current tree
+  provides with the target tree's and, for those that disappear, asks the
+  database which are installed. That is a warning by default — a module can also
+  come from extra-addons or the image — and a refusal under `strict`.
+- The coding agent's own checkout for the environment follows the switch through
+  the existing create hook, which already refuses to clobber uncommitted work.
+- Live-mounted environments ([[0021-code-delivery-modes]]) are rejected: their
+  git state belongs to the developer's checkout, not to Oduflow.
+
+## Consequences
+
+- The task boundary no longer costs a provision-and-destroy cycle, and the
+  addresses an MCP client or a browser is already using survive it.
+- Environment count stops tracking branch count, which makes the pooled hostname
+  slots of [[0048-reusable-environment-hostname-slots]] and the idle reaper far
+  less load-bearing: fewer environments are created, so fewer need reaping.
+- Environment name and branch are now routinely different. Name-derived
+  resources keep the original name forever, so operators read the branch, not the
+  name, to know what an environment serves — the dashboard shows the branch on
+  every card and the info tools report it.
+- A reused database accumulates schema from every branch it has served. For the
+  intended flow (branch merged, next branch cut from the updated default) that is
+  simply the merged work; for abandoned branches, residue remains, and the
+  preflight only reports the part that is detectable.
+- Declarative Stacks ([[0046-declarative-oduflow-stacks]]) still treat a changed
+  branch as immutable drift and recreate the environment. Reconciling it in place
+  through this operation is a natural follow-up, not part of this decision.
+
+## History
+
+- `litnimax/bangkok` (2026-08-17) — `switch_branch` MCP tool, REST endpoint and
+  dashboard control; `fetch_branch` / `checkout_branch` / `tree_modules` git
+  plumbing; dropped-module preflight; `presynced` sync path in
+  `pull_environment`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -67,6 +67,7 @@ precursors).
 | [0046](0046-declarative-oduflow-stacks.md) | 2026-08-11 | Declarative Oduflow Stacks: versioned YAML, plan/apply reconciliation, ownership and startup bootstrap |
 | [0047](0047-three-way-bundled-upgrades.md) | 2026-08-14 | Three-way upgrades for deployed bundled files with persistent baselines and safe conflict sidecars |
 | [0048](0048-reusable-environment-hostname-slots.md) | 2026-08-16 | Reusable environment hostname slots decouple public routing from branch identity |
+| [0049](0049-environment-reuse-by-branch-switch.md) | 2026-08-17 | Environment reuse: the branch becomes a mutable property switched in place |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -40,6 +40,7 @@ from oduflow.env_tokens import MCP_TOKEN_LABEL, generate_token, invalidate_cache
 from oduflow.errors import (
     ConflictError,
     ExternalCommandError,
+    FlowError,
     NotFoundError,
     PrerequisiteNotMetError,
     ProtectedError,
@@ -3062,6 +3063,7 @@ def pull_environment(
     upgrade: list[str] | None = None,
     restart: bool = False,
     strict: bool = False,
+    presynced: tuple[str, list[str]] | None = None,
 ) -> dict[str, Any]:
     """Sync code into an environment and apply the right Odoo action.
 
@@ -3073,6 +3075,12 @@ def pull_environment(
     * **live-mount** (``oduflow.local_path`` label, gated by allow_local_path) — the
       agent's checkout is already bind-mounted, so there is nothing to pull;
       changes are detected from Oduflow's last successful local snapshot.
+
+    ``presynced`` is for callers that already moved the checkout themselves and
+    hold the resulting ``(old_head, changed_files)`` — currently
+    :func:`switch_environment_branch`. Pulling again would find the clone
+    already at origin's tip and report "up to date", losing the very diff that
+    has to be applied, so the sync step is skipped and those values are used.
 
     Action selection:
 
@@ -3126,11 +3134,15 @@ def pull_environment(
         classify_units.append((repo_path, base_ref, all_changed))
         main_changed_files = all_changed
     else:
-        _trace("pull_environment(%s): git pull started", env_name)
-        git_branch = container_obj.labels.get("oduflow.git_branch", env_name)
-        old_head, changed_files = pull_repo(
-            repo_path, git_branch, cred_file=team.git_credentials_file()
-        )
+        if presynced is not None:
+            _trace("pull_environment(%s): using pre-synced checkout", env_name)
+            old_head, changed_files = presynced
+        else:
+            _trace("pull_environment(%s): git pull started", env_name)
+            git_branch = container_obj.labels.get("oduflow.git_branch", env_name)
+            old_head, changed_files = pull_repo(
+                repo_path, git_branch, cred_file=team.git_credentials_file()
+            )
         base_ref = old_head
         classify_units.append((repo_path, old_head, changed_files))
 
@@ -3319,6 +3331,267 @@ def pull_environment(
         result["warnings"] = warnings
     if is_local and int(result.get("exit_code", 0)) == 0:
         _write_local_snapshot(repo_path, env_name, team)
+    return result
+
+
+# Module directories come from a git tree, so they are already tame — but the
+# preflight interpolates them into a SQL IN(...) list, so only accept names that
+# Odoo itself would accept as a module.
+_MODULE_NAME_RE = re.compile(r"^[a-zA-Z0-9_]+$")
+
+
+def _dropped_module_warnings(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    repo_path: str,
+    target_ref: str,
+) -> list[str]:
+    """Warn when a target branch drops a module this database has installed.
+
+    The failure mode reuse introduces and a fresh environment cannot have: the
+    database outlives the code. Switching to a branch that never carried module
+    X leaves X installed with nothing to load it from.
+
+    Advisory on purpose. A module can legitimately come from extra-addons or
+    the image, the query needs a reachable database, and neither is worth
+    turning a routine switch into a hard failure — so this reports and only
+    ``strict`` refuses. An unanswerable question yields no warning.
+    """
+    from oduflow.git_ops import tree_modules
+
+    try:
+        dropped = tree_modules(repo_path, "HEAD") - tree_modules(repo_path, target_ref)
+    except FlowError as exc:
+        logger.info("Skipping dropped-module preflight for '%s': %s", env_name, exc)
+        return []
+
+    candidates = tuple(sorted(name for name in dropped if _MODULE_NAME_RE.match(name)))
+    if not candidates:
+        return []
+
+    from oduflow.docker_ops.odoo_ops import _get_module_states
+
+    try:
+        states = _get_module_states(settings, team, env_name, candidates)
+    except Exception as exc:
+        logger.info(
+            "Could not read module states for '%s' during branch switch: %s",
+            env_name,
+            exc,
+        )
+        return []
+
+    installed = [name for name in candidates if states.get(name) == "installed"]
+    if not installed:
+        return []
+    return [
+        "The target branch does not provide these modules, which are installed "
+        f"in the database: {', '.join(installed)}. Odoo will start without their "
+        "code. Uninstall them first, or create a separate environment for this "
+        "branch."
+    ]
+
+
+def switch_environment_branch(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    branch: str,
+    *,
+    install: list[str] | None = None,
+    upgrade: list[str] | None = None,
+    restart: bool = False,
+    strict: bool = False,
+    extra_addons: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Point an existing environment at another git branch and apply the diff.
+
+    The environment is the reusable unit. Its name, database, filestore,
+    hostname, ports, credentials and scoped MCP token all stay exactly as they
+    are — only the code it serves changes. That is what turns a finished
+    branch's environment into the starting point for the next task instead of
+    something to delete and provision again ([[0048]] pooled the hostname; this
+    pools the whole environment).
+
+    Order matters:
+
+    1. Fetch the target branch. A branch that was never pushed fails here, with
+       nothing mutated.
+    2. Preflight the database against the target tree (see
+       :func:`_dropped_module_warnings`); ``strict`` refuses instead of warning.
+    3. Flip the ``oduflow.git_branch`` label — deliberately *before* the
+       checkout. Labels are frozen at container creation, so this recreates the
+       container; if it fails, the environment is still on the old branch in
+       both label and tree. The reverse order would leave a switched tree that
+       the next pull silently resets back to the old branch.
+    4. Check out the branch and hand the resulting diff to
+       :func:`pull_environment`, so the switch shares one implementation of
+       classification, the guardrail, extra-addons mounts and apply.
+    """
+    from oduflow.git_ops import checkout_branch, fetch_branch, is_git_repository
+    from oduflow.naming import PROD_ENV_PREFIX
+
+    # Productions deploy from productions.json and keep a deploy log for
+    # rollback; moving their branch behind that record would strand both. The
+    # MCP tool is already fenced off by the dev-tool namespace check, so this is
+    # the guard for the REST route and any direct caller.
+    if env_name.startswith(PROD_ENV_PREFIX):
+        raise ConflictError(
+            f"'{env_name}' is a production environment. Change the branch it "
+            "deploys with update_production, which records the deploy and keeps "
+            "rollback available."
+        )
+
+    client = get_client()
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
+    try:
+        container_obj = client.containers.get(odoo_container_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(
+            f"Environment '{env_name}' does not exist. Use create_environment first."
+        )
+
+    labels = dict(container_obj.labels or {})
+    if labels.get("oduflow.prod") == "true":
+        raise ConflictError(
+            f"Environment '{env_name}' is a production container. Change the "
+            "branch it deploys with update_production."
+        )
+    local_path = labels.get("oduflow.local_path", "")
+    if local_path:
+        raise PrerequisiteNotMetError(
+            f"Environment '{env_name}' is live-mounted from {local_path}, so its "
+            "git state belongs to that checkout, not to Oduflow. Switch the "
+            "branch there and call pull_and_apply."
+        )
+
+    current_branch = labels.get("oduflow.git_branch", env_name)
+    repo_path = get_repo_path(env_name, team.workspaces_dir)
+    if not is_git_repository(repo_path):
+        raise NotFoundError(
+            f"Repository for environment '{env_name}' not found at {repo_path}"
+        )
+
+    extra_override = (
+        _normalize_extra_addons(extra_addons) if extra_addons is not None else None
+    )
+
+    if branch == current_branch and extra_override is None:
+        # Not an error: the caller wanted this environment on this branch, and it
+        # is. Pull instead, so "switch" is safe to call at the start of any task.
+        result = pull_environment(
+            settings,
+            team,
+            env_name,
+            install=install,
+            upgrade=upgrade,
+            restart=restart,
+            strict=strict,
+        )
+        result["branch"] = branch
+        result["previous_branch"] = current_branch
+        result["branch_switched"] = False
+        result["message"] = (
+            f"Environment '{env_name}' is already on branch '{branch}'; pulled it "
+            f"instead. {result.get('message', '')}".strip()
+        )
+        return result
+
+    target_sha = fetch_branch(repo_path, branch, cred_file=team.git_credentials_file())
+    warnings = _dropped_module_warnings(settings, team, env_name, repo_path, target_sha)
+    if strict and warnings:
+        return {
+            "action": "blocked",
+            "warnings": warnings,
+            "branch": current_branch,
+            "requested_branch": branch,
+            "branch_switched": False,
+            "changed_files": [],
+            "message": (
+                f"Guardrail (strict) blocked the switch to '{branch}': it does not "
+                "carry every module installed in this database. Uninstall them, "
+                "use a separate environment for this branch, or pass "
+                "strict=False to switch anyway."
+            ),
+        }
+
+    label_overrides = {"oduflow.git_branch": branch}
+    if extra_override is not None:
+        label_overrides["oduflow.extra_addons"] = json.dumps(extra_override)
+    logger.info(
+        "Switching environment branch",
+        extra={
+            "env_name": env_name,
+            "from_branch": current_branch,
+            "to_branch": branch,
+        },
+    )
+    # Dependencies are deliberately not reinstalled here: the checkout is still
+    # on the old branch at this point. A changed requirements.txt / apt list is
+    # part of the diff below, which pull_environment installs before restarting.
+    update_environment(
+        settings,
+        team,
+        env_name,
+        label_overrides=label_overrides,
+        pull_image=False,
+        install_dependencies=False,
+    )
+
+    try:
+        old_head, new_head, changed_files = checkout_branch(repo_path, branch)
+    except FlowError as exc:
+        raise ExternalCommandError(
+            "git checkout",
+            1,
+            f"Environment '{env_name}' is now labelled with branch '{branch}', but "
+            f"its checkout is still on '{current_branch}': {exc} Re-run "
+            "switch_branch (or pull_and_apply) once the clone is healthy.",
+        ) from exc
+
+    # The coding agent's own checkout for this environment follows the switch;
+    # uncommitted work there is preserved by clone-env.sh, which warns instead.
+    _agent_add_env(
+        client,
+        settings,
+        team,
+        env_name,
+        labels.get(settings.repo_label, ""),
+        branch,
+        labels.get("oduflow.git_user", ""),
+    )
+
+    result = pull_environment(
+        settings,
+        team,
+        env_name,
+        install=install,
+        upgrade=upgrade,
+        restart=restart,
+        strict=strict,
+        presynced=(old_head, changed_files),
+    )
+
+    switched = f"Switched '{env_name}' from '{current_branch}' to '{branch}'."
+    # "Already up to date" is the pull vocabulary and reads as a contradiction
+    # right after a switch; what it means here is that the two branches leave
+    # the running Odoo with nothing to catch up on.
+    tail = (
+        "No code difference to apply."
+        if result.get("action") == "none"
+        else str(result.get("message", ""))
+    )
+    result["branch"] = branch
+    result["previous_branch"] = current_branch
+    result["branch_switched"] = True
+    result["old_head"] = old_head
+    result["new_head"] = new_head
+    result["message"] = f"{switched} {tail}".strip()
+    if warnings:
+        result["warnings"] = warnings + list(result.get("warnings") or [])
     return result
 
 

--- a/src/oduflow/git_ops.py
+++ b/src/oduflow/git_ops.py
@@ -5,7 +5,7 @@ import subprocess
 from typing import Any
 from urllib.parse import ParseResult, urlparse
 
-from oduflow.errors import ExternalCommandError, FlowError
+from oduflow.errors import ExternalCommandError, FlowError, NotFoundError
 from oduflow.naming import redact_url_credentials, sanitize_repo_url
 
 logger = logging.getLogger("oduflow")
@@ -393,6 +393,114 @@ def pull_repo(
         env=env,
     )
     return old_head, [f for f in result.stdout.strip().splitlines() if f]
+
+
+def fetch_branch(repo_path: str, branch: str, cred_file: str = "") -> str:
+    """Fetch one branch from origin and return the commit it points at.
+
+    The validate-before-mutate half of a branch switch: the working tree is not
+    touched, so the common "the branch only exists on my machine" case fails
+    here — with an actionable message — instead of half-way through a switch.
+    """
+    env = git_env_for_team(cred_file) if cred_file else _GIT_BASE_ENV
+
+    try:
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "fetch",
+                "--recurse-submodules=no",
+                "origin",
+                f"+refs/heads/{branch}:refs/remotes/origin/{branch}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+    except subprocess.CalledProcessError as e:
+        error_msg = redact_url_credentials(e.stderr or str(e))
+        # Git reports an absent branch as a plain fetch failure. Translate it:
+        # "push the branch first" is a different action from "fix your remote".
+        if "couldn't find remote ref" in error_msg or "not our ref" in error_msg:
+            raise NotFoundError(
+                f"Branch '{branch}' does not exist on origin. Push it first "
+                f"(git push -u origin {branch}), then retry."
+            )
+        raise ExternalCommandError("git fetch", e.returncode, error_msg)
+    except subprocess.TimeoutExpired:
+        raise ExternalCommandError("git fetch", -1, "Fetch timed out (60s).")
+
+    return rev_parse(repo_path, f"refs/remotes/origin/{branch}")
+
+
+def checkout_branch(repo_path: str, branch: str) -> tuple[str, str, list[str]]:
+    """Move the checkout onto *branch* at origin's already-fetched tip.
+
+    Returns ``(old_head, new_head, changed_files)``. The file list is the *tree*
+    diff between the two commits (``git diff A..B``), not a commit range: two
+    branches need no shared history for the classifier to see what the running
+    Odoo must catch up on, which is what keeps squash-merged branches sane.
+
+    Local modifications are discarded, matching :func:`pull_repo` — the managed
+    clone is Oduflow's, and the agent's own work lives in its own checkout.
+    Requires the remote ref to be present; call :func:`fetch_branch` first.
+    """
+    old_head = rev_parse(repo_path, "HEAD")
+
+    try:
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "checkout",
+                "--force",
+                "-B",
+                branch,
+                f"refs/remotes/origin/{branch}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_GIT_BASE_ENV,
+        )
+    except subprocess.CalledProcessError as e:
+        raise ExternalCommandError(
+            "git checkout", e.returncode, redact_url_credentials(e.stderr or str(e))
+        )
+
+    new_head = rev_parse(repo_path, "HEAD")
+    if old_head == new_head:
+        return old_head, new_head, []
+    return old_head, new_head, diff_names(repo_path, old_head, new_head)
+
+
+def tree_modules(repo_path: str, ref: str = "HEAD") -> set[str]:
+    """Odoo module names a tree provides — directories with a ``__manifest__.py``.
+
+    Read through git rather than the filesystem so the *target* of a branch
+    switch can be inspected before the checkout moves onto it.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo_path, "ls-tree", "-r", "--name-only", ref],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_GIT_BASE_ENV,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        raise ExternalCommandError("git ls-tree", e.returncode, e.stderr or "")
+
+    modules = set()
+    for path in out.splitlines():
+        if path.endswith("/__manifest__.py"):
+            modules.add(path.rsplit("/", 2)[-2])
+    return modules
 
 
 def rev_parse(repo_path: str, ref: str = "HEAD") -> str:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1752,6 +1752,100 @@ def pull_and_apply(
     return header
 
 
+@mcp.tool()
+@handle_errors
+@with_env_lock
+def switch_branch(
+    env_name: str,
+    branch: str,
+    install: str = "",
+    upgrade: str = "",
+    restart: bool = False,
+    strict: bool = False,
+    extra_addons: str = "",
+    ctx: Context | None = None,
+) -> str:
+    """
+    Move an existing environment onto another git branch — reuse it instead of
+    creating a new one.
+
+    Everything except the code stays: the environment name, database, filestore,
+    URL / hostname, ports, database credentials and the scoped MCP endpoint. Use
+    this at the start of a task when a previous branch is finished (merged) —
+    it replaces "delete the old environment, create a fresh one", which re-clones
+    the repository and re-copies the template database.
+
+    The branch must already exist on origin, so push it first. Oduflow then
+    diffs the old and new tips and applies exactly the logic of pull_and_apply:
+    pass install / upgrade / restart explicitly when you know what changed, or
+    leave them empty to let Oduflow classify the difference itself.
+
+    Because the database is kept, it can outlive the code: if the target branch
+    never carried a module that is installed here, the response says so (with
+    strict=True the switch is refused instead). Live-mounted environments are
+    rejected — there the checkout is yours, so switch the branch in it and call
+    pull_and_apply.
+
+    Errors and tracebacks are returned directly in this response — do NOT call
+    get_environment_logs to check for them.
+
+    Args:
+        env_name: The environment to move onto another branch.
+        branch: Target git branch; it must already exist on origin.
+        install: Comma-separated modules to install (-i). Leave empty for automatic classification.
+        upgrade: Comma-separated modules to upgrade (-u). Leave empty for automatic classification.
+        restart: Restart the Odoo container (for Python-only differences).
+        strict: Refuse instead of warning when the target branch drops an installed module, or when the requested action looks incomplete for the diff.
+        extra_addons: Optional comma-separated extra addon repos with branches (e.g. "enterprise:19.0,custom-themes:main") to switch along with the main repo. Leave empty to keep the current ones.
+    """
+    settings = _get_settings()
+    team = _resolve_team(ctx)
+    woke_note = _wake_for_work(settings, team, env_name, "to switch the branch")
+    result = env_ops.switch_environment_branch(
+        settings,
+        team,
+        env_name,
+        branch,
+        install=[m.strip() for m in install.split(",") if m.strip()] or None,
+        upgrade=[m.strip() for m in upgrade.split(",") if m.strip()] or None,
+        restart=restart,
+        strict=strict,
+        extra_addons=_parse_extra_addons(extra_addons) if extra_addons else None,
+    )
+    action = result["action"]
+    warnings = result.get("warnings") or []
+
+    if action == "blocked":
+        lines = [woke_note + "BLOCKED (strict mode):"]
+        lines.extend(f"  ⚠ {w}" for w in warnings)
+        lines.append("")
+        lines.append(result["message"])
+        return "\n".join(lines)
+
+    header_lines = [woke_note + result["message"]]
+    if result.get("modules_installed"):
+        header_lines.append(f"Installed: {', '.join(result['modules_installed'])}")
+    if result.get("modules_upgraded"):
+        header_lines.append(f"Upgraded: {', '.join(result['modules_upgraded'])}")
+    changed = result.get("changed_files", [])
+    if changed:
+        header_lines.append(f"Changed files ({len(changed)}):")
+        header_lines.extend(f"  - {f}" for f in changed[:20])
+        if len(changed) > 20:
+            header_lines.append(f"  ... and {len(changed) - 20} more")
+    if warnings:
+        header_lines.append("Warnings (switched anyway):")
+        header_lines.extend(f"  ⚠ {w}" for w in warnings)
+
+    header = "\n".join(header_lines)
+    output = result.get("output", "")
+    if output:
+        return _maybe_cache(
+            output, header, "switch_branch", f"env={env_name}, branch={branch}"
+        )
+    return header
+
+
 # =============================================================================
 # MCP Tools — Output cache drill-down
 # =============================================================================

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -38,17 +38,28 @@ Call `create_environment` with the branch, correct Odoo image, and either
 
 ```text
 1. list_environments
-2. if creation is needed: repo_url must git push -u origin HEAD first;
-   local_path needs no push; then call create_environment
+2. if an existing environment's branch is finished (merged), reuse it:
+   git push -u origin HEAD, then switch_branch to your branch;
+   otherwise create_environment (repo_url must be pushed first;
+   local_path needs no push)
 3. get_odoo_development_guide before module code changes
 4. edit code locally
 5. repo_url: commit + push; local_path: no delivery step
 6. pull_and_apply with the action required by the edit
 7. read that response; if it failed, fix and repeat from step 4
 8. run_odoo_tests for the changed modules
-9. delete_environment when the task is done or cancelled and nobody still
-   needs the URL or its test data
+9. leave the environment for the next branch, or delete_environment when
+   nobody still needs the URL or its test data
 ```
+
+Prefer step 2's reuse over a new environment. `switch_branch` keeps the
+database, filestore, URL and scoped MCP endpoint and only changes the code, so
+it is much faster than provisioning — and the address you are already using
+stays valid. It applies the branch difference exactly like `pull_and_apply`. The
+target branch must exist on origin; live-mounted environments are rejected
+(switch the branch in the mounted checkout and call `pull_and_apply`). If the
+target branch does not carry a module installed in that database, the response
+warns; create a separate environment when that matters.
 
 Do not delete and recreate an environment to fix an application error or run
 a migration. It recreates the same starting state and discards useful test

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -248,7 +248,15 @@
   }
   .env-header .left { display: flex; align-items: center; gap: 10px; }
   .branch-name { font-weight: 600; font-size: var(--text-lg); }
-  .git-branch { font-size: var(--text-xs); color: var(--text-dim); font-weight: 400; }
+  .git-branch { font-size: var(--text-xs); color: var(--text-dim); font-weight: 400; font-family: var(--font-mono); }
+  /* An environment is reusable: the branch it serves is a property you can
+     change, so the chip that shows it is also the affordance that changes it. */
+  .git-branch[role="button"] {
+    cursor: pointer;
+    border-bottom: 1px dashed transparent;
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .git-branch[role="button"]:hover { border-bottom-color: var(--accent); color: var(--accent); }
   .badge {
     display: inline-block;
     padding: 2px 8px;
@@ -801,6 +809,8 @@
   .sync-action-refresh { background: color-mix(in oklab, var(--accent) 15%, transparent); color: var(--accent); }
   .sync-action-restart { background: color-mix(in oklab, var(--yellow) 15%, transparent); color: var(--yellow); }
   .sync-action-install, .sync-action-upgrade { background: color-mix(in oklab, var(--green) 15%, transparent); color: var(--green); }
+  .sync-action-blocked { background: color-mix(in oklab, var(--red) 15%, transparent); color: var(--red); }
+  .sync-warnings li { font-size: var(--text-xs); line-height: 1.6; color: var(--yellow); margin-left: 16px; }
   .sync-message { font-size: var(--text-md); margin-bottom: 12px; }
   .sync-section { margin-bottom: 12px; }
   .sync-section-title { font-size: var(--text-xs); font-weight: 600; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }
@@ -1282,7 +1292,7 @@
     .toast { transition: opacity 0.1s; transform: none; }
     .toast.show { transform: none; }
     .usage-bar-fill { transition: none; }
-    .btn, .tab-btn, .repo-link, .copy-db, .license-badge { transition: none; }
+    .btn, .tab-btn, .repo-link, .copy-db, .git-branch[role="button"], .license-badge { transition: none; }
   }
 </style>
 </head>
@@ -1977,6 +1987,27 @@
     </div>
   </div>
 </div>
+<div class="modal-overlay" id="switch-branch-modal" onclick="closeSwitchBranch(event)">
+  <div class="modal modal-sm">
+    <div class="modal-header">
+      <h2 id="switch-branch-title">Switch branch</h2>
+      <button class="modal-close" onclick="closeSwitchBranch()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p class="modal-note">Reuse this environment for another branch instead of creating a new one. The database, filestore, hostname and URL are kept — only the code changes. The branch must already exist on origin; Oduflow then installs, upgrades or restarts as the difference between the two branches requires.</p>
+      <div class="form-group">
+        <label for="switch-branch-input">Target branch</label>
+        <input id="switch-branch-input" class="mono-input" type="text" placeholder="feature/next-task"
+               onkeydown="if (event.key === 'Enter') { event.preventDefault(); confirmSwitchBranch(); }">
+        <p class="modal-note">Currently on <strong id="switch-branch-current"></strong>.</p>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeSwitchBranch()">Cancel</button>
+        <button class="btn-create" onclick="confirmSwitchBranch()">Switch branch</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="modal-overlay" id="mcp-access-modal" onclick="closeMcpAccess(event)">
   <div class="modal modal-sm">
     <div class="modal-header">
@@ -2372,13 +2403,19 @@ function closeSyncResult(event) {
   hideModal('sync-result-modal');
 }
 
-function showSyncResult(branch, result) {
-  var actionLabels = {none: 'No changes', refresh: 'Refresh', restart: 'Restart', install: 'Install', upgrade: 'Upgrade'};
+function showSyncResult(branch, result, title) {
+  var actionLabels = {none: 'No changes', refresh: 'Refresh', restart: 'Restart', install: 'Install', upgrade: 'Upgrade', blocked: 'Blocked'};
   var action = result.action || 'none';
   var label = actionLabels[action] || action;
 
   var html = '<span class="sync-result-action sync-action-' + action + '">' + label + '</span>';
   html += '<div class="sync-message">' + esc(result.message || '') + '</div>';
+
+  if (result.warnings && result.warnings.length) {
+    html += '<div class="sync-section"><div class="sync-section-title">Warnings</div><ul class="sync-warnings">';
+    result.warnings.forEach(function(w) { html += '<li>' + esc(w) + '</li>'; });
+    html += '</ul></div>';
+  }
 
   if (result.modules_installed && result.modules_installed.length) {
     html += '<div class="sync-section"><div class="sync-section-title">Installed modules</div><div class="sync-modules">';
@@ -2403,7 +2440,7 @@ function showSyncResult(branch, result) {
     html += '<div class="sync-section"><div class="sync-section-title">Odoo output</div><div class="sync-output">' + esc(result.output) + '</div></div>';
   }
 
-  document.getElementById('sync-result-title').textContent = 'Sync — ' + branch;
+  document.getElementById('sync-result-title').textContent = (title || 'Sync') + ' — ' + branch;
   document.getElementById('sync-result-body').innerHTML = html;
   showModal('sync-result-modal');
 }
@@ -2602,7 +2639,15 @@ function renderEnvironments(envs, force) {
           '<span class="branch-name copy-db" role="button" tabindex="0" ' +
             'title="Copy environment name" aria-label="Copy environment name" ' +
             'onclick="copyToClipboard(\'' + escAttr(env.branch) + '\')">' + esc(env.branch) + '</span>' +
-          (env.git_branch && env.git_branch !== env.branch ? '<span class="git-branch">⎇ ' + esc(env.git_branch) + '</span>' : '') +
+          // The branch is a mutable property of a reusable environment, so it is
+          // always on the card (not only when it differs from the name) and is
+          // itself the control that switches it. Live-mount has no managed clone.
+          (env.local_path
+            ? ''
+            : '<span class="git-branch" role="button" tabindex="0" title="Switch this environment to another branch" ' +
+                'onclick="openSwitchBranch(\'' + escAttr(env.branch) + '\')" ' +
+                'onkeydown="if (event.key === \'Enter\' || event.key === \' \') { event.preventDefault(); openSwitchBranch(\'' + escAttr(env.branch) + '\'); }"' +
+                '>⎇ ' + esc(env.git_branch || env.branch) + '</span>') +
           repoLinksHtml +
           '<span class="badge ' + badgeClass(env.status) + '"' +
             (env.status === 'partial' ? ' title="' + env.containers.filter(function(c) { return c.status === 'running'; }).length + ' of ' + env.containers.length + ' containers running"' : '') +
@@ -2640,6 +2685,10 @@ function renderEnvironments(envs, force) {
                 (env.note ? 'Edit note' : 'Add note') + '</button>' +
               '<button role="menuitem" title="' + (env.protected ? 'Allow Stop, Update, Recreate and Delete again' : 'Disable Stop, Update, Recreate and Delete') + '" onclick="doProtect(\'' + escAttr(env.branch) + '\',' + (env.protected ? 'true' : 'false') + ')" ' + dis + '>' +
                 (env.protected ? 'Unprotect' : 'Protect') + '</button>' +
+              (env.local_path
+                ? ''
+                : '<button role="menuitem" onclick="openSwitchBranch(\'' + escAttr(env.branch) + '\')" ' + dis +
+                    'title="Reuse this environment for another branch, keeping its database and URL">Switch branch</button>') +
               '<button role="menuitem" onclick="doUpdate(\'' + escAttr(env.branch) + '\')" ' + dis +
                 (env.protected ? 'disabled title="Environment is protected"' : 'title="Recreate the container, keep the database and filestore"') + '>Update</button>' +
               '<button role="menuitem" onclick="doRecreate(\'' + escAttr(env.branch) + '\')" ' + dis +
@@ -3120,6 +3169,53 @@ async function loadStats() {
   } catch (e) {
     // stats are optional, don't show errors
   }
+}
+
+var _switchBranchEnv = '';
+
+function openSwitchBranch(branch) {
+  var env = cachedEnvs.find(function(e) { return e.branch === branch; });
+  if (env && env.local_path) {
+    showToast('Live-mounted: switch the branch in your own checkout, then Sync', true);
+    return;
+  }
+  _switchBranchEnv = branch;
+  document.getElementById('switch-branch-title').textContent = 'Switch branch — ' + branch;
+  document.getElementById('switch-branch-current').textContent = (env && (env.git_branch || env.branch)) || branch;
+  var input = document.getElementById('switch-branch-input');
+  input.value = '';
+  showModal('switch-branch-modal');
+  input.focus();
+}
+
+function closeSwitchBranch(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('switch-branch-modal');
+}
+
+async function confirmSwitchBranch() {
+  var target = document.getElementById('switch-branch-input').value.trim();
+  if (!target) { showToast('Enter the target branch', true); return; }
+  var branch = _switchBranchEnv;
+  hideModal('switch-branch-modal');
+  setBusy(branch, 'Switching branch');
+  try {
+    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/switch-branch', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({branch: target})
+    });
+    const data = await readResult(r);
+    if (data.ok) {
+      showSyncResult(branch, data.result, 'Switch branch');
+    } else {
+      showToast(data.error || 'Switch failed', true);
+    }
+  } catch (e) {
+    showToast('Connection error: ' + e.message, true);
+  }
+  clearBusy(branch);
+  await loadEnvironments(true);
 }
 
 async function doUpdate(branch) {

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -920,6 +920,43 @@ def _build_routes(
         finally:
             locks.release_env(branch)
 
+    async def api_switch_branch(request: Request) -> JSONResponse:
+        branch = request.path_params["branch"]
+        team = _get_ui_team(request)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        target = ((body or {}).get("branch") or "").strip()
+        if not target:
+            return JSONResponse(
+                {"ok": False, "error": "A target branch is required."}, status_code=400
+            )
+        try:
+            locks.acquire_env(branch, team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            settings = get_settings()
+            activity.touch(team, branch)
+            result = await _offload(
+                env_ops.switch_environment_branch,
+                settings,
+                team,
+                branch,
+                target,
+            )
+            return JSONResponse({"ok": True, "result": result})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in api_switch_branch")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+        finally:
+            locks.release_env(branch)
+
     def api_delete(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
         team = _get_ui_team(request)
@@ -4714,6 +4751,11 @@ def _build_routes(
         Route("/api/environments/{branch:path}/stop", api_stop, methods=["POST"]),
         Route("/api/environments/{branch:path}/restart", api_restart, methods=["POST"]),
         Route("/api/environments/{branch:path}/sync", api_sync, methods=["POST"]),
+        Route(
+            "/api/environments/{branch:path}/switch-branch",
+            api_switch_branch,
+            methods=["POST"],
+        ),
         Route("/api/environments/{branch:path}/protect", api_protect, methods=["POST"]),
         Route(
             "/api/environments/{branch:path}/unprotect", api_unprotect, methods=["POST"]

--- a/tests/fixtures.yaml
+++ b/tests/fixtures.yaml
@@ -100,6 +100,26 @@ scenarios:
     expect_contains:
       - "started"
 
+  # Reuse the same environment for another branch, then put it back, so the
+  # shared fixture environment is left on the branch it was created from.
+  switch_branch_away:
+    tool: switch_branch
+    needs_env: true
+    args:
+      env_name: "19.0"
+      branch: "18.0"
+    expect_contains:
+      - "Switched '19.0' from 'main' to '18.0'"
+
+  switch_branch_back:
+    tool: switch_branch
+    needs_env: true
+    args:
+      env_name: "19.0"
+      branch: "main"
+    expect_contains:
+      - "Switched '19.0' from '18.0' to 'main'"
+
   # ── Odoo operations ──────────────────────────────────────────────
   logs_main:
     tool: get_environment_logs

--- a/tests/test_switch_branch.py
+++ b/tests/test_switch_branch.py
@@ -1,0 +1,480 @@
+"""Reusing an environment for another branch (``switch_environment_branch``).
+
+The environment is the reusable unit: switching the branch must keep the
+database, filestore and routing while changing only the code. What these tests
+pin down is the part that is easy to get subtly wrong — the *order* of the
+mutations, and the two refusals that keep a reused environment honest (a branch
+that was never pushed, a database whose installed modules the target branch does
+not carry).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow import git_ops
+from oduflow.docker_ops import env_ops
+from oduflow.errors import (
+    ConflictError,
+    ExternalCommandError,
+    NotFoundError,
+    PrerequisiteNotMetError,
+)
+from oduflow.settings import Settings, TeamSettings
+
+
+def _team(tmp_path) -> TeamSettings:
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def _settings(tmp_path) -> Settings:
+    return Settings(teams={"1": _team(tmp_path)})
+
+
+def _container(labels: dict[str, str]) -> MagicMock:
+    container = MagicMock()
+    container.labels = labels
+    return container
+
+
+def _labels(**overrides: str) -> dict[str, str]:
+    labels = {
+        "oduflow.branch": "dev1",
+        "oduflow.git_branch": "feature/old",
+        "oduflow.repo": "https://github.com/acme/addons.git",
+        "oduflow.git_user": "ada",
+    }
+    labels.update(overrides)
+    return labels
+
+
+# --- git plumbing ---------------------------------------------------------
+
+
+class TestFetchBranch:
+    def test_an_unpushed_branch_is_reported_as_missing_not_as_a_git_failure(
+        self, tmp_path
+    ):
+        error = subprocess.CalledProcessError(128, ["git", "fetch"])
+        error.stderr = "fatal: couldn't find remote ref refs/heads/feature/new"
+
+        with patch("subprocess.run", side_effect=error):
+            with pytest.raises(NotFoundError) as excinfo:
+                git_ops.fetch_branch(str(tmp_path), "feature/new")
+
+        assert "does not exist on origin" in str(excinfo.value)
+        assert "git push -u origin feature/new" in str(excinfo.value)
+
+    def test_any_other_fetch_failure_stays_an_external_command_error(self, tmp_path):
+        error = subprocess.CalledProcessError(128, ["git", "fetch"])
+        error.stderr = "fatal: Authentication failed"
+
+        with patch("subprocess.run", side_effect=error):
+            with pytest.raises(ExternalCommandError):
+                git_ops.fetch_branch(str(tmp_path), "feature/new")
+
+    def test_credentials_are_never_echoed_back_in_the_error(self, tmp_path):
+        error = subprocess.CalledProcessError(128, ["git", "fetch"])
+        error.stderr = "fatal: https://ada:ghp_secret@github.com/acme/addons.git denied"
+
+        with patch("subprocess.run", side_effect=error):
+            with pytest.raises(ExternalCommandError) as excinfo:
+                git_ops.fetch_branch(str(tmp_path), "feature/new")
+
+        assert "ghp_secret" not in str(excinfo.value)
+
+    def test_returns_the_fetched_remote_tip(self, tmp_path):
+        with (
+            patch("subprocess.run") as run,
+            patch.object(git_ops, "rev_parse", return_value="cafe123") as rev_parse,
+        ):
+            assert git_ops.fetch_branch(str(tmp_path), "feature/new") == "cafe123"
+
+        assert run.call_count == 1
+        assert rev_parse.call_args[0][1] == "refs/remotes/origin/feature/new"
+
+
+class TestCheckoutBranch:
+    def test_moves_the_clone_onto_the_branch_and_returns_the_tree_diff(self, tmp_path):
+        heads = iter(["old111", "new222"])
+
+        with (
+            patch("subprocess.run") as run,
+            patch.object(
+                git_ops, "rev_parse", side_effect=lambda *_a, **_k: next(heads)
+            ),
+            patch.object(git_ops, "diff_names", return_value=["sale_x/models/a.py"]),
+        ):
+            old, new, files = git_ops.checkout_branch(str(tmp_path), "feature/new")
+
+        assert (old, new, files) == ("old111", "new222", ["sale_x/models/a.py"])
+        argv = run.call_args[0][0]
+        # --force keeps the managed clone's policy identical to pull_repo's
+        # reset --hard, and -B pins the local branch on the fetched remote tip.
+        assert argv[3:] == [
+            "checkout",
+            "--force",
+            "-B",
+            "feature/new",
+            "refs/remotes/origin/feature/new",
+        ]
+
+    def test_an_identical_tip_reports_no_changed_files(self, tmp_path):
+        with (
+            patch("subprocess.run"),
+            patch.object(git_ops, "rev_parse", return_value="same"),
+            patch.object(git_ops, "diff_names") as diff_names,
+        ):
+            old, new, files = git_ops.checkout_branch(str(tmp_path), "feature/new")
+
+        assert (old, new, files) == ("same", "same", [])
+        diff_names.assert_not_called()
+
+
+class TestTreeModules:
+    def test_reads_module_names_from_manifests_anywhere_in_the_tree(self, tmp_path):
+        listing = (
+            "README.md\n"
+            "sale_x/__manifest__.py\n"
+            "sale_x/models/sale.py\n"
+            "addons/deep/crm_y/__manifest__.py\n"
+            "__manifest__.py\n"
+        )
+        with patch("subprocess.run", return_value=MagicMock(stdout=listing)):
+            modules = git_ops.tree_modules(str(tmp_path), "origin/main")
+
+        # The repository root is never an addons directory, so a root manifest
+        # is not a module the addons path could load.
+        assert modules == {"sale_x", "crm_y"}
+
+
+# --- switch_environment_branch -------------------------------------------
+
+
+@pytest.fixture
+def switch_env(tmp_path):
+    """Patch everything a switch touches; yield the mocks it is asserted on."""
+    client = MagicMock()
+    client.containers.get.return_value = _container(_labels())
+
+    with (
+        patch.object(env_ops, "get_client", return_value=client),
+        patch.object(git_ops, "is_git_repository", return_value=True),
+        patch.object(git_ops, "fetch_branch", return_value="tip999") as fetch,
+        patch.object(
+            git_ops,
+            "checkout_branch",
+            return_value=("old111", "new222", ["sale_x/a.py"]),
+        ) as checkout,
+        patch.object(env_ops, "update_environment") as update,
+        patch.object(
+            env_ops,
+            "pull_environment",
+            return_value={"action": "restart", "message": "Restarted."},
+        ) as pull,
+        patch.object(env_ops, "_agent_add_env") as agent,
+        patch.object(env_ops, "_dropped_module_warnings", return_value=[]) as preflight,
+    ):
+        yield {
+            "client": client,
+            "fetch": fetch,
+            "checkout": checkout,
+            "update": update,
+            "pull": pull,
+            "agent": agent,
+            "preflight": preflight,
+        }
+
+
+def _switch(tmp_path, **kwargs):
+    return env_ops.switch_environment_branch(
+        _settings(tmp_path), _team(tmp_path), "dev1", "feature/new", **kwargs
+    )
+
+
+class TestSwitchEnvironmentBranch:
+    def test_the_label_is_flipped_before_the_checkout(self, tmp_path, switch_env):
+        calls: list[str] = []
+        switch_env["update"].side_effect = lambda *a, **k: calls.append("label")
+        switch_env["checkout"].side_effect = lambda *a, **k: (
+            calls.append("checkout") or ("old111", "new222", ["sale_x/a.py"])
+        )
+
+        _switch(tmp_path)
+
+        # Reversed, a failed label flip would leave a switched tree that the
+        # next pull silently resets back to the old branch.
+        assert calls == ["label", "checkout"]
+
+    def test_only_the_branch_label_changes_and_no_image_is_pulled(
+        self, tmp_path, switch_env
+    ):
+        _switch(tmp_path)
+
+        kwargs = switch_env["update"].call_args.kwargs
+        assert kwargs["label_overrides"] == {"oduflow.git_branch": "feature/new"}
+        assert kwargs["pull_image"] is False
+        # The checkout is still on the old branch at that point, so a changed
+        # requirements.txt belongs to the diff, not to this recreate.
+        assert kwargs["install_dependencies"] is False
+
+    def test_the_diff_is_handed_to_the_normal_apply_path(self, tmp_path, switch_env):
+        _switch(tmp_path, upgrade=["sale_x"], strict=True)
+
+        kwargs = switch_env["pull"].call_args.kwargs
+        assert kwargs["presynced"] == ("old111", ["sale_x/a.py"])
+        assert kwargs["upgrade"] == ["sale_x"]
+        assert kwargs["strict"] is True
+
+    def test_the_result_records_both_branches_and_the_switch(
+        self, tmp_path, switch_env
+    ):
+        result = _switch(tmp_path)
+
+        assert result["branch"] == "feature/new"
+        assert result["previous_branch"] == "feature/old"
+        assert result["branch_switched"] is True
+        assert result["old_head"] == "old111"
+        assert result["new_head"] == "new222"
+        assert result["message"].startswith(
+            "Switched 'dev1' from 'feature/old' to 'feature/new'."
+        )
+
+    def test_two_branches_with_the_same_tree_do_not_report_being_up_to_date(
+        self, tmp_path, switch_env
+    ):
+        switch_env["checkout"].return_value = ("same", "same", [])
+        switch_env["pull"].return_value = {
+            "action": "none",
+            "message": "Already up to date.",
+        }
+
+        result = _switch(tmp_path)
+
+        # "Already up to date" is pull vocabulary; after a switch it reads as a
+        # contradiction of the switch that just happened.
+        assert result["message"] == (
+            "Switched 'dev1' from 'feature/old' to 'feature/new'. "
+            "No code difference to apply."
+        )
+
+    def test_the_agents_own_checkout_follows_the_switch(self, tmp_path, switch_env):
+        _switch(tmp_path)
+
+        args = switch_env["agent"].call_args[0]
+        assert args[3:] == (
+            "dev1",
+            "https://github.com/acme/addons.git",
+            "feature/new",
+            "ada",
+        )
+
+    def test_extra_addons_branches_switch_with_the_main_repo(
+        self, tmp_path, switch_env
+    ):
+        _switch(tmp_path, extra_addons={"enterprise": "19.0"})
+
+        overrides = switch_env["update"].call_args.kwargs["label_overrides"]
+        assert overrides["oduflow.git_branch"] == "feature/new"
+        assert overrides["oduflow.extra_addons"] == '{"enterprise": "19.0"}'
+
+    def test_switching_to_the_branch_it_is_already_on_pulls_instead(
+        self, tmp_path, switch_env
+    ):
+        switch_env["client"].containers.get.return_value = _container(
+            _labels(**{"oduflow.git_branch": "feature/new"})
+        )
+
+        result = _switch(tmp_path)
+
+        assert result["branch_switched"] is False
+        switch_env["update"].assert_not_called()
+        switch_env["checkout"].assert_not_called()
+        switch_env["pull"].assert_called_once()
+        assert "already on branch 'feature/new'" in result["message"]
+
+    def test_a_live_mounted_environment_is_refused(self, tmp_path, switch_env):
+        switch_env["client"].containers.get.return_value = _container(
+            _labels(**{"oduflow.local_path": "/home/ada/addons"})
+        )
+
+        with pytest.raises(PrerequisiteNotMetError) as excinfo:
+            _switch(tmp_path)
+
+        assert "/home/ada/addons" in str(excinfo.value)
+        switch_env["update"].assert_not_called()
+
+    def test_a_production_is_refused_by_name_before_docker_is_touched(
+        self, tmp_path, switch_env
+    ):
+        with pytest.raises(ConflictError) as excinfo:
+            env_ops.switch_environment_branch(
+                _settings(tmp_path), _team(tmp_path), "prod-erp", "feature/new"
+            )
+
+        assert "update_production" in str(excinfo.value)
+        switch_env["client"].containers.get.assert_not_called()
+
+    def test_a_production_container_is_refused_by_label_too(self, tmp_path, switch_env):
+        switch_env["client"].containers.get.return_value = _container(
+            _labels(**{"oduflow.prod": "true"})
+        )
+
+        with pytest.raises(ConflictError):
+            _switch(tmp_path)
+
+        switch_env["update"].assert_not_called()
+
+    def test_an_unpushed_branch_leaves_the_environment_untouched(
+        self, tmp_path, switch_env
+    ):
+        switch_env["fetch"].side_effect = NotFoundError("no such branch on origin")
+
+        with pytest.raises(NotFoundError):
+            _switch(tmp_path)
+
+        switch_env["update"].assert_not_called()
+        switch_env["checkout"].assert_not_called()
+
+    def test_a_failed_checkout_says_the_label_already_moved(self, tmp_path, switch_env):
+        switch_env["checkout"].side_effect = ExternalCommandError(
+            "git checkout", 1, "index locked"
+        )
+
+        with pytest.raises(ExternalCommandError) as excinfo:
+            _switch(tmp_path)
+
+        message = str(excinfo.value)
+        assert "labelled with branch 'feature/new'" in message
+        assert "still on 'feature/old'" in message
+        switch_env["pull"].assert_not_called()
+
+    def test_a_missing_environment_is_a_not_found_error(self, tmp_path, switch_env):
+        import docker
+
+        switch_env["client"].containers.get.side_effect = docker.errors.NotFound("nope")
+
+        with pytest.raises(NotFoundError):
+            _switch(tmp_path)
+
+
+class TestDroppedModulePreflight:
+    def test_a_dropped_installed_module_is_reported_but_still_switches(
+        self, tmp_path, switch_env
+    ):
+        switch_env["preflight"].return_value = ["sale_x is installed but absent"]
+
+        result = _switch(tmp_path)
+
+        assert result["branch_switched"] is True
+        assert result["warnings"] == ["sale_x is installed but absent"]
+        switch_env["update"].assert_called_once()
+
+    def test_strict_refuses_and_mutates_nothing(self, tmp_path, switch_env):
+        switch_env["preflight"].return_value = ["sale_x is installed but absent"]
+
+        result = _switch(tmp_path, strict=True)
+
+        assert result["action"] == "blocked"
+        assert result["branch"] == "feature/old"
+        assert result["requested_branch"] == "feature/new"
+        switch_env["update"].assert_not_called()
+        switch_env["checkout"].assert_not_called()
+        switch_env["pull"].assert_not_called()
+
+    def test_warnings_from_the_switch_and_from_the_guardrail_are_both_kept(
+        self, tmp_path, switch_env
+    ):
+        switch_env["preflight"].return_value = ["module gone"]
+        switch_env["pull"].return_value = {
+            "action": "restart",
+            "message": "Restarted.",
+            "warnings": ["a data file changed but nothing was upgraded"],
+        }
+
+        result = _switch(tmp_path)
+
+        assert result["warnings"] == [
+            "module gone",
+            "a data file changed but nothing was upgraded",
+        ]
+
+    def test_only_modules_installed_in_the_database_are_warned_about(self, tmp_path):
+        trees = {"HEAD": {"sale_x", "crm_y"}, "tip999": {"crm_y"}}
+
+        with (
+            patch.object(
+                git_ops, "tree_modules", side_effect=lambda _p, ref: trees[ref]
+            ),
+            patch(
+                "oduflow.docker_ops.odoo_ops._get_module_states",
+                return_value={"sale_x": "installed"},
+            ) as states,
+        ):
+            warnings = env_ops._dropped_module_warnings(
+                _settings(tmp_path), _team(tmp_path), "dev1", "/repo", "tip999"
+            )
+
+        assert states.call_args[0][3] == ("sale_x",)
+        assert len(warnings) == 1
+        assert "sale_x" in warnings[0]
+
+    def test_an_uninstalled_module_is_not_worth_a_warning(self, tmp_path):
+        trees = {"HEAD": {"sale_x"}, "tip999": set()}
+
+        with (
+            patch.object(
+                git_ops, "tree_modules", side_effect=lambda _p, ref: trees[ref]
+            ),
+            patch(
+                "oduflow.docker_ops.odoo_ops._get_module_states",
+                return_value={"sale_x": "uninstalled"},
+            ),
+        ):
+            assert (
+                env_ops._dropped_module_warnings(
+                    _settings(tmp_path), _team(tmp_path), "dev1", "/repo", "tip999"
+                )
+                == []
+            )
+
+    def test_an_unreachable_database_does_not_block_the_switch(self, tmp_path):
+        trees = {"HEAD": {"sale_x"}, "tip999": set()}
+
+        with (
+            patch.object(
+                git_ops, "tree_modules", side_effect=lambda _p, ref: trees[ref]
+            ),
+            patch(
+                "oduflow.docker_ops.odoo_ops._get_module_states",
+                side_effect=RuntimeError("postgres is down"),
+            ),
+        ):
+            assert (
+                env_ops._dropped_module_warnings(
+                    _settings(tmp_path), _team(tmp_path), "dev1", "/repo", "tip999"
+                )
+                == []
+            )
+
+    def test_module_names_git_would_allow_but_sql_should_not_are_dropped(
+        self, tmp_path
+    ):
+        trees = {"HEAD": {"sale_x", "we'ird-name"}, "tip999": set()}
+
+        with (
+            patch.object(
+                git_ops, "tree_modules", side_effect=lambda _p, ref: trees[ref]
+            ),
+            patch(
+                "oduflow.docker_ops.odoo_ops._get_module_states", return_value={}
+            ) as states,
+        ):
+            env_ops._dropped_module_warnings(
+                _settings(tmp_path), _team(tmp_path), "dev1", "/repo", "tip999"
+            )
+
+        assert states.call_args[0][3] == ("sale_x",)


### PR DESCRIPTION
## What

Adds `switch_branch` — reuse an existing environment for the next branch instead of delete-and-create. Everything except the code stays: name, database, filestore, hostname/URL, ports, PostgreSQL credentials and the scoped MCP endpoint and token.

## How

- `git_ops`: `fetch_branch` (validate-before-mutate, "push it first" on an unpushed branch), `checkout_branch` (forced `-B` onto origin's tip, returns the tree diff between the two tips), `tree_modules` (module inventory of a ref, read through git).
- `env_ops.switch_environment_branch`: fetch → dropped-module preflight → flip the `oduflow.git_branch` label (before the checkout, so a failed switch leaves both label and tree on the old branch) → checkout → hand `(old_head, changed_files)` to `pull_environment` via the new `presynced` parameter, sharing one implementation of classification, guardrails, extra-addons resolution and apply.
- Preflight warns when the target branch does not carry a module installed in the database; `strict=True` refuses instead. Productions (by name and by label) and live-mounted environments are rejected.
- Surfaces: MCP tool `switch_branch`, REST `POST /api/environments/{branch}/switch-branch`, and a dashboard control — the branch chip on each card opens the switch modal.
- Decision record `specs/0049-environment-reuse-by-branch-switch.md`; docs and agent guide updated.

## Testing

- New `tests/test_switch_branch.py` (28 tests): mutation order, refusals, preflight, message shaping.
- Full unit suite: 2379 passed. `ruff` and `mypy` clean.