### PR TITLE
Granular resource locks for MCP tools

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -181,15 +181,17 @@ All containers are labeled with `oduflow.managed=true` and `oduflow.team={team_i
 
 ## Concurrency & Locking
 
-Oduflow uses a granular `LockManager` (`locking.py`) with per-branch and per-team locks:
+Oduflow uses a granular `LockManager` (`locking.py`) that locks the smallest
+resource an operation actually touches:
 
 | Lock Level | Scope | Example Operations |
 |---|---|---|
 | **Per-branch** | One operation per branch at a time | `create_environment`, `delete_environment`, `install_odoo_modules`, `pull_and_apply`, `export_module_translations` |
-| **Per-team** | One team-level operation at a time | `add_extra_repo`, `setup_repo_auth`, `create_service` |
-| **System/cluster** | Cross-environment infrastructure operation | startup initialization, `destroy`, production cluster PITR |
+| **Per-resource** | One operation per service / volume / production / credential store | `create_service`, `delete_volume`, `setup_repo_auth`, `snapshot_production` |
+| **Per-team** | One team-wide operation at a time | template publishing (`save_as_template`, `refresh_template`, `delete_template`) — they remount other environments' overlay filestores |
+| **System/cluster** | Cross-environment infrastructure operation | startup initialization, `destroy`, `restore_cluster_pitr` (excludes every production lock) |
 
-Operations on **different branches** run in parallel. If a lock cannot be acquired, the tool immediately returns `BusyError` (no queuing).
+Operations on **different resources** run in parallel. If a lock cannot be acquired, the tool immediately returns `BusyError` (no queuing). Some tools take no `LockManager` lock at all: pure reads, the `odoo_*` tools (PostgreSQL arbitrates concurrent ORM calls), and the extra-repo tools (`extra_addons.py` serialises per repo itself).
 
 ## Error Handling
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3099,12 +3099,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `get_environment_logs` | | Retrieve recent container logs |
 | `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |
 | `run_odoo_shell` | ✓ | Execute Python code in the Odoo shell context with full ORM access; `auto_commit=True` commits successful writes, while `False` leaves the shell transaction uncommitted |
-| `odoo_search_read` | ✓ | Search and read records (XML-RPC `search_read`/`search_count`) as any user, with ACLs and record rules applied |
-| `odoo_create` | ✓ | Create one or many records (XML-RPC `create`). Committed immediately |
-| `odoo_write` | ✓ | Update records (XML-RPC `write`). Committed immediately |
-| `odoo_unlink` | ✓ | ⚠️ Delete records (XML-RPC `unlink`). Committed immediately, not recoverable |
-| `odoo_call` | ✓ | Call public model methods not covered by the dedicated CRUD tools (`read_group`, `name_search`, `action_*`, …) |
-| `odoo_schema` | ✓ | Page through models, or describe one model's fields (XML-RPC `fields_get`) |
+| `odoo_search_read` | | Search and read records (XML-RPC `search_read`/`search_count`) as any user, with ACLs and record rules applied |
+| `odoo_create` | | Create one or many records (XML-RPC `create`). Committed immediately |
+| `odoo_write` | | Update records (XML-RPC `write`). Committed immediately |
+| `odoo_unlink` | | ⚠️ Delete records (XML-RPC `unlink`). Committed immediately, not recoverable |
+| `odoo_call` | | Call public model methods not covered by the dedicated CRUD tools (`read_group`, `name_search`, `action_*`, …) |
+| `odoo_schema` | | Page through models, or describe one model's fields (XML-RPC `fields_get`) |
 | `read_file_in_odoo` | | Read a text file or list a directory inside the Odoo container. Supports line ranges (e.g. `"1:50"`) |
 | `write_file_in_odoo` | ✓ | Write a text file inside the container (CSV imports, scripts, configs) |
 | `search_in_odoo` | | Search for a pattern (fixed-string grep) in files inside the Odoo container |
@@ -3125,12 +3125,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik |
 | `delete_service` | ✓ | Stop and remove a service container |
-| `restart_service` | | Restart a service container |
+| `restart_service` | ✓ | Restart a service container |
 | `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
-| `run_service_command` | | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
+| `run_service_command` | ✓ | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
 | **Volumes** | | |
 | `create_volume` | ✓ | Create a named Docker volume for use with services |
 | `list_volumes` | | List all managed Docker volumes and their usage by services |
@@ -3147,10 +3147,10 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Repository Auth** | | |
 | `setup_repo_auth` | ✓ | Cache git credentials for a private repository |
 | **Extra Addons** | | |
-| `add_extra_repo` | ✓ | Clone an extra addons repository (e.g. Odoo Enterprise) for use with environments |
+| `add_extra_repo` | | Clone an extra addons repository (e.g. Odoo Enterprise) for use with environments |
 | `list_extra_repos` | | List all cloned extra addons repositories |
-| `update_extra_repo` | ✓ | Fetch latest changes from the remote for an extra addons repository |
-| `delete_extra_repo` | ✓ | Delete a cloned extra addons repository |
+| `update_extra_repo` | | Fetch latest changes from the remote for an extra addons repository |
+| `delete_extra_repo` | | Delete a cloned extra addons repository |
 | **Production Hosting** | | Requires `[production].enabled = true` |
 | `create_production` | ✓ | Provision a long-lived production with its own domain and the dedicated production PostgreSQL cluster; optionally seed it from a template |
 | `list_productions` | | List productions with status, domain, deployed commit, and auto-update state |
@@ -3178,7 +3178,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `report_issue` | | Build a prefilled link for the user to file a bug, feature request, or feedback about Oduflow on GitHub |
 
 !!! info "Locking"
-    Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.
+    Tools marked with ✓ acquire a lock on exactly what they touch: the branch, one service, one volume, the team's credential store — or the whole team, for the few operations that really are team-wide (template publishing). Operations on different resources run in parallel. If another operation on the **same** resource is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.
 
 The exact current signature and defaults for every tool are also available from
 `oduflow list` (`oduflow list --verbose` adds descriptions). The production
@@ -4310,15 +4310,17 @@ All containers are labeled with `oduflow.managed=true` and `oduflow.team={team_i
 
 ## Concurrency & Locking
 
-Oduflow uses a granular `LockManager` (`locking.py`) with per-branch and per-team locks:
+Oduflow uses a granular `LockManager` (`locking.py`) that locks the smallest
+resource an operation actually touches:
 
 | Lock Level | Scope | Example Operations |
 |---|---|---|
 | **Per-branch** | One operation per branch at a time | `create_environment`, `delete_environment`, `install_odoo_modules`, `pull_and_apply`, `export_module_translations` |
-| **Per-team** | One team-level operation at a time | `add_extra_repo`, `setup_repo_auth`, `create_service` |
-| **System/cluster** | Cross-environment infrastructure operation | startup initialization, `destroy`, production cluster PITR |
+| **Per-resource** | One operation per service / volume / production / credential store | `create_service`, `delete_volume`, `setup_repo_auth`, `snapshot_production` |
+| **Per-team** | One team-wide operation at a time | template publishing (`save_as_template`, `refresh_template`, `delete_template`) — they remount other environments' overlay filestores |
+| **System/cluster** | Cross-environment infrastructure operation | startup initialization, `destroy`, `restore_cluster_pitr` (excludes every production lock) |
 
-Operations on **different branches** run in parallel. If a lock cannot be acquired, the tool immediately returns `BusyError` (no queuing).
+Operations on **different resources** run in parallel. If a lock cannot be acquired, the tool immediately returns `BusyError` (no queuing). Some tools take no `LockManager` lock at all: pure reads, the `odoo_*` tools (PostgreSQL arbitrates concurrent ORM calls), and the extra-repo tools (`extra_addons.py` serialises per repo itself).
 
 ## Error Handling
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -25,12 +25,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `get_environment_logs` | | Retrieve recent container logs |
 | `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |
 | `run_odoo_shell` | ✓ | Execute Python code in the Odoo shell context with full ORM access; `auto_commit=True` commits successful writes, while `False` leaves the shell transaction uncommitted |
-| `odoo_search_read` | ✓ | Search and read records (XML-RPC `search_read`/`search_count`) as any user, with ACLs and record rules applied |
-| `odoo_create` | ✓ | Create one or many records (XML-RPC `create`). Committed immediately |
-| `odoo_write` | ✓ | Update records (XML-RPC `write`). Committed immediately |
-| `odoo_unlink` | ✓ | ⚠️ Delete records (XML-RPC `unlink`). Committed immediately, not recoverable |
-| `odoo_call` | ✓ | Call public model methods not covered by the dedicated CRUD tools (`read_group`, `name_search`, `action_*`, …) |
-| `odoo_schema` | ✓ | Page through models, or describe one model's fields (XML-RPC `fields_get`) |
+| `odoo_search_read` | | Search and read records (XML-RPC `search_read`/`search_count`) as any user, with ACLs and record rules applied |
+| `odoo_create` | | Create one or many records (XML-RPC `create`). Committed immediately |
+| `odoo_write` | | Update records (XML-RPC `write`). Committed immediately |
+| `odoo_unlink` | | ⚠️ Delete records (XML-RPC `unlink`). Committed immediately, not recoverable |
+| `odoo_call` | | Call public model methods not covered by the dedicated CRUD tools (`read_group`, `name_search`, `action_*`, …) |
+| `odoo_schema` | | Page through models, or describe one model's fields (XML-RPC `fields_get`) |
 | `read_file_in_odoo` | | Read a text file or list a directory inside the Odoo container. Supports line ranges (e.g. `"1:50"`) |
 | `write_file_in_odoo` | ✓ | Write a text file inside the container (CSV imports, scripts, configs) |
 | `search_in_odoo` | | Search for a pattern (fixed-string grep) in files inside the Odoo container |
@@ -51,12 +51,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Auxiliary Services** | | |
 | `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik |
 | `delete_service` | ✓ | Stop and remove a service container |
-| `restart_service` | | Restart a service container |
+| `restart_service` | ✓ | Restart a service container |
 | `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode |
 | `list_services` | | List all managed service containers |
 | `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
-| `run_service_command` | | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
+| `run_service_command` | ✓ | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
 | **Volumes** | | |
 | `create_volume` | ✓ | Create a named Docker volume for use with services |
 | `list_volumes` | | List all managed Docker volumes and their usage by services |
@@ -73,10 +73,10 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Repository Auth** | | |
 | `setup_repo_auth` | ✓ | Cache git credentials for a private repository |
 | **Extra Addons** | | |
-| `add_extra_repo` | ✓ | Clone an extra addons repository (e.g. Odoo Enterprise) for use with environments |
+| `add_extra_repo` | | Clone an extra addons repository (e.g. Odoo Enterprise) for use with environments |
 | `list_extra_repos` | | List all cloned extra addons repositories |
-| `update_extra_repo` | ✓ | Fetch latest changes from the remote for an extra addons repository |
-| `delete_extra_repo` | ✓ | Delete a cloned extra addons repository |
+| `update_extra_repo` | | Fetch latest changes from the remote for an extra addons repository |
+| `delete_extra_repo` | | Delete a cloned extra addons repository |
 | **Production Hosting** | | Requires `[production].enabled = true` |
 | `create_production` | ✓ | Provision a long-lived production with its own domain and the dedicated production PostgreSQL cluster; optionally seed it from a template |
 | `list_productions` | | List productions with status, domain, deployed commit, and auto-update state |
@@ -104,7 +104,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `report_issue` | | Build a prefilled link for the user to file a bug, feature request, or feedback about Oduflow on GitHub |
 
 !!! info "Locking"
-    Tools marked with ✓ acquire a per-branch or per-team lock. Operations on different branches run in parallel. If another operation on the **same branch** (or team, for team-level tools) is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.
+    Tools marked with ✓ acquire a lock on exactly what they touch: the branch, one service, one volume, the team's credential store — or the whole team, for the few operations that really are team-wide (template publishing). Operations on different resources run in parallel. If another operation on the **same** resource is already in progress, the call is rejected with `BusyError`. The rejection names the operation holding the lock and how long it has held it (e.g. *"Another operation on environment 'main' (pull_and_apply, running for 4m12s) is in progress"*), so a long install is distinguishable from a hung one. A lock is released when its operation finishes — including when the client that started it timed out and stopped waiting, which is why restarting the environment is the wrong response.
 
 The exact current signature and defaults for every tool are also available from
 `oduflow list` (`oduflow list --verbose` adds descriptions). The production

--- a/specs/0015-granular-locking.md
+++ b/specs/0015-granular-locking.md
@@ -78,6 +78,20 @@ resource is in progress and to retry, instead of the request hanging.
   cross-process safety on shared files (e.g. the port registry) is handled
   separately with an flock (see [[0004-stable-addressing-port-registry-and-traefik]]).
 
+## Evolution
+
+- **2026-08-17 — the team lock stops being the catch-all**
+  ([[0049-granular-resource-locks]]). The three scopes proved right; the *choice*
+  of scope did not. Per-team had become the default for anything that was not one
+  environment — services, volumes, extra repos, credentials, presets, backup
+  pruning, template listing — which, through the team↔environment mutual
+  exclusion, let a long `create_environment` reject unrelated service and volume
+  work. Those operations moved to narrow resource keys on the same generic keyed
+  lock, the team lock was reserved for template mutations (the one operation that
+  really does touch other environments), and the system lock — dead since this
+  record was written — was revived for cluster PITR, mutually exclusive with the
+  whole production keyspace.
+
 ## History
 
 - `3a26c70` (2026-02-06) — global mutex introduced: `_busy = threading.Lock()` +

--- a/specs/0049-granular-resource-locks.md
+++ b/specs/0049-granular-resource-locks.md
@@ -1,0 +1,97 @@
+# 0049 — Resource-scoped locks: the team lock stops being the catch-all
+
+**Status:** Adopted
+**Type:** Architecture
+**First introduced:** 2026-08-17
+**Key code today:** `locking.py` (resource key builders, `keyed_mutex`, `acquire_system`), `server.py` (`with_key_lock`), `web_ui.py`, `docker_ops/service_ops.py`, `docker_ops/volume_ops.py`
+
+## Context
+
+[[0015-granular-locking]] replaced a global mutex with per-branch, per-team and
+system locks — and per-team became the default for everything that was not
+obviously one environment: services, volumes, extra-addon repos, credentials,
+service presets, backup pruning, even *listing* templates.
+
+That scope is far wider than what those operations touch. Because the lock
+manager also enforces team↔environment mutual exclusion (a team-wide operation
+must not run while any of the team's environments is busy, and vice versa), a
+ten-minute `create_environment` made `delete_service`, `create_volume`,
+`add_extra_repo` and `list_templates` all fail with `BusyError` — and a service
+tweak could reject an environment build. Agents read those rejections as stuck
+state and reach for restarts. Meanwhile the coarse lock was not even buying
+correctness where it mattered: `restart_service` and `run_service_command` took
+no lock at all, and backup pruning could run in the middle of a snapshot,
+because productions lock in their own `prod:` keyspace that the team lock never
+touched. The one genuine team-wide invariant — publishing a template remounts
+other environments' overlay filestores — was hidden among a dozen operations
+that had nothing team-wide about them.
+
+## Decision
+
+**Lock the resource, not the tenant.** Every operation takes the narrowest key
+that names what it actually mutates, using the lock manager's existing generic
+keyed lock:
+
+- `svc:{team}:{name}`, `vol:{team}:{name}`, `preset:{team}`, `creds:{team}`,
+  `prod-backups:{team}` — acquired *without* a team id, so they sit outside the
+  team↔environment mutex entirely.
+- The **team lock is reserved for the one real team×environments invariant**:
+  template mutations that remount live environments' filestores.
+- Operations that another mechanism already serialises take **no** lock:
+  extra-addon repos (per-repo RLock plus a container-based dependency guard in
+  `extra_addons.py`), pure reads, and the `odoo_*` XML-RPC tools — PostgreSQL,
+  not Oduflow, arbitrates concurrent ORM calls, exactly as it already did for
+  the neighbouring lock-free `http_request_to_odoo`.
+- The **system lock**, dead since [[0015-granular-locking]], is revived for
+  `restore_cluster_pitr` and made mutually exclusive with the whole `prod:`
+  keyspace in both directions — the honest expression of "this rewrites the
+  cluster every team's productions live in".
+
+## How it works (macro)
+
+- One module builds every key string, because the MCP tools and the REST
+  dashboard must lock the same resource under the same key or they stop seeing
+  each other. A `with_key_lock(key_builder)` decorator applies it to tools; the
+  dashboard calls the same builders.
+- Below the tool layer, two invariants span calls the tool layer cannot see: the
+  service-slot count, and "no service mounts this volume". These use a short,
+  blocking, re-entrant `keyed_mutex` inside `docker_ops` rather than a
+  user-visible lock — it must be held across `update_service`'s remove-and-
+  recreate window, and a caller has nothing useful to do but wait for
+  milliseconds. Ordering is fixed (tool key first, then the mutex; nothing under
+  the mutex takes a tool key), so the two schemes cannot deadlock.
+- Lock-free tools that wake a stopped environment made an existing
+  check-then-start race reachable; the wake is now atomic per environment
+  through the same keyed mutex.
+- Contention still surfaces as `BusyError` naming the holding operation and its
+  age — the diagnostic contract agents depend on is unchanged, only its blast
+  radius shrank.
+
+## Consequences
+
+- Work on unrelated resources genuinely runs in parallel: a long environment
+  build no longer bounces service, volume, credential or repo operations, and
+  vice versa. Locks now fail only when two callers really do want the same
+  thing.
+- Races that the coarse lock never actually covered are closed: service restart
+  and exec now exclude delete/update, prune excludes snapshot and restore, and
+  cluster PITR excludes every production operation including the blocking
+  webhook-deploy path.
+- **Accepted window:** `create_environment` materialises shared extra-addon
+  checkouts *before* its container exists, so the delete guard cannot see it. A
+  `delete_extra_repo` landing exactly there makes the in-flight create fail with
+  a clear error instead of every repo operation queueing behind a team lock for
+  minutes. Documented at the guard.
+- The team lock now means something specific, so the "which scope?" question for
+  a new tool has a sharper answer — but the answer is no longer "team by
+  default", and mis-scoping is still the standing risk of granular locking.
+- Locks remain in-process; cross-process safety on shared files stays with the
+  registries' own flocks.
+
+## History
+
+- `3a26c70` (2026-02-06) — global mutex.
+- `ad3b382` (2026-03-01) — `LockManager` with per-branch/per-team/system locks
+  ([[0015-granular-locking]]).
+- 2026-08-17 — resource-scoped keys, template-only team lock, lock-free `odoo_*`
+  and extra-repo tools, revived system lock for `restore_cluster_pitr`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -67,6 +67,7 @@ precursors).
 | [0046](0046-declarative-oduflow-stacks.md) | 2026-08-11 | Declarative Oduflow Stacks: versioned YAML, plan/apply reconciliation, ownership and startup bootstrap |
 | [0047](0047-three-way-bundled-upgrades.md) | 2026-08-14 | Three-way upgrades for deployed bundled files with persistent baselines and safe conflict sidecars |
 | [0048](0048-reusable-environment-hostname-slots.md) | 2026-08-16 | Reusable environment hostname slots decouple public routing from branch identity |
+| [0049](0049-granular-resource-locks.md) | 2026-08-17 | Resource-scoped locks: the team lock stops being the catch-all |
 
 ## Design docs
 

--- a/src/oduflow/backup_scheduler.py
+++ b/src/oduflow/backup_scheduler.py
@@ -34,7 +34,7 @@ from typing import Any, Callable
 
 from oduflow import production_registry
 from oduflow.errors import BusyError
-from oduflow.locking import LockManager
+from oduflow.locking import LockManager, prod_backups_lock_key
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -172,10 +172,18 @@ def _run_snapshot_job(
     from oduflow.server import prod_lock_key
 
     key = prod_lock_key(team.team_id, name)
+    backups_key = prod_backups_lock_key(team.team_id)
     try:
         locks.acquire_env(key, operation="scheduled backup")
     except BusyError:
         return  # deploy/restore in flight; still due next tick
+    try:
+        # Same order as the MCP tool: the production first, then the team's
+        # backup store, so a prune cannot run mid-snapshot.
+        locks.acquire_env(backups_key, operation="scheduled backup")
+    except BusyError:
+        locks.release_env(key)
+        return  # prune/restore is using the store; still due next tick
     started = time.time()
     backup_state: dict[str, Any] = {
         "last_attempt_at": now.isoformat(),
@@ -231,6 +239,7 @@ def _run_snapshot_job(
             },
         )
     finally:
+        locks.release_env(backups_key)
         locks.release_env(key)
 
 
@@ -296,8 +305,9 @@ def _run_prune_job(
     _save_cluster_state(settings, state)
     ok = True
     for team in settings.teams.values():
+        backups_key = prod_backups_lock_key(team.team_id)
         try:
-            locks.acquire_team(team.team_id, operation="scheduled backup prune")
+            locks.acquire_env(backups_key, operation="scheduled backup prune")
         except BusyError:
             ok = False
             continue
@@ -325,7 +335,7 @@ def _run_prune_job(
                 },
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(backups_key)
     if ok:
         prune_state["last_success_at"] = now.isoformat()
         prune_state["slot_attempts"] = 0

--- a/src/oduflow/chunkstore/backup.py
+++ b/src/oduflow/chunkstore/backup.py
@@ -270,7 +270,8 @@ def backup(
     """Create a new revision of *source_dir* under *snapshot_id*.
 
     Caller contract: backups and prunes against one storage are serialized
-    (Oduflow runs them under the team lock / a single scheduler thread).
+    (Oduflow runs them under the team's `prod-backups:` lock / a single
+    scheduler thread).
     """
     if not os.path.isdir(source_dir):
         raise FileNotFoundError(f"source_dir does not exist: {source_dir}")

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -46,6 +46,7 @@ from oduflow.errors import (
 )
 from oduflow.git_ops import RepoAuthError, git_env_for_team
 from oduflow.hostname_registry import allocate_hostname, release_hostname
+from oduflow.locking import env_wake_key, keyed_mutex
 from oduflow.naming import (
     get_agent_checkout_dir,
     get_agent_container_name,
@@ -2514,21 +2515,26 @@ def ensure_running(settings: Settings, env_name: str, team: TeamSettings) -> boo
     Returns True when a start was needed (the caller may want to tell the
     agent the environment was woken up), False when it was already running.
     """
-    client = get_client()
-    odoo_container_name = get_resource_name(
-        env_name, "odoo", settings.prefix, team.team_id
-    )
-    try:
-        container = client.containers.get(odoo_container_name)
-    except docker.errors.NotFound:
-        raise NotFoundError(
-            f"Environment '{env_name}' does not exist. Use create_environment first."
+    # Callers reach this without the environment lock (the lock-free odoo_* and
+    # http tools), so two of them can find the same stopped container at once.
+    # The wake key makes read-status-then-start atomic per environment: the
+    # second caller waits, then sees "running" and reports no wake-up.
+    with keyed_mutex(env_wake_key(team.team_id, env_name)):
+        client = get_client()
+        odoo_container_name = get_resource_name(
+            env_name, "odoo", settings.prefix, team.team_id
         )
-    _assert_team_owns(container, settings, team, env_name)
-    if container.status == "running":
-        return False
-    start_environment(settings, env_name, team)
-    return True
+        try:
+            container = client.containers.get(odoo_container_name)
+        except docker.errors.NotFound:
+            raise NotFoundError(
+                f"Environment '{env_name}' does not exist. Use create_environment first."
+            )
+        _assert_team_owns(container, settings, team, env_name)
+        if container.status == "running":
+            return False
+        start_environment(settings, env_name, team)
+        return True
 
 
 def _assert_team_owns(

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -16,6 +16,7 @@ from oduflow.errors import (
     NotFoundError,
     PrerequisiteNotMetError,
 )
+from oduflow.locking import keyed_mutex, service_registry_key
 from oduflow.naming import get_service_container_name
 from oduflow.settings import Settings, TeamSettings
 
@@ -253,6 +254,29 @@ def _needs_traefik_acme_mount(settings: Settings, container: Any) -> bool:
     return True
 
 
+def _assert_free_service_slot(
+    settings: Settings, team: TeamSettings, client: Any
+) -> None:
+    """Reject a new service when the team has no free slot (0 = unlimited)."""
+    if team.service_slots <= 0:
+        return
+    services = client.containers.list(
+        all=True,
+        filters={
+            "label": [
+                f"{settings.managed_label}=true",
+                f"{settings.team_label}={team.team_id}",
+                "oduflow.service",
+            ]
+        },
+    )
+    if len(services) >= team.service_slots:
+        raise FlowError(
+            f"No free service slots (configured: {team.service_slots}). "
+            "Delete an unused service to free a slot."
+        )
+
+
 def create_service(
     settings: Settings,
     team: TeamSettings,
@@ -282,22 +306,10 @@ def create_service(
     except docker.errors.NotFound:
         is_new_service = True
 
-    if is_new_service and team.service_slots > 0:
-        services = client.containers.list(
-            all=True,
-            filters={
-                "label": [
-                    f"{settings.managed_label}=true",
-                    f"{settings.team_label}={team.team_id}",
-                    "oduflow.service",
-                ]
-            },
-        )
-        if len(services) >= team.service_slots:
-            raise FlowError(
-                f"No free service slots (configured: {team.service_slots}). "
-                "Delete an unused service to free a slot."
-            )
+    if is_new_service:
+        # Fail before pulling a possibly huge image. Repeated under the registry
+        # lock further down, where it is the authoritative admission check.
+        _assert_free_service_slot(settings, team, client)
 
     # Services join the team's isolated network (not needed for host mode).
     team_network = ""
@@ -401,9 +413,9 @@ def create_service(
     if env_vars:
         run_kwargs["environment"] = env_vars
 
-    vol_binds = _resolve_service_volume_binds(settings, team, volumes, client=client)
-    if vol_binds:
-        run_kwargs["volumes"] = vol_binds
+    # Reject a missing or reserved volume before the image pull; the binds that
+    # are actually used are resolved again under the registry lock below.
+    _resolve_service_volume_binds(settings, team, volumes, client=client)
 
     if privileged:
         run_kwargs["privileged"] = True
@@ -413,7 +425,22 @@ def create_service(
     logger.info("Pulling image %s for service %s", image, name)
     _pull_service_image(client, image)
 
-    client.containers.run(**run_kwargs)
+    # Registry section: slot admission and the volume binds are both read here
+    # and consumed by the `run` below with nothing in between. Concurrent
+    # creates therefore cannot overshoot the slot count, and delete_volume —
+    # which takes the same key around its in-use check — cannot remove a volume
+    # this container is about to mount (Docker would silently re-create it as an
+    # empty, unmanaged volume). Held only around these calls; the image pull
+    # above and the preset write below stay outside.
+    with keyed_mutex(service_registry_key(team.team_id)):
+        if is_new_service:
+            _assert_free_service_slot(settings, team, client)
+        vol_binds = _resolve_service_volume_binds(
+            settings, team, volumes, client=client
+        )
+        if vol_binds:
+            run_kwargs["volumes"] = vol_binds
+        client.containers.run(**run_kwargs)
     logger.info("Created service container %s from image %s", container_name, image)
 
     # Auto-save preset for future restore
@@ -952,27 +979,35 @@ def update_service(
         config_changed,
     )
 
-    # Stop and remove the old container
-    container.stop()
-    container.remove(v=True)
-    logger.info("Removed old container %s for update", container_name)
+    # The service is invisible to the registry between remove and re-create, so
+    # both happen under the registry key: a delete_volume that looked in that
+    # window would find the volume unused and remove it out from under the
+    # recreated container. The mutex is re-entrant — create_service takes the
+    # same key for its own admission check. Its (already-pulled, cache-warm)
+    # image pull is inside this window; splitting the window to exclude it would
+    # reopen the very race it exists to close.
+    with keyed_mutex(service_registry_key(team.team_id)):
+        # Stop and remove the old container
+        container.stop()
+        container.remove(v=True)
+        logger.info("Removed old container %s for update", container_name)
 
-    # Re-create with the (possibly overridden) settings
-    result = create_service(
-        settings,
-        team,
-        name=name,
-        image=target_image,
-        port=port,
-        hostname=hostname,
-        env_vars=env_vars or None,
-        host_mode=is_host_mode,
-        volumes=old_volumes or None,
-        cap_add=cap_add,
-        privileged=privileged,
-        routes=routes,
-        stack_labels=effective_stack_labels,
-    )
+        # Re-create with the (possibly overridden) settings
+        result = create_service(
+            settings,
+            team,
+            name=name,
+            image=target_image,
+            port=port,
+            hostname=hostname,
+            env_vars=env_vars or None,
+            host_mode=is_host_mode,
+            volumes=old_volumes or None,
+            cap_add=cap_add,
+            privileged=privileged,
+            routes=routes,
+            stack_labels=effective_stack_labels,
+        )
 
     result["image_updated"] = image_updated
     result["config_updated"] = config_changed

--- a/src/oduflow/docker_ops/volume_ops.py
+++ b/src/oduflow/docker_ops/volume_ops.py
@@ -13,6 +13,7 @@ from typing import Any
 import docker
 from oduflow.docker_ops.client import get_client
 from oduflow.errors import ConflictError, NotFoundError
+from oduflow.locking import keyed_mutex, service_registry_key
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -155,16 +156,20 @@ def delete_volume(settings: Settings, team: TeamSettings, name: str) -> dict[str
     except docker.errors.NotFound:
         raise NotFoundError(f"Volume '{name}' not found.")
 
-    usage = _find_all_volume_usage(settings, team)
-    used_by = usage.get(docker_name, [])
-    if used_by:
-        svc_list = ", ".join(used_by)
-        raise ConflictError(
-            f"Volume '{name}' is in use by: {svc_list}. "
-            "Remove the volume from those services first."
-        )
+    # Same registry key service creation/update takes around attaching volumes,
+    # so "no service uses this" cannot go stale between the check and the
+    # removal — including while an update_service has its container removed.
+    with keyed_mutex(service_registry_key(team.team_id)):
+        usage = _find_all_volume_usage(settings, team)
+        used_by = usage.get(docker_name, [])
+        if used_by:
+            svc_list = ", ".join(used_by)
+            raise ConflictError(
+                f"Volume '{name}' is in use by: {svc_list}. "
+                "Remove the volume from those services first."
+            )
 
-    vol.remove()
+        vol.remove()
     logger.info("Deleted volume %s", docker_name)
     return {"name": name, "docker_name": docker_name}
 

--- a/src/oduflow/extra_addons.py
+++ b/src/oduflow/extra_addons.py
@@ -355,6 +355,12 @@ def _delete_extra_repo_unlocked(
             f"{', '.join(dependent)}"
         )
 
+    # Containers are the dependency record, so there is a window this guard
+    # cannot see: create_environment materialises shared checkouts *before* its
+    # container exists. A delete landing exactly there is accepted — the
+    # in-flight create fails with a clear "not found" instead of every unrelated
+    # repo operation being serialised behind a team lock for minutes.
+
     # Cached SHA checkouts intentionally outlive environments. They disappear
     # only with the owning extra repo, after the dependency guard above proves
     # that no running/stopped managed container still mounts them.

--- a/src/oduflow/locking.py
+++ b/src/oduflow/locking.py
@@ -1,16 +1,103 @@
 """Granular lock manager for concurrent MCP tool execution.
 
-Provides per-environment, per-team, and system-level locks so that operations on
-different environments / teams can run in parallel while operations on the same
-resource are serialised.
+Provides per-resource, per-team, and system-level locks so that operations on
+different environments / services / volumes / teams can run in parallel while
+operations on the same resource are serialised.
+
+``acquire_env`` is a generic keyed lock: the key is an environment name for
+environment tools, and a namespaced resource key (``svc:``, ``vol:``, ``prod:``,
+…) for everything else. Only keys acquired *with* a ``team_id`` take part in the
+team↔environment mutual exclusion, so narrow resource keys never block — and are
+never blocked by — a team-wide operation.
 """
 
 from __future__ import annotations
 
 import threading
 import time
+from contextlib import contextmanager
+from typing import Iterator
 
 from oduflow.errors import BusyError
+
+# Keys in the production keyspace. The system lock (cluster-wide PITR) and every
+# `prod:` key are mutually exclusive; see acquire_system.
+PROD_KEY_PREFIX = "prod:"
+
+
+def _is_prod_key(key: str) -> bool:
+    return key.startswith(PROD_KEY_PREFIX)
+
+
+# -- resource lock keys -------------------------------------------------------
+#
+# One place builds every key string, because MCP tools (server.py) and the REST
+# dashboard (web_ui.py) must lock the *same* resource under the *same* key or
+# they simply do not see each other. Team-scoped builders take an unused `name`
+# so every builder shares one signature and can be handed to `with_key_lock`.
+
+
+def service_lock_key(team_id: str, name: str) -> str:
+    """One auxiliary service — create/update/delete/restart/exec/restore."""
+    return f"svc:{team_id}:{name}"
+
+
+def service_registry_key(team_id: str, name: str = "") -> str:
+    """The team's *set* of services: slot admission and volume-usage checks."""
+    return f"svc-registry:{team_id}"
+
+
+def volume_lock_key(team_id: str, name: str) -> str:
+    """One managed Docker volume, including writes to files inside it."""
+    return f"vol:{team_id}:{name}"
+
+
+def service_preset_lock_key(team_id: str, name: str = "") -> str:
+    """The team's saved service presets."""
+    return f"preset:{team_id}"
+
+
+def credentials_lock_key(team_id: str, name: str = "") -> str:
+    """The team's git credential store."""
+    return f"creds:{team_id}"
+
+
+def prod_backups_lock_key(team_id: str, name: str = "") -> str:
+    """The team's snapshot/chunk store — prune vs. snapshot vs. restore."""
+    return f"prod-backups:{team_id}"
+
+
+def env_wake_key(team_id: str, env_name: str) -> str:
+    """Auto-start of one environment (see :func:`keyed_mutex`)."""
+    return f"wake:{team_id}:{env_name}"
+
+
+_keyed_mutexes: dict[str, threading.RLock] = {}
+_keyed_mutexes_guard = threading.Lock()
+
+
+@contextmanager
+def keyed_mutex(key: str) -> Iterator[None]:
+    """Blocking, re-entrant, process-wide mutex for a short critical section.
+
+    Unlike :class:`LockManager` keys — non-blocking, contention surfaced to the
+    agent as ``BusyError`` — these guard read-then-write sections deep inside
+    ``docker_ops`` that last milliseconds, where the caller has nothing better
+    to do than wait, and which must hold across a call the tool layer cannot
+    see (``update_service`` removing and re-creating a container).
+
+    Lock ordering: always taken *after* the caller's ``LockManager`` key, never
+    before, so the two orders cannot deadlock. Nothing under this mutex takes a
+    ``LockManager`` lock. Re-entrant because ``update_service`` holds one across
+    its delegation to ``create_service``.
+    """
+    with _keyed_mutexes_guard:
+        lock = _keyed_mutexes.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _keyed_mutexes[key] = lock
+    with lock:
+        yield
 
 
 def _format_age(seconds: float) -> str:
@@ -54,8 +141,10 @@ class LockManager:
         # read a bare "in progress" as a stale lock and reach for restarts).
         self._env_holders: dict[str, _Holder] = {}
         self._team_holders: dict[str, _Holder] = {}
+        # Keys currently held in the production keyspace, for the system lock's
+        # mutual exclusion (and its holder hints).
+        self._active_prod_keys: set[str] = set()
         self._system_holder: _Holder | None = None
-        self._system_lock = threading.Lock()
         self._map_lock = threading.Lock()  # protects dict access
 
     # -- environment locks --
@@ -74,6 +163,10 @@ class LockManager:
         holder = self._team_holders.get(team_id)
         return holder.describe() if holder else ""
 
+    def _system_holder_hint(self) -> str:
+        holder = self._system_holder
+        return holder.describe() if holder else ""
+
     def acquire_env(
         self, env_name: str, team_id: str | None = None, operation: str = ""
     ) -> None:
@@ -83,6 +176,11 @@ class LockManager:
                     f"Another team-level operation (team '{team_id}')"
                     f"{self._team_holder_hint(team_id)} is in progress. "
                     "Try again later."
+                )
+            if _is_prod_key(env_name) and self._system_holder is not None:
+                raise BusyError(
+                    f"A system-level operation{self._system_holder_hint()} is in "
+                    "progress. Try again later."
                 )
             if env_name not in self._env_locks:
                 self._env_locks[env_name] = threading.Lock()
@@ -95,6 +193,8 @@ class LockManager:
                     "rather than restarting the environment."
                 )
             self._env_holders[env_name] = _Holder(operation)
+            if _is_prod_key(env_name):
+                self._active_prod_keys.add(env_name)
             if team_id is not None:
                 self._env_lock_teams[env_name] = team_id
                 self._active_env_counts_by_team[team_id] = (
@@ -109,10 +209,19 @@ class LockManager:
         Returns False when the timeout expires (caller skips the run)."""
         lock = self._get_env_lock(env_name)
         acquired = lock.acquire(blocking=True, timeout=timeout)
-        if acquired:
-            with self._map_lock:
-                self._env_holders[env_name] = _Holder(operation)
-        return acquired
+        if not acquired:
+            return False
+        with self._map_lock:
+            if _is_prod_key(env_name) and self._system_holder is not None:
+                # A cluster-wide operation owns the production keyspace. Waiting
+                # it out is pointless here, so the caller skips this run exactly
+                # as it would on a timeout.
+                lock.release()
+                return False
+            self._env_holders[env_name] = _Holder(operation)
+            if _is_prod_key(env_name):
+                self._active_prod_keys.add(env_name)
+        return True
 
     def describe_env_holder(self, env_name: str) -> str:
         """Holder hint for callers that report contention without raising."""
@@ -129,6 +238,7 @@ class LockManager:
             except RuntimeError:
                 return
             self._env_holders.pop(env_name, None)
+            self._active_prod_keys.discard(env_name)
             team_id = self._env_lock_teams.pop(env_name, None)
             if team_id is not None:
                 count = self._active_env_counts_by_team.get(team_id, 0) - 1
@@ -187,17 +297,29 @@ class LockManager:
     # -- system lock --
 
     def acquire_system(self, operation: str = "") -> None:
-        if not self._system_lock.acquire(blocking=False):
-            holder = self._system_holder
-            hint = holder.describe() if holder else ""
-            raise BusyError(
-                f"A system-level operation{hint} is in progress. Try again later."
-            )
-        self._system_holder = _Holder(operation)
+        """Take the single system-wide lock (cluster PITR).
+
+        Mutually exclusive with the whole production keyspace in both
+        directions: no `prod:` key may be held when this is taken, and none may
+        be taken while it is held. Environment and team locks are unaffected —
+        a cluster restore does not touch development environments.
+        """
+        with self._map_lock:
+            if self._system_holder is not None:
+                raise BusyError(
+                    f"A system-level operation{self._system_holder_hint()} is in "
+                    "progress. Try again later."
+                )
+            if self._active_prod_keys:
+                busy = ", ".join(
+                    f"'{key}'{self._env_holder_hint(key)}"
+                    for key in sorted(self._active_prod_keys)
+                )
+                raise BusyError(
+                    f"A production operation is in progress: {busy}. Try again later."
+                )
+            self._system_holder = _Holder(operation)
 
     def release_system(self) -> None:
-        self._system_holder = None
-        try:
-            self._system_lock.release()
-        except RuntimeError:
-            pass
+        with self._map_lock:
+            self._system_holder = None

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -49,7 +49,15 @@ from oduflow.docker_ops import (
     volume_ops,
 )
 from oduflow.errors import FlowError, NotFoundError, PrerequisiteNotMetError
-from oduflow.locking import LockManager
+from oduflow.locking import (
+    PROD_KEY_PREFIX,
+    LockManager,
+    credentials_lock_key,
+    prod_backups_lock_key,
+    service_lock_key,
+    service_preset_lock_key,
+    volume_lock_key,
+)
 from oduflow.output_cache import CachedOutput, OutputCache
 from oduflow.po_tools import PoEntry
 from oduflow.settings import Settings, TeamSettings, find_toml
@@ -313,6 +321,21 @@ def _wake_for_work(
     return ""
 
 
+def _wake_for_rpc(settings: Settings, team: TeamSettings, env_name: str) -> str:
+    """Wake helper for the lock-free ``odoo_*`` tools.
+
+    They take no environment lock (XML-RPC against a live Odoo is
+    transactional), so they record activity themselves — otherwise an
+    environment driven purely through these tools would look idle to the reaper
+    and be auto-stopped mid-session.
+    """
+    try:
+        activity.touch(team, env_name)
+    except Exception:
+        pass  # activity tracking is best-effort
+    return _wake_for_work(settings, team, env_name)
+
+
 def with_team_lock(fn: Callable[P, R]) -> Callable[P, R]:
     """Acquire a per-team lock before executing the tool function."""
 
@@ -329,10 +352,48 @@ def with_team_lock(fn: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
+def with_key_lock(
+    key_fn: Callable[[str, str], str], require_name: bool = True
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Serialise a tool on a narrow resource key instead of the whole team.
+
+    ``key_fn(team_id, name)`` builds the key from the caller's team and the
+    tool's first argument (``name``); pass ``require_name=False`` for tools
+    whose key is team-scoped only — their first positional argument is not a
+    resource name and is ignored.
+
+    These keys are deliberately acquired *without* a ``team_id``, so they stay
+    outside the team↔environment mutual exclusion: deleting a service must not
+    wait for a ten-minute ``create_environment``, and vice versa.
+    """
+
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+        @functools.wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            name = ""
+            if require_name:
+                raw_name = kwargs.get("name") or (args[0] if args else None)
+                if not raw_name:
+                    raise ToolError("name is required")
+                name = cast(str, raw_name)
+            ctx = cast("Context | None", kwargs.get("ctx"))
+            team = _resolve_team(ctx)
+            key = key_fn(team.team_id, name)
+            _locks.acquire_env(key, operation=fn.__name__)
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _locks.release_env(key)
+
+        return wrapper
+
+    return decorator
+
+
 def prod_lock_key(team_id: str, name: str) -> str:
     """Lock key for a production — team-scoped so two teams' same-named
     productions never contend (unlike raw env keys)."""
-    return f"prod:{team_id}:{name}"
+    return f"{PROD_KEY_PREFIX}{team_id}:{name}"
 
 
 _PRODUCTION_DISABLED_MESSAGE = (
@@ -381,7 +442,7 @@ def with_prod_lock(fn: Callable[P, R]) -> Callable[P, R]:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(credentials_lock_key, require_name=False)
 def setup_repo_auth(repo_url: str, ctx: Context | None = None) -> str:
     """
     Cache git credentials for a private repository.
@@ -406,12 +467,15 @@ def setup_repo_auth(repo_url: str, ctx: Context | None = None) -> str:
 
 # =============================================================================
 # MCP Tools — Extra addons repos
+#
+# No tool lock here: extra_addons.py already serialises every mutator on a
+# per-repo RLock, and delete refuses while any managed container references the
+# repo. A team lock only added false contention with unrelated work.
 # =============================================================================
 
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
 def add_extra_repo(name: str, repo_url: str, ctx: Context | None = None) -> str:
     """
     Clone an extra addons repository for use with environments.
@@ -453,7 +517,6 @@ def list_extra_repos(ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
 def delete_extra_repo(name: str, ctx: Context | None = None) -> str:
     """
     Delete a cloned extra addons repository.
@@ -471,7 +534,6 @@ def delete_extra_repo(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
 def update_extra_repo(name: str, ctx: Context | None = None) -> str:
     """
     Pull latest changes from the remote for an extra addons repository.
@@ -820,7 +882,6 @@ def save_as_template(
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
 def list_templates(ctx: Context | None = None) -> str:
     """List available template profiles (database + filestore snapshots)."""
     settings = _get_settings()
@@ -2682,6 +2743,12 @@ def run_db_query(
 #   - Odoo-side failures (AccessError, ValidationError, ...) are returned as
 #     text with the server traceback — they are answers, not tool failures.
 #   - Every call is its own committed transaction.
+#
+# These tools take NO environment lock: PostgreSQL, not Oduflow, arbitrates
+# concurrent ORM writes, and the neighbouring http_request_to_odoo /
+# search_in_odoo already reach the same live server lock-free. Holding the
+# environment lock here only made an agent's reads bounce off its own long
+# install/test run.
 
 
 def _rpc_user(as_user: str) -> str:
@@ -2745,7 +2812,6 @@ def _rpc_response(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
 def odoo_search_read(
     env_name: str,
     model: str,
@@ -2802,7 +2868,7 @@ def odoo_search_read(
     user = _rpc_user(as_user)
     parsed_domain = odoo_rpc.parse_domain(domain)
     parsed_context = odoo_rpc.parse_context(context)
-    woke = _wake_for_work(settings, team, env_name)
+    woke = _wake_for_rpc(settings, team, env_name)
 
     if count_only:
         args: list[Any] = [parsed_domain]
@@ -2848,7 +2914,6 @@ def odoo_search_read(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
 def odoo_create(
     env_name: str,
     model: str,
@@ -2881,7 +2946,7 @@ def odoo_create(
     user = _rpc_user(as_user)
     parsed_values = odoo_rpc.parse_values(values, allow_list=True)
     parsed_context = odoo_rpc.parse_context(context)
-    woke = _wake_for_work(settings, team, env_name)
+    woke = _wake_for_rpc(settings, team, env_name)
 
     kwargs: dict[str, Any] = {}
     if parsed_context is not None:
@@ -2903,7 +2968,6 @@ def odoo_create(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
 def odoo_write(
     env_name: str,
     model: str,
@@ -2935,7 +2999,7 @@ def odoo_write(
     parsed_ids = odoo_rpc.parse_ids(ids)
     parsed_values = odoo_rpc.parse_values(values)
     parsed_context = odoo_rpc.parse_context(context)
-    woke = _wake_for_work(settings, team, env_name)
+    woke = _wake_for_rpc(settings, team, env_name)
 
     kwargs: dict[str, Any] = {}
     if parsed_context is not None:
@@ -2963,7 +3027,6 @@ def odoo_write(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
 def odoo_unlink(
     env_name: str,
     model: str,
@@ -2993,7 +3056,7 @@ def odoo_unlink(
     user = _rpc_user(as_user)
     parsed_ids = odoo_rpc.parse_ids(ids)
     parsed_context = odoo_rpc.parse_context(context)
-    woke = _wake_for_work(settings, team, env_name)
+    woke = _wake_for_rpc(settings, team, env_name)
 
     kwargs: dict[str, Any] = {}
     if parsed_context is not None:
@@ -3014,7 +3077,6 @@ def odoo_unlink(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
 def odoo_call(
     env_name: str,
     model: str,
@@ -3075,7 +3137,7 @@ def odoo_call(
     parsed_context = odoo_rpc.parse_context(context)
     if parsed_context is not None:
         parsed_kwargs["context"] = parsed_context
-    woke = _wake_for_work(settings, team, env_name)
+    woke = _wake_for_rpc(settings, team, env_name)
 
     result = odoo_rpc.call_kw(
         settings,
@@ -3103,7 +3165,6 @@ def odoo_call(
 
 @mcp.tool()
 @handle_errors
-@with_env_lock
 def odoo_schema(
     env_name: str,
     model: str = "",
@@ -3141,7 +3202,7 @@ def odoo_schema(
     settings = _get_settings()
     team = _resolve_team(ctx)
     user = _rpc_user(as_user)
-    woke = _wake_for_work(settings, team, env_name)
+    woke = _wake_for_rpc(settings, team, env_name)
 
     if not model:
         domain: list[Any] = []
@@ -3232,7 +3293,7 @@ def _service_internal_host_line(container_name: str, host_mode: bool) -> str:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(service_lock_key)
 def create_service(
     name: str,
     image: str,
@@ -3308,7 +3369,7 @@ def create_service(
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(service_lock_key)
 def update_service(
     name: str,
     env_vars: str = "",
@@ -3395,7 +3456,7 @@ def update_service(
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(service_lock_key)
 def delete_service(name: str, ctx: Context | None = None) -> str:
     """
     Stop and remove a managed auxiliary service container.
@@ -3409,6 +3470,7 @@ def delete_service(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
+@with_key_lock(service_lock_key)
 def restart_service(name: str, ctx: Context | None = None) -> str:
     """
     Restart a managed auxiliary service container.
@@ -3546,7 +3608,7 @@ def list_service_presets(ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(service_lock_key)
 def restore_service(name: str, ctx: Context | None = None) -> str:
     """
     Restore a service from a saved preset. Recreates the service container with the same configuration.
@@ -3601,7 +3663,7 @@ def restore_service(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(service_preset_lock_key)
 def delete_service_preset(name: str, ctx: Context | None = None) -> str:
     """
     Remove a saved service preset.
@@ -3658,6 +3720,7 @@ def get_service_logs(name: str, n_lines: int = 100, ctx: Context | None = None) 
 
 @mcp.tool()
 @handle_errors
+@with_key_lock(service_lock_key)
 def run_service_command(
     name: str,
     command: str,
@@ -3699,7 +3762,7 @@ def run_service_command(
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(volume_lock_key)
 def create_volume(
     name: str,
     description: str = "",
@@ -3772,7 +3835,7 @@ def inspect_volume(name: str, ctx: Context | None = None) -> str:
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(volume_lock_key)
 def delete_volume(name: str, ctx: Context | None = None) -> str:
     """
     Delete a managed Docker volume. Fails if the volume is in use by any service.
@@ -3824,7 +3887,7 @@ def read_file_in_volume(
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(volume_lock_key)
 def write_file_in_volume(
     name: str,
     path: str,
@@ -3888,7 +3951,7 @@ def search_in_volume(
 
 @mcp.tool()
 @handle_errors
-@with_team_lock
+@with_key_lock(volume_lock_key)
 def delete_file_in_volume(
     name: str,
     path: str,
@@ -4239,6 +4302,9 @@ def production_deploys(name: str, limit: int = 20, ctx: Context | None = None) -
 @handle_errors
 @production_enabled
 @with_prod_lock
+# Lock order everywhere: the production first, then the team's backup store.
+# Prune takes the store key alone, so it can never run mid-snapshot.
+@with_key_lock(prod_backups_lock_key, require_name=False)
 def snapshot_production(name: str, note: str = "", ctx: Context | None = None) -> str:
     """
     Take a snapshot of a production to S3: database dump + deduplicated
@@ -4302,6 +4368,8 @@ def list_production_snapshots(
 @handle_errors
 @production_enabled
 @with_prod_lock
+# Same lock order as snapshot_production: production first, then backup store.
+@with_key_lock(prod_backups_lock_key, require_name=False)
 def restore_production(
     name: str, snapshot_id: str, confirm: str = "", ctx: Context | None = None
 ) -> str:
@@ -4381,6 +4449,7 @@ def set_production_backup_schedule(
 @mcp.tool()
 @handle_errors
 @production_enabled
+@with_key_lock(prod_backups_lock_key, require_name=False)
 def prune_production_backups(ctx: Context | None = None) -> str:
     """
     Apply the retention policy ([backup] keep) to the team's snapshots and
@@ -4392,11 +4461,7 @@ def prune_production_backups(ctx: Context | None = None) -> str:
 
     settings = _get_settings()
     team = _resolve_team(ctx)
-    _locks.acquire_team(team.team_id, operation="prune_backups")
-    try:
-        result = backup_ops.prune_backups(settings, team)
-    finally:
-        _locks.release_team(team.team_id)
+    result = backup_ops.prune_backups(settings, team)
     import json as _json
 
     return _json.dumps(result, indent=2)
@@ -4433,7 +4498,11 @@ def restore_cluster_pitr(
 
     settings = _get_settings()
     _resolve_team(ctx)  # authenticate the caller; PITR spans all teams
-    _locks.acquire_env("prod:__cluster__", operation="restore_cluster_pitr")
+    # The one true system-level operation: it rewrites the cluster every team's
+    # productions live in, so it excludes the whole `prod:` keyspace at once
+    # (per-production locks would each have to be enumerated and could still be
+    # taken behind our back).
+    _locks.acquire_system(operation="restore_cluster_pitr")
     try:
         from oduflow.docker_ops.client import get_client
 
@@ -4458,7 +4527,7 @@ def restore_cluster_pitr(
             except Exception as exc:
                 logger.warning("Could not restart production %s: %s", entry, exc)
     finally:
-        _locks.release_env("prod:__cluster__")
+        _locks.release_system()
     return (
         f"Cluster restored to {result['target_time']}. Previous data "
         f"directory kept inside the volume as {result['displaced_data_dir']} "

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -68,6 +68,7 @@ from oduflow.licensing import get_license_info, install_license_from_text
 from oduflow.locking import (
     LockManager,
     credentials_lock_key,
+    prod_backups_lock_key,
     service_lock_key,
     service_preset_lock_key,
     volume_lock_key,
@@ -4328,8 +4329,15 @@ def _build_routes(
     def _production_action(
         request: Request,
         action: Callable[[Settings, TeamSettings, str], dict[str, Any]],
+        *,
+        with_backup_store: bool = False,
     ) -> JSONResponse:
-        """Shared lock/error wrapper for simple per-production POST actions."""
+        """Shared lock/error wrapper for simple per-production POST actions.
+
+        with_backup_store additionally takes the team's backup-store lock in
+        the same order as the MCP tools (production first, then the store), so
+        a prune cannot run mid-snapshot/restore.
+        """
         settings = get_settings()
         team = _get_ui_team(request)
         name = request.path_params["name"]
@@ -4337,6 +4345,12 @@ def _build_routes(
             locks.acquire_env(_prod_lock_key(team, name))
         except FlowError as e:
             return _error_response(e)
+        if with_backup_store:
+            try:
+                locks.acquire_env(prod_backups_lock_key(team.team_id))
+            except FlowError as e:
+                locks.release_env(_prod_lock_key(team, name))
+                return _error_response(e)
         try:
             result = action(settings, team, name)
             return JSONResponse({"ok": True, **result})
@@ -4350,6 +4364,8 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
+            if with_backup_store:
+                locks.release_env(prod_backups_lock_key(team.team_id))
             locks.release_env(_prod_lock_key(team, name))
 
     def api_production_start(request: Request) -> JSONResponse:
@@ -4544,7 +4560,7 @@ def _build_routes(
         ) -> dict[str, Any]:
             return backup_ops.snapshot_production(settings, team, name, trigger="ui")
 
-        return _production_action(request, _snapshot)
+        return _production_action(request, _snapshot, with_backup_store=True)
 
     async def api_production_restore(request: Request) -> JSONResponse:
         from oduflow import backup_ops
@@ -4573,6 +4589,13 @@ def _build_routes(
             locks.acquire_env(_prod_lock_key(team, name))
         except FlowError as e:
             return _error_response(e)
+        # Same order as the MCP tool: the production first, then the team's
+        # backup store, so a prune cannot delete artifacts mid-restore.
+        try:
+            locks.acquire_env(prod_backups_lock_key(team.team_id))
+        except FlowError as e:
+            locks.release_env(_prod_lock_key(team, name))
+            return _error_response(e)
         try:
             result = await _offload(
                 backup_ops.restore_production, settings, team, name, snapshot_id
@@ -4586,6 +4609,7 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
+            locks.release_env(prod_backups_lock_key(team.team_id))
             locks.release_env(_prod_lock_key(team, name))
 
     async def api_production_backup_schedule(request: Request) -> JSONResponse:

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -65,7 +65,13 @@ from oduflow.docker_ops.stats import (
 )
 from oduflow.errors import BusyError, ConflictError, FlowError, NotFoundError
 from oduflow.licensing import get_license_info, install_license_from_text
-from oduflow.locking import LockManager
+from oduflow.locking import (
+    LockManager,
+    credentials_lock_key,
+    service_lock_key,
+    service_preset_lock_key,
+    volume_lock_key,
+)
 from oduflow.naming import validate_template_name
 from oduflow.settings import Settings, TeamSettings
 
@@ -1387,11 +1393,9 @@ def _build_routes(
             )
 
     def api_templates(request: Request) -> JSONResponse:
+        # Read-only: no lock, so listing templates never bounces off (or delays)
+        # a publish. Mirrors the list_templates MCP tool.
         team = _get_ui_team(request)
-        try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
         try:
             templates = system_ops.list_templates(get_settings(), team)
             return JSONResponse({"ok": True, "templates": templates})
@@ -1402,8 +1406,6 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
-        finally:
-            locks.release_team(team.team_id)
 
     def api_template_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -2177,10 +2179,9 @@ def _build_routes(
 
     async def api_service_create(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
-        try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
+        # The body carries the service name, and the lock key is per service —
+        # so it is read before the lock is taken (the MCP tool gets the name as
+        # an argument and locks in its decorator).
         try:
             body = await request.json()
             name = (body.get("name") or "").strip()
@@ -2214,6 +2215,21 @@ def _build_routes(
             privileged = bool(body.get("privileged", False))
             net_admin = bool(body.get("net_admin", False))
             cap_add = ["NET_ADMIN"] if net_admin else None
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in api_service_create")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+        key = service_lock_key(team.team_id, name)
+        try:
+            locks.acquire_env(key, operation="create_service")
+        except BusyError as e:
+            return _error_response(e)
+        try:
             result = await _offload(
                 service_ops.create_service,
                 get_settings(),
@@ -2240,13 +2256,14 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(key)
 
     async def api_service_update(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         team = _get_ui_team(request)
+        key = service_lock_key(team.team_id, name)
         try:
-            locks.acquire_team(team.team_id)
+            locks.acquire_env(key, operation="update_service")
         except BusyError as e:
             return _error_response(e)
         try:
@@ -2319,14 +2336,18 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(key)
 
     def api_service_restart(request: Request) -> JSONResponse:
         name = request.path_params["name"]
+        team = _get_ui_team(request)
+        key = service_lock_key(team.team_id, name)
         try:
-            result = service_ops.restart_service(
-                get_settings(), _get_ui_team(request), name
-            )
+            locks.acquire_env(key, operation="restart_service")
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            result = service_ops.restart_service(get_settings(), team, name)
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -2335,18 +2356,19 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
+        finally:
+            locks.release_env(key)
 
     def api_service_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         team = _get_ui_team(request)
+        key = service_lock_key(team.team_id, name)
         try:
-            locks.acquire_team(team.team_id)
+            locks.acquire_env(key, operation="delete_service")
         except BusyError as e:
             return _error_response(e)
         try:
-            result = service_ops.delete_service(
-                get_settings(), _get_ui_team(request), name
-            )
+            result = service_ops.delete_service(get_settings(), team, name)
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
@@ -2356,7 +2378,7 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(key)
 
     def api_service_logs(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -2391,10 +2413,7 @@ def _build_routes(
 
     async def api_service_restore(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
-        try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
+        # Body first, then the per-service lock — see api_service_create.
         try:
             body = await request.json()
             name = (body.get("name") or "").strip()
@@ -2428,6 +2447,21 @@ def _build_routes(
             privileged = bool(body.get("privileged", False))
             net_admin = bool(body.get("net_admin", False))
             cap_add = ["NET_ADMIN"] if net_admin else None
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in api_service_restore")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+        key = service_lock_key(team.team_id, name)
+        try:
+            locks.acquire_env(key, operation="restore_service")
+        except BusyError as e:
+            return _error_response(e)
+        try:
             result = await _offload(
                 service_ops.create_service,
                 get_settings(),
@@ -2454,12 +2488,18 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(key)
 
     def api_service_preset_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
+        team = _get_ui_team(request)
+        key = service_preset_lock_key(team.team_id)
         try:
-            service_presets.delete_preset(_get_ui_team(request), name)
+            locks.acquire_env(key, operation="delete_service_preset")
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            service_presets.delete_preset(team, name)
             return JSONResponse({"ok": True, "result": {"deleted": name}})
         except FlowError as e:
             return _error_response(e)
@@ -2468,6 +2508,8 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
+        finally:
+            locks.release_env(key)
 
     def api_volumes(request: Request) -> JSONResponse:
         try:
@@ -2483,10 +2525,7 @@ def _build_routes(
 
     async def api_volume_create(request: Request) -> JSONResponse:
         team = _get_ui_team(request)
-        try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
+        # Body first, then the per-volume lock — see api_service_create.
         try:
             body = await request.json()
             name = (body.get("name") or "").strip()
@@ -2496,6 +2535,16 @@ def _build_routes(
                     {"ok": False, "error": "Volume name is required."},
                     status_code=400,
                 )
+        except Exception:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body."}, status_code=400
+            )
+        key = volume_lock_key(team.team_id, name)
+        try:
+            locks.acquire_env(key, operation="create_volume")
+        except BusyError as e:
+            return _error_response(e)
+        try:
             result = await _offload(
                 volume_ops.create_volume,
                 get_settings(),
@@ -2512,13 +2561,14 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(key)
 
     def api_volume_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         team = _get_ui_team(request)
+        key = volume_lock_key(team.team_id, name)
         try:
-            locks.acquire_team(team.team_id)
+            locks.acquire_env(key, operation="delete_volume")
         except BusyError as e:
             return _error_response(e)
         try:
@@ -2532,7 +2582,7 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
-            locks.release_team(team.team_id)
+            locks.release_env(key)
 
     def api_agent_guides_list(request: Request) -> JSONResponse:
         try:
@@ -2889,11 +2939,9 @@ def _build_routes(
             )
 
     async def api_extra_repo_add(request: Request) -> JSONResponse:
+        # No lock: extra_addons serialises every mutator per repo (see the MCP
+        # extra-repo tools).
         team = _get_ui_team(request)
-        try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
         try:
             body = await request.json()
             name = (body.get("name") or "").strip()
@@ -2917,16 +2965,10 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
-        finally:
-            locks.release_team(team.team_id)
 
     async def api_extra_repo_pull(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         team = _get_ui_team(request)
-        try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
         try:
             from oduflow.extra_addons import fetch_extra_repo
 
@@ -2939,8 +2981,6 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
-        finally:
-            locks.release_team(team.team_id)
 
     def api_extra_repo_protect(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -2978,10 +3018,6 @@ def _build_routes(
         name = request.path_params["name"]
         team = _get_ui_team(request)
         try:
-            locks.acquire_team(team.team_id)
-        except BusyError as e:
-            return _error_response(e)
-        try:
             from oduflow.extra_addons import delete_extra_repo
 
             delete_extra_repo(get_settings(), team, name)
@@ -2993,8 +3029,6 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
-        finally:
-            locks.release_team(team.team_id)
 
     def api_credentials(request: Request) -> JSONResponse:
         from oduflow.git_ops import list_credentials
@@ -3010,6 +3044,7 @@ def _build_routes(
             )
 
     async def api_credential_add(request: Request) -> JSONResponse:
+        team = _get_ui_team(request)
         try:
             body = await request.json()
             repo_url = (body.get("repo_url") or "").strip()
@@ -3018,9 +3053,20 @@ def _build_routes(
                     {"ok": False, "error": "repo_url is required."},
                     status_code=400,
                 )
-            from oduflow import git_ops
+        except Exception:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body."}, status_code=400
+            )
+        from oduflow import git_ops
 
-            team = _get_ui_team(request)
+        # Same key as the setup_repo_auth MCP tool: one writer at a time on the
+        # team's credential store.
+        key = credentials_lock_key(team.team_id)
+        try:
+            locks.acquire_env(key, operation="setup_repo_auth")
+        except BusyError as e:
+            return _error_response(e)
+        try:
             result = await _offload(
                 git_ops.setup_repo_auth, repo_url, cred_file=team.git_credentials_file()
             )
@@ -3032,8 +3078,12 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
+        finally:
+            locks.release_env(key)
 
     async def api_credential_delete(request: Request) -> JSONResponse:
+        team = _get_ui_team(request)
+        key = credentials_lock_key(team.team_id)
         try:
             body = await request.json()
             host = (body.get("host") or "").strip()
@@ -3045,10 +3095,17 @@ def _build_routes(
                 )
             from oduflow.git_ops import delete_credential
 
-            team = _get_ui_team(request)
-            removed = delete_credential(
-                host, username, cred_file=team.git_credentials_file()
-            )
+            # Rewrites the same store setup_repo_auth appends to.
+            try:
+                locks.acquire_env(key, operation="delete_credential")
+            except BusyError as e:
+                return _error_response(e)
+            try:
+                removed = delete_credential(
+                    host, username, cred_file=team.git_credentials_file()
+                )
+            finally:
+                locks.release_env(key)
             if not removed:
                 return JSONResponse(
                     {

--- a/tests/fixtures.yaml
+++ b/tests/fixtures.yaml
@@ -100,8 +100,11 @@ scenarios:
     expect_contains:
       - "started"
 
-  # Reuse the same environment for another branch, then put it back, so the
-  # shared fixture environment is left on the branch it was created from.
+  # Each scenario gets a freshly created environment on 'main'
+  # (live_environment is function-scoped), so a switch cannot be staged by a
+  # previous scenario. Cover the two entry states from one starting point: a
+  # real switch to another branch, and the idempotent call for the branch the
+  # environment is already on (documented to pull instead of failing).
   switch_branch_away:
     tool: switch_branch
     needs_env: true
@@ -111,14 +114,14 @@ scenarios:
     expect_contains:
       - "Switched '19.0' from 'main' to '18.0'"
 
-  switch_branch_back:
+  switch_branch_same:
     tool: switch_branch
     needs_env: true
     args:
       env_name: "19.0"
       branch: "main"
     expect_contains:
-      - "Switched '19.0' from '18.0' to 'main'"
+      - "already on branch 'main'; pulled it instead"
 
   # ── Odoo operations ──────────────────────────────────────────────
   logs_main:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 
@@ -334,6 +335,52 @@ def test_ensure_running_starts_stopped_env(monkeypatch, tmp_path):
     state["status"] = "running"
     assert env_ops.ensure_running(settings, "env-x", settings.teams["1"]) is False
     assert started == ["env-x"]
+
+
+def test_ensure_running_wakes_a_stopped_env_once(monkeypatch, tmp_path):
+    """The odoo_* tools wake environments without holding the env lock, so two
+    calls can meet here — the wake must still start the container only once."""
+    from oduflow.docker_ops import env_ops
+
+    state = {"status": "exited"}
+
+    class FakeContainer:
+        labels = {"oduflow.team": "1"}
+
+        @property
+        def status(self):
+            return state["status"]
+
+    class FakeContainers:
+        def get(self, name):
+            return FakeContainer()
+
+    class FakeClient:
+        containers = FakeContainers()
+
+    started: list[str] = []
+
+    def fake_start(s, n, t=None):
+        time.sleep(0.05)  # widen the check-then-start window
+        started.append(n)
+        state["status"] = "running"
+
+    monkeypatch.setattr(env_ops, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(env_ops, "start_environment", fake_start)
+
+    settings = _settings(tmp_path)
+    team = settings.teams["1"]
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = [
+            f.result()
+            for f in [
+                pool.submit(env_ops.ensure_running, settings, "env-race", team)
+                for _ in range(2)
+            ]
+        ]
+
+    assert started == ["env-race"]
+    assert sorted(results) == [False, True]
 
 
 # --- _wake_for_work (tool-level wake-up) -----------------------------------

--- a/tests/test_locking.py
+++ b/tests/test_locking.py
@@ -12,7 +12,15 @@ import threading
 import pytest
 
 from oduflow.errors import BusyError
-from oduflow.locking import LockManager, _format_age
+from oduflow.locking import (
+    LockManager,
+    _format_age,
+    keyed_mutex,
+    prod_backups_lock_key,
+    service_lock_key,
+    volume_lock_key,
+)
+from oduflow.server import prod_lock_key
 
 
 class TestFormatAge:
@@ -234,3 +242,181 @@ class TestSystemLock:
         LockManager().acquire_system()
 
         LockManager().acquire_system()  # must not raise
+
+
+class TestResourceKeys:
+    """Narrow keys must be independent of the team and of each other."""
+
+    def test_two_services_do_not_contend(self):
+        locks = LockManager()
+        locks.acquire_env(service_lock_key("1", "redis"))
+
+        locks.acquire_env(service_lock_key("1", "meili"))  # must not raise
+
+    def test_the_same_service_contends(self):
+        locks = LockManager()
+        locks.acquire_env(service_lock_key("1", "redis"), operation="delete_service")
+
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_env(
+                service_lock_key("1", "redis"), operation="restart_service"
+            )
+        assert "delete_service" in str(exc.value)
+
+    def test_the_same_service_of_another_team_does_not_contend(self):
+        locks = LockManager()
+        locks.acquire_env(service_lock_key("1", "redis"))
+
+        locks.acquire_env(service_lock_key("2", "redis"))  # must not raise
+
+    def test_a_service_lock_does_not_block_the_team(self):
+        # The whole point: a service operation is not a team-wide operation.
+        locks = LockManager()
+        locks.acquire_env(service_lock_key("1", "redis"))
+
+        locks.acquire_team("1")  # must not raise
+
+    def test_a_team_operation_does_not_block_a_service(self):
+        locks = LockManager()
+        locks.acquire_team("1", operation="save_as_template")
+
+        locks.acquire_env(service_lock_key("1", "redis"))  # must not raise
+
+    def test_a_service_lock_does_not_block_an_environment(self):
+        locks = LockManager()
+        locks.acquire_env(service_lock_key("1", "redis"))
+
+        locks.acquire_env("main", team_id="1")  # must not raise
+
+    def test_a_volume_lock_is_separate_from_a_same_named_service(self):
+        locks = LockManager()
+        locks.acquire_env(service_lock_key("1", "data"))
+
+        locks.acquire_env(volume_lock_key("1", "data"))  # must not raise
+
+    def test_prune_and_snapshot_share_the_backup_store(self):
+        # The old team lock never covered this: snapshots hold a prod: key,
+        # which lives in a different keyspace than the team lock.
+        locks = LockManager()
+        locks.acquire_env(prod_backups_lock_key("1"), operation="snapshot_production")
+
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_env(prod_backups_lock_key("1"), operation="prune_backups")
+        assert "snapshot_production" in str(exc.value)
+
+    def test_another_team_prunes_in_parallel(self):
+        locks = LockManager()
+        locks.acquire_env(prod_backups_lock_key("1"))
+
+        locks.acquire_env(prod_backups_lock_key("2"))  # must not raise
+
+
+class TestSystemLockExcludesProductions:
+    """restore_cluster_pitr rewrites every team's production cluster."""
+
+    def test_a_production_lock_blocks_the_system_lock(self):
+        locks = LockManager()
+        locks.acquire_env(prod_lock_key("1", "erp"), operation="update_production")
+
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_system(operation="restore_cluster_pitr")
+        message = str(exc.value)
+        assert "prod:1:erp" in message
+        assert "update_production" in message
+
+    def test_the_system_lock_blocks_a_production_lock(self):
+        locks = LockManager()
+        locks.acquire_system(operation="restore_cluster_pitr")
+
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_env(
+                prod_lock_key("1", "erp"), operation="snapshot_production"
+            )
+        message = str(exc.value)
+        assert "system-level" in message
+        assert "restore_cluster_pitr" in message
+
+    def test_the_system_lock_blocks_the_blocking_acquire_too(self):
+        # Webhook deploys queue on a blocking acquire; waiting out a cluster
+        # restore is pointless, so the caller skips the run instead.
+        locks = LockManager()
+        locks.acquire_system(operation="restore_cluster_pitr")
+
+        assert locks.acquire_env_blocking(prod_lock_key("1", "erp"), 0.05) is False
+        # The underlying lock was handed back, not leaked.
+        locks.release_system()
+        assert locks.acquire_env_blocking(prod_lock_key("1", "erp"), 0.05) is True
+
+    def test_a_blocking_acquire_blocks_the_system_lock(self):
+        locks = LockManager()
+        assert locks.acquire_env_blocking(
+            prod_lock_key("1", "erp"), 0.05, operation="webhook deploy"
+        )
+
+        with pytest.raises(BusyError) as exc:
+            locks.acquire_system()
+        assert "webhook deploy" in str(exc.value)
+
+    def test_releasing_the_production_frees_the_system_lock(self):
+        locks = LockManager()
+        locks.acquire_env("prod:__cluster__", operation="scheduled base backup")
+        locks.release_env("prod:__cluster__")
+
+        locks.acquire_system()  # must not raise
+
+    def test_environments_are_unaffected_by_the_system_lock(self):
+        # A cluster restore touches productions only; development work goes on.
+        locks = LockManager()
+        locks.acquire_system(operation="restore_cluster_pitr")
+
+        locks.acquire_env("main", team_id="1")  # must not raise
+        locks.acquire_env(service_lock_key("1", "redis"))  # must not raise
+
+
+class TestKeyedMutex:
+    def test_it_serialises_the_same_key(self):
+        order: list[str] = []
+        entered = threading.Event()
+        release = threading.Event()
+
+        def first() -> None:
+            with keyed_mutex("test:serialise"):
+                order.append("first-in")
+                entered.set()
+                release.wait(2)
+                order.append("first-out")
+
+        def second() -> None:
+            entered.wait(2)
+            with keyed_mutex("test:serialise"):
+                order.append("second-in")
+
+        t1 = threading.Thread(target=first)
+        t2 = threading.Thread(target=second)
+        t1.start()
+        t2.start()
+        # The second thread is blocked until the first leaves its section.
+        entered.wait(2)
+        release.set()
+        t1.join(2)
+        t2.join(2)
+
+        assert order == ["first-in", "first-out", "second-in"]
+
+    def test_different_keys_do_not_serialise(self):
+        with keyed_mutex("test:key-a"):
+            done = threading.Event()
+
+            def other() -> None:
+                with keyed_mutex("test:key-b"):
+                    done.set()
+
+            threading.Thread(target=other).start()
+            assert done.wait(2)
+
+    def test_it_is_reentrant(self):
+        # update_service holds the service-registry key across create_service,
+        # which takes the same key for its own admission check.
+        with keyed_mutex("test:reentrant"):
+            with keyed_mutex("test:reentrant"):
+                pass

--- a/tests/test_production_backup_locks_web.py
+++ b/tests/test_production_backup_locks_web.py
@@ -1,0 +1,59 @@
+"""REST snapshot/restore must serialize with prune on the backup-store key,
+mirroring the MCP tools (production lock first, then the team's backup store)."""
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.locking import LockManager, prod_backups_lock_key
+from oduflow.server import prod_lock_key
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path) -> tuple[TestClient, LockManager]:
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team_1"))
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        prod_enabled=True,
+        teams={"1": team},
+    )
+    app = Starlette()
+    locks = LockManager()
+    mount_web_ui(app, lambda: settings, locks)
+    return TestClient(app), locks
+
+
+def _assert_prod_lock_released(locks: LockManager) -> None:
+    locks.acquire_env(prod_lock_key("1", "erp"))
+    locks.release_env(prod_lock_key("1", "erp"))
+
+
+def test_rest_snapshot_bounces_off_a_running_prune(tmp_path):
+    client, locks = _client(tmp_path)
+    key = prod_backups_lock_key("1")
+    locks.acquire_env(key, operation="prune_production_backups")
+    try:
+        response = client.post("/api/productions/erp/snapshot")
+    finally:
+        locks.release_env(key)
+
+    assert response.status_code == 409
+    assert "prune_production_backups" in response.json()["error"]
+    _assert_prod_lock_released(locks)
+
+
+def test_rest_restore_bounces_off_a_running_prune(tmp_path):
+    client, locks = _client(tmp_path)
+    key = prod_backups_lock_key("1")
+    locks.acquire_env(key, operation="prune_production_backups")
+    try:
+        response = client.post(
+            "/api/productions/erp/restore",
+            json={"confirm": "erp", "snapshot_id": "snap-1"},
+        )
+    finally:
+        locks.release_env(key)
+
+    assert response.status_code == 409
+    assert "prune_production_backups" in response.json()["error"]
+    _assert_prod_lock_released(locks)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1150,19 +1150,190 @@ class TestEnvLock:
             _locks.release_env("main")
 
 
-class TestTemplateListLock:
-    @patch("oduflow.docker_ops.system_ops.list_templates")
-    def test_busy_raises_tool_error_without_listing(self, mock_list):
+class TestResourceLocks:
+    """Service/volume tools lock the resource, not the whole team."""
+
+    @staticmethod
+    def _locks():
+        import oduflow.server
+
+        return oduflow.server._locks
+
+    @patch("oduflow.docker_ops.service_ops.restart_service")
+    def test_restart_service_waits_for_a_delete_of_the_same_service(self, mock_restart):
+        # restart_service used to take no lock at all and could run against a
+        # container delete_service was in the middle of removing.
+        from oduflow.locking import service_lock_key
+
+        locks = self._locks()
+        key = service_lock_key("1", "redis")
+        locks.acquire_env(key, operation="delete_service")
+        try:
+            with pytest.raises(ToolError, match="delete_service"):
+                _get_tool_fn("restart_service")(name="redis")
+        finally:
+            locks.release_env(key)
+        mock_restart.assert_not_called()
+
+    @patch("oduflow.docker_ops.service_ops.run_command_in_service")
+    def test_run_service_command_waits_for_the_same_service(self, mock_run):
+        from oduflow.locking import service_lock_key
+
+        locks = self._locks()
+        key = service_lock_key("1", "redis")
+        locks.acquire_env(key, operation="update_service")
+        try:
+            with pytest.raises(ToolError, match="update_service"):
+                _get_tool_fn("run_service_command")(name="redis", command="ping")
+        finally:
+            locks.release_env(key)
+        mock_run.assert_not_called()
+
+    @patch("oduflow.docker_ops.service_ops.restart_service")
+    def test_another_service_is_unaffected(self, mock_restart):
+        from oduflow.locking import service_lock_key
+
+        mock_restart.return_value = {"name": "meili", "container_name": "c"}
+        locks = self._locks()
+        key = service_lock_key("1", "redis")
+        locks.acquire_env(key, operation="delete_service")
+        try:
+            _get_tool_fn("restart_service")(name="meili")
+        finally:
+            locks.release_env(key)
+        mock_restart.assert_called_once()
+
+    @patch("oduflow.docker_ops.volume_ops.create_volume")
+    def test_volumes_run_during_a_team_operation(self, mock_create):
+        # A template publish holds the team lock for minutes; unrelated volume
+        # work must not queue behind it.
+        mock_create.return_value = {
+            "name": "data",
+            "docker_name": "oduflow-vol-1-data",
+            "description": "",
+        }
+        locks = self._locks()
+        locks.acquire_team("1", operation="save_as_template")
+        try:
+            _get_tool_fn("create_volume")(name="data")
+        finally:
+            locks.release_team("1")
+        mock_create.assert_called_once()
+
+    @patch("oduflow.docker_ops.service_ops.delete_service")
+    def test_a_service_operation_does_not_block_the_team(self, mock_delete):
+        from oduflow.locking import service_lock_key
+
+        locks = self._locks()
+        key = service_lock_key("1", "redis")
+        locks.acquire_env(key, operation="delete_service")
+        try:
+            locks.acquire_team("1")  # must not raise
+            locks.release_team("1")
+        finally:
+            locks.release_env(key)
+
+
+class TestProductionBackupLocks:
+    """Prune must exclude snapshot and restore, which the team lock never did:
+    productions lock in their own `prod:` keyspace."""
+
+    @staticmethod
+    def _prod_settings():
+        return replace(TEST_SETTINGS, prod_enabled=True)
+
+    def test_prune_waits_for_a_running_snapshot(self):
+        import oduflow.server
+        from oduflow.locking import prod_backups_lock_key
+
+        locks = oduflow.server._locks
+        key = prod_backups_lock_key("1")
+        locks.acquire_env(key, operation="snapshot_production")
+        with patch.object(oduflow.server, "_settings", self._prod_settings()):
+            try:
+                with pytest.raises(ToolError, match="snapshot_production"):
+                    _get_tool_fn("prune_production_backups")()
+            finally:
+                locks.release_env(key)
+
+    def test_snapshot_waits_for_a_running_prune(self):
+        import oduflow.server
+        from oduflow.locking import prod_backups_lock_key
+
+        locks = oduflow.server._locks
+        key = prod_backups_lock_key("1")
+        locks.acquire_env(key, operation="prune_production_backups")
+        with patch.object(oduflow.server, "_settings", self._prod_settings()):
+            try:
+                with pytest.raises(ToolError, match="prune_production_backups"):
+                    _get_tool_fn("snapshot_production")(name="erp")
+            finally:
+                locks.release_env(key)
+        # The production's own lock was handed back, not leaked.
+        locks.acquire_env(oduflow.server.prod_lock_key("1", "erp"))
+        locks.release_env(oduflow.server.prod_lock_key("1", "erp"))
+
+    def test_cluster_pitr_excludes_a_running_production_operation(self):
         import oduflow.server
 
         locks = oduflow.server._locks
+        key = oduflow.server.prod_lock_key("1", "erp")
+        locks.acquire_env(key, operation="update_production")
+        with patch.object(oduflow.server, "_settings", self._prod_settings()):
+            try:
+                with pytest.raises(ToolError, match="update_production"):
+                    _get_tool_fn("restore_cluster_pitr")(confirm="RESTORE-CLUSTER")
+            finally:
+                locks.release_env(key)
+
+
+class TestOdooRpcToolsAreLockFree:
+    """XML-RPC against a live Odoo is arbitrated by PostgreSQL, not by us."""
+
+    @pytest.mark.parametrize(
+        "tool,kwargs",
+        [
+            ("odoo_search_read", {"model": "res.partner"}),
+            ("odoo_create", {"model": "res.partner", "values": '{"name": "x"}'}),
+            ("odoo_write", {"model": "res.partner", "ids": "1", "values": "{}"}),
+            ("odoo_unlink", {"model": "res.partner", "ids": "1"}),
+            ("odoo_call", {"model": "res.partner", "method": "name_search"}),
+            ("odoo_schema", {}),
+        ],
+    )
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_rpc.call_kw")
+    def test_they_run_while_the_environment_lock_is_held(
+        self, mock_call, mock_ensure, tool, kwargs
+    ):
+        import oduflow.server
+        from oduflow.docker_ops.odoo_rpc import RpcResult
+
+        mock_call.return_value = RpcResult(ok=True, value=[], login="admin", uid=2)
+        locks = oduflow.server._locks
+        locks.acquire_env("main", "1", operation="run_odoo_tests")
+        try:
+            _get_tool_fn(tool)(env_name="main", **kwargs)
+        finally:
+            locks.release_env("main")
+        mock_call.assert_called_once()
+
+
+class TestTemplateListLock:
+    @patch("oduflow.docker_ops.system_ops.list_templates")
+    def test_listing_needs_no_lock(self, mock_list):
+        # A pure read must not bounce off a template publish that legitimately
+        # holds the team lock for minutes.
+        import oduflow.server
+
+        mock_list.return_value = []
+        locks = oduflow.server._locks
         locks.acquire_team("1")
         try:
-            with pytest.raises(ToolError, match="Another team-level operation"):
-                _call_tool("list_templates")
+            assert "No template profiles found." in _call_tool("list_templates")
         finally:
             locks.release_team("1")
-        mock_list.assert_not_called()
+        mock_list.assert_called_once()
 
 
 class TestListServicePresetsTool:

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -790,7 +790,9 @@ class TestUpdateService:
             ) as mock_resolve,
         ):
             service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "redis")
-            assert mock_resolve.call_count == 2
+            # update pre-validates, then create both pre-validates (before the
+            # image pull) and re-resolves under the service-registry lock.
+            assert mock_resolve.call_count == 3
             mock_resolve.assert_any_call(TEST_TEAM, volumes)
 
     def test_update_port_mode_legacy_no_preset(self, mock_docker_client):

--- a/tests/test_template_metadata_web.py
+++ b/tests/test_template_metadata_web.py
@@ -127,12 +127,14 @@ def test_template_metadata_update_busy_keeps_foreign_lock(tmp_path):
         locks.release_team("1")
 
 
-def test_template_list_busy_keeps_foreign_lock(tmp_path):
+def test_template_list_reads_during_a_team_operation(tmp_path):
+    # Listing is a pure read: it must not bounce off a running publish, and must
+    # not touch the team lock either (same contract as the list_templates tool).
     client, locks = _client(tmp_path)
     locks.acquire_team("1")
     try:
         response = client.get("/api/templates")
-        assert response.status_code == 409
+        assert response.status_code == 200
         with pytest.raises(BusyError):
             locks.acquire_team("1")
     finally:


### PR DESCRIPTION
## Summary

Replaces the coarse per-team lock with narrow keyed locks so operations that don't share data run in parallel. A minutes-long `create_environment` no longer blocks `delete_service`, `create_volume`, `add_extra_repo` or `list_templates` for the whole team.

- **Services** → `svc:{team}:{name}` + a narrow `svc-registry` mutex around slot admission and volume-bind resolution; `restart_service` / `run_service_command` gain the lock they never had (closes an existing race with delete/update).
- **Volumes** → `vol:{team}:{name}`; `delete_volume`'s in-use check runs under the same registry mutex as service create/update (closes the TOCTOU).
- **Extra repos / `list_templates`** → locks dropped (per-repo RLock + container dependency guard / pure read).
- **`setup_repo_auth`** → `creds:{team}`; REST credential endpoints (previously lockless) use the same key.
- **Production backups** → `prod-backups:{team}` shared by prune, snapshot and restore — the old team lock never actually excluded prod-keyed locks. Backup scheduler migrated to the same keys.
- **`restore_cluster_pitr`** → revived system lock, mutually exclusive with the whole `prod:` keyspace in both directions.
- **`odoo_*` XML-RPC tools** → env lock dropped (Odoo is transactional; `http_request_to_odoo` was already lock-free against the same live instance); `ensure_running` wake made atomic per environment.
- **Template mutations keep the team lock** — they remount live environments' overlay filestores; the team↔env mutual exclusion stays intact for them.
- Web UI REST routes mirror the exact same keys, so no new REST↔MCP races.
- Drive-by fix: `update_service` re-resolves volume binds under the registry mutex, so Docker no longer silently recreates a deleted named volume.

Decision record: `specs/0049-granular-resource-locks.md` (+ Evolution note in `0015-granular-locking.md`).

## Testing

- `pytest -m "not integration and not heavyweight"` — 2384 passed
- `pytest -m integration` (Docker) — 15 passed
- `ruff check`, `ruff format --check`, `mypy` — clean