### PR TITLE
Rename environments in place with new_name on switch_branch

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -200,6 +200,31 @@ scoped MCP endpoint and token. This matters twice over — provisioning is skipp
 (no fresh clone, no template database copy), and the MCP client you already
 pointed at `/mcp/dev1` keeps working, because the address never changed.
 
+#### Renaming While Switching
+
+The environment name is a slot label, not a description of what the slot
+currently serves — but a name left over from a finished branch can get
+confusing. Pass `new_name` to relabel the slot in the same operation:
+
+```bash
+oduflow call switch_branch '{"env_name": "dev1", "branch": "feature/next-task", "new_name": "next-task"}'
+```
+
+The database, filestore, ports, credentials and the environment's URL all move
+with it, so the browser tab you have open keeps working. Two things to know:
+
+- **The scoped MCP endpoint moves too**, from `/mcp/dev1` to `/mcp/next-task`
+  (the token itself is unchanged). Re-point any MCP client configured against
+  the old path.
+- **Environments without a pooled hostname slot** — created before
+  `environment_slots` was configured, so their hostname is derived from their
+  name — get a new URL, since the hostname follows the name.
+
+The name must be free: a rename onto a name that already has an environment,
+workspace directory or database is refused before anything is touched.
+Environments managed by a [Stack](stacks.md) are refused as well — there the
+name comes from the stack definition.
+
 After the switch, Oduflow diffs the two branch tips and applies the same logic
 as [Smart Pull](#smart-pull--intelligent-change-detection). Pass
 `install` / `upgrade` / `restart` when you know what changed, or leave them empty

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1759,6 +1759,31 @@ scoped MCP endpoint and token. This matters twice over — provisioning is skipp
 (no fresh clone, no template database copy), and the MCP client you already
 pointed at `/mcp/dev1` keeps working, because the address never changed.
 
+#### Renaming While Switching
+
+The environment name is a slot label, not a description of what the slot
+currently serves — but a name left over from a finished branch can get
+confusing. Pass `new_name` to relabel the slot in the same operation:
+
+```bash
+oduflow call switch_branch '{"env_name": "dev1", "branch": "feature/next-task", "new_name": "next-task"}'
+```
+
+The database, filestore, ports, credentials and the environment's URL all move
+with it, so the browser tab you have open keeps working. Two things to know:
+
+- **The scoped MCP endpoint moves too**, from `/mcp/dev1` to `/mcp/next-task`
+  (the token itself is unchanged). Re-point any MCP client configured against
+  the old path.
+- **Environments without a pooled hostname slot** — created before
+  `environment_slots` was configured, so their hostname is derived from their
+  name — get a new URL, since the hostname follows the name.
+
+The name must be free: a rename onto a name that already has an environment,
+workspace directory or database is refused before anything is touched.
+Environments managed by a [Stack](stacks.md) are refused as well — there the
+name comes from the stack definition.
+
 After the switch, Oduflow diffs the two branch tips and applies the same logic
 as [Smart Pull](#smart-pull--intelligent-change-detection). Pass
 `install` / `upgrade` / `restart` when you know what changed, or leave them empty
@@ -2972,7 +2997,7 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
-| `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch` |
+| `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch`, optional `new_name` to rename the environment at the same time. The response's `env_name` is the name to address it by afterwards |
 | `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars`, `odoo_image` |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |
@@ -3140,7 +3165,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
-| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create |
+| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -15,7 +15,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
-| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create |
+| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -47,7 +47,7 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
-| `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch` |
+| `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch`, optional `new_name` to rename the environment at the same time. The response's `env_name` is the name to address it by afterwards |
 | `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars`, `odoo_image` |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |

--- a/specs/0049-environment-reuse-by-branch-switch.md
+++ b/specs/0049-environment-reuse-by-branch-switch.md
@@ -44,7 +44,7 @@ checkout directory are all derived, and no transaction spans a rename of an
 registries — a half-renamed environment is a worse failure than a name that no
 longer echoes the branch. Instead the branch is displayed as a first-class,
 always-visible property of the card, and the environment name becomes what it
-already effectively was: a stable slot label.
+already effectively was: a stable slot label. (Revisited — see *Evolution*.)
 
 ## How it works (macro)
 
@@ -92,9 +92,59 @@ already effectively was: a stable slot label.
   branch as immutable drift and recreate the environment. Reconciling it in place
   through this operation is a natural follow-up, not part of this decision.
 
+## Evolution
+
+**Renaming, after all (optional `new_name` on `switch_branch`).** The original
+refusal was about the *failure mode*, not about the value: a name left over from
+a merged branch is a real annoyance, and "the name is just a slot label" only
+holds while somebody is willing to read it that way. What made it safe to add was
+noticing that the switch already re-creates the container — labels are frozen at
+creation — so the rename needs no recreate of its own. It rides on that same one,
+in the window where the container is down.
+
+The "no transaction" objection is answered by ordering rather than by a
+transaction that cannot exist. Every check (name validity, the production
+namespace, a container / workspace directory / database already holding the
+target name, stack membership) runs before the first mutation. Then each step is
+individually atomic and ordered so that an interruption leaves an environment's
+*data* whole under exactly one of the two names: move the workspace directory
+(atomic within a filesystem), rename the database (the one step that can still
+fail on its own — a failure moves the directory back), then move the registry
+keys. The container is the accepted casualty: it is removed before the
+relocation, so a failure from that point on (the database rename, the final
+container creation) leaves the environment without a working container, and
+nothing here can bring the old one back. A relocation failure states that
+outcome explicitly instead of pretending to roll back (a failed final container
+creation surfaces the raw Docker error, as it always has); recovery is
+re-provisioning the slot — a dev environment, so an acceptable cost for a
+failure this rare.
+
+Two properties are deliberately preserved rather than re-derived: the port and
+hostname registry keys are *moved*, not released and re-allocated, because they
+are the environment's address; and the coding agent's checkout is moved rather
+than removed and re-cloned, because it can hold uncommitted work. What does not
+survive is the scoped MCP path: `/mcp/<name>` follows the name, so an MCP client
+configured against the old one must be re-pointed. That is the cost the rename
+carries, and it is why the tool's response states the new name explicitly.
+
+Stack-managed environments are refused: there the name comes from the stack
+definition, and renaming behind it would read as drift on the next reconcile.
+A strict guardrail refusal blocks the rename as well, so "blocked" keeps meaning
+that nothing changed.
+
+One deliberate rough edge remains: the agent checkout is moved *after* the
+container recreate, so a recreate that fails leaves the environment under the new
+name with its agent checkout still under the old slug. That is a best-effort
+side path — the next console or chat re-clones it — and buying atomicity there
+would mean moving it before a step that can still fail.
+
 ## History
 
 - `litnimax/bangkok` (2026-08-17) — `switch_branch` MCP tool, REST endpoint and
   dashboard control; `fetch_branch` / `checkout_branch` / `tree_modules` git
   plumbing; dropped-module preflight; `presynced` sync path in
   `pull_environment`.
+- `litnimax/montgomery-v1` (2026-08-17) — optional `new_name`: `rename_to` in
+  `update_environment` with `check_rename_target` /
+  `_relocate_environment_state`, `rename_env` in the port and hostname
+  registries, `activity.rename`, `agent_sessions.rename`, `_agent_rename_env`.

--- a/src/oduflow/activity.py
+++ b/src/oduflow/activity.py
@@ -193,6 +193,20 @@ def remove(team: TeamSettings, env_name: str) -> None:
     _mutate(team, fn)
 
 
+def rename(team: TeamSettings, old_name: str, new_name: str) -> None:
+    """Carry the record of a renamed environment over to its new name, so the
+    idle reaper does not read it as brand new."""
+
+    def fn(records: dict[str, dict[str, Any]]) -> bool:
+        rec = records.pop(old_name, None)
+        if rec is None:
+            return False
+        records[new_name] = rec
+        return True
+
+    _mutate(team, fn)
+
+
 def prune(team: TeamSettings, existing: set[str]) -> None:
     """Drop records of environments that no longer exist."""
 

--- a/src/oduflow/agent_sessions.py
+++ b/src/oduflow/agent_sessions.py
@@ -217,6 +217,22 @@ def clear_current(team: TeamSettings, branch: str, agent_type: str) -> None:
         _save(team, data)
 
 
+def rename(team: TeamSettings, old_name: str, new_name: str) -> None:
+    """Move an environment's stored sessions to its new name.
+
+    A renamed environment is the same environment, so the chat conversation
+    follows it instead of starting over. Anything already stored under the new
+    name (a previous environment of that name) is replaced.
+    """
+    with _LOCK:
+        data = _load(team)
+        state = data.pop(old_name, None)
+        if state is None:
+            return
+        data[new_name] = state
+        _save(team, data)
+
+
 def clear_session(
     team: TeamSettings, branch: str, agent_type: str | None = None
 ) -> None:

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -46,7 +46,11 @@ from oduflow.errors import (
     ProtectedError,
 )
 from oduflow.git_ops import RepoAuthError, git_env_for_team
-from oduflow.hostname_registry import allocate_hostname, release_hostname
+from oduflow.hostname_registry import (
+    allocate_hostname,
+    release_hostname,
+)
+from oduflow.hostname_registry import rename_env as rename_hostname_env
 from oduflow.locking import env_wake_key, keyed_mutex
 from oduflow.naming import (
     get_agent_checkout_dir,
@@ -70,6 +74,7 @@ from oduflow.naming import (
     validate_env_hostname,
 )
 from oduflow.port_registry import allocate_port, release_port
+from oduflow.port_registry import rename_env as rename_port_env
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -2124,6 +2129,54 @@ def ensure_agent_env_checkout(
     _agent_add_env(client, settings, team, env_name, repo_url, branch, git_user)
 
 
+def _agent_rename_env(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    old_name: str,
+    new_name: str,
+) -> None:
+    """Move an environment's agent checkout and attachments to its new name.
+
+    Deliberately a move, not remove + re-clone: the checkout can hold the coding
+    agent's uncommitted work, which ``_agent_remove_env`` would delete. The
+    caller follows with :func:`_agent_add_env`, which rewrites that checkout's
+    ``.mcp.json`` with the renamed environment's scoped MCP URL. Best-effort,
+    like every other agent-container side effect.
+    """
+    if not team.agent_enabled:
+        return
+    # Same guard as _agent_remove_env: an empty slug would make the paths below
+    # the shared /workspace volume itself.
+    if not slugify_branch(old_name) or not slugify_branch(new_name):
+        return
+    try:
+        container = client.containers.get(
+            get_agent_container_name(team.team_id, settings.prefix)
+        )
+    except docker.errors.NotFound:
+        return
+    except Exception:
+        logger.warning("Agent checkout move failed for '%s'", old_name, exc_info=True)
+        return
+    for old_dir, new_dir in (
+        (get_agent_checkout_dir(old_name), get_agent_checkout_dir(new_name)),
+        (get_agent_upload_dir(old_name), get_agent_upload_dir(new_name)),
+    ):
+        if old_dir == new_dir:
+            continue
+        with contextlib.suppress(Exception):
+            container.exec_run(
+                [
+                    "sh",
+                    "-c",
+                    f'[ -d "{old_dir}" ] || exit 0; rm -rf -- "{new_dir}"; '
+                    f'mv -- "{old_dir}" "{new_dir}"',
+                ],
+                user=AGENT_USER,
+            )
+
+
 def _agent_remove_env(
     client: DockerClient, settings: Settings, team: TeamSettings, env_name: str
 ) -> None:
@@ -3410,15 +3463,16 @@ def switch_environment_branch(
     restart: bool = False,
     strict: bool = False,
     extra_addons: dict[str, str] | None = None,
+    new_name: str | None = None,
 ) -> dict[str, Any]:
     """Point an existing environment at another git branch and apply the diff.
 
-    The environment is the reusable unit. Its name, database, filestore,
-    hostname, ports, credentials and scoped MCP token all stay exactly as they
-    are — only the code it serves changes. That is what turns a finished
-    branch's environment into the starting point for the next task instead of
-    something to delete and provision again ([[0048]] pooled the hostname; this
-    pools the whole environment).
+    The environment is the reusable unit. Its database, filestore, hostname,
+    ports, credentials and scoped MCP token all stay exactly as they are — only
+    the code it serves changes. That is what turns a finished branch's
+    environment into the starting point for the next task instead of something
+    to delete and provision again ([[0048]] pooled the hostname; this pools the
+    whole environment).
 
     Order matters:
 
@@ -3434,6 +3488,12 @@ def switch_environment_branch(
     4. Check out the branch and hand the resulting diff to
        :func:`pull_environment`, so the switch shares one implementation of
        classification, the guardrail, extra-addons mounts and apply.
+
+    ``new_name`` optionally renames the environment along the way, so a slot
+    whose name still echoes a finished branch can be relabelled instead of
+    re-provisioned. It rides on the same container recreate as the label flip
+    (step 3), which keeps the whole switch at one recreate; everything after
+    that point works under the new name.
     """
     from oduflow.git_ops import checkout_branch, fetch_branch, is_git_repository
     from oduflow.naming import PROD_ENV_PREFIX
@@ -3474,6 +3534,27 @@ def switch_environment_branch(
             "branch there and call pull_and_apply."
         )
 
+    rename_to = (new_name or "").strip()
+    if rename_to == env_name:
+        rename_to = ""
+    if rename_to:
+        if labels.get("oduflow.stack"):
+            raise ConflictError(
+                f"Environment '{env_name}' belongs to stack "
+                f"'{labels['oduflow.stack']}', which reconciles environments by "
+                "name. Rename it in the stack definition instead."
+            )
+        # Everything below this point mutates; a bad or taken target name must
+        # fail here.
+        check_rename_target(
+            settings=settings,
+            team=team,
+            client=client,
+            env_name=env_name,
+            new_name=rename_to,
+            container_id=container_obj.id,
+        )
+
     current_branch = labels.get("oduflow.git_branch", env_name)
     repo_path = get_repo_path(env_name, team.workspaces_dir)
     if not is_git_repository(repo_path):
@@ -3488,6 +3569,7 @@ def switch_environment_branch(
     if branch == current_branch and extra_override is None:
         # Not an error: the caller wanted this environment on this branch, and it
         # is. Pull instead, so "switch" is safe to call at the start of any task.
+        previous_env_name = env_name
         result = pull_environment(
             settings,
             team,
@@ -3497,31 +3579,72 @@ def switch_environment_branch(
             restart=restart,
             strict=strict,
         )
+        # The pull runs first so that a strict refusal keeps its meaning:
+        # "blocked" has to mean nothing changed, the name included.
+        if rename_to and result.get("action") != "blocked":
+            update_environment(
+                settings,
+                team,
+                env_name,
+                rename_to=rename_to,
+                pull_image=False,
+                install_dependencies=False,
+            )
+            _agent_rename_env(client, settings, team, env_name, rename_to)
+            env_name = rename_to
+            _agent_add_env(
+                client,
+                settings,
+                team,
+                env_name,
+                labels.get(settings.repo_label, ""),
+                branch,
+                labels.get("oduflow.git_user", ""),
+            )
+            result["renamed_from"] = previous_env_name
         result["branch"] = branch
         result["previous_branch"] = current_branch
         result["branch_switched"] = False
+        result["env_name"] = env_name
+        blocked = result.get("action") == "blocked"
+        renamed = (
+            f"Renamed '{previous_env_name}' to '{env_name}'. "
+            if rename_to and not blocked
+            else ""
+        )
+        not_renamed = (
+            f" The rename to '{rename_to}' was not applied."
+            if rename_to and blocked
+            else ""
+        )
         result["message"] = (
-            f"Environment '{env_name}' is already on branch '{branch}'; pulled it "
-            f"instead. {result.get('message', '')}".strip()
+            f"{renamed}Environment '{env_name}' is already on branch '{branch}'; "
+            f"pulled it instead. {result.get('message', '')}".strip()
+            + not_renamed
         )
         return result
 
     target_sha = fetch_branch(repo_path, branch, cred_file=team.git_credentials_file())
     warnings = _dropped_module_warnings(settings, team, env_name, repo_path, target_sha)
     if strict and warnings:
+        blocked_message = (
+            f"Guardrail (strict) blocked the switch to '{branch}': it does not "
+            "carry every module installed in this database. Uninstall them, "
+            "use a separate environment for this branch, or pass "
+            "strict=False to switch anyway."
+        )
+        if rename_to:
+            # "Blocked" has to mean nothing changed — the name included.
+            blocked_message += f" The rename to '{rename_to}' was not applied."
         return {
             "action": "blocked",
             "warnings": warnings,
             "branch": current_branch,
             "requested_branch": branch,
             "branch_switched": False,
+            "env_name": env_name,
             "changed_files": [],
-            "message": (
-                f"Guardrail (strict) blocked the switch to '{branch}': it does not "
-                "carry every module installed in this database. Uninstall them, "
-                "use a separate environment for this branch, or pass "
-                "strict=False to switch anyway."
-            ),
+            "message": blocked_message,
         }
 
     label_overrides = {"oduflow.git_branch": branch}
@@ -3538,6 +3661,8 @@ def switch_environment_branch(
     # Dependencies are deliberately not reinstalled here: the checkout is still
     # on the old branch at this point. A changed requirements.txt / apt list is
     # part of the diff below, which pull_environment installs before restarting.
+    # A requested rename rides on this same recreate.
+    previous_env_name = env_name
     update_environment(
         settings,
         team,
@@ -3545,7 +3670,12 @@ def switch_environment_branch(
         label_overrides=label_overrides,
         pull_image=False,
         install_dependencies=False,
+        rename_to=rename_to or None,
     )
+    if rename_to:
+        _agent_rename_env(client, settings, team, env_name, rename_to)
+        env_name = rename_to
+        repo_path = get_repo_path(env_name, team.workspaces_dir)
 
     try:
         old_head, new_head, changed_files = checkout_branch(repo_path, branch)
@@ -3581,7 +3711,13 @@ def switch_environment_branch(
         presynced=(old_head, changed_files),
     )
 
-    switched = f"Switched '{env_name}' from '{current_branch}' to '{branch}'."
+    if rename_to:
+        switched = (
+            f"Switched '{previous_env_name}' from '{current_branch}' to '{branch}' "
+            f"and renamed it to '{env_name}'."
+        )
+    else:
+        switched = f"Switched '{env_name}' from '{current_branch}' to '{branch}'."
     # "Already up to date" is the pull vocabulary and reads as a contradiction
     # right after a switch; what it means here is that the two branches leave
     # the running Odoo with nothing to catch up on.
@@ -3593,12 +3729,207 @@ def switch_environment_branch(
     result["branch"] = branch
     result["previous_branch"] = current_branch
     result["branch_switched"] = True
+    result["env_name"] = env_name
+    if rename_to:
+        result["renamed_from"] = previous_env_name
     result["old_head"] = old_head
     result["new_head"] = new_head
     result["message"] = f"{switched} {tail}".strip()
     if warnings:
         result["warnings"] = warnings + list(result.get("warnings") or [])
     return result
+
+
+def check_rename_target(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    new_name: str,
+    *,
+    container_id: str = "",
+) -> None:
+    """Reject a rename target before anything is mutated.
+
+    A name keys three independent resources — a container, a workspace directory
+    and a database — and slugification is lossy (``feature/x`` and ``feature-x``
+    collide on all three). Every check therefore compares against the resource
+    the *target* name derives, and skips the case where that resource is the
+    environment's own (a rename whose slug does not change).
+    """
+    from oduflow.naming import PROD_ENV_PREFIX, validate_env_name
+
+    validate_env_name(new_name)
+    if new_name.startswith(PROD_ENV_PREFIX):
+        raise ConflictError(
+            f"'{new_name}' is reserved for production environments; choose "
+            "another name."
+        )
+
+    target_container = get_resource_name(
+        new_name, "odoo", settings.prefix, team.team_id
+    )
+    try:
+        existing = client.containers.get(target_container)
+    except docker.errors.NotFound:
+        pass
+    else:
+        if not container_id or existing.id != container_id:
+            raise ConflictError(
+                f"An environment named '{new_name}' already exists. Delete it "
+                "first or pick another name."
+            )
+
+    old_workspace = get_workspace_path(env_name, team.workspaces_dir)
+    new_workspace = get_workspace_path(new_name, team.workspaces_dir)
+    if os.path.normpath(old_workspace) != os.path.normpath(
+        new_workspace
+    ) and os.path.exists(new_workspace):
+        raise ConflictError(
+            f"A workspace directory for '{new_name}' already exists at "
+            f"{new_workspace}. Remove it first or pick another name."
+        )
+
+    old_db = get_db_name(env_name, team.team_id)
+    new_db = get_db_name(new_name, team.team_id)
+    if new_db != old_db and _db_exists(client, settings, new_db):
+        raise ConflictError(
+            f"Database '{new_db}' (derived from '{new_name}') already exists. "
+            "Pick another name."
+        )
+
+
+def _repair_extra_worktrees(workspace_path: str) -> None:
+    """Re-point legacy per-workspace extra-addon worktrees after a move.
+
+    A worktree and its bare repository record each other's absolute path, so
+    moving the workspace directory breaks the pair. ``git worktree repair`` run
+    inside the moved worktree rewrites both sides. Environments on the shared
+    SHA-keyed checkouts keep their addons outside the workspace and are not
+    affected. Best-effort: a broken legacy worktree is re-created by the next
+    pull.
+    """
+    extra_dir = os.path.join(workspace_path, "extra")
+    if not os.path.isdir(extra_dir):
+        return
+    for repo_name in sorted(os.listdir(extra_dir)):
+        worktree_path = os.path.join(extra_dir, repo_name)
+        if not os.path.exists(os.path.join(worktree_path, ".git")):
+            continue
+        try:
+            subprocess.run(
+                ["git", "-C", worktree_path, "worktree", "repair"],
+                check=True,
+                capture_output=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning("Could not repair extra worktree %s: %s", worktree_path, exc)
+
+
+def _rebase_volumes(
+    volumes: dict[str, dict[str, str]],
+    old_workspace: str,
+    new_workspace: str,
+    old_db: str,
+    new_db: str,
+) -> dict[str, dict[str, str]]:
+    """Re-point an existing container's binds at the renamed environment.
+
+    Two things move with the name: the host side of every bind under the
+    workspace directory, and the filestore's container-side path, which Odoo
+    derives from the database name.
+    """
+    rebased: dict[str, dict[str, str]] = {}
+    for source, spec in volumes.items():
+        if source == old_workspace or source.startswith(old_workspace + os.sep):
+            source = new_workspace + source[len(old_workspace) :]
+        bind = spec.get("bind", "")
+        if old_db != new_db and bind.endswith(f"/filestore/{old_db}"):
+            spec = {**spec, "bind": bind[: -len(old_db)] + new_db}
+        rebased[source] = spec
+    return rebased
+
+
+def _relocate_environment_state(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    old_name: str,
+    new_name: str,
+) -> None:
+    """Move everything an environment's *name* keys, with its container down.
+
+    Called from :func:`update_environment` in the window between removing the
+    old container and creating the new one — the only moment at which the
+    workspace directory can be moved and the database renamed. No transaction
+    spans a directory rename, an ``ALTER DATABASE`` and three registries, so the
+    order is chosen to keep the environment's *data* whole under exactly one of
+    the two names. The container itself is already gone either way — a failure
+    here leaves the environment containerless, which :func:`update_environment`
+    reports explicitly instead of pretending to roll back:
+
+    1. Unmount the filestore overlay and move the workspace directory. The move
+       is atomic within one filesystem.
+    2. Rename the database. This is the one step that can fail on its own (a
+       connection that survived container removal), so a failure moves the
+       directory back and re-raises, leaving the environment whole under its old
+       name.
+    3. Move the registry keys — port, hostname, activity, agent sessions — which
+       carry the environment's port, URL, idle clock and chat history over.
+    """
+    old_workspace = get_workspace_path(old_name, team.workspaces_dir)
+    new_workspace = get_workspace_path(new_name, team.workspaces_dir)
+    old_db = get_db_name(old_name, team.team_id)
+    new_db = get_db_name(new_name, team.team_id)
+
+    moved = False
+    if os.path.normpath(old_workspace) != os.path.normpath(
+        new_workspace
+    ) and os.path.isdir(old_workspace):
+        _unmount_filestore(old_name, team)
+        _wait_unmounted(get_filestore_paths(old_name, team.workspaces_dir)["merged"])
+        os.makedirs(os.path.dirname(new_workspace) or ".", exist_ok=True)
+        os.rename(old_workspace, new_workspace)
+        moved = True
+        _repair_extra_worktrees(new_workspace)
+
+    if new_db != old_db and _db_exists(client, settings, old_db):
+        try:
+            # The container is gone, but a psql session or a pooled connection
+            # can still hold the database and make RENAME fail.
+            _exec_sql(
+                client,
+                settings,
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{old_db}' AND pid <> pg_backend_pid();",
+            )
+            _exec_sql(
+                client, settings, f'ALTER DATABASE "{old_db}" RENAME TO "{new_db}";'
+            )
+        except Exception:
+            if moved:
+                with contextlib.suppress(OSError):
+                    os.rename(new_workspace, old_workspace)
+            raise
+
+    rename_port_env(team.port_registry_path, old_name, new_name)
+    if team.hostname_registry_path or team.data_dir:
+        rename_hostname_env(_hostname_registry_path(team), old_name, new_name)
+    activity.rename(team, old_name, new_name)
+
+    from oduflow import agent_sessions
+
+    with contextlib.suppress(Exception):
+        agent_sessions.rename(team, old_name, new_name)
+
+    # The scoped MCP endpoint is /mcp/<env>, and its token->environment mapping
+    # is cached; the renamed environment answers on a different path.
+    invalidate_cache()
+    logger.info(
+        "Environment state relocated",
+        extra={"env_name": new_name, "previous_env_name": old_name},
+    )
 
 
 def update_environment(
@@ -3613,6 +3944,7 @@ def update_environment(
     pull_image: bool = True,
     install_dependencies: bool = True,
     label_overrides: dict[str, str] | None = None,
+    rename_to: str | None = None,
 ) -> dict[str, Any]:
     """Re-create an environment's container, preserving DB, repo and filestore.
 
@@ -3625,6 +3957,14 @@ def update_environment(
     redundant dependency reinstall. The PostgreSQL connection variables
     (HOST/USER/PASSWORD) are always re-derived from the environment credentials,
     and image-baked env comes from the image itself.
+
+    ``rename_to`` additionally moves the environment onto another name. The
+    container has to be re-created for that anyway — it carries the name in its
+    own name, its labels and its bind mounts — so the rename rides on the same
+    recreate instead of adding a second one: the name-keyed state is relocated
+    (see :func:`_relocate_environment_state`) while the container is down, and
+    everything the rest of this function derives from ``env_name`` is then
+    derived from the new one.
     """
     client = get_client()
     odoo_container_name = get_resource_name(
@@ -3639,6 +3979,15 @@ def update_environment(
     except docker.errors.NotFound:
         raise NotFoundError(
             f"Environment '{env_name}' does not exist. Use create_environment first."
+        )
+
+    if rename_to == env_name:
+        rename_to = None
+    if rename_to:
+        # Before the first mutation: a taken name must not cost the environment
+        # its container.
+        check_rename_target(
+            client, settings, team, env_name, rename_to, container_id=container.id
         )
 
     # Labels
@@ -3769,6 +4118,42 @@ def update_environment(
             container.remove(v=True, force=True)
         except Exception:
             pass
+
+    # ------------------------------------------------------------------
+    # 2b. Rename: relocate the name-keyed state, then work under the new name
+    # ------------------------------------------------------------------
+    if rename_to:
+        old_workspace = get_workspace_path(env_name, team.workspaces_dir)
+        old_db_name = get_db_name(env_name, team.team_id)
+        try:
+            _relocate_environment_state(client, settings, team, env_name, rename_to)
+        except Exception as exc:
+            # The old container is already removed and cannot be brought back
+            # from here; a bare ALTER DATABASE / rename error would hide that.
+            # State exactly what the failed operation left behind.
+            raise FlowError(
+                f"Renaming '{env_name}' to '{rename_to}' failed after the old "
+                f"container was already removed: {exc} The database and "
+                f"workspace are intact under '{env_name}', but the environment "
+                "currently has no container."
+            ) from exc
+        env_name = rename_to
+        odoo_container_name = get_resource_name(
+            env_name, "odoo", settings.prefix, team.team_id
+        )
+        # The environment's identity in every listing (see list_environments).
+        labels[settings.branch_label] = env_name
+        new_db_name = get_db_name(env_name, team.team_id)
+        volumes = _rebase_volumes(
+            volumes,
+            old_workspace,
+            get_workspace_path(env_name, team.workspaces_dir),
+            old_db_name,
+            new_db_name,
+        )
+        if command and old_db_name != new_db_name:
+            # The command is "odoo -d <db> ...", captured from the old container.
+            command = command.replace(old_db_name, new_db_name)
 
     # ------------------------------------------------------------------
     # 3. Re-mount filestore overlay if needed (only for overlay-mode envs)
@@ -3935,6 +4320,7 @@ def update_environment(
 
     return {
         "url": url,
+        "env_name": env_name,
         "hostname": get_env_short_hostname(env_name, route_hostname),
         "odoo_container": odoo_container_name,
         "database": env_db,

--- a/src/oduflow/hostname_registry.py
+++ b/src/oduflow/hostname_registry.py
@@ -150,5 +150,26 @@ def release_hostname(registry_path: str, env_name: str) -> None:
             logger.info("Released hostname %s for environment '%s'", hostname, env_name)
 
 
+def rename_env(registry_path: str, old_name: str, new_name: str) -> None:
+    """Move a hostname reservation to a renamed environment.
+
+    Keeping the same hostname is the point: the environment's URL — the address
+    a browser and an MCP client already hold — must survive a rename, so this
+    moves the key instead of releasing and re-allocating a slot.
+    """
+    with _registry_lock(registry_path):
+        registry = _load_registry(registry_path)
+        if old_name not in registry:
+            return
+        registry[new_name] = registry.pop(old_name)
+        _save_registry(registry_path, registry)
+        logger.info(
+            "Moved hostname %s from environment '%s' to '%s'",
+            registry[new_name],
+            old_name,
+            new_name,
+        )
+
+
 def get_hostname(registry_path: str, env_name: str) -> str | None:
     return _load_registry(registry_path).get(env_name)

--- a/src/oduflow/port_registry.py
+++ b/src/oduflow/port_registry.py
@@ -150,6 +150,28 @@ def release_port(registry_path: str, env_name: str) -> None:
             logger.info("Released port %d for environment '%s'", port, env_name)
 
 
+def rename_env(registry_path: str, old_name: str, new_name: str) -> None:
+    """Move a reservation to a renamed environment, keeping the same port.
+
+    A release + allocate pair would be observably different: the environment
+    could come back on another port, and a concurrent allocation could take the
+    old one in between. The port is part of the environment's address, so a
+    rename must preserve it.
+    """
+    with _registry_lock(registry_path):
+        registry = _load_registry(registry_path)
+        if old_name not in registry:
+            return
+        registry[new_name] = registry.pop(old_name)
+        _save_registry(registry_path, registry)
+        logger.info(
+            "Moved port %d from environment '%s' to '%s'",
+            registry[new_name],
+            old_name,
+            new_name,
+        )
+
+
 def get_port(registry_path: str, env_name: str) -> int | None:
     """Get the assigned port for an environment, or None if not assigned."""
     registry = _load_registry(registry_path)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1824,22 +1824,28 @@ def switch_branch(
     restart: bool = False,
     strict: bool = False,
     extra_addons: str = "",
+    new_name: str = "",
     ctx: Context | None = None,
 ) -> str:
     """
     Move an existing environment onto another git branch — reuse it instead of
     creating a new one.
 
-    Everything except the code stays: the environment name, database, filestore,
-    URL / hostname, ports, database credentials and the scoped MCP endpoint. Use
-    this at the start of a task when a previous branch is finished (merged) —
-    it replaces "delete the old environment, create a fresh one", which re-clones
-    the repository and re-copies the template database.
+    Everything except the code stays: the database, filestore, URL / hostname,
+    ports, database credentials and the scoped MCP token. Use this at the start
+    of a task when a previous branch is finished (merged) — it replaces "delete
+    the old environment, create a fresh one", which re-clones the repository and
+    re-copies the template database.
 
     The branch must already exist on origin, so push it first. Oduflow then
     diffs the old and new tips and applies exactly the logic of pull_and_apply:
     pass install / upgrade / restart explicitly when you know what changed, or
     leave them empty to let Oduflow classify the difference itself.
+
+    Pass new_name to rename the environment in the same operation — useful when
+    its name still echoes the finished branch. The URL is kept, but the scoped
+    MCP endpoint moves from /mcp/<old name> to /mcp/<new name>, so an MCP client
+    configured against the old path has to be re-pointed.
 
     Because the database is kept, it can outlive the code: if the target branch
     never carried a module that is installed here, the response says so (with
@@ -1858,21 +1864,34 @@ def switch_branch(
         restart: Restart the Odoo container (for Python-only differences).
         strict: Refuse instead of warning when the target branch drops an installed module, or when the requested action looks incomplete for the diff.
         extra_addons: Optional comma-separated extra addon repos with branches (e.g. "enterprise:19.0,custom-themes:main") to switch along with the main repo. Leave empty to keep the current ones.
+        new_name: Optional new name for the environment. Leave empty to keep the current name.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
     woke_note = _wake_for_work(settings, team, env_name, "to switch the branch")
-    result = env_ops.switch_environment_branch(
-        settings,
-        team,
-        env_name,
-        branch,
-        install=[m.strip() for m in install.split(",") if m.strip()] or None,
-        upgrade=[m.strip() for m in upgrade.split(",") if m.strip()] or None,
-        restart=restart,
-        strict=strict,
-        extra_addons=_parse_extra_addons(extra_addons) if extra_addons else None,
-    )
+    rename_to = (new_name or "").strip()
+    if rename_to and rename_to != env_name:
+        # The tool decorator locks env_name only; hold the target name too, so a
+        # concurrent create_environment cannot claim it mid-rename.
+        _locks.acquire_env(rename_to, team.team_id, operation="switch_branch")
+    else:
+        rename_to = ""
+    try:
+        result = env_ops.switch_environment_branch(
+            settings,
+            team,
+            env_name,
+            branch,
+            install=[m.strip() for m in install.split(",") if m.strip()] or None,
+            upgrade=[m.strip() for m in upgrade.split(",") if m.strip()] or None,
+            restart=restart,
+            strict=strict,
+            extra_addons=_parse_extra_addons(extra_addons) if extra_addons else None,
+            new_name=rename_to or None,
+        )
+    finally:
+        if rename_to:
+            _locks.release_env(rename_to)
     action = result["action"]
     warnings = result.get("warnings") or []
 
@@ -1883,7 +1902,13 @@ def switch_branch(
         lines.append(result["message"])
         return "\n".join(lines)
 
+    final_env_name = str(result.get("env_name") or env_name)
     header_lines = [woke_note + result["message"]]
+    if result.get("renamed_from"):
+        header_lines.append(
+            f"Use env_name='{final_env_name}' from now on; its scoped MCP endpoint "
+            f"is /mcp/{final_env_name}."
+        )
     if result.get("modules_installed"):
         header_lines.append(f"Installed: {', '.join(result['modules_installed'])}")
     if result.get("modules_upgraded"):
@@ -1902,7 +1927,7 @@ def switch_branch(
     output = result.get("output", "")
     if output:
         return _maybe_cache(
-            output, header, "switch_branch", f"env={env_name}, branch={branch}"
+            output, header, "switch_branch", f"env={final_env_name}, branch={branch}"
         )
     return header
 

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -61,6 +61,12 @@ target branch must exist on origin; live-mounted environments are rejected
 target branch does not carry a module installed in that database, the response
 warns; create a separate environment when that matters.
 
+The environment name is a slot label, not a description of the branch, so a
+mismatch is normal — no need to rename on every switch. When the user asks for
+a different name, pass `new_name` to `switch_branch`: the URL and database
+follow the rename, but the scoped MCP endpoint becomes `/mcp/<new name>`, so use
+the new name in every later call.
+
 Do not delete and recreate an environment to fix an application error or run
 a migration. It recreates the same starting state and discards useful test
 data. Environments auto-stop when idle and container-level tools wake them

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -939,10 +939,21 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "A target branch is required."}, status_code=400
             )
+        new_name = ((body or {}).get("new_name") or "").strip()
+        if new_name == branch:
+            new_name = ""
         try:
             locks.acquire_env(branch, team.team_id)
         except BusyError as e:
             return _error_response(e)
+        # The rename target is locked too, so a concurrent create cannot claim
+        # the name while the environment is moving onto it.
+        if new_name:
+            try:
+                locks.acquire_env(new_name, team.team_id)
+            except BusyError as e:
+                locks.release_env(branch)
+                return _error_response(e)
         try:
             settings = get_settings()
             activity.touch(team, branch)
@@ -952,16 +963,21 @@ def _build_routes(
                 team,
                 branch,
                 target,
+                new_name=new_name or None,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:
             return _error_response(e)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except Exception:
             logger.exception("Unexpected error in api_switch_branch")
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
         finally:
+            if new_name:
+                locks.release_env(new_name)
             locks.release_env(branch)
 
     def api_delete(request: Request) -> JSONResponse:

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -11,7 +11,12 @@ import pytest
 import docker
 from oduflow import po_tools
 from oduflow.docker_ops import env_ops, odoo_ops, system_ops
-from oduflow.errors import ConflictError, NotFoundError, PrerequisiteNotMetError
+from oduflow.errors import (
+    ConflictError,
+    FlowError,
+    NotFoundError,
+    PrerequisiteNotMetError,
+)
 from oduflow.settings import DEFAULT_AGENT_IMAGE, Settings, TeamSettings
 
 TEST_TEAM = TeamSettings(
@@ -1319,6 +1324,116 @@ class TestUpdateEnvironment:
         assert result["image"] == "odoo:17.0"
         assert result["image_updated"] is True
         assert result["env_vars"] == {"FOO": "new"}
+
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements", return_value=(False, "")
+    )
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value="")
+    @patch("oduflow.docker_ops.env_ops._resolve_instance_conf")
+    @patch("oduflow.docker_ops.env_ops.os.path.isfile", return_value=False)
+    @patch("oduflow.docker_ops.env_ops.os.path.isdir", return_value=False)
+    @patch("oduflow.docker_ops.env_ops._create_pg_role")
+    @patch(
+        "oduflow.docker_ops.env_ops.load_credentials",
+        return_value={"pg_user": "u_1_main", "pg_password": "pw"},
+    )
+    @patch("oduflow.docker_ops.env_ops.check_rename_target")
+    @patch("oduflow.docker_ops.env_ops._relocate_environment_state")
+    def test_rename_recreates_the_container_under_the_new_name(
+        self,
+        mock_relocate,
+        mock_check,
+        mock_creds,
+        mock_role,
+        mock_isdir,
+        mock_isfile,
+        mock_resolve_conf,
+        mock_apt,
+        mock_pip,
+        mock_docker_client,
+    ):
+        mock_resolve_conf.return_value.exists.return_value = False
+        container = self._make_container()
+        container.attrs["HostConfig"]["Binds"] = [
+            "/tmp/flow-test/workspaces/main/repo:/mnt/extra-addons:rw",
+            "/tmp/flow-test/workspaces/main/filestore:"
+            "/var/lib/odoo/.local/share/Odoo/filestore/oduflow_1_main:rw",
+        ]
+        mock_docker_client.containers.get.return_value = container
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        result = env_ops.update_environment(
+            TEST_SETTINGS, TEST_TEAM, "main", pull_image=False, rename_to="next"
+        )
+
+        # The name-keyed state moves while the container is down — after it was
+        # removed, before the new one is created.
+        assert mock_relocate.call_args[0][3:] == ("main", "next")
+        run_kwargs = mock_docker_client.containers.run.call_args.kwargs
+        assert run_kwargs["name"] == "oduflow-1-next-odoo"
+        assert run_kwargs["labels"][TEST_SETTINGS.branch_label] == "next"
+        assert run_kwargs["command"] == "odoo -d oduflow_1_next --dev=xml"
+        assert set(run_kwargs["volumes"]) == {
+            "/tmp/flow-test/workspaces/next/repo",
+            "/tmp/flow-test/workspaces/next/filestore",
+        }
+        assert run_kwargs["volumes"]["/tmp/flow-test/workspaces/next/filestore"][
+            "bind"
+        ] == ("/var/lib/odoo/.local/share/Odoo/filestore/oduflow_1_next")
+        assert result["env_name"] == "next"
+        assert result["database"] == "oduflow_1_next"
+
+    @patch("oduflow.docker_ops.env_ops.check_rename_target")
+    @patch(
+        "oduflow.docker_ops.env_ops._relocate_environment_state",
+        side_effect=RuntimeError("database is being accessed by other users"),
+    )
+    def test_a_failed_relocation_reports_the_containerless_state(
+        self, mock_relocate, mock_check, mock_docker_client
+    ):
+        # The old container is removed before the relocation and cannot be
+        # brought back; the error must say what the operation left behind
+        # instead of surfacing a bare ALTER DATABASE failure.
+        container = self._make_container()
+        mock_docker_client.containers.get.return_value = container
+
+        with pytest.raises(FlowError) as excinfo:
+            env_ops.update_environment(
+                TEST_SETTINGS, TEST_TEAM, "main", pull_image=False, rename_to="next"
+            )
+
+        message = str(excinfo.value)
+        assert "Renaming 'main' to 'next' failed" in message
+        assert "database is being accessed by other users" in message
+        assert "currently has no container" in message
+        mock_docker_client.containers.run.assert_not_called()
+
+    def test_rename_to_the_current_name_is_ignored(self, mock_docker_client):
+        container = self._make_container()
+        mock_docker_client.containers.get.return_value = container
+
+        with (
+            patch("oduflow.docker_ops.env_ops.check_rename_target") as check,
+            patch.object(env_ops, "_relocate_environment_state") as relocate,
+            patch(
+                "oduflow.docker_ops.env_ops.load_credentials",
+                return_value={"pg_user": "u_1_main", "pg_password": "pw"},
+            ),
+            patch("oduflow.docker_ops.env_ops._create_pg_role"),
+            patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value=""),
+            patch(
+                "oduflow.docker_ops.env_ops._install_pip_requirements",
+                return_value=(False, ""),
+            ),
+            patch("oduflow.docker_ops.env_ops._resolve_instance_conf") as conf,
+        ):
+            conf.return_value.exists.return_value = False
+            env_ops.update_environment(
+                TEST_SETTINGS, TEST_TEAM, "main", pull_image=False, rename_to="main"
+            )
+
+        check.assert_not_called()
+        relocate.assert_not_called()
 
     def test_update_aborts_when_image_unavailable(self, mock_docker_client):
         # Image can't be pulled and isn't local: abort WITHOUT removing the old

--- a/tests/test_switch_branch.py
+++ b/tests/test_switch_branch.py
@@ -176,7 +176,9 @@ def switch_env(tmp_path):
             return_value={"action": "restart", "message": "Restarted."},
         ) as pull,
         patch.object(env_ops, "_agent_add_env") as agent,
+        patch.object(env_ops, "_agent_rename_env") as agent_rename,
         patch.object(env_ops, "_dropped_module_warnings", return_value=[]) as preflight,
+        patch.object(env_ops, "_db_exists", return_value=False) as db_exists,
     ):
         yield {
             "client": client,
@@ -185,7 +187,9 @@ def switch_env(tmp_path):
             "update": update,
             "pull": pull,
             "agent": agent,
+            "agent_rename": agent_rename,
             "preflight": preflight,
+            "db_exists": db_exists,
         }
 
 
@@ -478,3 +482,354 @@ class TestDroppedModulePreflight:
             )
 
         assert states.call_args[0][3] == ("sale_x",)
+
+
+# --- renaming an environment while switching -----------------------------
+
+
+def _rename_team(tmp_path) -> TeamSettings:
+    """A team whose registries live on disk, so key moves can be asserted."""
+    return TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path),
+        port_registry_path=str(tmp_path / "ports.json"),
+        hostname_registry_path=str(tmp_path / "hostnames.json"),
+    )
+
+
+class TestSwitchWithRename:
+    def test_the_rename_rides_on_the_same_container_recreate(
+        self, tmp_path, switch_env
+    ):
+        _switch(tmp_path, new_name="dev2")
+
+        # A separate recreate for the rename would stop Odoo twice for one
+        # operation.
+        switch_env["update"].assert_called_once()
+        kwargs = switch_env["update"].call_args.kwargs
+        assert kwargs["rename_to"] == "dev2"
+        assert kwargs["label_overrides"] == {"oduflow.git_branch": "feature/new"}
+
+    def test_the_checkout_and_the_apply_run_under_the_new_name(
+        self, tmp_path, switch_env
+    ):
+        _switch(tmp_path, new_name="dev2")
+
+        # The workspace directory moved with the rename, so the old path no
+        # longer exists by the time the branch is checked out.
+        assert switch_env["checkout"].call_args[0][0].endswith("/dev2/repo")
+        assert switch_env["pull"].call_args[0][2] == "dev2"
+
+    def test_the_agent_checkout_is_moved_not_re_cloned(self, tmp_path, switch_env):
+        _switch(tmp_path, new_name="dev2")
+
+        # Removing it would delete the coding agent's uncommitted work.
+        assert switch_env["agent_rename"].call_args[0][3:] == ("dev1", "dev2")
+        assert switch_env["agent"].call_args[0][3] == "dev2"
+
+    def test_the_result_and_message_report_both_names(self, tmp_path, switch_env):
+        result = _switch(tmp_path, new_name="dev2")
+
+        assert result["env_name"] == "dev2"
+        assert result["renamed_from"] == "dev1"
+        assert result["message"].startswith(
+            "Switched 'dev1' from 'feature/old' to 'feature/new' and renamed it "
+            "to 'dev2'."
+        )
+
+    def test_renaming_to_the_current_name_is_a_plain_switch(self, tmp_path, switch_env):
+        result = _switch(tmp_path, new_name="dev1")
+
+        assert switch_env["update"].call_args.kwargs["rename_to"] is None
+        assert "renamed_from" not in result
+        switch_env["agent_rename"].assert_not_called()
+
+    def test_a_rename_alone_is_applied_when_the_branch_is_unchanged(
+        self, tmp_path, switch_env
+    ):
+        switch_env["client"].containers.get.return_value = _container(
+            _labels(**{"oduflow.git_branch": "feature/new"})
+        )
+
+        result = _switch(tmp_path, new_name="dev2")
+
+        assert switch_env["update"].call_args.kwargs["rename_to"] == "dev2"
+        assert result["branch_switched"] is False
+        assert result["env_name"] == "dev2"
+        assert result["renamed_from"] == "dev1"
+        # The pull that stands in for the switch runs first, under the old name,
+        # so a strict refusal can still leave the name untouched.
+        assert switch_env["pull"].call_args[0][2] == "dev1"
+        assert switch_env["agent"].call_args[0][3] == "dev2"
+
+    def test_a_guardrail_refusal_blocks_the_rename_too(self, tmp_path, switch_env):
+        switch_env["client"].containers.get.return_value = _container(
+            _labels(**{"oduflow.git_branch": "feature/new"})
+        )
+        switch_env["pull"].return_value = {
+            "action": "blocked",
+            "message": "Guardrail (strict) refused.",
+        }
+
+        result = _switch(tmp_path, new_name="dev2", strict=True)
+
+        # "Blocked" has to mean nothing changed — the name included.
+        switch_env["update"].assert_not_called()
+        assert result["env_name"] == "dev1"
+        assert "renamed_from" not in result
+        assert "was not applied" in result["message"]
+
+    def test_a_dropped_module_refusal_blocks_the_rename_too(
+        self, tmp_path, switch_env
+    ):
+        switch_env["preflight"].return_value = ["Module 'sale_x' would be dropped."]
+
+        result = _switch(tmp_path, new_name="dev2", strict=True)
+
+        # The full-switch guardrail must behave like the same-branch one:
+        # "blocked" means nothing changed, the name included — and says so.
+        switch_env["update"].assert_not_called()
+        assert result["action"] == "blocked"
+        assert result["env_name"] == "dev1"
+        assert "renamed_from" not in result
+        assert "The rename to 'dev2' was not applied." in result["message"]
+
+    def test_an_invalid_name_is_refused_before_anything_is_mutated(
+        self, tmp_path, switch_env
+    ):
+        with pytest.raises(ValueError):
+            _switch(tmp_path, new_name="../escape")
+
+        switch_env["update"].assert_not_called()
+        switch_env["fetch"].assert_not_called()
+
+    def test_a_stack_managed_environment_is_refused(self, tmp_path, switch_env):
+        switch_env["client"].containers.get.return_value = _container(
+            _labels(**{"oduflow.stack": "demo"})
+        )
+
+        with pytest.raises(ConflictError) as excinfo:
+            _switch(tmp_path, new_name="dev2")
+
+        assert "demo" in str(excinfo.value)
+        switch_env["update"].assert_not_called()
+
+    def test_a_name_taken_by_another_environment_is_refused(self, tmp_path, switch_env):
+        taken = _container(_labels())
+        own = switch_env["client"].containers.get.return_value
+
+        def by_name(name: str):
+            return taken if name.endswith("-dev2-odoo") else own
+
+        switch_env["client"].containers.get.side_effect = by_name
+
+        with pytest.raises(ConflictError) as excinfo:
+            _switch(tmp_path, new_name="dev2")
+
+        assert "already exists" in str(excinfo.value)
+        switch_env["update"].assert_not_called()
+
+
+class TestCheckRenameTarget:
+    def _check(self, tmp_path, new_name, *, client=None, db_exists=False):
+        client = client or MagicMock()
+        with patch.object(env_ops, "_db_exists", return_value=db_exists):
+            env_ops.check_rename_target(
+                client,
+                _settings(tmp_path),
+                _team(tmp_path),
+                "dev1",
+                new_name,
+                container_id="own",
+            )
+
+    def test_a_free_name_passes(self, tmp_path):
+        import docker
+
+        client = MagicMock()
+        client.containers.get.side_effect = docker.errors.NotFound("nope")
+
+        self._check(tmp_path, "dev2", client=client)
+
+    def test_the_production_namespace_is_reserved(self, tmp_path):
+        import docker
+
+        client = MagicMock()
+        client.containers.get.side_effect = docker.errors.NotFound("nope")
+
+        with pytest.raises(ConflictError):
+            self._check(tmp_path, "prod-erp", client=client)
+
+    def test_an_existing_workspace_directory_is_a_conflict(self, tmp_path):
+        import docker
+
+        client = MagicMock()
+        client.containers.get.side_effect = docker.errors.NotFound("nope")
+        (tmp_path / "workspaces" / "dev2").mkdir(parents=True)
+
+        with pytest.raises(ConflictError) as excinfo:
+            self._check(tmp_path, "dev2", client=client)
+
+        assert "workspace directory" in str(excinfo.value)
+
+    def test_an_existing_database_is_a_conflict(self, tmp_path):
+        import docker
+
+        client = MagicMock()
+        client.containers.get.side_effect = docker.errors.NotFound("nope")
+
+        with pytest.raises(ConflictError) as excinfo:
+            self._check(tmp_path, "dev2", client=client, db_exists=True)
+
+        assert "oduflow_1_dev2" in str(excinfo.value)
+
+    def test_a_rename_that_keeps_the_slug_does_not_collide_with_itself(self, tmp_path):
+        # feature/x and feature-x derive the same container, path and database;
+        # the environment's own resources must not read as someone else's.
+        client = MagicMock()
+        client.containers.get.return_value = MagicMock(id="own")
+        (tmp_path / "workspaces" / "feature-x").mkdir(parents=True)
+
+        with patch.object(env_ops, "_db_exists", return_value=True):
+            env_ops.check_rename_target(
+                client,
+                _settings(tmp_path),
+                _team(tmp_path),
+                "feature/x",
+                "feature-x",
+                container_id="own",
+            )
+
+
+class TestRelocateEnvironmentState:
+    def _relocate(self, tmp_path, *, sql=None, db_exists=True):
+        client = MagicMock()
+        with (
+            patch.object(env_ops, "_unmount_filestore"),
+            patch.object(env_ops, "_db_exists", return_value=db_exists),
+            patch.object(env_ops, "_exec_sql", side_effect=sql) as exec_sql,
+        ):
+            env_ops._relocate_environment_state(
+                client, _settings(tmp_path), _rename_team(tmp_path), "dev1", "dev2"
+            )
+        return exec_sql
+
+    def test_the_workspace_directory_moves_with_its_contents(self, tmp_path):
+        old = tmp_path / "workspaces" / "dev1"
+        old.mkdir(parents=True)
+        (old / "env_credentials.json").write_text('{"pg_user": "u_1_dev1"}')
+        (old / ".protected").touch()
+
+        self._relocate(tmp_path)
+
+        new = tmp_path / "workspaces" / "dev2"
+        assert not old.exists()
+        # Credentials, protection and the note are keyed by the directory, so
+        # they follow the environment without any per-file handling.
+        assert (new / "env_credentials.json").read_text() == '{"pg_user": "u_1_dev1"}'
+        assert (new / ".protected").exists()
+
+    def test_open_connections_are_terminated_before_the_database_is_renamed(
+        self, tmp_path
+    ):
+        (tmp_path / "workspaces" / "dev1").mkdir(parents=True)
+
+        exec_sql = self._relocate(tmp_path)
+
+        statements = [call[0][2] for call in exec_sql.call_args_list]
+        assert "pg_terminate_backend" in statements[0]
+        assert "oduflow_1_dev1" in statements[0]
+        assert statements[1] == (
+            'ALTER DATABASE "oduflow_1_dev1" RENAME TO "oduflow_1_dev2";'
+        )
+
+    def test_a_failed_database_rename_puts_the_directory_back(self, tmp_path):
+        old = tmp_path / "workspaces" / "dev1"
+        old.mkdir(parents=True)
+
+        def fail(*_a, **_k):
+            raise RuntimeError("database is being accessed by other users")
+
+        with pytest.raises(RuntimeError):
+            self._relocate(tmp_path, sql=fail)
+
+        # Half-renamed is the failure this operation must not produce: the
+        # environment stays whole under its old name.
+        assert old.exists()
+        assert not (tmp_path / "workspaces" / "dev2").exists()
+
+    def test_port_hostname_activity_and_chat_sessions_follow_the_name(self, tmp_path):
+        from oduflow import activity, agent_sessions, hostname_registry, port_registry
+
+        team = _rename_team(tmp_path)
+        (tmp_path / "workspaces" / "dev1").mkdir(parents=True)
+        port_registry.allocate_port(team.port_registry_path, "dev1", 50000, 50010)
+        hostname_registry.allocate_hostname(
+            team.hostname_registry_path, "dev1", 5, hostname_prefix="dev"
+        )
+        activity.touch(team, "dev1")
+        agent_sessions.set_session(team, "dev1", "claude", "session-1")
+
+        self._relocate(tmp_path)
+
+        # The port and the hostname ARE the environment's address; a release +
+        # re-allocate could hand back different ones.
+        assert port_registry.get_port(team.port_registry_path, "dev1") is None
+        assert port_registry.get_port(team.port_registry_path, "dev2") == 50000
+        assert hostname_registry.get_hostname(team.hostname_registry_path, "dev2") == (
+            "dev1"
+        )
+        assert "dev1" not in activity.get_all(team)
+        assert "dev2" in activity.get_all(team)
+        assert agent_sessions.get_session(team, "dev1", "claude") is None
+        assert agent_sessions.get_session(team, "dev2", "claude") == "session-1"
+
+    def test_a_rename_that_keeps_the_slug_leaves_the_database_alone(self, tmp_path):
+        client = MagicMock()
+        (tmp_path / "workspaces" / "feature-x").mkdir(parents=True)
+
+        with (
+            patch.object(env_ops, "_unmount_filestore"),
+            patch.object(env_ops, "_db_exists", return_value=True),
+            patch.object(env_ops, "_exec_sql") as exec_sql,
+        ):
+            env_ops._relocate_environment_state(
+                client,
+                _settings(tmp_path),
+                _rename_team(tmp_path),
+                "feature/x",
+                "feature-x",
+            )
+
+        # Same slug, same database name — ALTER DATABASE would fail on it.
+        exec_sql.assert_not_called()
+
+
+class TestRebaseVolumes:
+    def test_workspace_binds_and_the_filestore_path_follow_the_rename(self):
+        volumes = {
+            "/data/workspaces/dev1/repo": {"bind": "/mnt/extra-addons", "mode": "rw"},
+            "/data/workspaces/dev1/filestore": {
+                "bind": "/var/lib/odoo/.local/share/Odoo/filestore/oduflow_1_dev1",
+                "mode": "rw",
+            },
+            "/data/shared_extra_checkouts/enterprise/abc": {
+                "bind": "/mnt/extra-addons-enterprise",
+                "mode": "ro",
+            },
+        }
+
+        rebased = env_ops._rebase_volumes(
+            volumes,
+            "/data/workspaces/dev1",
+            "/data/workspaces/dev2",
+            "oduflow_1_dev1",
+            "oduflow_1_dev2",
+        )
+
+        assert rebased["/data/workspaces/dev2/repo"]["bind"] == "/mnt/extra-addons"
+        assert rebased["/data/workspaces/dev2/filestore"]["bind"] == (
+            "/var/lib/odoo/.local/share/Odoo/filestore/oduflow_1_dev2"
+        )
+        # Shared checkouts live outside the workspace and are not name-keyed.
+        assert "/data/shared_extra_checkouts/enterprise/abc" in rebased


### PR DESCRIPTION
Adds an optional `new_name` parameter to the `switch_branch` MCP tool and the `/switch-branch` REST endpoint, so a reused environment slot whose name still echoes a finished branch can be relabelled on the same container recreate as the branch switch. Everything the name keys moves with it — workspace directory, database (`ALTER DATABASE` after terminating connections), port/hostname registry entries, activity record, agent chat sessions and the coding agent's checkout (moved, not re-cloned, to preserve uncommitted work) — while the URL, credentials and scoped MCP token stay; only the `/mcp/<name>` endpoint path follows the new name, and the tool response says so. A taken or invalid target name (existing container, workspace, database, production namespace, stack-managed environments) is refused before anything mutates, and a strict guardrail refusal blocks the rename too, reporting "The rename was not applied". A relocation failure after the old container is removed reports the containerless state explicitly instead of surfacing a bare error. Docs, spec 0049 Evolution section, agent instructions and unit tests (rename target checks, state relocation, volume rebase, blocked paths) are included.