### PR TITLE
Make oduflow upgrade --force overwrite unresolved bundled files

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,7 @@ oduflow destroy
 # Three-way merge deployed files with the installed bundled versions
 oduflow upgrade
 
-# Skip the confirmation prompt (conflicts still fail safely)
+# Skip the confirmation prompt and overwrite conflicts with the new bundle
 oduflow upgrade --force
 
 # Preview the unified host resource plan and managed config diffs
@@ -96,9 +96,15 @@ On a clean merge the live file and baseline advance together. On conflict the
 live file and accepted baseline stay untouched; the merge result is written to
 `*.oduflow-merge`. Existing customized installations with no baseline receive
 `*.oduflow-new` for a one-time manual reconciliation. Resolve/install the
-sidecar and remove it; until then the command exits with status 1. `--force`
-only skips the confirmation prompt and never overwrites a conflict. A first-line
-`# KEEP` remains an unconditional opt-out.
+sidecar and remove it; until then the command exits with status 1.
+
+`--force` makes the command fully non-interactive: it skips the confirmation
+prompt and resolves conflicts, legacy files, and merge failures in favour of
+the new bundle. The replaced live file is saved under
+`<team-data>/.bundled_upgrade/backups/`, the baseline advances, and any stale
+sidecar is removed, so a forced run leaves nothing to review and exits 0.
+Clean merges still merge, local-only changes are still left untouched, and a
+first-line `# KEEP` remains an unconditional opt-out.
 
 This command is separate from upgrading the Python package (for example,
 `uv tool upgrade oduflow`). It does not manage `postgresql.conf`; use

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,9 +121,12 @@ similarly leaves the live file untouched and writes `*.oduflow-merge`; resolve
 that file, install the resolved content as the live file, and remove the
 sidecar. Until the sidecar is resolved, `oduflow upgrade` exits non-zero.
 
-For unattended upgrades, pass `--force`. It skips only the stdin confirmation:
-legacy files and conflicts are still preserved and still produce a non-zero
-exit code.
+For unattended upgrades, pass `--force`. It skips the stdin confirmation and
+resolves legacy files, conflicts, and merge failures in favour of the new
+bundle: the live file is copied to `.bundled_upgrade/backups/`, then
+overwritten, the baseline advances, and any stale sidecar is removed. A forced
+run therefore leaves no sidecar to review and exits 0. Clean merges are still
+merged and local-only changes are still preserved.
 
 Automatic merging is the default. To opt a file out of all bundled changes,
 add `# KEEP` as the **very first line**:
@@ -136,7 +139,7 @@ add `# KEEP` as the **very first line**:
 ```
 
 Files marked with `# KEEP` are skipped and listed as `(kept)` in the upgrade
-output.
+output, including under `--force`.
 
 ## Configuration Reference
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -101,9 +101,12 @@ upgrade` three-way merges each team's bundled `odoo.conf`, agent guides, and
 sanitize script against a stored pristine baseline. Conflicts preserve the live
 file and create `*.oduflow-merge`; pre-baseline installations create
 `*.oduflow-new` for one-time manual reconciliation. Both cases exit non-zero
-until the sidecar is resolved and removed. `--force` skips only the stdin
-confirmation. A first-line `# KEEP` opts a file out entirely. PostgreSQL config
-changes use `oduflow retune-postgres`, not `oduflow upgrade`.
+until the sidecar is resolved and removed. `--force` skips the stdin
+confirmation and resolves those cases in favour of the new bundle: the live
+file is backed up under `.bundled_upgrade/backups/` and overwritten, so the
+command needs no manual follow-up. A first-line `# KEEP` opts a file out
+entirely, even under `--force`. PostgreSQL config changes use
+`oduflow retune-postgres`, not `oduflow upgrade`.
 
 ### Set up a template
 
@@ -675,9 +678,12 @@ similarly leaves the live file untouched and writes `*.oduflow-merge`; resolve
 that file, install the resolved content as the live file, and remove the
 sidecar. Until the sidecar is resolved, `oduflow upgrade` exits non-zero.
 
-For unattended upgrades, pass `--force`. It skips only the stdin confirmation:
-legacy files and conflicts are still preserved and still produce a non-zero
-exit code.
+For unattended upgrades, pass `--force`. It skips the stdin confirmation and
+resolves legacy files, conflicts, and merge failures in favour of the new
+bundle: the live file is copied to `.bundled_upgrade/backups/`, then
+overwritten, the baseline advances, and any stale sidecar is removed. A forced
+run therefore leaves no sidecar to review and exits 0. Clean merges are still
+merged and local-only changes are still preserved.
 
 Automatic merging is the default. To opt a file out of all bundled changes,
 add `# KEEP` as the **very first line**:
@@ -690,7 +696,7 @@ add `# KEEP` as the **very first line**:
 ```
 
 Files marked with `# KEEP` are skipped and listed as `(kept)` in the upgrade
-output.
+output, including under `--force`.
 
 ## Configuration Reference
 
@@ -3334,7 +3340,7 @@ oduflow destroy
 # Three-way merge deployed files with the installed bundled versions
 oduflow upgrade
 
-# Skip the confirmation prompt (conflicts still fail safely)
+# Skip the confirmation prompt and overwrite conflicts with the new bundle
 oduflow upgrade --force
 
 # Preview the unified host resource plan and managed config diffs
@@ -3362,9 +3368,15 @@ On a clean merge the live file and baseline advance together. On conflict the
 live file and accepted baseline stay untouched; the merge result is written to
 `*.oduflow-merge`. Existing customized installations with no baseline receive
 `*.oduflow-new` for a one-time manual reconciliation. Resolve/install the
-sidecar and remove it; until then the command exits with status 1. `--force`
-only skips the confirmation prompt and never overwrites a conflict. A first-line
-`# KEEP` remains an unconditional opt-out.
+sidecar and remove it; until then the command exits with status 1.
+
+`--force` makes the command fully non-interactive: it skips the confirmation
+prompt and resolves conflicts, legacy files, and merge failures in favour of
+the new bundle. The replaced live file is saved under
+`<team-data>/.bundled_upgrade/backups/`, the baseline advances, and any stale
+sidecar is removed, so a forced run leaves nothing to review and exits 0.
+Clean merges still merge, local-only changes are still left untouched, and a
+first-line `# KEEP` remains an unconditional opt-out.
 
 This command is separate from upgrading the Python package (for example,
 `uv tool upgrade oduflow`). It does not manage `postgresql.conf`; use

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -101,9 +101,12 @@ upgrade` three-way merges each team's bundled `odoo.conf`, agent guides, and
 sanitize script against a stored pristine baseline. Conflicts preserve the live
 file and create `*.oduflow-merge`; pre-baseline installations create
 `*.oduflow-new` for one-time manual reconciliation. Both cases exit non-zero
-until the sidecar is resolved and removed. `--force` skips only the stdin
-confirmation. A first-line `# KEEP` opts a file out entirely. PostgreSQL config
-changes use `oduflow retune-postgres`, not `oduflow upgrade`.
+until the sidecar is resolved and removed. `--force` skips the stdin
+confirmation and resolves those cases in favour of the new bundle: the live
+file is backed up under `.bundled_upgrade/backups/` and overwritten, so the
+command needs no manual follow-up. A first-line `# KEEP` opts a file out
+entirely, even under `--force`. PostgreSQL config changes use
+`oduflow retune-postgres`, not `oduflow upgrade`.
 
 ### Set up a template
 

--- a/src/oduflow/bundled_upgrade.py
+++ b/src/oduflow/bundled_upgrade.py
@@ -23,6 +23,7 @@ ActionKind = Literal[
     "local-only",
     "resolved",
     "merge",
+    "overwrite",
     "keep",
     "legacy",
     "legacy-pending",
@@ -90,6 +91,7 @@ class ReconcilePlan:
             "create",
             "update",
             "merge",
+            "overwrite",
             "legacy",
             "legacy-pending",
             "conflict",
@@ -128,8 +130,15 @@ def seed_managed_file(managed: ManagedFile) -> bool:
     return False
 
 
-def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
-    """Classify one file without changing the filesystem."""
+def plan_reconcile(managed: ManagedFile, *, force: bool = False) -> ReconcilePlan:
+    """Classify one file without changing the filesystem.
+
+    With ``force`` the cases that would otherwise stop for a human — legacy
+    files, merge conflicts, and merge failures — resolve in favour of the new
+    bundle instead: the live file is backed up and overwritten.  Clean merges
+    still merge, local-only changes are still left alone, and a first-line
+    ``# KEEP`` remains an unconditional opt-out.
+    """
     source_content = managed.source.read_bytes()
     try:
         local_content = managed.destination.read_bytes()
@@ -169,6 +178,8 @@ def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
     # Sidecars are explicit gates. Keep refreshing them from the last accepted
     # baseline until the operator reconciles the live file and removes them.
     if managed.new_path.exists():
+        if force:
+            return _overwrite_plan(managed, source_content, local_content)
         return ReconcilePlan(
             managed,
             "legacy-pending",
@@ -180,6 +191,8 @@ def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
 
     if managed.merge_path.exists():
         if baseline_content is None:
+            if force:
+                return _overwrite_plan(managed, source_content, local_content)
             return ReconcilePlan(
                 managed,
                 "error",
@@ -189,6 +202,8 @@ def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
                 error="conflict sidecar exists but its accepted baseline is missing",
             )
         merged_content, error, conflicted = _merge_file(managed, managed.baseline_path)
+        if (error or conflicted) and force:
+            return _overwrite_plan(managed, source_content, local_content)
         if error:
             return ReconcilePlan(
                 managed,
@@ -224,6 +239,8 @@ def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
         pending_acknowledged = True
 
     if baseline_content is None:
+        if force:
+            return _overwrite_plan(managed, source_content, local_content)
         return ReconcilePlan(
             managed,
             "legacy",
@@ -265,6 +282,8 @@ def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
         )
 
     merged_content, error, conflicted = _merge_file(managed, base_path)
+    if (error or conflicted) and force:
+        return _overwrite_plan(managed, source_content, local_content)
     if error:
         return ReconcilePlan(
             managed,
@@ -286,6 +305,19 @@ def plan_reconcile(managed: ManagedFile) -> ReconcilePlan:
         result_content=merged_content,
         base_path=base_path,
         pending_acknowledged=pending_acknowledged,
+    )
+
+
+def _overwrite_plan(
+    managed: ManagedFile, source_content: bytes, local_content: bytes
+) -> ReconcilePlan:
+    """Resolve a would-be sidecar case in favour of the new bundle."""
+    return ReconcilePlan(
+        managed,
+        "overwrite",
+        source_content,
+        local_content=local_content,
+        result_content=source_content,
     )
 
 
@@ -332,7 +364,7 @@ def apply_reconcile(plan: ReconcilePlan) -> None:
         _remove_generated_sidecars(managed)
         return
 
-    if plan.kind in {"update", "merge"}:
+    if plan.kind in {"update", "merge", "overwrite"}:
         if plan.local_content is None or plan.result_content is None:
             raise BundledUpgradeError(f"Incomplete {plan.kind} plan")
         _atomic_write(

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4811,7 +4811,10 @@ def _run_upgrade(settings: Settings, *, force: bool = False) -> bool:
         print("Nothing to upgrade — no bundled files found.")
         return True
 
-    plans = [bundled_upgrade.plan_reconcile(managed) for managed in managed_files]
+    plans = [
+        bundled_upgrade.plan_reconcile(managed, force=force)
+        for managed in managed_files
+    ]
     actionable = [plan for plan in plans if plan.needs_confirmation]
     kept = [plan for plan in plans if plan.kind == "keep"]
 
@@ -4845,8 +4848,12 @@ def _run_upgrade(settings: Settings, *, force: bool = False) -> bool:
         for plan in kept:
             print(f"  {plan.managed.label} {plan.managed.destination} (kept)")
     print()
-    print("  Conflicts and legacy files keep the live file unchanged and create")
-    print("  a sidecar for manual resolution.")
+    if force:
+        print("  --force: conflicts and legacy files are overwritten with the new")
+        print("  bundle. The replaced file is kept under .bundled_upgrade/backups/.")
+    else:
+        print("  Conflicts and legacy files keep the live file unchanged and create")
+        print("  a sidecar for manual resolution.")
     print()
 
     if not force:
@@ -4858,7 +4865,9 @@ def _run_upgrade(settings: Settings, *, force: bool = False) -> bool:
 
     success = _apply_upgrade_plans(plans)
     if success:
-        changed = sum(plan.kind in {"create", "update", "merge"} for plan in plans)
+        changed = sum(
+            plan.kind in {"create", "update", "merge", "overwrite"} for plan in plans
+        )
         print(
             f"\nDone. Reconciled {changed} file(s) across "
             f"{len(settings.teams)} team(s)."
@@ -4876,6 +4885,7 @@ def _upgrade_plan_description(plan: bundled_upgrade.ReconcilePlan) -> str:
         "create": "new",
         "update": "upstream update",
         "merge": "clean merge",
+        "overwrite": "overwritten with the new bundle; local file backed up",
         "legacy": f"legacy; review {plan.managed.new_path}",
         "legacy-pending": f"pending review; update {plan.managed.new_path}",
         "conflict": f"conflict; resolve {plan.managed.merge_path}",
@@ -4901,6 +4911,8 @@ def _apply_upgrade_plans(plans: list[bundled_upgrade.ReconcilePlan]) -> bool:
             print(f"  Updated: {destination}")
         elif plan.kind == "merge":
             print(f"  Merged: {destination}")
+        elif plan.kind == "overwrite":
+            print(f"  Overwritten: {destination} (backup: {plan.managed.backup_path})")
         elif plan.kind in {"legacy", "legacy-pending"}:
             print(
                 f"  REVIEW: {destination} kept; merge {plan.managed.new_path} "
@@ -5837,7 +5849,10 @@ def _run_cli() -> None:
     p_upgrade.add_argument(
         "--force",
         action="store_true",
-        help="reconcile changed bundled files without prompting",
+        help=(
+            "reconcile without prompting and overwrite conflicting or legacy "
+            "files with the new bundle (the replaced file is backed up)"
+        ),
     )
     p_retune = sub.add_parser(
         "retune-postgres",

--- a/tests/test_bundled_upgrade.py
+++ b/tests/test_bundled_upgrade.py
@@ -259,6 +259,132 @@ def test_missing_git_fails_safe_and_exposes_new_bundle(tmp_path: Path):
     assert managed.error_path.read_bytes() == b"alpha=1\nbeta=2\n"
 
 
+def test_force_overwrites_a_conflict_and_backs_up_the_live_file(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"value=upstream\n",
+        local=b"value=local\n",
+        baseline=b"value=base\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "overwrite"
+    assert plan.needs_attention is False
+    assert managed.destination.read_bytes() == b"value=upstream\n"
+    assert managed.baseline_path.read_bytes() == b"value=upstream\n"
+    assert managed.backup_path.read_bytes() == b"value=local\n"
+    assert not managed.merge_path.exists()
+    assert not managed.pending_path.exists()
+    assert bundled_upgrade.plan_reconcile(managed).kind == "up-to-date"
+
+
+def test_force_overwrites_a_legacy_file(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"custom legacy\n",
+        baseline=None,
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "overwrite"
+    assert managed.destination.read_bytes() == b"bundled v2\n"
+    assert managed.baseline_path.read_bytes() == b"bundled v2\n"
+    assert managed.backup_path.read_bytes() == b"custom legacy\n"
+    assert not managed.new_path.exists()
+    assert not managed.pending_path.exists()
+    assert bundled_upgrade.plan_reconcile(managed).kind == "up-to-date"
+
+
+def test_force_clears_sidecars_left_by_an_earlier_run(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"bundled v2\n",
+        local=b"custom legacy\n",
+        baseline=None,
+    )
+    bundled_upgrade.apply_reconcile(bundled_upgrade.plan_reconcile(managed))
+    assert managed.new_path.exists()
+
+    forced = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(forced)
+
+    assert forced.kind == "overwrite"
+    assert managed.destination.read_bytes() == b"bundled v2\n"
+    assert managed.baseline_path.read_bytes() == b"bundled v2\n"
+    assert not managed.new_path.exists()
+    assert not managed.pending_path.exists()
+    assert bundled_upgrade.plan_reconcile(managed).kind == "up-to-date"
+
+
+def test_force_overwrites_when_merging_is_unavailable(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"alpha=1\nbeta=2\n",
+        local=b"alpha=2\nbeta=1\n",
+        baseline=b"alpha=1\nbeta=1\n",
+    )
+
+    with patch(
+        "oduflow.bundled_upgrade.subprocess.run",
+        side_effect=FileNotFoundError("git not found"),
+    ):
+        plan = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "overwrite"
+    assert managed.destination.read_bytes() == b"alpha=1\nbeta=2\n"
+    assert managed.backup_path.read_bytes() == b"alpha=2\nbeta=1\n"
+    assert not managed.error_path.exists()
+
+
+def test_force_still_merges_disjoint_changes(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"alpha=1\nunchanged one\nunchanged two\nbeta=2\n",
+        local=b"alpha=2\nunchanged one\nunchanged two\nbeta=1\n",
+        baseline=b"alpha=1\nunchanged one\nunchanged two\nbeta=1\n",
+    )
+
+    plan = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(plan)
+
+    assert plan.kind == "merge"
+    assert managed.destination.read_bytes() == (
+        b"alpha=2\nunchanged one\nunchanged two\nbeta=2\n"
+    )
+
+
+def test_force_leaves_local_only_changes_and_keep_files_alone(tmp_path: Path):
+    local_only = _managed(
+        tmp_path / "local-only",
+        source=b"value=old\n",
+        local=b"value=new\n",
+        baseline=b"value=old\n",
+    )
+    kept_content = b"# KEEP\nvalue=local\n"
+    kept = _managed(
+        tmp_path / "kept",
+        source=b"value=upstream\n",
+        local=kept_content,
+        baseline=b"value=base\n",
+    )
+
+    local_plan = bundled_upgrade.plan_reconcile(local_only, force=True)
+    bundled_upgrade.apply_reconcile(local_plan)
+    kept_plan = bundled_upgrade.plan_reconcile(kept, force=True)
+    bundled_upgrade.apply_reconcile(kept_plan)
+
+    assert local_plan.kind == "local-only"
+    assert local_only.destination.read_bytes() == b"value=new\n"
+    assert kept_plan.kind == "keep"
+    assert kept.destination.read_bytes() == kept_content
+
+
 def test_apply_refuses_a_file_changed_after_planning(tmp_path: Path):
     managed = _managed(
         tmp_path,

--- a/tests/test_bundled_upgrade.py
+++ b/tests/test_bundled_upgrade.py
@@ -321,6 +321,54 @@ def test_force_clears_sidecars_left_by_an_earlier_run(tmp_path: Path):
     assert bundled_upgrade.plan_reconcile(managed).kind == "up-to-date"
 
 
+def test_force_clears_a_conflict_sidecar_left_by_an_earlier_run(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"value=upstream\n",
+        local=b"value=local\n",
+        baseline=b"value=base\n",
+    )
+    bundled_upgrade.apply_reconcile(bundled_upgrade.plan_reconcile(managed))
+    assert managed.merge_path.exists()
+    assert managed.pending_path.exists()
+
+    forced = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(forced)
+
+    assert forced.kind == "overwrite"
+    assert managed.destination.read_bytes() == b"value=upstream\n"
+    assert managed.baseline_path.read_bytes() == b"value=upstream\n"
+    assert managed.backup_path.read_bytes() == b"value=local\n"
+    assert not managed.merge_path.exists()
+    assert not managed.pending_path.exists()
+    assert not managed.new_path.exists()
+    assert not managed.error_path.exists()
+    assert bundled_upgrade.plan_reconcile(managed).kind == "up-to-date"
+
+
+def test_force_overwrites_a_conflict_sidecar_whose_baseline_is_missing(tmp_path: Path):
+    managed = _managed(
+        tmp_path,
+        source=b"value=upstream\n",
+        local=b"value=local\n",
+        baseline=None,
+    )
+    managed.merge_path.write_bytes(b"stale merge artifact\n")
+
+    assert bundled_upgrade.plan_reconcile(managed).kind == "error"
+
+    forced = bundled_upgrade.plan_reconcile(managed, force=True)
+    bundled_upgrade.apply_reconcile(forced)
+
+    assert forced.kind == "overwrite"
+    assert managed.destination.read_bytes() == b"value=upstream\n"
+    assert managed.baseline_path.read_bytes() == b"value=upstream\n"
+    assert managed.backup_path.read_bytes() == b"value=local\n"
+    assert not managed.merge_path.exists()
+    assert not managed.pending_path.exists()
+    assert bundled_upgrade.plan_reconcile(managed).kind == "up-to-date"
+
+
 def test_force_overwrites_when_merging_is_unavailable(tmp_path: Path):
     managed = _managed(
         tmp_path,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -176,12 +176,8 @@ class TestCLIUpgrade:
 
         assert deployed_guide.read_text(encoding="utf-8") == "bundled v2\n"
 
-    def test_upgrade_legacy_file_requires_review_without_overwriting(
-        self, tmp_path, monkeypatch
-    ):
-        server, settings, deployed_guide = self._settings_with_changed_guide(
-            tmp_path, monkeypatch
-        )
+    @staticmethod
+    def _make_legacy(settings, deployed_guide):
         baseline = (
             Path(settings.teams["1"].data_dir)
             / ".bundled_upgrade"
@@ -191,14 +187,45 @@ class TestCLIUpgrade:
         )
         baseline.unlink()
         deployed_guide.write_text("custom legacy\n", encoding="utf-8")
+        return baseline
 
-        assert server._run_upgrade(settings, force=True) is False
+    def test_upgrade_legacy_file_requires_review_without_force(
+        self, tmp_path, monkeypatch
+    ):
+        server, settings, deployed_guide = self._settings_with_changed_guide(
+            tmp_path, monkeypatch
+        )
+        self._make_legacy(settings, deployed_guide)
+
+        with patch("builtins.input", return_value=""):
+            assert server._run_upgrade(settings) is False
 
         assert deployed_guide.read_text(encoding="utf-8") == "custom legacy\n"
         assert (
             Path(f"{deployed_guide}.oduflow-new").read_text(encoding="utf-8")
             == "bundled v2\n"
         )
+
+    def test_upgrade_force_overwrites_a_legacy_file(self, tmp_path, monkeypatch):
+        server, settings, deployed_guide = self._settings_with_changed_guide(
+            tmp_path, monkeypatch
+        )
+        baseline = self._make_legacy(settings, deployed_guide)
+        backup = (
+            Path(settings.teams["1"].data_dir)
+            / ".bundled_upgrade"
+            / "backups"
+            / "agent_guides"
+            / "guide.md"
+        )
+
+        with patch("builtins.input", side_effect=AssertionError("unexpected prompt")):
+            assert server._run_upgrade(settings, force=True) is True
+
+        assert deployed_guide.read_text(encoding="utf-8") == "bundled v2\n"
+        assert baseline.read_text(encoding="utf-8") == "bundled v2\n"
+        assert backup.read_text(encoding="utf-8") == "custom legacy\n"
+        assert not Path(f"{deployed_guide}.oduflow-new").exists()
 
     def test_upgrade_does_not_manage_postgresql_conf(self, tmp_path, monkeypatch):
         from oduflow import server

--- a/tests/test_switch_branch.py
+++ b/tests/test_switch_branch.py
@@ -579,9 +579,7 @@ class TestSwitchWithRename:
         assert "renamed_from" not in result
         assert "was not applied" in result["message"]
 
-    def test_a_dropped_module_refusal_blocks_the_rename_too(
-        self, tmp_path, switch_env
-    ):
+    def test_a_dropped_module_refusal_blocks_the_rename_too(self, tmp_path, switch_env):
         switch_env["preflight"].return_value = ["Module 'sale_x' would be dropped."]
 
         result = _switch(tmp_path, new_name="dev2", strict=True)


### PR DESCRIPTION
## What

`oduflow upgrade --force` now overwrites existing deployed files without asking.

Until now `--force` only skipped the stdin confirmation. Conflicts, legacy files (no stored baseline) and merge failures still kept the live file, wrote a sidecar (`*.oduflow-merge` / `*.oduflow-new` / `*.oduflow-error-new`) and exited non-zero — so an "unattended" upgrade still needed a human.

With this change a forced run resolves those cases in favour of the new bundle:

- the live file is copied to `<team-data>/.bundled_upgrade/backups/`,
- the destination is overwritten with the bundled version,
- the baseline advances to the new bundle,
- stale sidecars and the `pending/` marker are removed,
- the run leaves nothing to review and exits 0.

## What is unchanged

- Clean three-way merges still merge (local edits are preserved).
- `local-only` changes — where the bundle did not change — are still left untouched.
- A first-line `# KEEP` remains an unconditional opt-out, also under `--force`.
- Without `--force`, behaviour is identical to before.

## Implementation

`plan_reconcile(managed, *, force=False)` returns a new `overwrite` plan kind for the branches that would otherwise produce a sidecar. `apply_reconcile` handles it on the existing backup + write + advance-baseline path, so the atomic write and post-plan drift checks are shared with `update`/`merge`. The CLI prints `Overwritten: <file> (backup: ...)` and states the forced policy in the summary block.

## Tests

Unit coverage for force over conflict, legacy, pending/legacy sidecars, stale conflict sidecars (including one whose baseline is missing), `git merge-file` unavailable, and the negative cases (clean merge still merges, `local-only` and `# KEEP` untouched). Each asserts that the following non-forced run reports `up-to-date`. `_run_upgrade` CLI tests split into the no-force (review required, exit 1) and force (overwrite, exit 0) paths.

`ruff check`, `ruff format`, `mypy src/oduflow`, and the unit suite (2448 passed) are green.

## Docs

`docs/cli.md`, `docs/installation.md` and `docs/llms.txt` documented the old contract ("`--force` only skips the confirmation prompt and never overwrites a conflict") and are updated; `docs/llms-full.txt` regenerated with `scripts/build_llms_full.py`.