### PR TITLE
Add dashboard import from running Odoo instances

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3030,7 +3030,7 @@ contain `/` are accepted and URL-decoded as one environment name.
 | `WebSocket` | `/api/environments/{branch}/agent` | Hosted Agent CLI PTY |
 | `WebSocket` | `/api/environments/{branch}/agent-acp` | Hosted Agent Chat ACP relay |
 
-## Templates and Odoo.sh import
+## Templates and Odoo imports
 
 | Method | Endpoint | Description |
 |---|---|---|
@@ -3039,6 +3039,7 @@ contain `/` are accepted and URL-decoded as one environment name.
 | `PUT` | `/api/templates/{name:path}/metadata` | Validate and atomically replace `metadata.json`; body: `content`, `revision` |
 | `POST` | `/api/templates/{name}/delete` | Delete a template |
 | `POST` | `/api/templates/{name}/rename` | Rename it; body: `new_name` |
+| `POST` | `/api/templates/import-from-odoo` | UI-authenticated: pull a backup from a running Odoo. Body: `odoo_url`, `master_pwd`, `template_name`, optional `db_name`, optional boolean `without_filestore` |
 | `POST` | `/api/templates/import-token` | UI-authenticated: mint a 15-minute Odoo.sh import token |
 | `GET` | `/api/templates/import/status` | Import-token authenticated: report resumable upload progress |
 | `POST` | `/api/templates/import/manifest` | Upload template metadata |
@@ -3049,9 +3050,14 @@ contain `/` are accepted and URL-decoded as one environment name.
 | `POST` | `/api/templates/import/finalize` | Validate staged data and atomically publish/restore the template |
 | `GET` | `/import-odoo.sh` | Download the token-authenticated Odoo.sh import client |
 
-Ingest endpoints accept the import token only in `Authorization: Bearer ...`,
-not in the URL. See [Template Management](templates.md) for the supported import
-workflow.
+The pull-import endpoint accepts HTTP and HTTPS source URLs. HTTP sends the Odoo
+master password without transport encryption, so HTTPS remains recommended.
+Loopback, link-local, metadata, and private-network targets remain blocked by
+the outbound URL safety check.
+
+Odoo.sh ingest endpoints accept the import token only in
+`Authorization: Bearer ...`, not in the URL. See
+[Template Management](templates.md) for the supported import workflow.
 
 ## Services, presets, and volumes
 

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -74,7 +74,7 @@ contain `/` are accepted and URL-decoded as one environment name.
 | `WebSocket` | `/api/environments/{branch}/agent` | Hosted Agent CLI PTY |
 | `WebSocket` | `/api/environments/{branch}/agent-acp` | Hosted Agent Chat ACP relay |
 
-## Templates and Odoo.sh import
+## Templates and Odoo imports
 
 | Method | Endpoint | Description |
 |---|---|---|
@@ -83,6 +83,7 @@ contain `/` are accepted and URL-decoded as one environment name.
 | `PUT` | `/api/templates/{name:path}/metadata` | Validate and atomically replace `metadata.json`; body: `content`, `revision` |
 | `POST` | `/api/templates/{name}/delete` | Delete a template |
 | `POST` | `/api/templates/{name}/rename` | Rename it; body: `new_name` |
+| `POST` | `/api/templates/import-from-odoo` | UI-authenticated: pull a backup from a running Odoo. Body: `odoo_url`, `master_pwd`, `template_name`, optional `db_name`, optional boolean `without_filestore` |
 | `POST` | `/api/templates/import-token` | UI-authenticated: mint a 15-minute Odoo.sh import token |
 | `GET` | `/api/templates/import/status` | Import-token authenticated: report resumable upload progress |
 | `POST` | `/api/templates/import/manifest` | Upload template metadata |
@@ -93,9 +94,14 @@ contain `/` are accepted and URL-decoded as one environment name.
 | `POST` | `/api/templates/import/finalize` | Validate staged data and atomically publish/restore the template |
 | `GET` | `/import-odoo.sh` | Download the token-authenticated Odoo.sh import client |
 
-Ingest endpoints accept the import token only in `Authorization: Bearer ...`,
-not in the URL. See [Template Management](templates.md) for the supported import
-workflow.
+The pull-import endpoint accepts HTTP and HTTPS source URLs. HTTP sends the Odoo
+master password without transport encryption, so HTTPS remains recommended.
+Loopback, link-local, metadata, and private-network targets remain blocked by
+the outbound URL safety check.
+
+Odoo.sh ingest endpoints accept the import token only in
+`Authorization: Bearer ...`, not in the URL. See
+[Template Management](templates.md) for the supported import workflow.
 
 ## Services, presets, and volumes
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3366,9 +3366,9 @@ def import_from_odoo(
 
     # SSRF guard: importing a DB from a URL is a clearly-external operation, so
     # block loopback, the cloud metadata endpoint, and internal RFC1918 hosts.
-    # Require HTTPS: the request carries the Odoo master password (see below),
-    # which must never cross the wire in cleartext.
-    assert_allowed_url(base, require_https=True, allow_private=False)
+    # HTTP is allowed for operator-managed Odoo instances, although it sends the
+    # master password without transport encryption.
+    assert_allowed_url(base, require_https=False, allow_private=False)
 
     if os.path.exists(template_dir):
         raise ConflictError(f"Template directory already exists: {template_dir}")

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1358,6 +1358,7 @@
 
 <div id="tab-templates" class="tab-content">
   <div class="tab-toolbar">
+    <button class="btn" onclick="openImportFromOdooModal()">Import from Odoo</button>
     <button class="btn-create" onclick="openImportOdooModal()">Import from Odoo.sh</button>
   </div>
   <div id="tpl-list"></div>
@@ -1770,6 +1771,49 @@
       <div class="form-actions">
         <button class="btn" onclick="closeCreateVolumeModal()">Cancel</button>
         <button class="btn-create" id="vol-submit" onclick="submitCreateVolume()">Create</button>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="modal-overlay" id="import-from-odoo-modal" onclick="closeImportFromOdooModal(event)">
+  <div class="modal">
+    <div class="modal-header">
+      <h2>Import from Odoo</h2>
+      <button class="modal-close" aria-label="Close import from Odoo" onclick="closeImportFromOdooModal()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="form-error" id="pull-import-error"></div>
+      <div class="form-group">
+        <label for="pull-import-url">Odoo URL</label>
+        <input class="mono-input" type="url" id="pull-import-url" placeholder="https://odoo.example.com" autocomplete="url">
+        <div class="hint">HTTP URLs are allowed, but the Odoo master password will be transmitted without encryption. Prefer HTTPS whenever possible.</div>
+      </div>
+      <div class="form-group">
+        <label for="pull-import-master-pwd">Master password</label>
+        <input type="password" id="pull-import-master-pwd" autocomplete="off">
+        <div class="hint">The database manager password used by Odoo's backup endpoint. It is sent only with this import request.</div>
+      </div>
+      <div class="form-group">
+        <label for="pull-import-db-name">Database name <span class="label-hint">— optional</span></label>
+        <input class="mono-input" type="text" id="pull-import-db-name" placeholder="Auto-detect when only one database exists" autocomplete="off">
+      </div>
+      <div class="form-group">
+        <label for="pull-import-tpl-name">Template name</label>
+        <input class="mono-input" type="text" id="pull-import-tpl-name" placeholder="e.g. production-copy" autocomplete="off">
+      </div>
+      <div class="form-group">
+        <div class="check-row">
+          <input type="checkbox" id="pull-import-without-filestore">
+          <label for="pull-import-without-filestore">Database only <span class="label-hint">— skip the filestore and request a PostgreSQL custom dump</span></label>
+        </div>
+      </div>
+      <div class="hint" id="pull-import-progress" role="status" aria-live="polite" style="display:none">
+        <span class="spinner" aria-hidden="true"></span>
+        Downloading and restoring the template… <span id="pull-import-elapsed" aria-hidden="true"></span>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeImportFromOdooModal()">Cancel</button>
+        <button class="btn-create" id="pull-import-submit" onclick="submitImportFromOdoo()">Import</button>
       </div>
     </div>
   </div>
@@ -3509,6 +3553,108 @@ async function doDeleteTemplate(name) {
     }
   } catch (e) {
     showToast('Connection error: ' + e.message, true);
+  }
+}
+
+function openImportFromOdooModal() {
+  document.getElementById('pull-import-url').value = '';
+  document.getElementById('pull-import-master-pwd').value = '';
+  document.getElementById('pull-import-db-name').value = '';
+  document.getElementById('pull-import-tpl-name').value = '';
+  document.getElementById('pull-import-without-filestore').checked = false;
+  var errEl = document.getElementById('pull-import-error');
+  errEl.style.display = 'none';
+  errEl.textContent = '';
+  document.getElementById('pull-import-progress').style.display = 'none';
+  document.getElementById('pull-import-elapsed').textContent = '';
+  var btn = document.getElementById('pull-import-submit');
+  btn.disabled = false;
+  btn.textContent = 'Import';
+  showModal('import-from-odoo-modal');
+  document.getElementById('pull-import-url').focus();
+}
+
+function closeImportFromOdooModal(event) {
+  if (event && event.target !== event.currentTarget) return;
+  document.getElementById('pull-import-master-pwd').value = '';
+  hideModal('import-from-odoo-modal');
+}
+
+async function submitImportFromOdoo() {
+  var odooUrl = document.getElementById('pull-import-url').value.trim();
+  var masterPwd = document.getElementById('pull-import-master-pwd').value;
+  var dbName = document.getElementById('pull-import-db-name').value.trim();
+  var templateName = document.getElementById('pull-import-tpl-name').value.trim();
+  var errEl = document.getElementById('pull-import-error');
+  if (!odooUrl) {
+    errEl.textContent = 'Odoo URL is required.';
+    errEl.style.display = 'block';
+    return;
+  }
+  if (!masterPwd) {
+    errEl.textContent = 'Master password is required.';
+    errEl.style.display = 'block';
+    return;
+  }
+  if (!templateName) {
+    errEl.textContent = 'Template name is required.';
+    errEl.style.display = 'block';
+    return;
+  }
+
+  errEl.style.display = 'none';
+  var btn = document.getElementById('pull-import-submit');
+  var progress = document.getElementById('pull-import-progress');
+  var elapsed = document.getElementById('pull-import-elapsed');
+  var started = Date.now();
+  btn.disabled = true;
+  btn.textContent = 'Importing…';
+  progress.style.display = 'block';
+  var updateProgress = function() {
+    elapsed.textContent = _fmtElapsed(Date.now() - started);
+  };
+  updateProgress();
+  var progressTimer = setInterval(updateProgress, 1000);
+  try {
+    var r = await fetch(API_TEMPLATES + '/import-from-odoo', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        odoo_url: odooUrl,
+        master_pwd: masterPwd,
+        db_name: dbName,
+        template_name: templateName,
+        without_filestore: document.getElementById('pull-import-without-filestore').checked
+      })
+    });
+    var data = await readResult(r);
+    if (r.ok && data.ok) {
+      var result = data.result || {};
+      closeImportFromOdooModal();
+      showToast('Imported template "' + templateName + '" from ' + (result.source_url || odooUrl));
+      await loadTemplates();
+      var failures = result.remount_failures || [];
+      if (failures.length) {
+        showToast('Template imported, but ' + failures.length + ' environment filestore remount' +
+          (failures.length === 1 ? ' failed.' : 's failed.'), true);
+      }
+    } else if (isAmbiguousGatewayStatus(r.status)) {
+      closeImportFromOdooModal();
+      showToast('The proxy stopped waiting, but importing template "' + templateName +
+        '" may still be running. Refresh in a moment.');
+      await loadTemplates();
+    } else {
+      errEl.textContent = data.error || 'Import failed';
+      errEl.style.display = 'block';
+    }
+  } catch (e) {
+    errEl.textContent = 'Connection error: ' + e.message;
+    errEl.style.display = 'block';
+  } finally {
+    clearInterval(progressTimer);
+    progress.style.display = 'none';
+    btn.disabled = false;
+    btn.textContent = 'Import';
   }
 }
 
@@ -5986,6 +6132,8 @@ var MODAL_CLOSERS = {
   'license-modal': closeLicenseModal,
   'add-extra-repo-modal': closeAddExtraRepoModal,
   'add-credential-modal': closeAddCredentialModal,
+  'import-from-odoo-modal': closeImportFromOdooModal,
+  'import-odoo-modal': closeImportOdooModal,
   'template-settings-modal': closeTemplateSettingsModal,
   'confirm-modal': cancelConfirm,
   'note-modal': closeNoteModal

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1461,6 +1461,96 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
 
+    async def api_import_template_from_odoo(request: Request) -> JSONResponse:
+        team = _get_ui_team(request)
+        try:
+            body = await request.json()
+        except ValueError:
+            return JSONResponse(
+                {"ok": False, "error": "Invalid JSON body"}, status_code=400
+            )
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"ok": False, "error": "JSON body must be an object"},
+                status_code=400,
+            )
+
+        odoo_url = str(body.get("odoo_url") or "").strip()
+        master_pwd = str(body.get("master_pwd") or "")
+        db_name = str(body.get("db_name") or "").strip()
+        template_name = str(body.get("template_name") or "").strip()
+        without_filestore = body.get("without_filestore", False)
+        if not odoo_url:
+            return JSONResponse(
+                {"ok": False, "error": "odoo_url is required"}, status_code=400
+            )
+        if not master_pwd:
+            return JSONResponse(
+                {"ok": False, "error": "master_pwd is required"}, status_code=400
+            )
+        if not template_name:
+            return JSONResponse(
+                {"ok": False, "error": "template_name is required"}, status_code=400
+            )
+        if not isinstance(without_filestore, bool):
+            return JSONResponse(
+                {"ok": False, "error": "without_filestore must be a boolean"},
+                status_code=400,
+            )
+        try:
+            validate_template_name(template_name)
+        except ValueError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
+
+        try:
+            locks.acquire_team(team.team_id)
+        except BusyError as e:
+            return _error_response(e)
+        try:
+            result = await _offload(
+                system_ops.import_from_odoo,
+                get_settings(),
+                team,
+                odoo_url=odoo_url,
+                master_pwd=master_pwd,
+                db_name=db_name,
+                template_name=template_name,
+                without_filestore=without_filestore,
+            )
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "result": {
+                        "template_name": result.get("template_name"),
+                        "source_url": result.get("source_url"),
+                        "source_db": result.get("source_db"),
+                        "odoo_version": result.get("odoo_version"),
+                        "odoo_image": result.get("odoo_image"),
+                        "template_db": result.get("template_db"),
+                        "includes_filestore": result.get("includes_filestore"),
+                        "zip_size_mb": result.get("zip_size_mb"),
+                        "restore_seconds": result.get("restore_seconds"),
+                        "affected_envs": result.get("affected_envs", []),
+                        "remount_failures": result.get("remount_failures", []),
+                    },
+                }
+            )
+        except FlowError as e:
+            logger.warning(
+                "import_from_odoo failed for template %s: %s", template_name, e
+            )
+            return _error_response(e)
+        except Exception:
+            logger.exception(
+                "Unexpected error in api_import_template_from_odoo for template %s",
+                template_name,
+            )
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+        finally:
+            locks.release_team(team.team_id)
+
     def api_template_delete(request: Request) -> JSONResponse:
         name = request.path_params["name"]
         team = _get_ui_team(request)
@@ -4784,6 +4874,11 @@ def _build_routes(
         Route("/api/templates", api_templates, methods=["GET"]),
         Route("/import-odoo.sh", import_odoo_script, methods=["GET"]),
         Route("/api/templates/import-token", api_import_token, methods=["POST"]),
+        Route(
+            "/api/templates/import-from-odoo",
+            api_import_template_from_odoo,
+            methods=["POST"],
+        ),
         Route("/api/templates/import/status", api_import_status, methods=["GET"]),
         Route("/api/templates/import/manifest", api_import_manifest, methods=["POST"]),
         Route("/api/templates/import/dump", api_import_dump, methods=["POST"]),

--- a/tests/test_import_template_from_odoo.py
+++ b/tests/test_import_template_from_odoo.py
@@ -68,8 +68,11 @@ def _remount():
     yield remount
 
 
-def _patch_import_dependencies(monkeypatch, backup_requests):
-    monkeypatch.setattr("oduflow.url_safety.assert_allowed_url", lambda *a, **k: None)
+def _patch_import_dependencies(monkeypatch, backup_requests, *, patch_url_safety=True):
+    if patch_url_safety:
+        monkeypatch.setattr(
+            "oduflow.url_safety.assert_allowed_url", lambda *a, **k: None
+        )
     monkeypatch.setattr(system_ops, "get_client", lambda: MagicMock())
     monkeypatch.setattr(system_ops, "_db_exists", lambda *a, **k: False)
     monkeypatch.setattr(system_ops, "check_db_quota", lambda *a, **k: None)
@@ -133,6 +136,24 @@ def test_import_from_odoo_default_zip_omits_filestore_field(monkeypatch, tmp_pat
     assert os.path.isfile(
         os.path.join(team.get_template_filestore_path("imported"), "ab", "abcdef")
     )
+
+
+def test_import_from_odoo_allows_http_source(monkeypatch, tmp_path):
+    team, settings = _team_and_settings(tmp_path)
+    backup_requests = []
+    _patch_import_dependencies(monkeypatch, backup_requests, patch_url_safety=False)
+
+    result = system_ops.import_from_odoo(
+        settings,
+        team,
+        odoo_url="http://8.8.8.8",
+        master_pwd="master",
+        db_name="prod",
+        template_name="http-import",
+    )
+
+    assert result["source_url"] == "http://8.8.8.8"
+    assert result["template_name"] == "http-import"
 
 
 def test_import_from_odoo_without_filestore_uses_custom_dump_and_skips_files(

--- a/tests/test_import_template_from_odoo_web.py
+++ b/tests/test_import_template_from_odoo_web.py
@@ -1,0 +1,170 @@
+"""Dashboard route tests for pulling a template from a running Odoo."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from oduflow.errors import ConflictError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client_with_locks(tmp_path):
+    team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team1"))
+    settings = Settings(base_data_dir=str(tmp_path), teams={"1": team})
+    locks = LockManager()
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, locks)
+    return TestClient(app), settings, team, locks
+
+
+def _payload(**overrides):
+    payload = {
+        "odoo_url": "http://odoo.example.com",
+        "master_pwd": "master-secret",
+        "db_name": "production",
+        "template_name": "production-copy",
+        "without_filestore": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _result():
+    return {
+        "template_name": "production-copy",
+        "source_url": "http://odoo.example.com",
+        "source_db": "production",
+        "odoo_version": "19.0",
+        "odoo_image": "odoo:19.0",
+        "template_db": "oduflow_template_1_production_copy",
+        "includes_filestore": False,
+        "zip_size_mb": 12.5,
+        "restore_seconds": 3.2,
+        "affected_envs": ["feature-x"],
+        "remount_failures": [],
+        "internal_path": "/srv/oduflow/templates/production-copy",
+    }
+
+
+def test_import_from_odoo_calls_shared_backend(tmp_path):
+    client, settings, team, _locks = _client_with_locks(tmp_path)
+    with patch(
+        "oduflow.web_ui.system_ops.import_from_odoo", return_value=_result()
+    ) as import_from_odoo:
+        response = client.post(
+            "/api/templates/import-from-odoo",
+            json=_payload(),
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["ok"] is True
+    assert body["result"]["template_name"] == "production-copy"
+    assert body["result"]["includes_filestore"] is False
+    assert "internal_path" not in body["result"]
+    assert "master-secret" not in response.text
+    import_from_odoo.assert_called_once_with(
+        settings,
+        team,
+        odoo_url="http://odoo.example.com",
+        master_pwd="master-secret",
+        db_name="production",
+        template_name="production-copy",
+        without_filestore=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        ({"odoo_url": ""}, "odoo_url is required"),
+        ({"master_pwd": ""}, "master_pwd is required"),
+        ({"template_name": ""}, "template_name is required"),
+        ({"template_name": "../escape"}, "template"),
+        ({"without_filestore": "yes"}, "must be a boolean"),
+    ],
+)
+def test_import_from_odoo_validates_request(tmp_path, overrides, error):
+    client, _settings, _team, _locks = _client_with_locks(tmp_path)
+    with patch("oduflow.web_ui.system_ops.import_from_odoo") as import_from_odoo:
+        response = client.post(
+            "/api/templates/import-from-odoo",
+            json=_payload(**overrides),
+        )
+
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    assert error.lower() in response.json()["error"].lower()
+    import_from_odoo.assert_not_called()
+
+
+def test_import_from_odoo_surfaces_backend_conflict(tmp_path):
+    client, _settings, _team, _locks = _client_with_locks(tmp_path)
+    with patch(
+        "oduflow.web_ui.system_ops.import_from_odoo",
+        side_effect=ConflictError("Template already exists"),
+    ):
+        response = client.post(
+            "/api/templates/import-from-odoo",
+            json=_payload(),
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"ok": False, "error": "Template already exists"}
+
+
+def test_import_from_odoo_returns_busy_for_team_operation(tmp_path):
+    client, _settings, _team, locks = _client_with_locks(tmp_path)
+    locks.acquire_team("1")
+    try:
+        with patch("oduflow.web_ui.system_ops.import_from_odoo") as import_from_odoo:
+            response = client.post(
+                "/api/templates/import-from-odoo",
+                json=_payload(),
+            )
+    finally:
+        locks.release_team("1")
+
+    assert response.status_code == 409
+    assert response.json()["ok"] is False
+    import_from_odoo.assert_not_called()
+
+
+def test_import_from_odoo_does_not_block_dashboard_reads(tmp_path):
+    client, _settings, _team, _locks = _client_with_locks(tmp_path)
+    operation_started = Event()
+    release_operation = Event()
+
+    def import_from_odoo(*args, **kwargs):
+        operation_started.set()
+        assert release_operation.wait(timeout=5)
+        return _result()
+
+    with (
+        client,
+        patch(
+            "oduflow.web_ui.system_ops.import_from_odoo",
+            side_effect=import_from_odoo,
+        ),
+        patch("oduflow.web_ui.system_ops.list_templates", return_value=[]),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        importing = executor.submit(
+            client.post,
+            "/api/templates/import-from-odoo",
+            json=_payload(),
+        )
+        assert operation_started.wait(timeout=5)
+        templates = client.get("/api/templates")
+        release_operation.set()
+        imported = importing.result(timeout=5)
+
+    assert templates.status_code == 200
+    assert templates.json() == {"ok": True, "templates": []}
+    assert imported.status_code == 200

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -194,6 +194,21 @@ def test_odoo_sh_import_exposes_best_effort_addon_policy(tmp_path):
     )
 
 
+def test_templates_tab_exposes_pull_import_from_odoo(tmp_path):
+    dashboard = _client(tmp_path).get("/").text
+
+    assert 'onclick="openImportFromOdooModal()">Import from Odoo</button>' in dashboard
+    assert 'id="import-from-odoo-modal"' in dashboard
+    assert 'id="pull-import-url"' in dashboard
+    assert 'id="pull-import-master-pwd"' in dashboard
+    assert 'id="pull-import-db-name"' in dashboard
+    assert 'id="pull-import-tpl-name"' in dashboard
+    assert 'id="pull-import-without-filestore"' in dashboard
+    assert "API_TEMPLATES + '/import-from-odoo'" in dashboard
+    assert "HTTP URLs are allowed" in dashboard
+    assert re.search(r"'import-from-odoo-modal':\s*closeImportFromOdooModal", dashboard)
+
+
 @pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
 def test_template_settings_form_round_trips_attribute_and_prototype_key_values():
     dashboard = _DASHBOARD.read_text(encoding="utf-8")


### PR DESCRIPTION
Adds a UI-authenticated dashboard flow and REST endpoint for importing a template directly from a running Odoo instance, including optional database autodetection and database-only backups.

Allows HTTP sources in the shared import backend while warning that the master password is sent without transport encryption and retaining outbound host safety checks.

Documents the endpoint and adds backend, route, locking, validation, concurrency, and dashboard coverage.

Tests: `pytest -q -m "not integration and not heavyweight"` (2459 passed).