### PR TITLE
Allow private-network hosts for URL imports

### DIFF
--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3364,11 +3364,12 @@ def import_from_odoo(
     template_dir = team.get_template_dir(template_name)
     tpl_db = get_template_db_name(template_name, team.team_id)
 
-    # SSRF guard: importing a DB from a URL is a clearly-external operation, so
-    # block loopback, the cloud metadata endpoint, and internal RFC1918 hosts.
+    # SSRF guard: block loopback and the cloud metadata endpoint. Internal
+    # RFC1918 hosts stay allowed (allow_private=True) because operator-managed
+    # Odoo instances commonly live on a private LAN.
     # HTTP is allowed for operator-managed Odoo instances, although it sends the
     # master password without transport encryption.
-    assert_allowed_url(base, require_https=False, allow_private=False)
+    assert_allowed_url(base, require_https=False, allow_private=True)
 
     if os.path.exists(template_dir):
         raise ConflictError(f"Template directory already exists: {template_dir}")

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2237,7 +2237,7 @@ def _build_routes(
         try:
             from oduflow.url_safety import assert_allowed_url
 
-            assert_allowed_url(origin_url, require_https=True, allow_private=False)
+            assert_allowed_url(origin_url, require_https=True, allow_private=True)
         except FlowError as e:
             return _error_response(e)
         branch = str((body or {}).get("branch") or "").strip()


### PR DESCRIPTION
## Context

`import_from_odoo` (MCP `import_template_from_odoo`) and the dashboard's addon-remote import both validated their user-supplied URL with `allow_private=False`, so any RFC1918 target — e.g. an Odoo instance at `192.168.10.8` — was rejected with:

```
Host '192.168.10.8' resolves to a blocked address (192.168.10.8); refusing the request to prevent SSRF.
```

The original rationale was that importing from a URL is a clearly-external operation. In practice operator-managed Odoo instances and internal git servers commonly live on a private LAN, and `validate_repo_url` already passes `allow_private=True` for the git path that the dashboard endpoint feeds — so the dashboard was stricter than the code it hands off to.

## Change

Both call sites now pass `allow_private=True`:

- `src/oduflow/docker_ops/system_ops.py` — `import_from_odoo`
- `src/oduflow/web_ui.py` — `POST /api/templates/import/addon-remote`

## What is still blocked

The parts of the guard that carry the real risk are untouched, because `_is_blocked` rejects them before it reaches the `allow_private` branch:

- loopback (`127.0.0.0/8`) — internal admin surfaces on the host itself
- link-local, including the `169.254.169.254` cloud metadata endpoint
- unspecified, multicast, reserved

`assert_allowed_url` / `assert_allowed_host` keep their `allow_private=False` default, and no new configuration knob was added.

## Verification

- `ruff check src/oduflow` — clean
- Full unit suite: 2459 passed, 17 deselected

The existing SSRF regression tests still pass unchanged: they assert loopback rejection (`tests/test_import_odoo_web.py`, `tests/test_security_fixes.py`) and the library-level private-range default (`tests/test_url_safety.py`).