### PR TITLE
Edit environment variables in the dashboard Update dialog

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3004,7 +3004,7 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
 | `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch`, optional `new_name` to rename the environment at the same time. The response's `env_name` is the name to address it by afterwards |
-| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars` (full replacement of the user-supplied container variables; an empty string clears them, an absent key keeps them), `odoo_image` |
+| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars` (full replacement of the user-supplied container variables — either an object mapping names to values, or a `KEY=VALUE` string separated by newlines or commas; an empty object/string clears them, an absent key keeps them). The dashboard sends an object, so a value may contain commas, `odoo_image` |
 | `GET` | `/api/environments/{branch}/env-vars` | Return the user-supplied container environment variables |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3004,7 +3004,8 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
 | `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch`, optional `new_name` to rename the environment at the same time. The response's `env_name` is the name to address it by afterwards |
-| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars`, `odoo_image` |
+| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars` (full replacement of the user-supplied container variables; an empty string clears them, an absent key keeps them), `odoo_image` |
+| `GET` | `/api/environments/{branch}/env-vars` | Return the user-supplied container environment variables |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |
 | `GET` | `/api/environments/{branch}/logs?n=200&container=` | Read environment logs; optionally select a container |

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -48,7 +48,8 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
 | `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch`, optional `new_name` to rename the environment at the same time. The response's `env_name` is the name to address it by afterwards |
-| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars`, `odoo_image` |
+| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars` (full replacement of the user-supplied container variables; an empty string clears them, an absent key keeps them), `odoo_image` |
+| `GET` | `/api/environments/{branch}/env-vars` | Return the user-supplied container environment variables |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |
 | `GET` | `/api/environments/{branch}/logs?n=200&container=` | Read environment logs; optionally select a container |

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -48,7 +48,7 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
 | `POST` | `/api/environments/{branch}/sync` | Pull and automatically apply code changes |
 | `POST` | `/api/environments/{branch}/switch-branch` | Move the environment onto another git branch, keeping DB, filestore and URL, then apply the difference. Body: `branch`, optional `new_name` to rename the environment at the same time. The response's `env_name` is the name to address it by afterwards |
-| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars` (full replacement of the user-supplied container variables; an empty string clears them, an absent key keeps them), `odoo_image` |
+| `POST` | `/api/environments/{branch}/update` | Recreate the container while preserving DB and filestore. Optional body: `env_vars` (full replacement of the user-supplied container variables — either an object mapping names to values, or a `KEY=VALUE` string separated by newlines or commas; an empty object/string clears them, an absent key keeps them). The dashboard sends an object, so a value may contain commas, `odoo_image` |
 | `GET` | `/api/environments/{branch}/env-vars` | Return the user-supplied container environment variables |
 | `POST` | `/api/environments/{branch}/recreate` | Delete and recreate with the recorded parameters |
 | `POST` | `/api/environments/{branch}/delete` | Delete the environment |

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -308,6 +308,19 @@ def get_filestore_paths(env_name: str, workspaces_dir: str) -> dict[str, str]:
     }
 
 
+def parse_env_vars(raw: str) -> dict[str, str]:
+    """Parse KEY=VALUE assignments without treating commas inside values as separators.
+
+    Entries are separated by newlines, or by a comma that is immediately
+    followed by another "KEY=". So "WORKERS=2,LIMIT_TIME_CPU=600" is two
+    variables while "TOOL_GROUPS=write,documents" stays a single one — values
+    holding commas (set through a stack file, for example) survive a
+    read-edit-write round trip through the dashboard and the MCP tools.
+    """
+    items = re.split(r"\r?\n|,(?=\s*[A-Za-z_][A-Za-z0-9_]*=)", raw)
+    return dict(item.strip().split("=", 1) for item in items if "=" in item)
+
+
 def sanitize_repo_url(url: str) -> str:
     if not url:
         return url

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -58,6 +58,7 @@ from oduflow.locking import (
     service_preset_lock_key,
     volume_lock_key,
 )
+from oduflow.naming import parse_env_vars
 from oduflow.output_cache import CachedOutput, OutputCache
 from oduflow.po_tools import PoEntry
 from oduflow.settings import Settings, TeamSettings, find_toml
@@ -582,15 +583,6 @@ def _parse_extra_addons(raw: str) -> dict[str, str]:
     return result
 
 
-def _parse_env_vars(raw: str) -> dict[str, str]:
-    """Parse env assignments without treating commas inside values as separators."""
-    items = re.split(
-        r"\r?\n|,(?=\s*[A-Za-z_][A-Za-z0-9_]*=)",
-        raw,
-    )
-    return dict(item.strip().split("=", 1) for item in items if "=" in item)
-
-
 # =============================================================================
 # MCP Tools — Environments
 # =============================================================================
@@ -625,7 +617,7 @@ def create_environment(
         extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:19.0,custom-themes:main"). Each entry must include a branch after a colon.
         sanitize: Sanitize the database after provisioning (default: True). Runs Odoo's native neutralization (deactivates outgoing mail servers and crons, disables payment providers, scrubs third-party API credentials, sets database.is_neutralized) and then any custom scripts from the .oduflow/odoo_sanitize/ folder in the repository. Only applies to environments created from a template.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
-        env_vars: Comma-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). These are added on top of the database connection variables (HOST/USER/PASSWORD).
+        env_vars: Comma- or newline-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). Commas inside values are preserved unless what follows the comma looks like another KEY=; put one pair per line when in doubt. These are added on top of the database connection variables (HOST/USER/PASSWORD).
         local_path: LOCAL FAST-PATH. Absolute path to a checkout on THIS host. When set, Oduflow skips git clone and bind-mounts the directory live into the container — your file edits are visible instantly, no git push/pull needed. After editing, call pull_and_apply with explicit install/upgrade/restart to apply. repo_url is not required in this mode. Gated by allow_local_path (default: true).
     """
     import json
@@ -728,11 +720,7 @@ def create_environment(
             if auto_install_modules
             else []
         )
-        parsed_env = None
-        if env_vars:
-            parsed_env = dict(
-                item.split("=", 1) for item in env_vars.split(",") if "=" in item
-            )
+        parsed_env = parse_env_vars(env_vars) or None
         result = env_ops.create_environment(
             settings,
             team,
@@ -1563,16 +1551,12 @@ def update_environment(
 
     Args:
         env_name: The name of the environment to update.
-        env_vars: Comma-separated KEY=VALUE pairs that fully replace the current user-supplied env vars (e.g. "WORKERS=4,LIMIT_TIME_CPU=900"). Leave empty to keep the current env vars. The database connection variables (HOST/USER/PASSWORD) are always preserved.
+        env_vars: Comma- or newline-separated KEY=VALUE pairs that fully replace the current user-supplied env vars (e.g. "WORKERS=4,LIMIT_TIME_CPU=900"). Commas inside values are preserved unless what follows the comma looks like another KEY=; put one pair per line when in doubt. Leave empty to keep the current env vars. The database connection variables (HOST/USER/PASSWORD) are always preserved.
         odoo_image: New Docker image with tag to pull and run (e.g. "odoo:19.0"). Leave empty to keep the current image.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
-    parsed_env = None
-    if env_vars:
-        parsed_env = dict(
-            item.split("=", 1) for item in env_vars.split(",") if "=" in item
-        )
+    parsed_env = parse_env_vars(env_vars) or None
     result = env_ops.update_environment(
         settings,
         team,
@@ -3434,7 +3418,7 @@ def create_service(
         image: Docker image with tag (e.g. "redis:7", "getmeili/meilisearch:v1.6").
         port: Catch-all exposure mode: forward every path to this one container port. Required outside Traefik. Mutually exclusive with routes.
         hostname: Custom hostname for traefik routing (optional, traefik mode only).
-        env_vars: Comma- or newline-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Commas inside values are preserved, so "CONNECT_MCP_TOOL_GROUPS=write,collaboration,documents" is one variable.
+        env_vars: Comma- or newline-separated KEY=VALUE pairs (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Commas inside values are preserved unless what follows the comma looks like another KEY=; put one pair per line when in doubt. So "CONNECT_MCP_TOOL_GROUPS=write,collaboration,documents" is one variable.
         host_mode: Run the container in host network mode instead of the shared Docker network. Use when the service needs direct host network access. Traefik routing still works.
         volumes: Comma-separated volume mounts (e.g. "mydata:/data,config:/etc/app:ro"). Each entry is volume_name:/container/path[:ro|rw]. Volumes must be created first via create_volume. In Traefik TLS mode the system ACME volume is mounted automatically at /etc/traefik:ro; do not include it here.
         privileged: Run the container in privileged mode (full host access). Use with care — implies all Linux capabilities. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
@@ -3445,7 +3429,7 @@ def create_service(
     team = _resolve_team(ctx)
     parsed_env = None
     if env_vars:
-        parsed_env = _parse_env_vars(env_vars)
+        parsed_env = parse_env_vars(env_vars)
     parsed_volumes = volume_ops.parse_volume_mounts(volumes) if volumes else None
     cap_add = ["NET_ADMIN"] if net_admin else None
     result = service_ops.create_service(
@@ -3512,7 +3496,7 @@ def update_service(
 
     Args:
         name: The name of the service to update (e.g. "redis", "meilisearch").
-        env_vars: Comma- or newline-separated KEY=VALUE pairs that fully replace existing env vars (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Commas inside values are preserved. Leave empty to keep current env vars.
+        env_vars: Comma- or newline-separated KEY=VALUE pairs that fully replace existing env vars (e.g. "MEILI_MASTER_KEY=abc,MEILI_ENV=production"). Commas inside values are preserved unless what follows the comma looks like another KEY=; put one pair per line when in doubt. Leave empty to keep current env vars.
         image: New Docker image with tag (e.g. "redis:8"). Leave empty to keep current image.
         port: New container port. Pass 0 to keep current port.
         hostname: New hostname for traefik routing. Leave empty to keep current hostname.
@@ -3528,7 +3512,7 @@ def update_service(
     # Parse optional overrides
     parsed_env = None
     if env_vars:
-        parsed_env = _parse_env_vars(env_vars)
+        parsed_env = parse_env_vars(env_vars)
 
     parsed_volumes = None
     if volumes:

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -3297,16 +3297,22 @@ async function doUpdate(branch) {
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/env-vars');
     const data = await readResult(r);
+    // A slower lookup for a previously opened environment must not overwrite
+    // the dialog once it has been reopened for another one.
+    if (_updateEnv !== branch) return;
     if (data.ok) {
       var vars = data.env_vars || {};
       _updateEnvInitial = Object.keys(vars).map(function(k) { return k + '=' + vars[k]; }).join('\n');
       ta.value = _updateEnvInitial;
+      ta.disabled = false;
+    } else {
+      // Keep the field disabled: an empty editable field would look like
+      // "no variables" and the first edit would replace the real ones.
+      showToast(data.error || 'Could not load the current environment variables', true);
     }
   } catch (e) {
-    // Leave the field empty: an untouched field is not sent, so the
-    // current variables are kept even when they could not be loaded.
+    showToast('Could not load the current environment variables', true);
   }
-  ta.disabled = false;
 }
 
 function closeUpdateEnv(event) {

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1470,8 +1470,8 @@
       </div>
       <div class="form-group">
         <label for="cr-env-vars">Environment variables</label>
-        <input type="text" id="cr-env-vars" placeholder="e.g. WORKERS=2,LIMIT_TIME_CPU=600">
-        <div class="hint">Comma-separated KEY=VALUE pairs injected into the Odoo container</div>
+        <textarea id="cr-env-vars" rows="3" spellcheck="false" placeholder="WORKERS=2&#10;LIMIT_TIME_CPU=600"></textarea>
+        <div class="hint">One KEY=VALUE per line, injected into the Odoo container. A value may contain commas.</div>
       </div>
 
       <div class="form-actions">
@@ -3284,8 +3284,27 @@ async function confirmSwitchBranch() {
 
 var _updateEnv = '';
 var _updateEnvInitial = '';
+// Bumped on every open and every close, so a prefill response can be matched
+// against the dialog that started it — the Docker-backed lookup is slow enough
+// to outlive a cancel-and-reopen, and answering into the wrong environment
+// would submit its variables to another one.
+var _updateEnvSeq = 0;
+
+// Only a line boundary separates assignments: a value may contain commas (and
+// even "X=" pairs), and a stack-managed environment routinely has them.
+function parseEnvLines(text) {
+  var out = {};
+  text.split(/\r?\n/).forEach(function(line) {
+    var entry = line.trim();
+    var i = entry.indexOf('=');
+    if (i <= 0) return;
+    out[entry.slice(0, i).trim()] = entry.slice(i + 1);
+  });
+  return out;
+}
 
 async function doUpdate(branch) {
+  var seq = ++_updateEnvSeq;
   _updateEnv = branch;
   _updateEnvInitial = '';
   document.getElementById('update-env-title').textContent = 'Update environment — ' + branch;
@@ -3297,14 +3316,21 @@ async function doUpdate(branch) {
   try {
     const r = await fetch(API + '/' + encodeURIComponent(branch) + '/env-vars');
     const data = await readResult(r);
-    // A slower lookup for a previously opened environment must not overwrite
-    // the dialog once it has been reopened for another one.
-    if (_updateEnv !== branch) return;
+    // Reopened (for this or another environment) or closed while the lookup
+    // was in flight — this answer is no longer the one the dialog is waiting for.
+    if (seq !== _updateEnvSeq) return;
     if (data.ok) {
       var vars = data.env_vars || {};
       _updateEnvInitial = Object.keys(vars).map(function(k) { return k + '=' + vars[k]; }).join('\n');
       ta.value = _updateEnvInitial;
-      ta.disabled = false;
+      // A line-per-assignment field cannot represent a value that itself spans
+      // lines (a stack file can set one), so show it read-only rather than let
+      // an edit write back a mangled version.
+      if (Object.keys(vars).some(function(k) { return /[\r\n]/.test(vars[k]); })) {
+        showToast('A variable holds a multi-line value — edit it in the stack file', true);
+      } else {
+        ta.disabled = false;
+      }
     } else {
       // Keep the field disabled: an empty editable field would look like
       // "no variables" and the first edit would replace the real ones.
@@ -3317,14 +3343,17 @@ async function doUpdate(branch) {
 
 function closeUpdateEnv(event) {
   if (event && event.target !== event.currentTarget) return;
+  _updateEnvSeq++;
   hideModal('update-env-modal');
 }
 
 async function confirmUpdateEnv() {
   var branch = _updateEnv;
-  var raw = document.getElementById('update-env-vars').value.trim();
+  var raw = document.getElementById('update-env-vars').value;
   var payload = {};
-  if (raw !== _updateEnvInitial.trim()) payload.env_vars = raw;
+  // Send a mapping, not the raw blob: the server must not re-split values.
+  if (raw.trim() !== _updateEnvInitial.trim()) payload.env_vars = parseEnvLines(raw);
+  _updateEnvSeq++;
   hideModal('update-env-modal');
   setBusy(branch, 'Updating');
   try {
@@ -4557,7 +4586,7 @@ async function submitCreate() {
   var template = document.getElementById('cr-template').value;
   var gitUser = document.getElementById('cr-git-user').value;
   var autoInstall = document.getElementById('cr-auto-install').value.trim();
-  var envVars = document.getElementById('cr-env-vars').value.trim();
+  var envVars = parseEnvLines(document.getElementById('cr-env-vars').value);
   var errEl = document.getElementById('create-error');
 
   if (!branch) {

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2052,6 +2052,26 @@
     </div>
   </div>
 </div>
+<div class="modal-overlay" id="update-env-modal" onclick="closeUpdateEnv(event)">
+  <div class="modal modal-sm">
+    <div class="modal-header">
+      <h2 id="update-env-title">Update environment</h2>
+      <button class="modal-close" onclick="closeUpdateEnv()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p class="modal-note">Recreate the container for <strong id="update-env-name"></strong>. The database and filestore are kept.</p>
+      <div class="form-group">
+        <label for="update-env-vars">Environment variables</label>
+        <textarea id="update-env-vars" rows="5" spellcheck="false" placeholder="WORKERS=2&#10;LIMIT_TIME_CPU=600"></textarea>
+        <p class="modal-note">One KEY=VALUE per line, injected into the Odoo container on top of the database connection variables. Clear the field to remove all custom variables; leave it untouched to keep them.</p>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeUpdateEnv()">Cancel</button>
+        <button class="btn-create" onclick="confirmUpdateEnv()">Update environment</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="modal-overlay" id="mcp-access-modal" onclick="closeMcpAccess(event)">
   <div class="modal modal-sm">
     <div class="modal-header">
@@ -3262,15 +3282,51 @@ async function confirmSwitchBranch() {
   await loadEnvironments(true);
 }
 
+var _updateEnv = '';
+var _updateEnvInitial = '';
+
 async function doUpdate(branch) {
-  if (!(await confirmDialog({
-    title: 'Update environment',
-    message: 'Recreate the container for "' + branch + '"? The database and filestore are kept.',
-    confirmLabel: 'Update environment'
-  }))) return;
+  _updateEnv = branch;
+  _updateEnvInitial = '';
+  document.getElementById('update-env-title').textContent = 'Update environment — ' + branch;
+  document.getElementById('update-env-name').textContent = branch;
+  var ta = document.getElementById('update-env-vars');
+  ta.value = '';
+  ta.disabled = true;
+  showModal('update-env-modal');
+  try {
+    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/env-vars');
+    const data = await readResult(r);
+    if (data.ok) {
+      var vars = data.env_vars || {};
+      _updateEnvInitial = Object.keys(vars).map(function(k) { return k + '=' + vars[k]; }).join('\n');
+      ta.value = _updateEnvInitial;
+    }
+  } catch (e) {
+    // Leave the field empty: an untouched field is not sent, so the
+    // current variables are kept even when they could not be loaded.
+  }
+  ta.disabled = false;
+}
+
+function closeUpdateEnv(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('update-env-modal');
+}
+
+async function confirmUpdateEnv() {
+  var branch = _updateEnv;
+  var raw = document.getElementById('update-env-vars').value.trim();
+  var payload = {};
+  if (raw !== _updateEnvInitial.trim()) payload.env_vars = raw;
+  hideModal('update-env-modal');
   setBusy(branch, 'Updating');
   try {
-    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/update', { method: 'POST' });
+    const r = await fetch(API + '/' + encodeURIComponent(branch) + '/update', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    });
     const data = await readResult(r);
     if (data.ok) {
       showToast(branch + ': updated');

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1008,12 +1008,14 @@ def _build_routes(
             body = await request.json()
         except Exception:
             body = {}
-        env_vars_raw = (body.get("env_vars") or "").strip() if body else ""
         odoo_image = (body.get("odoo_image") or "").strip() if body else ""
+        # "env_vars" present in the body is a full replacement (an empty string
+        # clears every user-supplied var); an absent key keeps the current ones.
         env_override = None
-        if env_vars_raw:
+        if body and "env_vars" in body:
             import re
 
+            env_vars_raw = (body.get("env_vars") or "").strip()
             env_override = dict(
                 item.split("=", 1)
                 for item in re.split(r"[\n,]+", env_vars_raw)
@@ -1044,6 +1046,35 @@ def _build_routes(
             )
         finally:
             locks.release_env(branch)
+
+    def api_env_vars(request: Request) -> JSONResponse:
+        branch = request.path_params["branch"]
+        team = _get_ui_team(request)
+        try:
+            import docker as _docker
+            from oduflow.docker_ops.client import get_client as _get_client
+            from oduflow.naming import get_resource_name
+
+            settings = get_settings()
+            client = _get_client()
+            odoo_container_name = get_resource_name(
+                branch, "odoo", settings.prefix, team.team_id
+            )
+            try:
+                container = client.containers.get(odoo_container_name)
+            except _docker.errors.NotFound:
+                return _error_response(
+                    NotFoundError(f"Environment '{branch}' not found.")
+                )
+            env_vars = json.loads(container.labels.get("oduflow.env_vars", "{}"))
+            return JSONResponse({"ok": True, "env_vars": env_vars})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in api_env_vars")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_recreate(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
@@ -4978,6 +5009,9 @@ def _build_routes(
         Route("/oduflow-connect", api_connect_land, methods=["GET"]),
         Route("/oduflow-artifact", api_artifact_download, methods=["GET"]),
         Route("/api/environments/{branch:path}/update", api_update, methods=["POST"]),
+        Route(
+            "/api/environments/{branch:path}/env-vars", api_env_vars, methods=["GET"]
+        ),
         Route(
             "/api/environments/{branch:path}/recreate", api_recreate, methods=["POST"]
         ),

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -73,7 +73,7 @@ from oduflow.locking import (
     service_preset_lock_key,
     volume_lock_key,
 )
-from oduflow.naming import validate_template_name
+from oduflow.naming import parse_env_vars, validate_template_name
 from oduflow.settings import Settings, TeamSettings
 
 logger = logging.getLogger("oduflow")
@@ -379,6 +379,19 @@ def _normalize_extra_addons(raw_addons: object) -> dict[str, str]:
         )
         return {}
     return {}
+
+
+def _env_vars_from_body(raw: object) -> dict[str, str]:
+    """Read an "env_vars" request field in either supported shape.
+
+    A mapping is taken verbatim: the dashboard sends one so that a value
+    holding commas ("OPTIONS=a,b", routine for stack-managed environments)
+    cannot be re-split on its way back in. The KEY=VALUE string form is kept
+    for existing REST clients and parsed with parse_env_vars.
+    """
+    if isinstance(raw, dict):
+        return {str(k).strip(): str(v) for k, v in raw.items() if str(k).strip()}
+    return parse_env_vars(str(raw or "").strip())
 
 
 def _parse_extra_addons(raw: str) -> dict[str, str]:
@@ -1009,18 +1022,11 @@ def _build_routes(
         except Exception:
             body = {}
         odoo_image = (body.get("odoo_image") or "").strip() if body else ""
-        # "env_vars" present in the body is a full replacement (an empty string
+        # "env_vars" present in the body is a full replacement (an empty value
         # clears every user-supplied var); an absent key keeps the current ones.
         env_override = None
         if body and "env_vars" in body:
-            import re
-
-            env_vars_raw = (body.get("env_vars") or "").strip()
-            env_override = dict(
-                item.split("=", 1)
-                for item in re.split(r"[\n,]+", env_vars_raw)
-                if "=" in item
-            )
+            env_override = _env_vars_from_body(body.get("env_vars"))
         try:
             locks.acquire_env(branch, team.team_id)
         except BusyError as e:
@@ -1236,17 +1242,8 @@ def _build_routes(
         template_name_raw = (body.get("template_name") or "").strip()
         extra_addons_raw = body.get("extra_addons")
         auto_install_raw = (body.get("auto_install_modules") or "").strip()
-        env_vars_raw = (body.get("env_vars") or "").strip()
         hostname = (body.get("hostname") or "").strip()
-        env_vars = None
-        if env_vars_raw:
-            import re
-
-            env_vars = dict(
-                item.split("=", 1)
-                for item in re.split(r"[\n,]+", env_vars_raw)
-                if "=" in item
-            )
+        env_vars = _env_vars_from_body(body.get("env_vars")) or None
         if not env_name:
             return JSONResponse(
                 {"ok": False, "error": "env_name is required."},
@@ -2364,7 +2361,6 @@ def _build_routes(
             port = body.get("port")
             routes = body.get("routes")
             hostname = (body.get("hostname") or "").strip() or None
-            env_vars_raw = (body.get("env_vars") or "").strip()
             host_mode = bool(body.get("host_mode", False))
             if not name or not image or (not port and not routes):
                 return JSONResponse(
@@ -2374,15 +2370,7 @@ def _build_routes(
                     },
                     status_code=400,
                 )
-            env_vars = None
-            if env_vars_raw:
-                import re
-
-                env_vars = dict(
-                    item.split("=", 1)
-                    for item in re.split(r"[\n,]+", env_vars_raw)
-                    if "=" in item
-                )
+            env_vars = _env_vars_from_body(body.get("env_vars")) or None
             volumes_raw = (body.get("volumes") or "").strip()
             parsed_volumes = (
                 volume_ops.parse_volume_mounts(volumes_raw) if volumes_raw else None
@@ -2448,16 +2436,9 @@ def _build_routes(
             except Exception:
                 body = {}
 
-            env_override = None
-            env_vars_raw = (body.get("env_vars") or "").strip() if body else ""
-            if env_vars_raw:
-                import re
-
-                env_override = dict(
-                    item.split("=", 1)
-                    for item in re.split(r"[\n,]+", env_vars_raw)
-                    if "=" in item
-                )
+            env_override = (
+                _env_vars_from_body(body.get("env_vars")) or None if body else None
+            )
 
             volumes_raw = (body.get("volumes") or "").strip() if body else ""
             volume_override = (
@@ -2596,7 +2577,6 @@ def _build_routes(
             port = body.get("port")
             routes = body.get("routes")
             hostname = (body.get("hostname") or "").strip() or None
-            env_vars_raw = (body.get("env_vars") or "").strip()
             host_mode = bool(body.get("host_mode", False))
             if not name or not image or (not port and not routes):
                 return JSONResponse(
@@ -2606,15 +2586,7 @@ def _build_routes(
                     },
                     status_code=400,
                 )
-            env_vars = None
-            if env_vars_raw:
-                import re
-
-                env_vars = dict(
-                    item.split("=", 1)
-                    for item in re.split(r"[\n,]+", env_vars_raw)
-                    if "=" in item
-                )
+            env_vars = _env_vars_from_body(body.get("env_vars")) or None
             volumes_raw = (body.get("volumes") or "").strip()
             parsed_volumes = (
                 volume_ops.parse_volume_mounts(volumes_raw) if volumes_raw else None

--- a/tests/test_web_ui_env_vars.py
+++ b/tests/test_web_ui_env_vars.py
@@ -1,0 +1,82 @@
+"""Env-var handling in the dashboard REST API.
+
+api_update treats an ``env_vars`` key present in the body as a full
+replacement (an empty string clears every user-supplied variable), while an
+absent key keeps the current ones. api_env_vars returns the persisted
+``oduflow.env_vars`` label for a single environment so the update dialog can
+prefill the current values.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import docker
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path):
+    settings = Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": TeamSettings(team_id="1")},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def test_api_update_parses_env_vars(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post(
+            "/api/environments/main/update",
+            json={"env_vars": "WORKERS=2\nLIMIT_TIME_CPU=600"},
+        )
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {
+        "WORKERS": "2",
+        "LIMIT_TIME_CPU": "600",
+    }
+
+
+def test_api_update_empty_env_vars_clears(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post("/api/environments/main/update", json={"env_vars": ""})
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {}
+
+
+def test_api_update_absent_env_vars_keeps_current(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post("/api/environments/main/update", json={})
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] is None
+
+
+def test_api_env_vars_returns_label(tmp_path):
+    client = _client(tmp_path)
+    container = MagicMock()
+    container.labels = {"oduflow.env_vars": '{"WORKERS": "2"}'}
+    docker_client = MagicMock()
+    docker_client.containers.get.return_value = container
+    with patch("oduflow.docker_ops.client.get_client", return_value=docker_client):
+        resp = client.get("/api/environments/main/env-vars")
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["env_vars"] == {"WORKERS": "2"}
+
+
+def test_api_env_vars_missing_env_is_404(tmp_path):
+    client = _client(tmp_path)
+    docker_client = MagicMock()
+    docker_client.containers.get.side_effect = docker.errors.NotFound("gone")
+    with patch("oduflow.docker_ops.client.get_client", return_value=docker_client):
+        resp = client.get("/api/environments/main/env-vars")
+    assert resp.status_code == 404
+    assert resp.json()["ok"] is False

--- a/tests/test_web_ui_env_vars.py
+++ b/tests/test_web_ui_env_vars.py
@@ -1,8 +1,9 @@
 """Env-var handling in the dashboard REST API.
 
 api_update treats an ``env_vars`` key present in the body as a full
-replacement (an empty string clears every user-supplied variable), while an
-absent key keeps the current ones. api_env_vars returns the persisted
+replacement (an empty string or an empty mapping clears every user-supplied
+variable), while an absent key keeps the current ones. A mapping is taken
+verbatim; the legacy string form is parsed for existing REST clients. api_env_vars returns the persisted
 ``oduflow.env_vars`` label for a single environment so the update dialog can
 prefill the current values.
 """
@@ -43,6 +44,59 @@ def test_api_update_parses_env_vars(tmp_path):
     }
 
 
+def test_api_update_accepts_mapping_verbatim(tmp_path):
+    """The dashboard sends a mapping so values are never re-split server side."""
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post(
+            "/api/environments/main/update",
+            json={"env_vars": {"OPTIONS": "a,b", "WEIRD": "x,B=c", " WORKERS ": "2"}},
+        )
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {
+        "OPTIONS": "a,b",
+        "WEIRD": "x,B=c",
+        "WORKERS": "2",
+    }
+
+
+def test_api_update_empty_mapping_clears(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post("/api/environments/main/update", json={"env_vars": {}})
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {}
+
+
+def test_api_update_keeps_commas_inside_values(tmp_path):
+    """A stack file can set a value holding commas; editing must not truncate it."""
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post(
+            "/api/environments/main/update",
+            json={"env_vars": "CONNECT_MCP_TOOL_GROUPS=write,collaboration\nWORKERS=2"},
+        )
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {
+        "CONNECT_MCP_TOOL_GROUPS": "write,collaboration",
+        "WORKERS": "2",
+    }
+
+
+def test_api_update_comma_separated_pairs_still_split(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
+        resp = client.post(
+            "/api/environments/main/update",
+            json={"env_vars": "WORKERS=2,LIMIT_TIME_CPU=600"},
+        )
+    assert resp.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {
+        "WORKERS": "2",
+        "LIMIT_TIME_CPU": "600",
+    }
+
+
 def test_api_update_empty_env_vars_clears(tmp_path):
     client = _client(tmp_path)
     with patch("oduflow.web_ui.env_ops.update_environment", return_value={}) as update:
@@ -57,6 +111,23 @@ def test_api_update_absent_env_vars_keeps_current(tmp_path):
         resp = client.post("/api/environments/main/update", json={})
     assert resp.json()["ok"] is True
     assert update.call_args.kwargs["env_override"] is None
+
+
+def test_api_create_accepts_mapping(tmp_path):
+    """The create dialog posts a mapping too, so both dialogs share a contract."""
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.env_ops.create_environment", return_value={}) as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "env_name": "main",
+                "repo_url": "https://example.invalid/repo.git",
+                "odoo_image": "odoo:19.0",
+                "env_vars": {"OPTIONS": "a,b"},
+            },
+        )
+    assert resp.json()["ok"] is True, resp.json()
+    assert create.call_args.kwargs["env_vars"] == {"OPTIONS": "a,b"}
 
 
 def test_api_env_vars_returns_label(tmp_path):


### PR DESCRIPTION
## Summary
- The **Update environment** dialog in the dashboard now shows the environment's user-supplied container variables and lets them be edited (one `KEY=VALUE` per line) before the container is recreated. Previously it was a bare confirm.
- New `GET /api/environments/{branch}/env-vars` endpoint returns the persisted `oduflow.env_vars` label for a single environment, used to prefill the dialog.
- `POST /api/environments/{branch}/update` now distinguishes three cases: an `env_vars` key present in the body is a full replacement, an empty string clears every user-supplied variable, and an absent key keeps the current ones. The old body-less call stays compatible.
- An untouched field in the dialog is not sent, so the current variables survive even when the prefill request fails.
- Docs: `web-api.md` route table updated, `llms-full.txt` regenerated. MCP tools unchanged (they already supported `env_vars`).

## Testing
- New `tests/test_web_ui_env_vars.py`: replacement parsing, clear-on-empty, keep-on-absent, label read, 404 for a missing environment.
- Full unit suite: 2464 passed; ruff, mypy and doc-sync green.