### PR TITLE
Allow custom environment names separate from git branch

### DIFF
--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1435,6 +1435,11 @@
         <input type="text" id="cr-branch" placeholder="e.g. feature/my-branch">
       </div>
       <div class="form-group">
+        <label for="cr-env-name">Environment name</label>
+        <input type="text" id="cr-env-name" placeholder="Same as branch">
+        <div class="hint">Optional; defaults to the branch name. Set it to run several environments from one branch</div>
+      </div>
+      <div class="form-group">
         <label for="cr-hostname">Hostname</label>
         <input type="text" id="cr-hostname" placeholder="Auto (dev1, dev2, ...)">
         <div class="hint">Optional prefix override; for dev.example.com, "qa" becomes qa.example.com</div>
@@ -4337,6 +4342,7 @@ function populateTemplateSelect() {
 function openCreateFromTemplate(templateName) {
   var tpl = cachedTemplates.find(function(t) { return t.template_name === templateName; });
   document.getElementById('cr-branch').value = '';
+  document.getElementById('cr-env-name').value = '';
   document.getElementById('cr-hostname').value = '';
   document.getElementById('cr-repo').value = tpl && tpl.repo_url ? tpl.repo_url : '';
   document.getElementById('cr-image').value = tpl && tpl.odoo_image ? tpl.odoo_image : '';
@@ -4382,6 +4388,7 @@ function openCreateFromTemplate(templateName) {
 
 function openCreateModal() {
   document.getElementById('cr-branch').value = '';
+  document.getElementById('cr-env-name').value = '';
   document.getElementById('cr-hostname').value = '';
   document.getElementById('cr-repo').value = '';
   document.getElementById('cr-image').value = '';
@@ -4489,6 +4496,7 @@ async function submitFeedback() {
 
 async function submitCreate() {
   var branch = document.getElementById('cr-branch').value.trim();
+  var envName = document.getElementById('cr-env-name').value.trim();
   var hostname = document.getElementById('cr-hostname').value.trim();
   var repo = document.getElementById('cr-repo').value.trim();
   var image = document.getElementById('cr-image').value.trim();
@@ -4527,7 +4535,8 @@ async function submitCreate() {
       return;
     }
     var payload = {
-      env_name: branch,
+      branch: branch,
+      env_name: envName,
       hostname: hostname,
       repo_url: repo,
       odoo_image: image,
@@ -4545,7 +4554,7 @@ async function submitCreate() {
     var data = await readResult(r);
     if (r.ok && data.ok) {
       closeCreateModal();
-      showToast('Environment "' + branch + '" created');
+      showToast('Environment "' + (envName || branch) + '" created');
       await loadEnvironments(true);
     } else {
       errEl.textContent = data.error || ('Creation failed (HTTP ' + r.status + ')');

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1082,6 +1082,10 @@ def _build_routes(
             git_user = labels.get("oduflow.git_user", "")
             env_vars = json.loads(labels.get("oduflow.env_vars", "{}")) or None
             local_path = labels.get("oduflow.local_path", "")
+            # The environment name and the git branch it tracks can differ
+            # (several environments off one branch), so recreate from the
+            # recorded branch label rather than from the environment name.
+            git_branch = labels.get("oduflow.git_branch", branch)
             hostname = labels.get(env_ops.ENV_HOSTNAME_LABEL, "")
 
             # Check disk space BEFORE deleting the old environment: refusing
@@ -1107,9 +1111,10 @@ def _build_routes(
             result = env_ops.create_environment(
                 settings,
                 team,
-                branch,
+                git_branch,
                 repo_url,
                 odoo_image,
+                env_name=branch,
                 template_name=template_name,
                 extra_addons=extra_addons,
                 git_user=git_user,
@@ -1199,6 +1204,11 @@ def _build_routes(
             )
 
         env_name = (body.get("env_name") or "").strip()
+        # Older dashboards (and cached ones) send only env_name and mean the
+        # branch by it; new ones send both so one branch can back several
+        # environments.
+        branch = (body.get("branch") or "").strip() or env_name
+        env_name = env_name or branch
         repo_url = (body.get("repo_url") or "").strip()
         odoo_image = (body.get("odoo_image") or "").strip()
         git_user = (body.get("git_user") or "").strip()
@@ -1218,7 +1228,7 @@ def _build_routes(
             )
         if not env_name:
             return JSONResponse(
-                {"ok": False, "error": "env_name is required."},
+                {"ok": False, "error": "branch is required."},
                 status_code=400,
             )
         from oduflow.naming import validate_env_name
@@ -1311,9 +1321,10 @@ def _build_routes(
                 env_ops.create_environment,
                 settings,
                 team,
-                env_name,
+                branch,
                 repo_url,
                 odoo_image,
+                env_name=env_name,
                 template_name=resolved_template,
                 extra_addons=extra_dict,
                 git_user=git_user,

--- a/tests/test_web_ui_create_lock.py
+++ b/tests/test_web_ui_create_lock.py
@@ -93,3 +93,106 @@ def test_api_create_passes_short_hostname(tmp_path):
 
     assert resp.json()["ok"] is True
     assert create.call_args.kwargs["hostname"] == "dev2"
+
+
+def test_api_create_separate_branch_and_env_name(tmp_path):
+    """The dashboard can name an environment differently from its branch."""
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    with patch(
+        "oduflow.web_ui.env_ops.create_environment",
+        return_value={"url": "http://localhost:50000"},
+    ) as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "branch": "staging",
+                "env_name": "oldstaging",
+                "repo_url": "r",
+                "odoo_image": "i",
+            },
+        )
+
+    assert resp.json()["ok"] is True
+    # _offload(fn, settings, team, branch, repo_url, odoo_image, ...)
+    assert create.call_args.args[2] == "staging"
+    assert create.call_args.kwargs["env_name"] == "oldstaging"
+
+
+def test_api_create_env_name_defaults_to_branch(tmp_path):
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    with patch(
+        "oduflow.web_ui.env_ops.create_environment",
+        return_value={"url": "http://localhost:50000"},
+    ) as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={"branch": "staging", "repo_url": "r", "odoo_image": "i"},
+        )
+
+    assert resp.json()["ok"] is True
+    assert create.call_args.args[2] == "staging"
+    assert create.call_args.kwargs["env_name"] == "staging"
+
+
+def test_api_create_legacy_payload_without_branch(tmp_path):
+    """A cached dashboard sends env_name only and means the branch by it."""
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    with patch(
+        "oduflow.web_ui.env_ops.create_environment",
+        return_value={"url": "http://localhost:50000"},
+    ) as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={"env_name": "main", "repo_url": "r", "odoo_image": "i"},
+        )
+
+    assert resp.json()["ok"] is True
+    assert create.call_args.args[2] == "main"
+    assert create.call_args.kwargs["env_name"] == "main"
+
+
+def test_api_recreate_uses_recorded_git_branch(tmp_path):
+    """An environment named apart from its branch recreates on THAT branch."""
+    from unittest.mock import MagicMock
+
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+
+    container = MagicMock()
+    container.labels = {
+        settings.repo_label: "https://github.com/x/y.git",
+        settings.image_label: "odoo:19.0",
+        "oduflow.template": "none",
+        "oduflow.git_branch": "staging",
+    }
+
+    with (
+        patch("oduflow.docker_ops.client.get_client") as mock_client,
+        patch("oduflow.docker_ops.system_ops.check_disk_space"),
+        patch("oduflow.docker_ops.system_ops.estimate_new_db_bytes", return_value=0),
+        patch("oduflow.docker_ops.env_ops.delete_environment"),
+        patch(
+            "oduflow.docker_ops.env_ops.create_environment",
+            return_value={"url": "http://localhost:50000"},
+        ) as create,
+    ):
+        mock_client.return_value.containers.get.return_value = container
+        resp = client.post("/api/environments/oldstaging/recreate")
+
+    assert resp.status_code == 200
+    assert create.call_args.args[2] == "staging"
+    assert create.call_args.kwargs["env_name"] == "oldstaging"


### PR DESCRIPTION
## Summary

Environments can now have names independent of their git branch, enabling multiple isolated environments from the same branch.

## What Changed

**Dashboard UI:**
- Added optional "Environment name" field to the create environment form
- Defaults to the branch name if not specified
- Updated form submission to send both `branch` and `env_name` separately

**API (`/api/environments/create`):**
- Now accepts separate `branch` and `env_name` parameters
- Maintains backward compatibility: cached dashboards sending only `env_name` treat it as the branch
- Passes both parameters to `create_environment`

**Recreate endpoint:**
- Reads `oduflow.git_branch` label to recreate environments on the correct branch
- Environments named apart from their branch now recreate properly

**Error message:**
- Updated from "env_name is required" to "branch is required" for clarity

## Testing

Added four new tests covering:
- Separate branch and env_name parameters
- env_name defaults to branch when omitted
- Legacy payload compatibility (env_name only)
- Recreate using recorded git branch