### PR TITLE
Reconcile pg_hba.conf from Docker IPAM; trust only verified MCP tokens

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,6 +61,21 @@
   password travels without transport encryption; the outbound host safety checks
   still apply. (#202)
 
+### Fixes
+
+- **PostgreSQL access follows the real Docker networks** — on every startup,
+  Oduflow now reads the actual IPAM subnets of its shared and per-team networks
+  and reconciles a marked block in the active `pg_hba.conf` for both development
+  and production clusters. This repairs reused or partially initialized data
+  volumes that lack a Docker host rule, avoids hard-coded `172.x` assumptions,
+  preserves every standard/operator rule outside the managed block, validates
+  the reloaded file and rolls back an invalid candidate. The rules use `md5`
+  while any role still holds a pre-PostgreSQL-14 md5 verifier and
+  `scram-sha-256` once every role has migrated, so reconciling an old data
+  volume never locks its environments out. The update travels through the
+  Docker API, so it also works when Oduflow itself runs in a container with
+  named config volumes.
+
 ## v1.69.0
 
 ### Features

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -62,6 +62,13 @@ Alternatively, start with `--network oduflow-net` if the network already exists.
 
 Shared infrastructure (Docker network, PostgreSQL, team directories) is initialized automatically on startup — no separate init step needed.
 
+Oduflow also reconciles the active PostgreSQL `pg_hba.conf` with the actual
+subnets reported by Docker IPAM for `oduflow-net` and every per-team network.
+Only a marked `ODUFLOW MANAGED NETWORKS` block is changed; the standard local,
+replication, and operator-managed rules remain intact. This works the same way
+when Oduflow runs directly on the host or through Docker-out-of-Docker because
+the file is updated through the Docker API rather than another host bind mount.
+
 To set up a template database:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -402,6 +402,14 @@ PostgreSQL tuning or Odoo settings globally:
   traefik/                ← Traefik dynamic configuration (auto-generated)
 ```
 
+`pg_hba.conf` remains in the PostgreSQL data volume rather than this config
+directory. On every startup Oduflow reads the active file reported by
+PostgreSQL and reconciles a marked block containing password-authenticated
+rules for the real Docker IPAM subnets of the shared and per-team networks.
+All standard and operator-managed rules outside that block are preserved. This
+also repairs an existing data volume whose original image initialization did
+not add a rule for Docker clients.
+
 The resource plan considers `[production].enabled`. With production disabled,
 the lean dev PostgreSQL profile targets about 10% of host RAM for
 `shared_buffers` (128 MB–1 GB). With production enabled, the planner budgets

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -74,6 +74,7 @@ src/oduflow/
   web_ui.py            # Starlette dashboard, REST/WS API, session+Basic auth middleware
   extra_addons.py      # Extra addon repo management (clone, worktree, odoo.conf generation)
   env_credentials.py   # Per-environment PostgreSQL credentials
+  pg_hba.py            # Managed PostgreSQL host rules rendered from Docker IPAM
   sanitizer.py         # DB sanitization (SQL/Python scripts)
   sync.py              # Sync template data from S3 or local path (aws s3 sync / rsync)
   licensing.py         # License verification and installation (RSA signatures)
@@ -178,6 +179,10 @@ This means no manual ownership fixups are ever needed on either platform.
 | **Traefik volume** (optional) | `oduflow-traefik-acme` | Let's Encrypt certificate storage |
 
 All containers are labeled with `oduflow.managed=true` and `oduflow.team={team_id}` for discovery and management.
+The PostgreSQL containers are attached to every team network. At startup,
+Oduflow reads those networks' real IPAM subnets and reconciles only its marked
+block in each cluster's active `pg_hba.conf`; standard and operator rules
+outside the block are preserved.
 
 ## Concurrency & Locking
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -959,6 +959,14 @@ PostgreSQL tuning or Odoo settings globally:
   traefik/                ← Traefik dynamic configuration (auto-generated)
 ```
 
+`pg_hba.conf` remains in the PostgreSQL data volume rather than this config
+directory. On every startup Oduflow reads the active file reported by
+PostgreSQL and reconciles a marked block containing password-authenticated
+rules for the real Docker IPAM subnets of the shared and per-team networks.
+All standard and operator-managed rules outside that block are preserved. This
+also repairs an existing data volume whose original image initialization did
+not add a rule for Docker clients.
+
 The resource plan considers `[production].enabled`. With production disabled,
 the lean dev PostgreSQL profile targets about 10% of host RAM for
 `shared_buffers` (128 MB–1 GB). With production enabled, the planner budgets
@@ -4125,6 +4133,13 @@ Alternatively, start with `--network oduflow-net` if the network already exists.
 
 Shared infrastructure (Docker network, PostgreSQL, team directories) is initialized automatically on startup — no separate init step needed.
 
+Oduflow also reconciles the active PostgreSQL `pg_hba.conf` with the actual
+subnets reported by Docker IPAM for `oduflow-net` and every per-team network.
+Only a marked `ODUFLOW MANAGED NETWORKS` block is changed; the standard local,
+replication, and operator-managed rules remain intact. This works the same way
+when Oduflow runs directly on the host or through Docker-out-of-Docker because
+the file is updated through the Docker API rather than another host bind mount.
+
 To set up a template database:
 
 ```bash
@@ -4299,6 +4314,7 @@ src/oduflow/
   web_ui.py            # Starlette dashboard, REST/WS API, session+Basic auth middleware
   extra_addons.py      # Extra addon repo management (clone, worktree, odoo.conf generation)
   env_credentials.py   # Per-environment PostgreSQL credentials
+  pg_hba.py            # Managed PostgreSQL host rules rendered from Docker IPAM
   sanitizer.py         # DB sanitization (SQL/Python scripts)
   sync.py              # Sync template data from S3 or local path (aws s3 sync / rsync)
   licensing.py         # License verification and installation (RSA signatures)
@@ -4403,6 +4419,10 @@ This means no manual ownership fixups are ever needed on either platform.
 | **Traefik volume** (optional) | `oduflow-traefik-acme` | Let's Encrypt certificate storage |
 
 All containers are labeled with `oduflow.managed=true` and `oduflow.team={team_id}` for discovery and management.
+The PostgreSQL containers are attached to every team network. At startup,
+Oduflow reads those networks' real IPAM subnets and reconciles only its marked
+block in each cluster's active `pg_hba.conf`; standard and operator rules
+outside the block are preserved.
 
 ## Concurrency & Locking
 
@@ -4614,6 +4634,44 @@ If step 3 reports `Transport endpoint is not connected` or an empty filestore,
 the overlay mount is broken — see [Overlay filestore](#overlay-filestore).
 Otherwise the failure is usually inside Odoo (a module install/upgrade error);
 read the container logs.
+
+### PostgreSQL reports `no pg_hba.conf entry`
+
+An error such as:
+
+```text
+FATAL: no pg_hba.conf entry for host "172.20.0.3", user "u_1_main",
+database "postgres", no encryption
+```
+
+means Docker networking already works: the client reached PostgreSQL, but the
+active HBA file has no matching host rule. Oduflow normally self-heals this on
+startup by reading the actual Docker IPAM subnets and reconciling its marked
+`ODUFLOW MANAGED NETWORKS` block in the active file. It then reloads PostgreSQL
+and validates `pg_hba_file_rules`; a failed candidate is rolled back.
+
+The generated rules use `md5` while any role still holds a pre-PostgreSQL-14
+md5 verifier, and `scram-sha-256` once every role has migrated. `md5` is not a
+downgrade: PostgreSQL performs a SCRAM exchange whenever the stored verifier is
+SCRAM. Reset the affected passwords under `password_encryption =
+scram-sha-256` to move an old cluster over.
+
+Restart Oduflow and inspect its startup log first. If reconciliation fails, the
+message names the invalid subnet, unsupported authentication method, existing
+HBA parse error, or file operation that blocked it. These read-only commands
+show the source state without guessing a Docker subnet:
+
+```bash
+docker exec oduflow-db psql -U odoo -d postgres -Atc \
+  'SHOW hba_file; SHOW password_encryption;'
+docker exec oduflow-db psql -U odoo -d postgres -P pager=off -c \
+  'SELECT line_number, type, address, auth_method, error FROM pg_hba_file_rules ORDER BY line_number;'
+docker network inspect oduflow-1-net --format '{{json .IPAM.Config}}'
+```
+
+Do not add a fixed `172.x` rule or replace the whole HBA manually. Docker may
+allocate a different subnet after a network recreate, and replacing the file
+can discard local or replication rules that PostgreSQL needs.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -150,6 +150,44 @@ the overlay mount is broken — see [Overlay filestore](#overlay-filestore).
 Otherwise the failure is usually inside Odoo (a module install/upgrade error);
 read the container logs.
 
+### PostgreSQL reports `no pg_hba.conf entry`
+
+An error such as:
+
+```text
+FATAL: no pg_hba.conf entry for host "172.20.0.3", user "u_1_main",
+database "postgres", no encryption
+```
+
+means Docker networking already works: the client reached PostgreSQL, but the
+active HBA file has no matching host rule. Oduflow normally self-heals this on
+startup by reading the actual Docker IPAM subnets and reconciling its marked
+`ODUFLOW MANAGED NETWORKS` block in the active file. It then reloads PostgreSQL
+and validates `pg_hba_file_rules`; a failed candidate is rolled back.
+
+The generated rules use `md5` while any role still holds a pre-PostgreSQL-14
+md5 verifier, and `scram-sha-256` once every role has migrated. `md5` is not a
+downgrade: PostgreSQL performs a SCRAM exchange whenever the stored verifier is
+SCRAM. Reset the affected passwords under `password_encryption =
+scram-sha-256` to move an old cluster over.
+
+Restart Oduflow and inspect its startup log first. If reconciliation fails, the
+message names the invalid subnet, unsupported authentication method, existing
+HBA parse error, or file operation that blocked it. These read-only commands
+show the source state without guessing a Docker subnet:
+
+```bash
+docker exec oduflow-db psql -U odoo -d postgres -Atc \
+  'SHOW hba_file; SHOW password_encryption;'
+docker exec oduflow-db psql -U odoo -d postgres -P pager=off -c \
+  'SELECT line_number, type, address, auth_method, error FROM pg_hba_file_rules ORDER BY line_number;'
+docker network inspect oduflow-1-net --format '{{json .IPAM.Config}}'
+```
+
+Do not add a fixed `172.x` rule or replace the whole HBA manually. Docker may
+allocate a different subnet after a network recreate, and replacing the file
+can discard local or replication rules that PostgreSQL needs.
+
 ---
 
 ## An environment runs out of database connections

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import docker
 from docker import DockerClient
+from oduflow import pg_hba
 from oduflow.docker_ops.client import chown_recursive, get_client, get_odoo_uid_gid
 from oduflow.docker_ops.stats import default_env_limits
 from oduflow.errors import (
@@ -1927,6 +1928,11 @@ def ensure_prod_infra(
     # Attach the (possibly new) prod DB to every team network.
     for team in settings.teams.values():
         ensure_team_network(client, settings, team)
+    _reconcile_pg_hba(
+        client,
+        settings,
+        container_name=settings.prod_db_container,
+    )
 
     try:
         walg.apply_archive_command(
@@ -2102,6 +2108,208 @@ def ensure_team_network(
     return net_name
 
 
+def _managed_pg_network_cidrs(client: DockerClient, settings: Settings) -> list[str]:
+    """Return the real IPAM subnets from every Oduflow-managed client network."""
+    network_names = {settings.shared_network}
+    network_names.update(
+        get_team_network_name(team.team_id, settings.prefix)
+        for team in settings.teams.values()
+    )
+
+    cidrs: list[str] = []
+    for network_name in sorted(network_names):
+        try:
+            network = client.networks.get(network_name)
+        except docker.errors.NotFound:
+            continue
+        attrs = getattr(network, "attrs", {})
+        ipam = attrs.get("IPAM", {}) if isinstance(attrs, dict) else {}
+        configs = ipam.get("Config", []) if isinstance(ipam, dict) else []
+        if not isinstance(configs, list):
+            continue
+        for config in configs:
+            if isinstance(config, dict) and config.get("Subnet"):
+                cidrs.append(str(config["Subnet"]))
+
+    try:
+        return pg_hba.normalize_cidrs(cidrs)
+    except ValueError as exc:
+        raise PrerequisiteNotMetError(
+            f"Docker reported an invalid network subnet for PostgreSQL: {exc}"
+        ) from exc
+
+
+def _container_output(output: bytes | str) -> str:
+    return (
+        output.decode("utf-8", errors="replace")
+        if isinstance(output, bytes)
+        else str(output)
+    )
+
+
+def _install_pg_hba_content(container: Any, hba_path: str, content: str) -> None:
+    """Atomically install *content* at the active HBA path in the PG volume."""
+    import tempfile
+
+    destination_dir = os.path.dirname(hba_path)
+    staged_name = f".pg_hba.oduflow-{uuid.uuid4().hex}"
+    staged_path = os.path.join(destination_dir, staged_name)
+    with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = tmp.name
+    try:
+        _copy_file_to_container(
+            container,
+            tmp_path,
+            destination_dir,
+            archive_name=staged_name,
+        )
+        command = [
+            "sh",
+            "-c",
+            "set -eu; "
+            f"chown postgres:postgres {shlex.quote(staged_path)}; "
+            f"chmod 600 {shlex.quote(staged_path)}; "
+            f"mv -f {shlex.quote(staged_path)} {shlex.quote(hba_path)}",
+        ]
+        exit_code, output = container.exec_run(command, user="root")
+        if exit_code != 0:
+            raise ExternalCommandError(
+                "install pg_hba.conf", exit_code, _container_output(output)
+            )
+    finally:
+        os.remove(tmp_path)
+        with contextlib.suppress(Exception):
+            container.exec_run(["rm", "-f", staged_path], user="root")
+
+
+def _pg_hba_errors(
+    client: DockerClient,
+    settings: Settings,
+    *,
+    container_name: str,
+) -> str:
+    return _exec_sql(
+        client,
+        settings,
+        "SELECT COALESCE(string_agg(line_number::text || ': ' || error, "
+        "E'\\n' ORDER BY line_number), '') FROM pg_hba_file_rules "
+        "WHERE error IS NOT NULL;",
+        container_name=container_name,
+    )
+
+
+def _pg_hba_auth_method(
+    client: DockerClient,
+    settings: Settings,
+    *,
+    container_name: str,
+) -> str:
+    """The HBA auth method every existing role can still authenticate with.
+
+    ``password_encryption`` only governs how *new* passwords are hashed, so a
+    data volume initialized by a pre-14 PostgreSQL image can report
+    ``scram-sha-256`` while its roles still hold md5 verifiers — and a strict
+    ``scram-sha-256`` rule locks those roles out. ``md5`` is the compatible
+    choice: PostgreSQL upgrades the exchange to SCRAM whenever the stored
+    verifier is SCRAM, so it costs nothing once every role has migrated.
+    """
+    legacy_md5 = _exec_sql(
+        client,
+        settings,
+        "SELECT EXISTS (SELECT 1 FROM pg_authid WHERE rolpassword LIKE 'md5%');",
+        container_name=container_name,
+    )
+    if legacy_md5.strip().lower() in {"t", "true"}:
+        return "md5"
+    return _exec_sql(
+        client,
+        settings,
+        "SHOW password_encryption;",
+        container_name=container_name,
+    )
+
+
+def _reconcile_pg_hba(
+    client: DockerClient,
+    settings: Settings,
+    *,
+    container_name: str,
+) -> bool:
+    """Allow password-authenticated access from the current managed networks."""
+    cidrs = _managed_pg_network_cidrs(client, settings)
+    if not cidrs:
+        raise PrerequisiteNotMetError(
+            "No Docker IPAM subnets were found for Oduflow-managed networks"
+        )
+
+    hba_path = _exec_sql(
+        client,
+        settings,
+        "SHOW hba_file;",
+        container_name=container_name,
+    )
+    auth_method = _pg_hba_auth_method(
+        client,
+        settings,
+        container_name=container_name,
+    )
+    container = client.containers.get(container_name)
+    exit_code, output = container.exec_run(["cat", hba_path])
+    if exit_code != 0:
+        raise ExternalCommandError(
+            "cat pg_hba.conf", exit_code, _container_output(output)
+        )
+    current = _container_output(output)
+
+    try:
+        candidate = pg_hba.reconcile_managed_block(current, cidrs, auth_method)
+    except ValueError as exc:
+        raise PrerequisiteNotMetError(
+            f"Could not generate PostgreSQL host authentication rules: {exc}"
+        ) from exc
+    if candidate == current:
+        return False
+
+    existing_errors = _pg_hba_errors(client, settings, container_name=container_name)
+    if existing_errors:
+        raise PrerequisiteNotMetError(
+            "The existing pg_hba.conf contains parse errors; refusing to modify it: "
+            f"{existing_errors}"
+        )
+
+    try:
+        _install_pg_hba_content(container, hba_path, candidate)
+        _exec_sql(
+            client,
+            settings,
+            "SELECT pg_reload_conf();",
+            container_name=container_name,
+        )
+        new_errors = _pg_hba_errors(client, settings, container_name=container_name)
+        if new_errors:
+            raise PrerequisiteNotMetError(
+                f"Generated pg_hba.conf contains parse errors: {new_errors}"
+            )
+    except Exception:
+        with contextlib.suppress(Exception):
+            _install_pg_hba_content(container, hba_path, current)
+            _exec_sql(
+                client,
+                settings,
+                "SELECT pg_reload_conf();",
+                container_name=container_name,
+            )
+        raise
+
+    logger.info(
+        "Reconciled %s access for Docker networks: %s",
+        container_name,
+        ", ".join(cidrs),
+    )
+    return True
+
+
 def _ensure_iptables_accept(client: DockerClient, network_name: str) -> None:
     try:
         net = client.networks.get(network_name)
@@ -2157,6 +2365,11 @@ def init_system(
 
     for team in settings.teams.values():
         ensure_team_network(client, settings, team)
+    _reconcile_pg_hba(
+        client,
+        settings,
+        container_name=settings.shared_db_container,
+    )
 
     # Production hosting is a strict opt-in. Disabled installations stop all
     # managed production workloads without deleting them; enabled installations

--- a/src/oduflow/pg_hba.py
+++ b/src/oduflow/pg_hba.py
@@ -1,0 +1,65 @@
+"""Render the PostgreSQL HBA rules owned by Oduflow."""
+
+from __future__ import annotations
+
+import ipaddress
+from collections.abc import Iterable
+
+BEGIN_MARKER = "# BEGIN ODUFLOW MANAGED NETWORKS"
+END_MARKER = "# END ODUFLOW MANAGED NETWORKS"
+SUPPORTED_AUTH_METHODS = frozenset({"md5", "scram-sha-256"})
+
+
+def normalize_cidrs(cidrs: Iterable[str]) -> list[str]:
+    """Return canonical, de-duplicated network CIDRs in stable order."""
+    networks = {ipaddress.ip_network(value, strict=False) for value in cidrs}
+    return [
+        network.with_prefixlen
+        for network in sorted(
+            networks,
+            key=lambda item: (item.version, int(item.network_address), item.prefixlen),
+        )
+    ]
+
+
+def render_managed_block(cidrs: Iterable[str], auth_method: str) -> str:
+    """Render the HBA block that permits Oduflow-managed Docker networks."""
+    auth_method = auth_method.strip().lower()
+    if auth_method not in SUPPORTED_AUTH_METHODS:
+        raise ValueError(f"Unsupported PostgreSQL host auth method: {auth_method}")
+
+    networks = normalize_cidrs(cidrs)
+    if not networks:
+        raise ValueError("At least one PostgreSQL client network is required")
+
+    lines = [
+        BEGIN_MARKER,
+        "# Reconciled from Docker network IPAM by Oduflow; do not edit this block.",
+    ]
+    lines.extend(f"host all all {cidr} {auth_method}" for cidr in networks)
+    lines.append(END_MARKER)
+    return "\n".join(lines)
+
+
+def reconcile_managed_block(
+    current: str, cidrs: Iterable[str], auth_method: str
+) -> str:
+    """Insert or replace Oduflow's block while preserving every other rule."""
+    block = render_managed_block(cidrs, auth_method)
+    begin_count = current.count(BEGIN_MARKER)
+    end_count = current.count(END_MARKER)
+    if begin_count != end_count or begin_count > 1:
+        raise ValueError("Malformed Oduflow-managed block in pg_hba.conf")
+
+    if begin_count == 0:
+        remainder = current.lstrip("\n")
+        result = f"{block}\n\n{remainder}" if remainder else f"{block}\n"
+    else:
+        start = current.index(BEGIN_MARKER)
+        end_start = current.find(END_MARKER)
+        if end_start < start:
+            raise ValueError("Malformed Oduflow-managed block in pg_hba.conf")
+        end = end_start + len(END_MARKER)
+        result = current[:start] + block + current[end:]
+
+    return result.rstrip("\n") + "\n"

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -24,6 +24,7 @@ except Exception:  # pragma: no cover - authlib internals may change
 
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
+from fastmcp.server.dependencies import get_access_token, get_http_request
 
 from oduflow import (
     activity,
@@ -114,30 +115,29 @@ def _get_settings() -> Settings:
 
 
 def _resolve_team(ctx: Context | None) -> TeamSettings:
-    """Resolve the team from MCP Context.
+    """Resolve the team for the current MCP request.
 
     Priority: token/OAuth client_id → Host header → single-team → team "1".
     """
     settings = _get_settings()
-    # 1. Token-based: client_id set by auth provider maps to team_id
-    team_id = ctx.client_id if ctx and ctx.client_id else None
+    # 1. Context.client_id comes from caller-controlled MCP request metadata,
+    # not the verified credential. Only trust the access token established by auth.
+    access_token = get_access_token()
+    team_id = access_token.client_id if access_token else None
     if team_id and team_id in settings.teams:
         return settings.teams[team_id]
     # 2. Hostname-based: match Host header against team hostnames
-    if ctx:
-        try:
-            from fastmcp.server.dependencies import get_http_request
-
-            request = get_http_request()
-            host = request.headers.get("host", "")
-            team = settings.get_team_by_hostname(host)
-            if team:
-                return team
-        except Exception:
-            # No HTTP request in scope (e.g. stdio transport) — fall through to
-            # the single-team / default-team resolution below. Logged, not
-            # silently swallowed, so misrouting is traceable.
-            logger.debug("Host-header team resolution unavailable", exc_info=True)
+    try:
+        request = get_http_request()
+        host = request.headers.get("host", "")
+        team = settings.get_team_by_hostname(host)
+        if team:
+            return team
+    except Exception:
+        # No HTTP request in scope (e.g. stdio transport) — fall through to
+        # the single-team / default-team resolution below. Logged, not
+        # silently swallowed, so misrouting is traceable.
+        logger.debug("Host-header team resolution unavailable", exc_info=True)
     # 3. Fallback: single team or default team "1". Only for stdio (implicit
     # local single user) and explicitly-unauthenticated HTTP: in a hosted
     # multi-client deployment a request that matches no token and no hostname

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -78,9 +78,12 @@ def mock_docker_client():
 
 
 class TestInitSystem:
+    @patch("oduflow.docker_ops.system_ops._reconcile_pg_hba")
     @patch("oduflow.docker_ops.system_ops._copy_file_to_container")
     @patch("oduflow.docker_ops.system_ops.os.path.isfile", return_value=True)
-    def test_init_system_fresh(self, mock_isfile, mock_copy, mock_docker_client):
+    def test_init_system_fresh(
+        self, mock_isfile, mock_copy, mock_hba, mock_docker_client
+    ):
         mock_docker_client.networks.get.side_effect = docker.errors.NotFound("nf")
         mock_docker_client.volumes.get.side_effect = docker.errors.NotFound("nf")
 
@@ -109,11 +112,17 @@ class TestInitSystem:
         created = [c.args[0] for c in mock_docker_client.networks.create.call_args_list]
         assert created == ["oduflow-net", "oduflow-1-net"]
         mock_docker_client.volumes.create.assert_called_once()
+        mock_hba.assert_called_once_with(
+            mock_docker_client,
+            TEST_SETTINGS,
+            container_name=TEST_SETTINGS.shared_db_container,
+        )
 
+    @patch("oduflow.docker_ops.system_ops._reconcile_pg_hba")
     @patch("oduflow.docker_ops.system_ops._db_exists", return_value=True)
     @patch("oduflow.docker_ops.system_ops._wait_pg_ready")
     def test_init_system_already_initialized(
-        self, mock_pg, mock_db_exists, mock_docker_client
+        self, mock_pg, mock_db_exists, mock_hba, mock_docker_client
     ):
         mock_docker_client.networks.get.return_value = MagicMock()
         mock_docker_client.volumes.get.return_value = MagicMock()
@@ -124,6 +133,11 @@ class TestInitSystem:
         result = system_ops.init_system(TEST_SETTINGS)
 
         assert result["status"] == "initialized"
+        mock_hba.assert_called_once_with(
+            mock_docker_client,
+            TEST_SETTINGS,
+            container_name=TEST_SETTINGS.shared_db_container,
+        )
 
 
 class TestDestroySystem:

--- a/tests/test_pg_hba.py
+++ b/tests/test_pg_hba.py
@@ -1,0 +1,298 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from oduflow import pg_hba
+from oduflow.docker_ops import system_ops
+from oduflow.errors import PrerequisiteNotMetError
+from oduflow.settings import Settings, TeamSettings
+
+
+def test_normalize_cidrs_is_canonical_stable_and_deduplicated():
+    assert pg_hba.normalize_cidrs(
+        ["fd00::1/64", "172.21.4.8/16", "172.20.0.0/16", "fd00::/64"]
+    ) == ["172.20.0.0/16", "172.21.0.0/16", "fd00::/64"]
+
+
+def test_reconcile_prepends_managed_rules_before_existing_reject():
+    current = "# standard rules\nhost all all all reject\n"
+
+    result = pg_hba.reconcile_managed_block(current, ["172.20.0.0/16"], "scram-sha-256")
+
+    assert result.startswith(pg_hba.BEGIN_MARKER)
+    assert "host all all 172.20.0.0/16 scram-sha-256" in result
+    assert result.index(pg_hba.END_MARKER) < result.index("host all all all reject")
+
+
+def test_reconcile_replaces_only_the_managed_block():
+    current = pg_hba.reconcile_managed_block(
+        "local all all trust\n", ["172.20.0.0/16"], "md5"
+    )
+
+    result = pg_hba.reconcile_managed_block(
+        current, ["172.22.0.0/16", "fd00::/64"], "scram-sha-256"
+    )
+
+    assert "172.20.0.0/16" not in result
+    assert "host all all 172.22.0.0/16 scram-sha-256" in result
+    assert "host all all fd00::/64 scram-sha-256" in result
+    assert result.endswith("local all all trust\n")
+
+
+def test_reconcile_is_idempotent():
+    first = pg_hba.reconcile_managed_block(
+        "local all all trust\n", ["172.20.0.0/16"], "scram-sha-256"
+    )
+    assert (
+        pg_hba.reconcile_managed_block(first, ["172.20.0.3/16"], "scram-sha-256")
+        == first
+    )
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        f"{pg_hba.BEGIN_MARKER}\nhost all all all md5\n",
+        f"{pg_hba.END_MARKER}\n{pg_hba.BEGIN_MARKER}\n",
+        f"{pg_hba.BEGIN_MARKER}\n{pg_hba.END_MARKER}\n{pg_hba.BEGIN_MARKER}\n{pg_hba.END_MARKER}\n",
+    ],
+)
+def test_reconcile_refuses_malformed_managed_blocks(content):
+    with pytest.raises(ValueError, match="Malformed"):
+        pg_hba.reconcile_managed_block(content, ["172.20.0.0/16"], "md5")
+
+
+def test_render_refuses_insecure_or_unknown_auth_methods():
+    with pytest.raises(ValueError, match="Unsupported"):
+        pg_hba.render_managed_block(["172.20.0.0/16"], "trust")
+
+
+def test_render_refuses_missing_or_invalid_networks():
+    with pytest.raises(ValueError, match="At least one"):
+        pg_hba.render_managed_block([], "scram-sha-256")
+    with pytest.raises(ValueError, match="does not appear"):
+        pg_hba.render_managed_block(["not-a-network"], "scram-sha-256")
+
+
+def test_managed_pg_network_cidrs_come_from_real_docker_ipam():
+    settings = Settings(
+        teams={
+            "1": TeamSettings(team_id="1"),
+            "2": TeamSettings(team_id="2"),
+        }
+    )
+    networks = {
+        "oduflow-net": {"IPAM": {"Config": [{"Subnet": "172.19.0.0/16"}]}},
+        "oduflow-1-net": {"IPAM": {"Config": [{"Subnet": "172.20.1.2/16"}]}},
+        "oduflow-2-net": {"IPAM": {"Config": [{"Subnet": "fd00:2::/64"}]}},
+    }
+    client = MagicMock()
+    client.networks.get.side_effect = lambda name: MagicMock(attrs=networks[name])
+
+    assert system_ops._managed_pg_network_cidrs(client, settings) == [
+        "172.19.0.0/16",
+        "172.20.0.0/16",
+        "fd00:2::/64",
+    ]
+
+
+def _reconcile_fixture(current: str):
+    settings = Settings(teams={"1": TeamSettings(team_id="1")})
+    client = MagicMock()
+    container = MagicMock()
+    container.exec_run.return_value = (0, current.encode())
+    client.containers.get.return_value = container
+    return settings, client, container
+
+
+def test_reconcile_pg_hba_installs_reloads_and_validates():
+    current = "local all all trust\n"
+    settings, client, container = _reconcile_fixture(current)
+    installed: list[str] = []
+
+    def exec_sql(_client, _settings, sql, **_kwargs):
+        if sql.startswith("SHOW hba_file"):
+            return "/var/lib/postgresql/data/pg_hba.conf"
+        if "pg_authid" in sql:
+            return "f"
+        if sql.startswith("SHOW password_encryption"):
+            return "scram-sha-256"
+        if "pg_hba_file_rules" in sql:
+            return ""
+        if "pg_reload_conf" in sql:
+            return "t"
+        raise AssertionError(sql)
+
+    with (
+        patch.object(
+            system_ops,
+            "_managed_pg_network_cidrs",
+            return_value=["172.20.0.0/16"],
+        ),
+        patch.object(system_ops, "_exec_sql", side_effect=exec_sql),
+        patch.object(
+            system_ops,
+            "_install_pg_hba_content",
+            side_effect=lambda _container, _path, content: installed.append(content),
+        ),
+    ):
+        changed = system_ops._reconcile_pg_hba(
+            client, settings, container_name=settings.shared_db_container
+        )
+
+    assert changed is True
+    assert len(installed) == 1
+    assert "host all all 172.20.0.0/16 scram-sha-256" in installed[0]
+    container.exec_run.assert_called_once_with(
+        ["cat", "/var/lib/postgresql/data/pg_hba.conf"]
+    )
+
+
+def test_reconcile_pg_hba_keeps_md5_for_legacy_role_verifiers():
+    # A data volume initialized before PostgreSQL 14 still holds md5 verifiers
+    # while password_encryption already reports scram-sha-256; a strict
+    # scram-sha-256 rule would lock those roles out.
+    current = "host all all all md5\n"
+    settings, client, _container = _reconcile_fixture(current)
+    installed: list[str] = []
+
+    def exec_sql(_client, _settings, sql, **_kwargs):
+        if sql.startswith("SHOW hba_file"):
+            return "/var/lib/postgresql/data/pg_hba.conf"
+        if "pg_authid" in sql:
+            return "t"
+        if sql.startswith("SHOW password_encryption"):
+            return "scram-sha-256"
+        if "pg_hba_file_rules" in sql:
+            return ""
+        if "pg_reload_conf" in sql:
+            return "t"
+        raise AssertionError(sql)
+
+    with (
+        patch.object(
+            system_ops,
+            "_managed_pg_network_cidrs",
+            return_value=["172.20.0.0/16"],
+        ),
+        patch.object(system_ops, "_exec_sql", side_effect=exec_sql),
+        patch.object(
+            system_ops,
+            "_install_pg_hba_content",
+            side_effect=lambda _container, _path, content: installed.append(content),
+        ),
+    ):
+        assert (
+            system_ops._reconcile_pg_hba(
+                client, settings, container_name=settings.shared_db_container
+            )
+            is True
+        )
+
+    assert "host all all 172.20.0.0/16 md5" in installed[0]
+    assert "scram-sha-256" not in installed[0]
+
+
+def test_reconcile_pg_hba_skips_an_unchanged_file():
+    current = pg_hba.reconcile_managed_block(
+        "local all all trust\n", ["172.20.0.0/16"], "scram-sha-256"
+    )
+    settings, client, _container = _reconcile_fixture(current)
+
+    def exec_sql(_client, _settings, sql, **_kwargs):
+        if sql.startswith("SHOW hba_file"):
+            return "/var/lib/postgresql/data/pg_hba.conf"
+        if "pg_authid" in sql:
+            return "f"
+        if sql.startswith("SHOW password_encryption"):
+            return "scram-sha-256"
+        raise AssertionError(sql)
+
+    with (
+        patch.object(
+            system_ops,
+            "_managed_pg_network_cidrs",
+            return_value=["172.20.0.0/16"],
+        ),
+        patch.object(system_ops, "_exec_sql", side_effect=exec_sql),
+        patch.object(system_ops, "_install_pg_hba_content") as install,
+    ):
+        changed = system_ops._reconcile_pg_hba(
+            client, settings, container_name=settings.shared_db_container
+        )
+
+    assert changed is False
+    install.assert_not_called()
+
+
+def test_reconcile_pg_hba_rolls_back_when_generated_file_is_invalid():
+    current = "local all all trust\n"
+    settings, client, _container = _reconcile_fixture(current)
+    installed: list[str] = []
+    error_results = iter(["", "9: invalid authentication method"])
+
+    def exec_sql(_client, _settings, sql, **_kwargs):
+        if sql.startswith("SHOW hba_file"):
+            return "/var/lib/postgresql/data/pg_hba.conf"
+        if "pg_authid" in sql:
+            return "f"
+        if sql.startswith("SHOW password_encryption"):
+            return "scram-sha-256"
+        if "pg_hba_file_rules" in sql:
+            return next(error_results)
+        if "pg_reload_conf" in sql:
+            return "t"
+        raise AssertionError(sql)
+
+    with (
+        patch.object(
+            system_ops,
+            "_managed_pg_network_cidrs",
+            return_value=["172.20.0.0/16"],
+        ),
+        patch.object(system_ops, "_exec_sql", side_effect=exec_sql),
+        patch.object(
+            system_ops,
+            "_install_pg_hba_content",
+            side_effect=lambda _container, _path, content: installed.append(content),
+        ),
+    ):
+        with pytest.raises(PrerequisiteNotMetError, match="parse errors"):
+            system_ops._reconcile_pg_hba(
+                client, settings, container_name=settings.shared_db_container
+            )
+
+    assert len(installed) == 2
+    assert installed[1] == current
+
+
+def test_reconcile_pg_hba_refuses_to_touch_an_already_invalid_file():
+    current = "local all all trust\n"
+    settings, client, _container = _reconcile_fixture(current)
+
+    def exec_sql(_client, _settings, sql, **_kwargs):
+        if sql.startswith("SHOW hba_file"):
+            return "/var/lib/postgresql/data/pg_hba.conf"
+        if "pg_authid" in sql:
+            return "f"
+        if sql.startswith("SHOW password_encryption"):
+            return "md5"
+        if "pg_hba_file_rules" in sql:
+            return "4: invalid connection type"
+        raise AssertionError(sql)
+
+    with (
+        patch.object(
+            system_ops,
+            "_managed_pg_network_cidrs",
+            return_value=["172.20.0.0/16"],
+        ),
+        patch.object(system_ops, "_exec_sql", side_effect=exec_sql),
+        patch.object(system_ops, "_install_pg_hba_content") as install,
+    ):
+        with pytest.raises(PrerequisiteNotMetError, match="existing pg_hba"):
+            system_ops._reconcile_pg_hba(
+                client, settings, container_name=settings.shared_db_container
+            )
+
+    install.assert_not_called()

--- a/tests/test_prod_infra.py
+++ b/tests/test_prod_infra.py
@@ -134,6 +134,7 @@ class TestLazyProvisioning:
             patch("oduflow.walg.ensure_walg"),
             patch.object(system_ops, "_wait_pg_ready"),
             patch.object(system_ops, "ensure_team_network"),
+            patch.object(system_ops, "_reconcile_pg_hba") as reconcile_hba,
             patch("oduflow.walg.apply_archive_command") as apply_cmd,
         ):
             assert system_ops.ensure_prod_infra(client, settings) is True
@@ -141,6 +142,9 @@ class TestLazyProvisioning:
         client.containers.run.assert_called_once()
         # No [backup] configured -> archive command stays disabled.
         assert apply_cmd.call_args[1]["enabled"] is False
+        reconcile_hba.assert_called_once_with(
+            client, settings, container_name=settings.prod_db_container
+        )
 
     def test_force_provisions_without_productions(self, settings):
         client = _client_without_prod()
@@ -148,6 +152,7 @@ class TestLazyProvisioning:
             patch("oduflow.walg.ensure_walg"),
             patch.object(system_ops, "_wait_pg_ready"),
             patch.object(system_ops, "ensure_team_network"),
+            patch.object(system_ops, "_reconcile_pg_hba"),
             patch("oduflow.walg.apply_archive_command"),
         ):
             assert system_ops.ensure_prod_infra(client, settings, force=True) is True
@@ -159,6 +164,7 @@ class TestLazyProvisioning:
             patch("oduflow.walg.ensure_walg", side_effect=RuntimeError("offline")),
             patch.object(system_ops, "_wait_pg_ready"),
             patch.object(system_ops, "ensure_team_network"),
+            patch.object(system_ops, "_reconcile_pg_hba"),
             patch("oduflow.walg.apply_archive_command") as apply_cmd,
         ):
             assert system_ops.ensure_prod_infra(client, settings, force=True) is True
@@ -172,6 +178,7 @@ class TestProdPgContainer:
             patch("oduflow.walg.ensure_walg"),
             patch.object(system_ops, "_wait_pg_ready"),
             patch.object(system_ops, "ensure_team_network"),
+            patch.object(system_ops, "_reconcile_pg_hba"),
             patch("oduflow.walg.apply_archive_command"),
         ):
             system_ops.ensure_prod_infra(client, settings, force=True)
@@ -202,6 +209,7 @@ class TestProdPgContainer:
             patch("oduflow.walg.ensure_walg"),
             patch.object(system_ops, "_wait_pg_ready"),
             patch.object(system_ops, "ensure_team_network"),
+            patch.object(system_ops, "_reconcile_pg_hba"),
             patch("oduflow.walg.apply_archive_command"),
         ):
             system_ops.ensure_prod_infra(client, settings, force=True)
@@ -216,6 +224,7 @@ class TestProdPgContainer:
             patch("oduflow.walg.ensure_walg"),
             patch.object(system_ops, "_wait_pg_ready"),
             patch.object(system_ops, "ensure_team_network"),
+            patch.object(system_ops, "_reconcile_pg_hba"),
             patch("oduflow.walg.apply_archive_command"),
         ):
             system_ops.ensure_prod_infra(client, settings)

--- a/tests/test_resolve_team.py
+++ b/tests/test_resolve_team.py
@@ -26,6 +26,13 @@ def _settings(n_teams: int = 2, allow_insecure_http: bool = False) -> Settings:
 
 @pytest.fixture
 def inject(monkeypatch):
+    monkeypatch.setattr(server, "get_access_token", lambda: None)
+
+    def _no_http_request():
+        raise RuntimeError("No active HTTP request")
+
+    monkeypatch.setattr(server, "get_http_request", _no_http_request)
+
     def _inject(settings: Settings, transport: str) -> None:
         monkeypatch.setattr(server, "_settings", settings)
         monkeypatch.setattr(settings_module, "TRANSPORT", transport)
@@ -58,7 +65,32 @@ def test_http_insecure_optout_keeps_fallback(inject):
     assert server._resolve_team(None).team_id == "1"
 
 
-def test_http_token_resolution_still_works(inject):
+def test_http_token_resolution_uses_verified_access_token(inject, monkeypatch):
     inject(_settings(n_teams=2), "http")
-    ctx = SimpleNamespace(client_id="2")
-    assert server._resolve_team(ctx).team_id == "2"
+    monkeypatch.setattr(
+        server, "get_access_token", lambda: SimpleNamespace(client_id="2")
+    )
+    assert server._resolve_team(None).team_id == "2"
+
+
+def test_http_request_metadata_cannot_override_verified_team(inject, monkeypatch):
+    inject(_settings(n_teams=2), "http")
+    monkeypatch.setattr(
+        server, "get_access_token", lambda: SimpleNamespace(client_id="1")
+    )
+    caller_metadata = SimpleNamespace(client_id="2")
+    assert server._resolve_team(caller_metadata).team_id == "1"
+
+
+def test_http_request_metadata_is_not_an_auth_identity(inject):
+    inject(_settings(n_teams=2), "http")
+    caller_metadata = SimpleNamespace(client_id="2")
+    with pytest.raises(NotFoundError, match="Cannot resolve a team"):
+        server._resolve_team(caller_metadata)
+
+
+def test_http_hostname_fallback_works_without_context_argument(inject, monkeypatch):
+    inject(_settings(n_teams=2), "http")
+    request = SimpleNamespace(headers={"host": "team2.example.com:8000"})
+    monkeypatch.setattr(server, "get_http_request", lambda: request)
+    assert server._resolve_team(None).team_id == "2"


### PR DESCRIPTION
## PostgreSQL host authentication follows the real Docker networks

PostgreSQL rejected clients whose Docker subnet had no host rule in the active
`pg_hba.conf` — a reused or partially initialized data volume, or a network that
Docker re-allocated to a different subnet:

```text
FATAL: no pg_hba.conf entry for host "172.20.0.3", user "u_1_main",
database "postgres", no encryption
```

On every startup Oduflow now reads the real IPAM subnets of the shared and
per-team networks and reconciles a marked `ODUFLOW MANAGED NETWORKS` block in
the active file, for both the development and the production cluster. Only that
block changes; standard local, replication and operator-managed rules are
preserved. The candidate is installed atomically through the Docker API — so it
works the same when Oduflow itself runs in a container — then reloaded,
validated against `pg_hba_file_rules`, and rolled back when it fails to parse.

The generated rules use `md5` while any role still holds a pre-PostgreSQL-14 md5
verifier, and `scram-sha-256` once every role has migrated, so reconciling an old
data volume never locks its environments out. `md5` is not a downgrade:
PostgreSQL performs a SCRAM exchange whenever the stored verifier is SCRAM.

## Team resolution only trusts the verified credential

`_resolve_team` read `Context.client_id`, which comes from caller-controlled MCP
request metadata rather than the verified credential, so a client could name
another team. It now reads `client_id` from the access token established by auth.
Host-header resolution no longer depends on a `Context` argument being passed.

## Testing

- `ruff check`, `ruff format`, `mypy` — clean.
- `pytest` — 2497 passed.
- `pytest tests/test_integration.py` — 10 passed.

New unit coverage in `tests/test_pg_hba.py` (rendering, idempotency, malformed
blocks, IPAM collection, install/reload/validate, rollback, md5 fallback) and in
`tests/test_resolve_team.py` (request metadata cannot override the verified team).
