### PR TITLE
Carry environment variables through templates

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Templates carry environment variables** — a template's `metadata.json` can
+  now hold an `env_vars` object, and every environment created from that
+  template gets those variables injected into its Odoo container. Saving a
+  template from a live environment records that environment's variables
+  automatically, so a tuned configuration (`WORKERS`, `LIMIT_TIME_CPU`, service
+  credentials) survives into every environment built from the snapshot instead
+  of being retyped at each `create_environment` call. Values passed at creation
+  time are merged **per key** over the template's, so one variable can be
+  overridden without restating the rest. Names are validated as shell
+  identifiers when a template is saved; a hand-edited file with an invalid entry
+  is ignored with a warning rather than blocking provisioning.
+
+### Dashboard
+
+- **Environment variables in the template Settings dialog** — a new field edits
+  a template's variables as one `KEY=VALUE` per line, the template card shows
+  how many are set (names and values stay hidden — they routinely carry
+  secrets), and the create-environment form prefills them from the selected
+  template. Multiline values stay inherited server-side instead of being put
+  through the line-based create field. In template Settings, such values are
+  shown read-only and pointed at the raw JSON editor.
+
 ## v1.71.0
 
 ### Features

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1539,6 +1539,7 @@ Each template profile can contain a `metadata.json` file that stores defaults an
   "odoo_image": "odoo:19.0",
   "repo_url": "https://github.com/company/addons.git",
   "extra_addons": {"enterprise": "19.0"},
+  "env_vars": {"WORKERS": "2", "LIMIT_TIME_CPU": "600"},
   "use_overlay": true,
   "source_url": "https://my-odoo.example.com",
   "source_db": "production",
@@ -1548,6 +1549,26 @@ Each template profile can contain a `metadata.json` file that stores defaults an
 ```
 
 When `create_environment` is called with a template name, `repo_url`, `odoo_image`, and `extra_addons` are automatically loaded from metadata if not explicitly provided. This means after importing or configuring a template, you can create environments with just `branch` and `template_name` — all other parameters are inherited.
+
+### Environment variables
+
+`env_vars` holds `{"NAME": "value"}` pairs injected into the Odoo container of every environment created from the template — the same mechanism as the `env_vars` argument of `create_environment`, but recorded once on the template instead of being repeated at each call. Saving a template from a live environment (`save_as_template`) carries that environment's variables over automatically.
+
+The two sets are **merged per key**, with the values passed at creation time winning:
+
+```bash
+# Template records WORKERS=2 and LIMIT_TIME_CPU=600
+oduflow call create_environment '{
+  "branch": "19.0",
+  "template_name": "default",
+  "env_vars": "WORKERS=8"
+}'
+# Container gets WORKERS=8 (overridden) and LIMIT_TIME_CPU=600 (inherited)
+```
+
+Edit them in the dashboard under **Templates → Settings → Environment variables** (one `KEY=VALUE` per line), or directly in `metadata.json`. Names must be valid shell identifiers (`[A-Za-z_][A-Za-z0-9_]*`); the dashboard rejects anything else on save, and a hand-edited file with an invalid entry is ignored with a warning rather than blocking environment creation.
+
+Variables set here are applied on top of the database connection variables (`HOST`, `USER`, `PASSWORD`) that Oduflow injects itself, so reusing those names overrides the connection settings.
 
 The `use_overlay` flag determines whether new environments use fuse-overlayfs (for large filestores) or a simple copy (for small ones). It is set automatically based on `overlay_threshold_mb` (in `[storage]`) when the template is created.
 
@@ -3006,7 +3027,7 @@ than a JSON API. Production routes are registered only when
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/environments` | List environments |
-| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `hostname`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user` |
+| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `hostname`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars` (merged per key over the template's), `git_user` |
 | `POST` | `/api/environments/{branch}/start` | Start an environment |
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |
@@ -3178,7 +3199,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables, merged per key over any recorded on the template |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -7,7 +7,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables, merged per key over any recorded on the template |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -193,6 +193,7 @@ Each template profile can contain a `metadata.json` file that stores defaults an
   "odoo_image": "odoo:19.0",
   "repo_url": "https://github.com/company/addons.git",
   "extra_addons": {"enterprise": "19.0"},
+  "env_vars": {"WORKERS": "2", "LIMIT_TIME_CPU": "600"},
   "use_overlay": true,
   "source_url": "https://my-odoo.example.com",
   "source_db": "production",
@@ -202,6 +203,26 @@ Each template profile can contain a `metadata.json` file that stores defaults an
 ```
 
 When `create_environment` is called with a template name, `repo_url`, `odoo_image`, and `extra_addons` are automatically loaded from metadata if not explicitly provided. This means after importing or configuring a template, you can create environments with just `branch` and `template_name` — all other parameters are inherited.
+
+### Environment variables
+
+`env_vars` holds `{"NAME": "value"}` pairs injected into the Odoo container of every environment created from the template — the same mechanism as the `env_vars` argument of `create_environment`, but recorded once on the template instead of being repeated at each call. Saving a template from a live environment (`save_as_template`) carries that environment's variables over automatically.
+
+The two sets are **merged per key**, with the values passed at creation time winning:
+
+```bash
+# Template records WORKERS=2 and LIMIT_TIME_CPU=600
+oduflow call create_environment '{
+  "branch": "19.0",
+  "template_name": "default",
+  "env_vars": "WORKERS=8"
+}'
+# Container gets WORKERS=8 (overridden) and LIMIT_TIME_CPU=600 (inherited)
+```
+
+Edit them in the dashboard under **Templates → Settings → Environment variables** (one `KEY=VALUE` per line), or directly in `metadata.json`. Names must be valid shell identifiers (`[A-Za-z_][A-Za-z0-9_]*`); the dashboard rejects anything else on save, and a hand-edited file with an invalid entry is ignored with a warning rather than blocking environment creation.
+
+Variables set here are applied on top of the database connection variables (`HOST`, `USER`, `PASSWORD`) that Oduflow injects itself, so reusing those names overrides the connection settings.
 
 The `use_overlay` flag determines whether new environments use fuse-overlayfs (for large filestores) or a simple copy (for small ones). It is set automatically based on `overlay_threshold_mb` (in `[storage]`) when the template is created.
 

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -42,7 +42,7 @@ than a JSON API. Production routes are registered only when
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/environments` | List environments |
-| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `hostname`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars`, `git_user` |
+| `POST` | `/api/environments/create` | Create an environment. Body: `env_name`, optional `hostname`, `repo_url`, `odoo_image`, `template_name`, `extra_addons`, `auto_install_modules`, `env_vars` (merged per key over the template's), `git_user` |
 | `POST` | `/api/environments/{branch}/start` | Start an environment |
 | `POST` | `/api/environments/{branch}/stop` | Stop an environment |
 | `POST` | `/api/environments/{branch}/restart` | Restart its Odoo container |

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -36,6 +36,7 @@ from oduflow.naming import (
     get_tablespace_name,
     get_team_network_name,
     get_template_db_name,
+    normalize_env_vars,
     validate_template_name,
 )
 from oduflow.settings import Settings, TeamSettings
@@ -2932,6 +2933,15 @@ def _source_env_metadata(settings: Settings, labels: dict[str, Any]) -> dict[str
     raw_auto = labels.get("oduflow.auto_install_modules", "")
     if raw_auto:
         metadata["auto_install_modules"] = raw_auto
+    raw_env = labels.get("oduflow.env_vars", "")
+    if raw_env:
+        try:
+            env_vars = normalize_env_vars(json.loads(raw_env))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.warning("Could not record env vars on the template: %s", exc)
+        else:
+            if env_vars:
+                metadata["env_vars"] = env_vars
     return metadata
 
 
@@ -4592,6 +4602,10 @@ def update_template_metadata(
         ) from exc
     if not isinstance(metadata, dict):
         raise TypeError("Template metadata must be a JSON object.")
+    if metadata.get("env_vars") is not None:
+        # Rejected here rather than at environment creation: a name Docker
+        # cannot export is worth surfacing while the editor is still open.
+        metadata["env_vars"] = normalize_env_vars(metadata["env_vars"])
 
     normalized = (json.dumps(metadata, indent=2, ensure_ascii=False) + "\n").encode(
         "utf-8"
@@ -4618,6 +4632,27 @@ def update_template_metadata(
         "content": normalized.decode("utf-8"),
         "revision": hashlib.sha256(normalized).hexdigest(),
     }
+
+
+def _template_env_vars(metadata: dict[str, Any], template_name: str) -> dict[str, str]:
+    """Env vars recorded on a template, or {} if the entry is unusable.
+
+    Never raises: a template whose metadata was hand-edited into an invalid
+    env_vars block must still list and still provision — the variables are
+    dropped with a warning instead of taking the environment down with them.
+    """
+    raw = metadata.get("env_vars")
+    if not raw:
+        return {}
+    try:
+        return normalize_env_vars(raw)
+    except (TypeError, ValueError) as exc:
+        logger.warning(
+            "Ignoring invalid env_vars in template %s metadata: %s",
+            template_name,
+            exc,
+        )
+        return {}
 
 
 def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any]]:
@@ -4668,6 +4703,7 @@ def list_templates(settings: Settings, team: TeamSettings) -> list[dict[str, Any
                 "filestore_size_mb": metadata.get("filestore_size_mb"),
                 "dump_size_mb": metadata.get("dump_size_mb"),
                 "auto_install_modules": metadata.get("auto_install_modules", ""),
+                "env_vars": _template_env_vars(metadata, template_name),
                 # Code the snapshot was taken from — the anchor for the lineage
                 # check run at environment creation.
                 "source_branch": metadata.get("source_branch", ""),

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 # A template name becomes both a filesystem path (templates/<name>, where "/"
@@ -319,6 +320,44 @@ def parse_env_vars(raw: str) -> dict[str, str]:
     """
     items = re.split(r"\r?\n|,(?=\s*[A-Za-z_][A-Za-z0-9_]*=)", raw)
     return dict(item.strip().split("=", 1) for item in items if "=" in item)
+
+
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def normalize_env_vars(raw: object) -> dict[str, str]:
+    """Coerce a stored or user-supplied env-var set into {NAME: value} strings.
+
+    Accepts the mapping shape (how templates and container labels store them)
+    or the KEY=VALUE text shape (MCP arguments, REST clients), so both reach
+    the container through one validated representation. Values are cast to str
+    because JSON round-trips integers ("WORKERS": 2) that Docker rejects.
+
+    Raises ValueError for a name that could not be exported anyway; a bad name
+    is a typo the caller must see, not something to silently drop.
+    """
+    if raw is None:
+        return {}
+    parsed: dict[Any, Any]
+    if isinstance(raw, str):
+        parsed = parse_env_vars(raw)
+    elif isinstance(raw, dict):
+        parsed = raw
+    else:
+        raise TypeError("Environment variables must be a mapping or KEY=VALUE text.")
+
+    result: dict[str, str] = {}
+    for name, value in parsed.items():
+        key = str(name).strip()
+        if not key:
+            continue
+        if not _ENV_VAR_NAME_RE.match(key):
+            raise ValueError(
+                f"Invalid environment variable name '{key}': use letters, "
+                "digits and underscores, not starting with a digit."
+            )
+        result[key] = "" if value is None else str(value)
+    return result
 
 
 def sanitize_repo_url(url: str) -> str:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -59,7 +59,7 @@ from oduflow.locking import (
     service_preset_lock_key,
     volume_lock_key,
 )
-from oduflow.naming import parse_env_vars
+from oduflow.naming import normalize_env_vars, parse_env_vars
 from oduflow.output_cache import CachedOutput, OutputCache
 from oduflow.po_tools import PoEntry
 from oduflow.settings import Settings, TeamSettings, find_toml
@@ -617,7 +617,7 @@ def create_environment(
         extra_addons: Comma-separated list of extra addon repo names with branches (e.g. "enterprise:19.0,custom-themes:main"). Each entry must include a branch after a colon.
         sanitize: Sanitize the database after provisioning (default: True). Runs Odoo's native neutralization (deactivates outgoing mail servers and crons, disables payment providers, scrubs third-party API credentials, sets database.is_neutralized) and then any custom scripts from the .oduflow/odoo_sanitize/ folder in the repository. Only applies to environments created from a template.
         auto_install_modules: Comma-separated list of Odoo modules to install automatically after the environment is provisioned (e.g. "sale,purchase,stock"). When a template is specified and this is empty, the value is loaded from template metadata.
-        env_vars: Comma- or newline-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). Commas inside values are preserved unless what follows the comma looks like another KEY=; put one pair per line when in doubt. These are added on top of the database connection variables (HOST/USER/PASSWORD).
+        env_vars: Comma- or newline-separated KEY=VALUE pairs injected as environment variables into the Odoo container (e.g. "WORKERS=2,LIMIT_TIME_CPU=600"). Commas inside values are preserved unless what follows the comma looks like another KEY=; put one pair per line when in doubt. These are added on top of the database connection variables (HOST/USER/PASSWORD). When a template records env_vars, the two sets are merged per key and the values passed here win.
         local_path: LOCAL FAST-PATH. Absolute path to a checkout on THIS host. When set, Oduflow skips git clone and bind-mounts the directory live into the container — your file edits are visible instantly, no git push/pull needed. After editing, call pull_and_apply with explicit install/upgrade/restart to apply. repo_url is not required in this mode. Gated by allow_local_path (default: true).
     """
     import json
@@ -639,6 +639,7 @@ def create_environment(
         effective_repo_url = repo_url
         effective_odoo_image = odoo_image
         effective_git_user = ""
+        template_env_vars: dict[str, str] = {}
         local_path = (local_path or "").strip()
         local_path_from_template = False
         if resolved_template:
@@ -664,6 +665,9 @@ def create_environment(
                             )
                 if not auto_install_modules:
                     auto_install_modules = metadata.get("auto_install_modules", "")
+                template_env_vars = system_ops._template_env_vars(
+                    metadata, resolved_template
+                )
                 # The template's live-mount path applies only when the caller
                 # gave no code source of their own (explicit repo_url wins, so
                 # http clients can still clone from a real remote).
@@ -720,7 +724,10 @@ def create_environment(
             if auto_install_modules
             else []
         )
-        parsed_env = parse_env_vars(env_vars) or None
+        # Per-key merge: the template supplies the baseline and an explicit
+        # argument overrides just the keys it names, so a caller can bump
+        # WORKERS without having to restate the template's whole set.
+        parsed_env = {**template_env_vars, **normalize_env_vars(env_vars)} or None
         result = env_ops.create_environment(
             settings,
             team,
@@ -890,6 +897,10 @@ def list_templates(ctx: Context | None = None) -> str:
             size_info = f", Filestore size={fs_str}, Dump size={dump_str}"
         auto_install = r.get("auto_install_modules", "")
         auto_info = f", Auto-install={auto_install}" if auto_install else ""
+        # Names only — a template's env vars routinely carry API keys, and this
+        # listing is the one template view an agent reads unprompted.
+        env_names = sorted(r.get("env_vars") or {})
+        env_info = f", Env={','.join(env_names)}" if env_names else ""
         # Provenance: which code this database snapshot came from. A branch that
         # does not contain that commit will hit upgrade failures against newer data.
         origin_parts = []
@@ -900,7 +911,7 @@ def list_templates(ctx: Context | None = None) -> str:
         if r.get("snapshot_at"):
             origin_parts.append(f"snapshot {str(r['snapshot_at'])[:10]}")
         origin_info = f", Source={' @ '.join(origin_parts)}" if origin_parts else ""
-        output += f"- {r['template_name']}: DB={db_status}, SQL={r['has_sql']}, Filestore={r['has_filestore']}, Mode={overlay_status}{size_info}{auto_info}{origin_info}\n"
+        output += f"- {r['template_name']}: DB={db_status}, SQL={r['has_sql']}, Filestore={r['has_filestore']}, Mode={overlay_status}{size_info}{auto_info}{env_info}{origin_info}\n"
     return output
 
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1476,7 +1476,7 @@
       <div class="form-group">
         <label for="cr-env-vars">Environment variables</label>
         <textarea id="cr-env-vars" rows="3" spellcheck="false" placeholder="WORKERS=2&#10;LIMIT_TIME_CPU=600"></textarea>
-        <div class="hint">One KEY=VALUE per line, injected into the Odoo container. A value may contain commas.</div>
+        <div class="hint" id="cr-env-vars-hint">One KEY=VALUE per line, injected into the Odoo container. A value may contain commas.</div>
       </div>
 
       <div class="form-actions">
@@ -1919,6 +1919,11 @@
           <label for="tset-auto-install">Auto-install modules</label>
           <input type="text" id="tset-auto-install" placeholder="e.g. sale,purchase,stock">
           <div class="hint">Comma-separated list of modules to install after provisioning</div>
+        </div>
+        <div class="form-group">
+          <label for="tset-env-vars">Environment variables</label>
+          <textarea id="tset-env-vars" rows="4" spellcheck="false" placeholder="WORKERS=2&#10;LIMIT_TIME_CPU=600"></textarea>
+          <div class="hint" id="tset-env-vars-hint">One KEY=VALUE per line. Injected into environments created from this template; values given at creation time override them per key.</div>
         </div>
         <div class="form-group">
           <label for="tset-overlay">Filestore mode</label>
@@ -3298,7 +3303,10 @@ var _updateEnvSeq = 0;
 // Only a line boundary separates assignments: a value may contain commas (and
 // even "X=" pairs), and a stack-managed environment routinely has them.
 function parseEnvLines(text) {
-  var out = {};
+  // Null prototype, like _tsetNormalizeExtras: a variable literally named
+  // __proto__ must land as an own key instead of hitting the setter and
+  // vanishing on its way to the container.
+  var out = Object.create(null);
   text.split(/\r?\n/).forEach(function(line) {
     var entry = line.trim();
     var i = entry.indexOf('=');
@@ -3306,6 +3314,34 @@ function parseEnvLines(text) {
     out[entry.slice(0, i).trim()] = entry.slice(i + 1);
   });
   return out;
+}
+
+function formatEnvLines(vars) {
+  return Object.keys(vars || {}).map(function(k) { return k + '=' + vars[k]; }).join('\n');
+}
+
+var CREATE_ENV_HINT = 'One KEY=VALUE per line, injected into the Odoo container. A value may contain commas.';
+
+function fillCreateTemplateEnvVars(tpl) {
+  var ta = document.getElementById('cr-env-vars');
+  var hint = document.getElementById('cr-env-vars-hint');
+  var vars = (tpl && tpl.env_vars) || {};
+  var singleLine = Object.create(null);
+  var multilineCount = 0;
+  Object.keys(vars).forEach(function(k) {
+    if (/\r|\n/.test(String(vars[k]))) multilineCount += 1;
+    else singleLine[k] = vars[k];
+  });
+  // The request is merged over template metadata server-side. Omitting values
+  // this textarea cannot represent leaves their exact multiline form inherited
+  // instead of sending a truncated override. Replacing the field on every
+  // template change also prevents values from the previous template leaking in.
+  ta.value = formatEnvLines(singleLine);
+  hint.textContent = multilineCount
+    ? CREATE_ENV_HINT + ' ' + multilineCount + ' multiline template ' +
+      (multilineCount === 1 ? 'value is' : 'values are') +
+      ' inherited unchanged and omitted here.'
+    : CREATE_ENV_HINT;
 }
 
 async function doUpdate(branch) {
@@ -3860,6 +3896,8 @@ var _templateSettingsLoadToken = 0;
 var _templateSettingsMeta = {};
 var _templateSettingsRawMode = false;
 
+var TSET_ENV_HINT = 'One KEY=VALUE per line. Injected into environments created from this template; values given at creation time override them per key.';
+
 // Provenance and size keys: recorded by the import/snapshot code, not editable
 // in the form (raw JSON mode can still change them).
 var TSET_FACTS = [
@@ -3978,6 +4016,17 @@ function _tsetFillForm(meta) {
   document.getElementById('tset-repo').value = meta.repo_url || '';
   document.getElementById('tset-local-path').value = meta.local_path || '';
   document.getElementById('tset-auto-install').value = meta.auto_install_modules || '';
+  // A line-per-assignment field cannot represent a value that itself spans
+  // lines, so show those read-only and send the editor to raw JSON instead of
+  // letting a save write back a mangled version.
+  var envTa = document.getElementById('tset-env-vars');
+  var envVars = meta.env_vars || {};
+  var envMultiline = Object.keys(envVars).some(function(k) { return /[\r\n]/.test(String(envVars[k])); });
+  envTa.value = formatEnvLines(envVars);
+  envTa.readOnly = envMultiline;
+  document.getElementById('tset-env-vars-hint').textContent = envMultiline
+    ? 'A variable holds a multi-line value — edit these in raw JSON mode.'
+    : TSET_ENV_HINT;
   var overlay = meta.use_overlay;
   document.getElementById('tset-overlay').value =
     overlay === true ? 'overlay' : (overlay === false ? 'copy' : 'auto');
@@ -4011,6 +4060,10 @@ function _tsetCollectForm() {
   meta.repo_url = document.getElementById('tset-repo').value.trim();
   meta.git_user = document.getElementById('tset-git-user').value;
   meta.auto_install_modules = document.getElementById('tset-auto-install').value.trim();
+  var envTa = document.getElementById('tset-env-vars');
+  var envVars = envTa.readOnly ? (_templateSettingsMeta.env_vars || {}) : parseEnvLines(envTa.value);
+  if (Object.keys(envVars).length) { meta.env_vars = envVars; }
+  else { delete meta.env_vars; }
   meta.extra_addons = extras;
   var localPath = document.getElementById('tset-local-path').value.trim();
   if (localPath) { meta.local_path = localPath; }
@@ -4380,6 +4433,8 @@ function renderTemplates(templates) {
       if (t.repo_url) parts.push('<span>Repo: <strong>' + esc(t.repo_url) + '</strong></span>');
       if (t.git_user) parts.push('<span>Git User: <strong>' + esc(t.git_user) + '</strong></span>');
       if (t.auto_install_modules) parts.push('<span>Auto-install: <strong>' + esc(t.auto_install_modules) + '</strong></span>');
+      var envCount = Object.keys(t.env_vars || {}).length;
+      if (envCount) parts.push('<span>Env vars: <strong>' + envCount + '</strong></span>');
       metaHtml = '<div class="tpl-meta" style="margin-top:8px;flex-wrap:wrap;">' + parts.join('') + '</div>';
     }
     return '<div class="tpl-card tpl-card-stacked">' +
@@ -4427,7 +4482,9 @@ function populateTemplateSelect() {
         if (brInput) brInput.value = tplExtras[cb.value] || '';
       });
     }
+    fillCreateTemplateEnvVars(tpl);
   };
+  fillCreateTemplateEnvVars(cachedTemplates.find(function(t) { return t.template_name === sel.value; }));
 }
 
 function openCreateFromTemplate(templateName) {
@@ -4438,6 +4495,7 @@ function openCreateFromTemplate(templateName) {
   document.getElementById('cr-repo').value = tpl && tpl.repo_url ? tpl.repo_url : '';
   document.getElementById('cr-image').value = tpl && tpl.odoo_image ? tpl.odoo_image : '';
   document.getElementById('cr-auto-install').value = tpl && tpl.auto_install_modules ? tpl.auto_install_modules : '';
+  fillCreateTemplateEnvVars(tpl);
   var errEl = document.getElementById('create-error');
   errEl.style.display = 'none';
   errEl.textContent = '';
@@ -4446,6 +4504,7 @@ function openCreateFromTemplate(templateName) {
     populateTemplateSelect();
     var sel = document.getElementById('cr-template');
     sel.value = templateName;
+    fillCreateTemplateEnvVars(cachedTemplates.find(function(t) { return t.template_name === templateName; }) || tpl);
   });
   loadCredentials().then(function() {
     var sel = document.getElementById('cr-git-user');
@@ -4485,6 +4544,7 @@ function openCreateModal() {
   document.getElementById('cr-image').value = '';
   document.getElementById('cr-auto-install').value = '';
   document.getElementById('cr-env-vars').value = '';
+  document.getElementById('cr-env-vars-hint').textContent = CREATE_ENV_HINT;
 
   var errEl = document.getElementById('create-error');
   errEl.style.display = 'none';

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1253,7 +1253,7 @@ def _build_routes(
         extra_addons_raw = body.get("extra_addons")
         auto_install_raw = (body.get("auto_install_modules") or "").strip()
         hostname = (body.get("hostname") or "").strip()
-        env_vars = _env_vars_from_body(body.get("env_vars")) or None
+        env_vars = _env_vars_from_body(body.get("env_vars"))
         if not env_name:
             return JSONResponse(
                 {"ok": False, "error": "branch is required."},
@@ -1289,6 +1289,7 @@ def _build_routes(
             elif isinstance(extra_addons_raw, str) and extra_addons_raw.strip():
                 extra_dict = _parse_extra_addons(extra_addons_raw.strip()) or None
             local_path_from_meta = ""
+            template_env_vars: dict[str, str] = {}
             if resolved_template:
                 metadata_path = team.get_template_metadata_path(resolved_template)
                 if os.path.isfile(metadata_path):
@@ -1306,6 +1307,9 @@ def _build_routes(
                             extra_dict = _normalize_extra_addons(raw) or None
                     if not auto_install_raw:
                         auto_install_raw = metadata.get("auto_install_modules", "")
+                    template_env_vars = system_ops._template_env_vars(
+                        metadata, resolved_template
+                    )
                     if not repo_url and metadata.get("local_path"):
                         if settings.allow_local_path:
                             local_path_from_meta = metadata["local_path"]
@@ -1357,7 +1361,9 @@ def _build_routes(
                 extra_addons=extra_dict,
                 git_user=git_user,
                 auto_install_modules=auto_install_list or None,
-                env_vars=env_vars,
+                # Template env vars are the baseline; the request overrides
+                # only the keys it names (same merge as the MCP tool).
+                env_vars={**template_env_vars, **env_vars} or None,
                 local_path=local_path_from_meta,
                 hostname=hostname,
             )

--- a/tests/test_template_env_vars.py
+++ b/tests/test_template_env_vars.py
@@ -1,0 +1,338 @@
+"""Tests for template-provided environment variables.
+
+A template records ``env_vars`` in its metadata; creating an environment from
+it injects them into the Odoo container. Values passed at creation time merge
+per key over the template's, so a caller can bump one variable without having
+to restate the whole set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+from tool_helpers import call_tool as _call_tool  # noqa: E402
+
+from oduflow.docker_ops.system_ops import (
+    _source_env_metadata,
+    _template_env_vars,
+    update_template_metadata,
+)
+from oduflow.naming import normalize_env_vars
+from oduflow.settings import Settings, TeamSettings
+
+
+def _make_env(tmp_path):
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(tmp_path / "team"),
+        port_registry_path=str(tmp_path / "ports.json"),
+    )
+    settings = Settings(
+        base_data_dir=str(tmp_path),
+        disable_telemetry=True,
+        teams={"1": team},
+    )
+    return settings, team
+
+
+@pytest.fixture
+def tool_env(tmp_path):
+    """Inject per-test settings/team into the MCP server module."""
+    import oduflow.server as server
+
+    settings, team = _make_env(tmp_path)
+    old = server._settings
+    server._settings = settings
+    with patch("oduflow.server._resolve_team", return_value=team):
+        yield settings, team
+    server._settings = old
+
+
+def _write_template(team: TeamSettings, name: str, metadata: dict) -> None:
+    path = team.get_template_metadata_path(name)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(metadata, f)
+
+
+_TEMPLATE = {
+    "odoo_image": "odoo:19.0",
+    "repo_url": "https://github.com/x/y.git",
+    "env_vars": {"WORKERS": "2", "LIMIT_TIME_CPU": "600"},
+}
+
+_CREATE_RESULT = {
+    "url": "http://localhost:50000",
+    "odoo_container": "oduflow-t-odoo",
+    "database": "oduflow_1_t",
+    "workspace": "/tmp/ws",
+}
+
+
+# --- normalize_env_vars ----------------------------------------------------
+
+
+class TestNormalizeEnvVars:
+    def test_mapping_is_kept_and_values_stringified(self):
+        # JSON round-trips numbers that Docker would refuse.
+        assert normalize_env_vars({"WORKERS": 2, "DEBUG": True}) == {
+            "WORKERS": "2",
+            "DEBUG": "True",
+        }
+
+    def test_text_form_keeps_commas_inside_values(self):
+        assert normalize_env_vars("A=1,B=x,y") == {"A": "1", "B": "x,y"}
+
+    def test_none_and_empty_names_drop_out(self):
+        assert normalize_env_vars(None) == {}
+        assert normalize_env_vars({"  ": "x", "OK": None}) == {"OK": ""}
+
+    @pytest.mark.parametrize("name", ["2WORKERS", "WITH-DASH", "with space", "A.B"])
+    def test_invalid_name_is_rejected(self, name):
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            normalize_env_vars({name: "x"})
+
+    def test_non_mapping_is_rejected(self):
+        with pytest.raises(TypeError):
+            normalize_env_vars(["A=1"])
+
+
+# --- save_as_template metadata --------------------------------------------
+
+
+class TestSourceEnvMetadata:
+    SETTINGS = Settings(teams={})
+
+    def _labels(self, **extra):
+        return {
+            self.SETTINGS.image_label: "odoo:19.0",
+            self.SETTINGS.repo_label: "https://github.com/x/y.git",
+            **extra,
+        }
+
+    def test_env_vars_are_carried_over_from_the_container(self):
+        labels = self._labels(**{"oduflow.env_vars": json.dumps({"WORKERS": "2"})})
+        assert _source_env_metadata(self.SETTINGS, labels)["env_vars"] == {
+            "WORKERS": "2"
+        }
+
+    def test_env_without_vars_records_no_key(self):
+        assert "env_vars" not in _source_env_metadata(self.SETTINGS, self._labels())
+
+    def test_unreadable_label_is_skipped_not_fatal(self):
+        labels = self._labels(**{"oduflow.env_vars": "{not json"})
+        assert "env_vars" not in _source_env_metadata(self.SETTINGS, labels)
+
+
+# --- reading env vars back off a template ---------------------------------
+
+
+class TestTemplateEnvVars:
+    def test_reads_and_normalizes(self):
+        assert _template_env_vars({"env_vars": {"WORKERS": 2}}, "tpl") == {
+            "WORKERS": "2"
+        }
+
+    def test_missing_or_empty_is_an_empty_dict(self):
+        assert _template_env_vars({}, "tpl") == {}
+        assert _template_env_vars({"env_vars": {}}, "tpl") == {}
+
+    def test_hand_edited_garbage_is_dropped_with_a_warning(self, caplog):
+        # A template broken by a filesystem edit must still provision.
+        assert _template_env_vars({"env_vars": {"2BAD": "x"}}, "tpl") == {}
+        assert "Ignoring invalid env_vars" in caplog.text
+
+
+# --- create_environment (MCP tool) ----------------------------------------
+
+
+class TestCreateFromTemplate:
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_template_env_vars_reach_the_container(
+        self, mock_create, tool_env, tmp_path
+    ):
+        _settings, team = tool_env
+        _write_template(team, "tpl", _TEMPLATE)
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        _call_tool("create_environment", branch="t", template_name="tpl")
+
+        assert mock_create.call_args.kwargs["env_vars"] == {
+            "WORKERS": "2",
+            "LIMIT_TIME_CPU": "600",
+        }
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_argument_merges_per_key_over_the_template(
+        self, mock_create, tool_env, tmp_path
+    ):
+        _settings, team = tool_env
+        _write_template(team, "tpl", _TEMPLATE)
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        _call_tool(
+            "create_environment",
+            branch="t",
+            template_name="tpl",
+            env_vars="WORKERS=8\nEXTRA=on",
+        )
+
+        # WORKERS overridden, LIMIT_TIME_CPU inherited, EXTRA added.
+        assert mock_create.call_args.kwargs["env_vars"] == {
+            "WORKERS": "8",
+            "LIMIT_TIME_CPU": "600",
+            "EXTRA": "on",
+        }
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_no_template_env_vars_leaves_the_argument_alone(
+        self, mock_create, tool_env, tmp_path
+    ):
+        _settings, team = tool_env
+        _write_template(team, "tpl", {**_TEMPLATE, "env_vars": {}})
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        _call_tool(
+            "create_environment", branch="t", template_name="tpl", env_vars="A=1"
+        )
+
+        assert mock_create.call_args.kwargs["env_vars"] == {"A": "1"}
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_invalid_argument_name_is_reported(self, mock_create, tool_env, tmp_path):
+        _settings, team = tool_env
+        _write_template(team, "tpl", _TEMPLATE)
+
+        with pytest.raises(ToolError, match="Invalid environment variable name"):
+            _call_tool(
+                "create_environment",
+                branch="t",
+                template_name="tpl",
+                env_vars="2BAD=x",
+            )
+        mock_create.assert_not_called()
+
+
+# --- create from template (Web UI) ----------------------------------------
+
+
+def _web_app(settings):
+    from starlette.applications import Starlette
+
+    from oduflow.locking import LockManager
+    from oduflow.web_ui import mount_web_ui
+
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return app
+
+
+class TestWebUICreateFromTemplate:
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_request_env_vars_merge_over_the_template(self, mock_create, tmp_path):
+        from starlette.testclient import TestClient
+
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "tpl", _TEMPLATE)
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        client = TestClient(_web_app(settings))
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "env_name": "t",
+                "template_name": "tpl",
+                "env_vars": {"WORKERS": "8"},
+            },
+        )
+
+        assert resp.status_code == 200
+        assert mock_create.call_args.kwargs["env_vars"] == {
+            "WORKERS": "8",
+            "LIMIT_TIME_CPU": "600",
+        }
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_template_env_vars_apply_without_a_request_override(
+        self, mock_create, tmp_path
+    ):
+        from starlette.testclient import TestClient
+
+        settings, team = _make_env(tmp_path)
+        _write_template(team, "tpl", _TEMPLATE)
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        client = TestClient(_web_app(settings))
+        resp = client.post(
+            "/api/environments/create",
+            json={"env_name": "t", "template_name": "tpl"},
+        )
+
+        assert resp.status_code == 200
+        assert mock_create.call_args.kwargs["env_vars"] == {
+            "WORKERS": "2",
+            "LIMIT_TIME_CPU": "600",
+        }
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    def test_without_a_template_env_vars_stay_none(self, mock_create, tmp_path):
+        from starlette.testclient import TestClient
+
+        settings, _team = _make_env(tmp_path)
+        mock_create.return_value = dict(_CREATE_RESULT)
+
+        client = TestClient(_web_app(settings))
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "env_name": "t",
+                "template_name": "none",
+                "repo_url": "https://github.com/x/y.git",
+                "odoo_image": "odoo:19.0",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert mock_create.call_args.kwargs["env_vars"] is None
+
+
+# --- editing a template's env vars ----------------------------------------
+
+
+class TestUpdateTemplateMetadata:
+    def _template(self, tmp_path, metadata):
+        _settings, team = _make_env(tmp_path)
+        _write_template(team, "tpl", metadata)
+        return team
+
+    def _revision(self, team):
+        from oduflow.docker_ops.system_ops import get_template_metadata
+
+        return get_template_metadata(team, "tpl")["revision"]
+
+    def test_values_are_stringified_on_save(self, tmp_path):
+        team = self._template(tmp_path, _TEMPLATE)
+        result = update_template_metadata(
+            team,
+            "tpl",
+            json.dumps({**_TEMPLATE, "env_vars": {"WORKERS": 4}}),
+            self._revision(team),
+        )
+        assert json.loads(result["content"])["env_vars"] == {"WORKERS": "4"}
+
+    def test_invalid_name_is_rejected_while_the_editor_is_open(self, tmp_path):
+        team = self._template(tmp_path, _TEMPLATE)
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            update_template_metadata(
+                team,
+                "tpl",
+                json.dumps({**_TEMPLATE, "env_vars": {"BAD NAME": "x"}}),
+                self._revision(team),
+            )
+        # The file on disk is untouched, so the editor can be corrected and retried.
+        with open(team.get_template_metadata_path("tpl")) as f:
+            assert json.load(f)["env_vars"] == _TEMPLATE["env_vars"]

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -214,7 +214,12 @@ def test_template_settings_form_round_trips_attribute_and_prototype_key_values()
     dashboard = _DASHBOARD.read_text(encoding="utf-8")
     functions = "\n".join(
         _js_function(dashboard, name)
-        for name in ("escHtmlAttr", "_tsetNormalizeExtras", "_tsetCollectForm")
+        for name in (
+            "escHtmlAttr",
+            "parseEnvLines",
+            "_tsetNormalizeExtras",
+            "_tsetCollectForm",
+        )
     )
     harness = (
         functions
@@ -225,6 +230,7 @@ var fields = {
   'tset-repo': {value: 'https://example.test/addons.git'},
   'tset-git-user': {value: "O'Reilly"},
   'tset-auto-install': {value: ''},
+  'tset-env-vars': {value: '__proto__=polluted\nWORKERS=2', readOnly: false},
   'tset-local-path': {value: ''},
   'tset-overlay': {value: 'auto'}
 };
@@ -281,10 +287,60 @@ process.stdout.write(JSON.stringify({
             "repo_url": "https://example.test/addons.git",
             "git_user": "O'Reilly",
             "auto_install_modules": "",
+            "env_vars": {"__proto__": "polluted", "WORKERS": "2"},
             "extra_addons": {
                 "__proto__": "feature'quote",
                 'missing"repo\\name': "release\\candidate",
             },
             "use_overlay": None,
         },
+    }
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_create_template_env_vars_refresh_and_preserve_multiline_inheritance():
+    dashboard = _DASHBOARD.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _js_function(dashboard, name)
+        for name in ("parseEnvLines", "formatEnvLines", "fillCreateTemplateEnvVars")
+    )
+    harness = (
+        functions
+        + r"""
+var CREATE_ENV_HINT = 'Environment variables';
+var fields = {
+  'cr-env-vars': {value: ''},
+  'cr-env-vars-hint': {textContent: ''}
+};
+global.document = {
+  getElementById: function (id) { return fields[id]; }
+};
+fillCreateTemplateEnvVars({env_vars: {TOKEN: 'customer-a', WORKERS: '2'}});
+var first = fields['cr-env-vars'].value;
+fields['cr-env-vars'].value = 'TOKEN=manual-edit';
+fillCreateTemplateEnvVars({env_vars: {TOKEN: 'customer-b', LIMIT: '600'}});
+var switched = fields['cr-env-vars'].value;
+fillCreateTemplateEnvVars({env_vars: {
+  CERT: '-----BEGIN-----\nbase64=payload\n-----END-----',
+  WORKERS: '4'
+}});
+process.stdout.write(JSON.stringify({
+  first: first,
+  switched: switched,
+  multilineField: fields['cr-env-vars'].value,
+  multilineParsed: parseEnvLines(fields['cr-env-vars'].value),
+  multilineHint: fields['cr-env-vars-hint'].textContent
+}));
+"""
+    )
+
+    assert _run_node(harness) == {
+        "first": "TOKEN=customer-a\nWORKERS=2",
+        "switched": "TOKEN=customer-b\nLIMIT=600",
+        "multilineField": "WORKERS=4",
+        "multilineParsed": {"WORKERS": "4"},
+        "multilineHint": (
+            "Environment variables 1 multiline template value is inherited "
+            "unchanged and omitted here."
+        ),
     }


### PR DESCRIPTION
## Summary
- store source environment variables in template metadata and inherit them during provisioning
- merge per-create overrides over template defaults across MCP and the dashboard API
- add template Settings and safe create-form handling, including template switching and multiline values
- document and test the new behavior

## Validation
- `python3 -m pytest -q tests/test_documentation_sync.py tests/test_web_ui_static.py tests/test_template_env_vars.py tests/test_web_ui_env_vars.py` (54 passed)
- `python3 -m ruff check src/oduflow/docker_ops/system_ops.py src/oduflow/naming.py src/oduflow/server.py src/oduflow/web_ui.py tests/test_template_env_vars.py tests/test_web_ui_static.py`
- `python3 -m mypy src/oduflow/naming.py src/oduflow/server.py src/oduflow/web_ui.py src/oduflow/docker_ops/system_ops.py`
- full non-integration suite: 2507 passed; 7 environment-only failures because Docker and rsync are unavailable in this workspace