### PR TITLE
Recover stale filestore overlays safely

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4809,9 +4809,35 @@ du -sh /srv/oduflow/team_1/workspaces/<env-slug>/filestore         # ~= template
 
 ### A broken mount (`Transport endpoint is not connected`)
 
-The `fuse-overlayfs` process for a mount died (e.g. it was killed when the disk
-filled). Detach the stale mount, then bring the environment back up through
-Oduflow (which remounts it):
+The `fuse-overlayfs` process for a mount died. Two ways that happens:
+
+- **Oduflow runs in Docker and was restarted.** The daemon lives in the Oduflow
+  container's PID namespace and dies with it, while the mount itself lives in
+  the host's mount namespace (it has to — Odoo containers bind-mount the merged
+  path, which Docker resolves on the host) and survives. So *every* overlay
+  environment goes stale at once on a restart. Running Oduflow directly on the
+  host, the daemon is detached from the Oduflow process and a restart leaves it
+  alone.
+- **The daemon was killed** — an OOM kill, or the disk filling up.
+
+Oduflow repairs this by itself: on every start it detects stale overlays,
+detaches them, remounts each against its template's lower layer **keeping the
+environment's own `filestore_upper` deltas**, and restarts the affected Odoo
+containers (required — a running container's bind mount still points at the
+dead mount). Recovery fails closed: Oduflow does not detach a mount unless the
+container is confirmed stopped, does not restart the container unless the new
+overlay is confirmed live, and always reuses the existing upper layer even if
+the template's default mode was later changed to copy. The `/healthz` endpoint
+and the dashboard's `OVERLAY` chip report stale or unexpectedly absent overlays;
+full filesystem paths stay in server logs. An environment whose template is
+gone is logged for manual recovery rather than touched.
+
+Note that a stale mount reads as *absent*, not as *mounted*: `stat` on the
+mountpoint fails with `ENOTCONN`, so `ls`, `os.path.ismount()` and
+`os.path.isdir()` all behave as if nothing is there.
+
+To detach one by hand — remount then happens through Oduflow (`restart` the
+server, or `update_environment`):
 
 ```bash
 umount /srv/oduflow/team_1/workspaces/<env-slug>/filestore \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -324,9 +324,35 @@ du -sh /srv/oduflow/team_1/workspaces/<env-slug>/filestore         # ~= template
 
 ### A broken mount (`Transport endpoint is not connected`)
 
-The `fuse-overlayfs` process for a mount died (e.g. it was killed when the disk
-filled). Detach the stale mount, then bring the environment back up through
-Oduflow (which remounts it):
+The `fuse-overlayfs` process for a mount died. Two ways that happens:
+
+- **Oduflow runs in Docker and was restarted.** The daemon lives in the Oduflow
+  container's PID namespace and dies with it, while the mount itself lives in
+  the host's mount namespace (it has to — Odoo containers bind-mount the merged
+  path, which Docker resolves on the host) and survives. So *every* overlay
+  environment goes stale at once on a restart. Running Oduflow directly on the
+  host, the daemon is detached from the Oduflow process and a restart leaves it
+  alone.
+- **The daemon was killed** — an OOM kill, or the disk filling up.
+
+Oduflow repairs this by itself: on every start it detects stale overlays,
+detaches them, remounts each against its template's lower layer **keeping the
+environment's own `filestore_upper` deltas**, and restarts the affected Odoo
+containers (required — a running container's bind mount still points at the
+dead mount). Recovery fails closed: Oduflow does not detach a mount unless the
+container is confirmed stopped, does not restart the container unless the new
+overlay is confirmed live, and always reuses the existing upper layer even if
+the template's default mode was later changed to copy. The `/healthz` endpoint
+and the dashboard's `OVERLAY` chip report stale or unexpectedly absent overlays;
+full filesystem paths stay in server logs. An environment whose template is
+gone is logged for manual recovery rather than touched.
+
+Note that a stale mount reads as *absent*, not as *mounted*: `stat` on the
+mountpoint fails with `ENOTCONN`, so `ls`, `os.path.ismount()` and
+`os.path.isdir()` all behave as if nothing is there.
+
+To detach one by hand — remount then happens through Oduflow (`restart` the
+server, or `update_environment`):
 
 ```bash
 umount /srv/oduflow/team_1/workspaces/<env-slug>/filestore \

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import errno
 import json
 import logging
 import os
 import pathlib
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import time
@@ -375,6 +377,105 @@ def _template_code_lineage(
         return empty
 
 
+# A dead ``fuse-overlayfs`` daemon leaves its mount table entry behind, and
+# every access to the mountpoint then fails with ENOTCONN ("Transport endpoint
+# is not connected"). Restarting Oduflow *in Docker* produces this on every
+# overlay environment at once: the daemon lives in the container's PID
+# namespace and dies with it, while the mount lives in the host's mount
+# namespace and survives — it has to live there, because Odoo containers
+# bind-mount the merged path and Docker resolves that on the host. Running
+# Oduflow directly on the host, the daemon is detached from the Oduflow process
+# and a restart leaves it alone; there a mount only goes stale to an OOM kill
+# or a full disk.
+#
+# ``os.path.ismount()`` cannot see this state: it swallows the ENOTCONN from
+# its own ``lstat`` and returns False, exactly as for a path that is not
+# mounted at all (``os.path.isdir()`` returns False for the same reason). So a
+# stale overlay is indistinguishable from an absent one unless we probe the
+# mountpoint and look at errno — which is what this module does everywhere it
+# needs to know whether an overlay is usable.
+_STALE_MOUNT_ERRNOS = frozenset({errno.ENOTCONN, errno.ECONNABORTED})
+
+MOUNT_ALIVE = "alive"
+MOUNT_STALE = "stale"
+MOUNT_ABSENT = "absent"
+
+
+def _is_directory_strict(path: str) -> bool:
+    """Like ``isdir``, but propagate permission and filesystem I/O errors."""
+    try:
+        mode = os.stat(path).st_mode
+    except FileNotFoundError:
+        return False
+    return stat.S_ISDIR(mode)
+
+
+def overlay_mount_state(merged: str) -> str:
+    """Liveness of a filestore mountpoint.
+
+    ``MOUNT_ALIVE`` — mounted and serving; ``MOUNT_STALE`` — mounted but its
+    daemon is gone (needs detaching and remounting); ``MOUNT_ABSENT`` — no
+    overlay mount here, which also covers a copy-mode filestore directory and a
+    path that does not exist.
+    """
+    try:
+        os.stat(merged)
+    except FileNotFoundError:
+        return MOUNT_ABSENT
+    except OSError as exc:
+        if exc.errno in _STALE_MOUNT_ERRNOS:
+            return MOUNT_STALE
+        # Permission and I/O failures are not evidence that a mount is absent.
+        # Let operational callers fail closed and let the health check surface
+        # the probe error instead of reporting a false green.
+        raise
+    return MOUNT_ALIVE if os.path.ismount(merged) else MOUNT_ABSENT
+
+
+def overlay_mount_issues(settings: Settings) -> list[dict[str, str]]:
+    """Stale or unexpectedly absent workspace overlay mounts.
+
+    A plain filesystem walk with no Docker calls, for the health check — there
+    the question is only whether anything needs repair, not what to do about it.
+    An existing ``upper`` directory makes an absent mount an error: it contains
+    environment-specific deltas that a plain template copy would ignore.
+    """
+    issues: list[dict[str, str]] = []
+    for team in settings.teams.values():
+        try:
+            entries = list(os.scandir(team.workspaces_dir))
+        except FileNotFoundError:
+            continue  # team never initialized
+        for entry in entries:
+            try:
+                if not entry.is_dir(follow_symlinks=False):
+                    continue
+            except FileNotFoundError:
+                continue  # workspace disappeared during the health scan
+            paths = get_filestore_paths(entry.name, team.workspaces_dir)
+            state = overlay_mount_state(paths["merged"])
+            expected = _is_directory_strict(paths["upper"])
+            if state == MOUNT_STALE or (state == MOUNT_ABSENT and expected):
+                issues.append(
+                    {
+                        "team_id": team.team_id,
+                        "env_name": entry.name,
+                        "state": state,
+                        "path": paths["merged"],
+                    }
+                )
+    return sorted(issues, key=lambda item: (item["team_id"], item["env_name"]))
+
+
+def stale_overlay_paths(settings: Settings) -> list[str]:
+    """Compatibility helper returning only dead-daemon mount paths."""
+    return [
+        issue["path"]
+        for issue in overlay_mount_issues(settings)
+        if issue["state"] == MOUNT_STALE
+    ]
+
+
 def _mount_filestore(
     client: DockerClient,
     settings: Settings,
@@ -385,15 +486,40 @@ def _mount_filestore(
     odoo_volumes: dict[str, Any],
     *,
     template_name: str,
+    force_overlay: bool = False,
 ) -> None:
     template_filestore = team.get_template_filestore_path(template_name)
     if not template_filestore or not os.path.isdir(template_filestore):
+        if force_overlay:
+            raise PrerequisiteNotMetError(
+                f"Template filestore is missing: {template_filestore}"
+            )
         logger.debug(
             "Dump filestore not found at %s, skipping overlay mount", template_filestore
         )
         return
 
     paths = get_filestore_paths(env_name, team.workspaces_dir)
+    if force_overlay and not _is_directory_strict(paths["upper"]):
+        raise PrerequisiteNotMetError(
+            f"Overlay upper layer is missing: {paths['upper']}"
+        )
+
+    # Detach a stale mount before anything else, whichever mode we end up in:
+    # mounting over it would stack a live overlay on a dead one, and the copy
+    # path (like the makedirs/chmod below) would just fail with ENOTCONN.
+    if overlay_mount_state(paths["merged"]) == MOUNT_STALE:
+        logger.warning(
+            "Stale filestore overlay at %s (fuse-overlayfs is gone); detaching",
+            paths["merged"],
+            extra={"env_name": env_name},
+        )
+        _unmount_filestore(env_name, team)
+        _wait_unmounted(paths["merged"])
+        if overlay_mount_state(paths["merged"]) != MOUNT_ABSENT:
+            raise PrerequisiteNotMetError(
+                f"Could not detach stale filestore overlay at {paths['merged']}"
+            )
 
     # Read use_overlay flag from template metadata (avoids slow filestore scan)
     use_overlay = None
@@ -406,7 +532,12 @@ def _mount_filestore(
         except (json.JSONDecodeError, OSError):
             pass
 
-    if use_overlay is None:
+    if force_overlay:
+        # A stale/live mount plus an existing upper layer proves that this
+        # environment is overlay-backed. Recovery must preserve those deltas
+        # even if the template's mutable default has since changed to copy.
+        use_overlay = True
+    elif use_overlay is None:
         # Fallback for old templates without the flag
         size_mb = _dir_size_mb(template_filestore)
         use_overlay = size_mb >= settings.overlay_threshold_mb
@@ -414,6 +545,10 @@ def _mount_filestore(
     # fuse-overlayfs is a Linux/FUSE binary; it cannot run on macOS. Off Linux,
     # always fall back to a plain filestore copy instead of failing.
     if use_overlay and not sys.platform.startswith("linux"):
+        if force_overlay:
+            raise PrerequisiteNotMetError(
+                "Cannot preserve an overlay filestore on a non-Linux platform"
+            )
         logger.info(
             "Non-Linux platform (%s): using filestore copy instead of overlay",
             sys.platform,
@@ -502,7 +637,10 @@ def _mount_filestore(
 def _unmount_filestore(env_name: str, team: TeamSettings) -> None:
     paths = get_filestore_paths(env_name, team.workspaces_dir)
     merged = paths["merged"]
-    if not os.path.isdir(merged) or not os.path.ismount(merged):
+    # Deliberately not ``isdir``/``ismount``: both report False for a stale
+    # mount, because the stat they rely on fails with ENOTCONN — and that is
+    # exactly the mount that most needs detaching.
+    if overlay_mount_state(merged) == MOUNT_ABSENT:
         return
 
     # Prefer a direct, clean ``umount``: Oduflow runs as root, and umount(2) is
@@ -535,7 +673,7 @@ def _unmount_filestore(env_name: str, team: TeamSettings) -> None:
 def _wait_unmounted(merged: str, timeout: float = 3.0) -> None:
     """Poll until ``merged`` is no longer a mount point (best-effort)."""
     deadline = time.time() + timeout
-    while time.time() < deadline and os.path.ismount(merged):
+    while time.time() < deadline and overlay_mount_state(merged) != MOUNT_ABSENT:
         time.sleep(0.1)
 
 
@@ -592,7 +730,9 @@ def remount_template_overlays(
         if env.get("template_name") != template_name:
             continue
         merged = get_filestore_paths(env_name, team.workspaces_dir)["merged"]
-        if not os.path.ismount(merged):
+        # Stale mounts are included: they need the very same stop / unmount /
+        # remount treatment, and skipping them left them broken and unnoticed.
+        if overlay_mount_state(merged) == MOUNT_ABSENT:
             continue
 
         container_name = get_resource_name(
@@ -643,8 +783,10 @@ def remount_template_overlays(
             env_name = a["env_name"]
             paths = get_filestore_paths(env_name, team.workspaces_dir)
             try:
-                if os.path.ismount(paths["merged"]):
-                    # Unmount failed earlier — don't stack a second mount.
+                if overlay_mount_state(paths["merged"]) == MOUNT_ALIVE:
+                    # Unmount failed earlier — don't stack a second mount. A
+                    # stale mount is not a reason to skip: _mount_filestore
+                    # detaches it first.
                     result.failures.append((env_name, "still mounted, skipped remount"))
                 else:
                     if reset_upper:
@@ -662,6 +804,7 @@ def remount_template_overlays(
                         a["image"],
                         {},
                         template_name=template_name,
+                        force_overlay=True,
                     )
                     logger.info("Remounted overlay for env %s", env_name)
                 if a["was_running"]:
@@ -674,6 +817,208 @@ def remount_template_overlays(
             except Exception as exc:  # noqa: BLE001 - best-effort, reported via result
                 logger.warning("Could not remount overlay for %s: %s", env_name, exc)
                 result.failures.append((env_name, f"remount: {exc}"))
+
+
+def reconcile_overlay_mounts(settings: Settings) -> list[dict[str, Any]]:
+    """Repair stale or unexpectedly absent filestore overlays.
+
+    Run on every server start. When Oduflow itself runs in Docker this is the
+    normal case rather than an exception (see :func:`overlay_mount_state`), and
+    until this existed every overlay environment came back from a restart with
+    a filestore that raised ENOTCONN on first access — with nothing in Oduflow
+    noticing, reporting or repairing it.
+
+    Each affected environment is stopped, detached when needed, remounted
+    against its template's lower layer keeping its own ``upper`` deltas, and
+    started again if it had been running. The container restart is required
+    rather than incidental: a running container's bind mount still points at
+    the dead mount, so remounting on the host alone would not reach it.
+
+    Best-effort per environment — a failure is logged and reported, never
+    raised, so one broken environment cannot keep the server from starting.
+    Returns one record per environment that needed attention.
+    """
+    results: list[dict[str, Any]] = []
+    client = get_client()
+
+    for team in settings.teams.values():
+        try:
+            envs = list_environments(settings, team)
+        except Exception as exc:  # noqa: BLE001 - startup must survive this
+            logger.warning(
+                "[team.%s] Could not list environments to reconcile overlays: %s",
+                team.team_id,
+                exc,
+            )
+            continue
+
+        for env in envs:
+            env_name = env["env_name"]
+            paths = get_filestore_paths(env_name, team.workspaces_dir)
+            record: dict[str, Any] = {
+                "team_id": team.team_id,
+                "env_name": env_name,
+                "repaired": False,
+                "detail": "",
+            }
+            try:
+                mount_state = overlay_mount_state(paths["merged"])
+                has_overlay_upper = _is_directory_strict(paths["upper"])
+            except OSError as exc:
+                record["detail"] = f"mount probe failed: {exc}"
+                logger.error(
+                    "Could not inspect filestore overlay for %s: %s", env_name, exc
+                )
+                results.append(record)
+                continue
+            if mount_state != MOUNT_STALE and not (
+                mount_state == MOUNT_ABSENT and has_overlay_upper
+            ):
+                continue
+            if not has_overlay_upper:
+                record["detail"] = "overlay upper layer is missing"
+                logger.error(
+                    "Broken filestore overlay for %s has no upper layer at %s; "
+                    "leaving the mount alone for manual recovery",
+                    env_name,
+                    paths["upper"],
+                )
+                results.append(record)
+                continue
+
+            template_name = env.get("template_name") or ""
+            if not template_name or template_name == "none":
+                # Without a template there is no lower layer to remount against,
+                # and only an operator can decide what to restore this from.
+                record["detail"] = "no template to remount against"
+                logger.error(
+                    "Broken filestore overlay for %s has no template: %s needs "
+                    "manual recovery",
+                    env_name,
+                    paths["merged"],
+                )
+                results.append(record)
+                continue
+
+            # _mount_filestore returns quietly when the lower layer is gone, so
+            # check it here — before detaching anything. Otherwise this pass
+            # would unmount the environment and report a repair it never made.
+            template_filestore = team.get_template_filestore_path(template_name)
+            if not template_filestore or not os.path.isdir(template_filestore):
+                record["detail"] = f"template filestore missing: {template_filestore}"
+                logger.error(
+                    "Broken filestore overlay for %s: template '%s' has no "
+                    "filestore at %s; leaving the mount alone for manual recovery",
+                    env_name,
+                    template_name,
+                    template_filestore,
+                )
+                results.append(record)
+                continue
+
+            logger.warning(
+                "[team.%s] Broken filestore overlay for %s (%s); repairing",
+                team.team_id,
+                env_name,
+                mount_state,
+            )
+            container_name = get_resource_name(
+                env_name, "odoo", settings.prefix, team.team_id
+            )
+            image = env.get("odoo_image") or "odoo:19.0"
+            was_running = False
+            container = None
+            try:
+                container = client.containers.get(container_name)
+                was_running = container.status == "running"
+                if container.image.tags:
+                    image = container.image.tags[0]
+            except docker.errors.NotFound:
+                pass
+            except Exception as exc:  # noqa: BLE001 - fail closed per environment
+                record["detail"] = f"container lookup failed: {exc}"
+                logger.error("Could not inspect %s: %s", container_name, exc)
+                results.append(record)
+                continue
+
+            if container is not None:
+                status = container.status
+                if status == "running":
+                    try:
+                        container.stop(timeout=10)
+                        container.reload()
+                    except Exception as exc:  # noqa: BLE001 - fail closed
+                        record["detail"] = f"stop failed: {exc}"
+                        logger.error("Could not stop %s: %s", container_name, exc)
+                        results.append(record)
+                        continue
+                    if container.status == "running":
+                        record["detail"] = "stop failed: container is still running"
+                        logger.error("Container %s is still running", container_name)
+                        results.append(record)
+                        continue
+                elif status not in {"created", "exited", "dead"}:
+                    record["detail"] = f"unsafe container state: {status}"
+                    logger.error(
+                        "Will not detach overlay while %s is %s",
+                        container_name,
+                        status,
+                    )
+                    results.append(record)
+                    continue
+
+            try:
+                _unmount_filestore(env_name, team)
+                _wait_unmounted(paths["merged"])
+                if overlay_mount_state(paths["merged"]) != MOUNT_ABSENT:
+                    raise PrerequisiteNotMetError("mount did not detach")
+                _mount_filestore(
+                    client,
+                    settings,
+                    team,
+                    env_name,
+                    get_db_name(env_name, team.team_id),
+                    image,
+                    {},
+                    template_name=template_name,
+                    force_overlay=True,
+                )
+                state = overlay_mount_state(paths["merged"])
+                if state != MOUNT_ALIVE:
+                    raise PrerequisiteNotMetError(
+                        f"remount did not become live (state: {state})"
+                    )
+            except Exception as exc:  # noqa: BLE001 - never block startup
+                record["detail"] = str(exc)
+                logger.error(
+                    "Could not repair filestore overlay for %s: %s", env_name, exc
+                )
+                # Do not restart against an absent or unverified filestore.
+                results.append(record)
+                continue
+
+            if was_running and container is not None:
+                try:
+                    container.start()
+                    container.reload()
+                    if container.status != "running":
+                        raise RuntimeError(
+                            f"container status after start is {container.status}"
+                        )
+                except Exception as exc:  # noqa: BLE001 - best-effort
+                    record["detail"] = f"restart failed: {exc}"
+                    logger.error("Could not restart %s: %s", container_name, exc)
+                    results.append(record)
+                    continue
+
+            record["repaired"] = True
+            logger.warning(
+                "Remounted filestore overlay for %s (upper deltas kept)",
+                env_name,
+            )
+            results.append(record)
+
+    return results
 
 
 def _install_apt_packages(container: Any, repo_path: str) -> str:
@@ -4161,7 +4506,10 @@ def update_environment(
     fs_paths = get_filestore_paths(env_name, team.workspaces_dir)
     merged = fs_paths["merged"]
     has_overlay_dirs = os.path.isdir(fs_paths["upper"])
-    if has_overlay_dirs and os.path.isdir(merged) and not os.path.ismount(merged):
+    # ``os.path.isdir(merged)`` used to be part of this condition and silently
+    # excluded the stale case, where it reports False (ENOTCONN) — the one
+    # state that most needs a remount.
+    if has_overlay_dirs and overlay_mount_state(merged) != MOUNT_ALIVE:
         env_db = get_db_name(env_name)
         template_name = labels.get("oduflow.template", "none")
         if template_name and template_name != "none":
@@ -4176,6 +4524,7 @@ def update_environment(
                     run_image,
                     _tmp_vols,
                     template_name=template_name,
+                    force_overlay=True,
                 )
             except Exception as exc:
                 logger.warning("Could not re-mount filestore overlay: %s", exc)

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -3243,6 +3243,7 @@ def publish_env_as_template(
                 source_image,
                 {},
                 template_name=template_name,
+                force_overlay=True,
             )
             if source_was_running:
                 try:

--- a/src/oduflow/health.py
+++ b/src/oduflow/health.py
@@ -1,4 +1,4 @@
-"""System health checks: dev PG, prod PG, Traefik, S3, disk, productions.
+"""System health checks: dev PG, prod PG, Traefik, S3, disk, overlays, productions.
 
 Backs the public ``GET /healthz`` endpoint (uptime-monitor friendly:
 200 all-ok / 503 degraded) and the dashboard's status-bar chips. Results
@@ -91,6 +91,53 @@ def _check_disk(settings: Settings) -> dict[str, Any]:
     }
 
 
+def _check_overlays(settings: Settings) -> dict[str, Any]:
+    """Filestore overlays that are stale, missing, or cannot be inspected.
+
+    A stale overlay is invisible from the outside — the environment's container
+    is up and the dashboard shows it green — while every filestore read inside
+    it fails with ENOTCONN. Surfacing it here is what turns that into something
+    an operator sees before a user does.
+    """
+    from oduflow.docker_ops.env_ops import overlay_mount_issues
+
+    try:
+        issues = overlay_mount_issues(settings)
+    except Exception:  # noqa: BLE001 - health must answer, but never false-green
+        logger.exception("Could not inspect filestore overlays")
+        return {
+            "status": "error",
+            "detail": "filestore overlay scan failed; check server logs",
+            "count": 0,
+            "affected": [],
+        }
+    if not issues:
+        return {"status": "ok", "detail": "", "count": 0, "affected": []}
+
+    # /healthz is public. Report bounded logical identifiers here and keep host
+    # filesystem paths in authenticated operator logs only.
+    public = [
+        {
+            "team_id": issue["team_id"],
+            "env_name": issue["env_name"],
+            "state": issue["state"],
+        }
+        for issue in issues[:20]
+    ]
+    identifiers = [f"{item['team_id']}/{item['env_name']}" for item in public]
+    suffix = (
+        f" (+{len(issues) - len(public)} more)" if len(issues) > len(public) else ""
+    )
+    return {
+        "status": "error",
+        "detail": "filestore overlay needs attention: "
+        + ", ".join(identifiers)
+        + suffix,
+        "count": len(issues),
+        "affected": public,
+    }
+
+
 def _unhealthy_productions(settings: Settings) -> list[str]:
     from oduflow import production_registry
 
@@ -161,6 +208,7 @@ def collect_health(settings: Settings, *, force: bool = False) -> dict[str, Any]
         checks["traefik"] = _check_traefik(client, settings)
     checks["s3"] = _check_s3(settings)
     checks["disk"] = _check_disk(settings)
+    checks["overlays"] = _check_overlays(settings)
 
     if not settings.prod_enabled and client is not None:
         checks["productions"] = _disabled_production_status(client, settings)
@@ -173,8 +221,17 @@ def collect_health(settings: Settings, *, force: bool = False) -> dict[str, Any]
         }
 
     # Critical checks: dev PG always; prod PG only when provisioned; traefik
-    # when in traefik mode; S3 when configured; unhealthy productions.
-    critical = ["dev_pg", "prod_pg", "traefik", "s3", "productions", "docker"]
+    # when in traefik mode; S3 when configured; unhealthy productions; broken
+    # filestore overlays (stale, unexpectedly absent, or unreadable).
+    critical = [
+        "dev_pg",
+        "prod_pg",
+        "traefik",
+        "s3",
+        "productions",
+        "docker",
+        "overlays",
+    ]
     ok = all(
         checks.get(name, {}).get("status") in ("ok", "warn", "off", None)
         for name in critical

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -4776,6 +4776,22 @@ def _ensure_initialized(settings: Settings) -> None:
             os.path.join(team.data_dir, "templates"),
         )
 
+    # Filestore overlays do not survive an Oduflow restart in Docker: the
+    # fuse-overlayfs daemons die with the container's PID namespace while their
+    # mounts live on in the host's. Repair them before anything serves traffic,
+    # so environments do not come back up on a filestore that raises ENOTCONN.
+    try:
+        repaired = env_ops.reconcile_overlay_mounts(settings)
+    except Exception:  # noqa: BLE001 - a repair pass must never block startup
+        logger.warning("Filestore overlay reconciliation failed", exc_info=True)
+    else:
+        if repaired:
+            logger.warning(
+                "Filestore overlay reconciliation: %d repaired, %d need attention",
+                sum(1 for r in repaired if r["repaired"]),
+                sum(1 for r in repaired if not r["repaired"]),
+            )
+
     global _instance_id  # noqa: PLW0603
     from oduflow.telemetry import record_startup
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -6697,7 +6697,8 @@ async function loadHealth() {
     var el = document.getElementById('health-chips');
     if (!el || !data.checks) return;
     var labels = {
-      dev_pg: 'PG DEV', prod_pg: 'PG PROD', traefik: 'TRAEFIK', s3: 'S3', disk: 'DISK'
+      dev_pg: 'PG DEV', prod_pg: 'PG PROD', traefik: 'TRAEFIK', s3: 'S3', disk: 'DISK',
+      overlays: 'OVERLAY'
     };
     el.innerHTML = Object.keys(labels).map(function(key) {
       var check = data.checks[key];

--- a/tests/test_filestore_unmount.py
+++ b/tests/test_filestore_unmount.py
@@ -10,6 +10,7 @@ profile — must be tried first.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from unittest.mock import MagicMock
 
@@ -23,16 +24,21 @@ def _team(workspaces_dir: str):
     return team
 
 
-def _mount_present(monkeypatch) -> None:
-    """Make the merged dir look like a live mountpoint."""
-    monkeypatch.setattr(env_ops.os.path, "isdir", lambda p: True)
+def _mount_present(monkeypatch, merged: str) -> None:
+    """Make the merged dir look like a live mountpoint.
+
+    The directory has to exist: liveness is decided by stat'ing the mountpoint
+    (a stale FUSE mount is the case where that stat fails), not by ``ismount``
+    alone.
+    """
+    os.makedirs(merged, exist_ok=True)
     monkeypatch.setattr(env_ops.os.path, "ismount", lambda p: True)
 
 
 class TestUnmountFilestore:
     def test_tries_clean_umount_first(self, tmp_path, monkeypatch):
         merged = get_filestore_paths("env1", str(tmp_path))["merged"]
-        _mount_present(monkeypatch)
+        _mount_present(monkeypatch, merged)
         calls = []
 
         def fake_run(cmd, **kw):
@@ -49,7 +55,7 @@ class TestUnmountFilestore:
 
     def test_falls_back_through_helpers_to_lazy(self, tmp_path, monkeypatch):
         merged = get_filestore_paths("env1", str(tmp_path))["merged"]
-        _mount_present(monkeypatch)
+        _mount_present(monkeypatch, merged)
         calls = []
 
         def fake_run(cmd, **kw):
@@ -71,7 +77,8 @@ class TestUnmountFilestore:
         ]
 
     def test_noop_when_not_mounted(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(env_ops.os.path, "isdir", lambda p: True)
+        merged = get_filestore_paths("env1", str(tmp_path))["merged"]
+        os.makedirs(merged, exist_ok=True)
         monkeypatch.setattr(env_ops.os.path, "ismount", lambda p: False)
         called = []
         monkeypatch.setattr(env_ops.subprocess, "run", lambda *a, **k: called.append(a))

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -288,3 +288,68 @@ class TestDiskCheck:
         assert result["status"] == "error"
         assert result["percent"] == 0
         assert "gone" in result["detail"]
+
+
+class TestOverlayCheck:
+    """A stale overlay is invisible without this check: the environment's
+    container is up and green while every filestore read inside it fails with
+    ENOTCONN."""
+
+    def test_no_overlays_is_ok(self, settings):
+        assert health._check_overlays(settings)["status"] == "ok"
+
+    def test_stale_overlay_is_an_error(self, settings):
+        with patch(
+            "oduflow.docker_ops.env_ops.overlay_mount_issues",
+            return_value=[
+                {
+                    "team_id": "1",
+                    "env_name": "wise-moth",
+                    "state": "stale",
+                    "path": "/srv/oduflow/team_1/workspaces/wise-moth/filestore",
+                }
+            ],
+        ):
+            result = health._check_overlays(settings)
+
+        assert result["status"] == "error"
+        assert result["count"] == 1
+        assert result["affected"] == [
+            {"team_id": "1", "env_name": "wise-moth", "state": "stale"}
+        ]
+        assert "wise-moth" in result["detail"]
+        assert "/srv/oduflow" not in str(result)
+
+    def test_scan_failure_is_reported_not_raised(self, settings):
+        with patch(
+            "oduflow.docker_ops.env_ops.overlay_mount_issues",
+            side_effect=OSError("nope"),
+        ):
+            result = health._check_overlays(settings)
+
+        assert result["status"] == "error"
+        assert result["detail"] == "filestore overlay scan failed; check server logs"
+        assert "nope" not in str(result)
+
+    def test_stale_overlay_degrades_healthz(self, settings):
+        client = _client(
+            {"oduflow-db": True, "oduflow-prod-db": True, "oduflow-traefik": True}
+        )
+        with (
+            patch("oduflow.docker_ops.client.get_client", return_value=client),
+            patch(
+                "oduflow.docker_ops.env_ops.overlay_mount_issues",
+                return_value=[
+                    {
+                        "team_id": "1",
+                        "env_name": "prod",
+                        "state": "stale",
+                        "path": "/srv/oduflow/team_1/workspaces/prod/filestore",
+                    }
+                ],
+            ),
+        ):
+            result = health.collect_health(settings, force=True)
+
+        assert result["ok"] is False
+        assert result["checks"]["overlays"]["status"] == "error"

--- a/tests/test_overlay_stale_mount.py
+++ b/tests/test_overlay_stale_mount.py
@@ -1,0 +1,618 @@
+"""Detection and repair of stale ``fuse-overlayfs`` filestore mounts.
+
+When the fuse-overlayfs daemon for an overlay filestore dies, the kernel keeps
+the mount table entry and every access to the mountpoint fails with ENOTCONN.
+Restarting Oduflow *in Docker* does exactly that to every overlay environment
+at once: the daemon lives in the container's PID namespace and dies with it,
+while the mount lives in the host's and survives.
+
+The trap these tests pin down is that ``os.path.ismount()`` swallows the
+ENOTCONN from its own ``lstat`` and reports False — indistinguishable from "not
+mounted" — so every guard written on top of it read a stale overlay as absent
+and left it broken.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import docker
+from oduflow.docker_ops import env_ops
+from oduflow.naming import get_filestore_paths
+from oduflow.settings import Settings, TeamSettings
+
+
+@pytest.fixture
+def stale(monkeypatch):
+    """Make chosen paths behave like the mountpoint of a dead FUSE mount."""
+    dead: set[str] = set()
+    real_stat, real_lstat = os.stat, os.lstat
+
+    def _raise_if_dead(path, real):
+        if str(path) in dead:
+            raise OSError(errno.ENOTCONN, "Transport endpoint is not connected")
+        return real(path)
+
+    monkeypatch.setattr(
+        env_ops.os, "stat", lambda p, **kw: _raise_if_dead(p, real_stat)
+    )
+    monkeypatch.setattr(
+        env_ops.os, "lstat", lambda p, **kw: _raise_if_dead(p, real_lstat)
+    )
+    return dead
+
+
+def _team(workspaces_dir: str):
+    team = MagicMock()
+    team.team_id = "1"
+    team.workspaces_dir = workspaces_dir
+    return team
+
+
+class TestOverlayMountState:
+    def test_absent_when_path_missing(self, tmp_path):
+        assert (
+            env_ops.overlay_mount_state(str(tmp_path / "nope")) == env_ops.MOUNT_ABSENT
+        )
+
+    def test_absent_for_plain_directory(self, tmp_path):
+        # Copy-mode filestores are real directories, not mounts.
+        (tmp_path / "filestore").mkdir()
+        state = env_ops.overlay_mount_state(str(tmp_path / "filestore"))
+        assert state == env_ops.MOUNT_ABSENT
+
+    def test_alive_when_mounted(self, tmp_path, monkeypatch):
+        (tmp_path / "filestore").mkdir()
+        monkeypatch.setattr(env_ops.os.path, "ismount", lambda p: True)
+        assert (
+            env_ops.overlay_mount_state(str(tmp_path / "filestore"))
+            == env_ops.MOUNT_ALIVE
+        )
+
+    def test_stale_when_daemon_is_gone(self, tmp_path, stale):
+        merged = str(tmp_path / "filestore")
+        stale.add(merged)
+        assert env_ops.overlay_mount_state(merged) == env_ops.MOUNT_STALE
+
+    def test_unexpected_probe_error_is_not_treated_as_absent(
+        self, tmp_path, monkeypatch
+    ):
+        merged = str(tmp_path / "filestore")
+        monkeypatch.setattr(
+            env_ops.os,
+            "stat",
+            lambda *a, **k: (_ for _ in ()).throw(PermissionError("denied")),
+        )
+
+        with pytest.raises(PermissionError, match="denied"):
+            env_ops.overlay_mount_state(merged)
+
+    def test_ismount_alone_cannot_tell_stale_from_absent(self, tmp_path, stale):
+        """The reason every guard here probes instead of calling ismount()."""
+        merged = str(tmp_path / "filestore")
+        stale.add(merged)
+        assert os.path.ismount(merged) is False
+        assert os.path.isdir(merged) is False
+        assert env_ops.overlay_mount_state(merged) == env_ops.MOUNT_STALE
+
+
+class TestUnmountStale:
+    def test_detaches_a_stale_mount(self, tmp_path, stale, monkeypatch):
+        merged = get_filestore_paths("env1", str(tmp_path))["merged"]
+        stale.add(merged)
+        calls = []
+        monkeypatch.setattr(
+            env_ops.subprocess,
+            "run",
+            lambda cmd, **kw: calls.append(cmd) or MagicMock(returncode=0),
+        )
+
+        env_ops._unmount_filestore("env1", _team(str(tmp_path)))
+
+        # Previously this returned early (isdir/ismount both False) and the
+        # stale mount could only be cleared by hand.
+        assert calls == [["umount", merged]]
+
+
+class TestMountFilestoreClearsStale:
+    def test_stale_mount_is_detached_before_remount(self, tmp_path, stale, monkeypatch):
+        template_fs = tmp_path / "template" / "filestore"
+        template_fs.mkdir(parents=True)
+        metadata = tmp_path / "template" / "metadata.json"
+        metadata.write_text(json.dumps({"use_overlay": False}))
+
+        team = _team(str(tmp_path / "workspaces"))
+        team.get_template_filestore_path.return_value = str(template_fs)
+        team.get_template_metadata_path.return_value = str(metadata)
+
+        merged = get_filestore_paths("env1", team.workspaces_dir)["merged"]
+        stale.add(merged)
+
+        order = []
+        monkeypatch.setattr(
+            env_ops, "_unmount_filestore", lambda *a, **k: order.append("unmount")
+        )
+        monkeypatch.setattr(
+            env_ops, "_wait_unmounted", lambda *a, **k: stale.discard(merged)
+        )
+        monkeypatch.setattr(env_ops, "get_odoo_uid_gid", lambda *a, **k: "101:101")
+        monkeypatch.setattr(env_ops, "chown_recursive", lambda *a, **k: None)
+        monkeypatch.setattr(
+            env_ops.shutil, "copytree", lambda *a, **k: order.append("copytree")
+        )
+
+        volumes: dict = {}
+        env_ops._mount_filestore(
+            MagicMock(),
+            Settings(base_data_dir=str(tmp_path)),
+            team,
+            "env1",
+            "db1",
+            "odoo:19.0",
+            volumes,
+            template_name="tpl",
+        )
+
+        # The detach has to happen first: copying into a dead mountpoint would
+        # itself fail with ENOTCONN.
+        assert order == ["unmount", "copytree"]
+        assert merged in volumes
+
+    def test_forced_recovery_ignores_copy_metadata(self, tmp_path, stale, monkeypatch):
+        template_fs = tmp_path / "template" / "filestore"
+        template_fs.mkdir(parents=True)
+        metadata = tmp_path / "template" / "metadata.json"
+        metadata.write_text(json.dumps({"use_overlay": False}))
+
+        team = _team(str(tmp_path / "workspaces"))
+        team.get_template_filestore_path.return_value = str(template_fs)
+        team.get_template_metadata_path.return_value = str(metadata)
+        merged = get_filestore_paths("env1", team.workspaces_dir)["merged"]
+        os.makedirs(
+            get_filestore_paths("env1", team.workspaces_dir)["upper"], exist_ok=True
+        )
+        stale.add(merged)
+        live: set[str] = set()
+
+        monkeypatch.setattr(env_ops, "_unmount_filestore", lambda *a, **k: None)
+        monkeypatch.setattr(
+            env_ops, "_wait_unmounted", lambda *a, **k: stale.discard(merged)
+        )
+        monkeypatch.setattr(env_ops, "get_odoo_uid_gid", lambda *a, **k: "101:101")
+        monkeypatch.setattr(env_ops, "chown_recursive", lambda *a, **k: None)
+        monkeypatch.setattr(env_ops.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(env_ops.os.path, "ismount", lambda path: str(path) in live)
+        copytree = MagicMock()
+        monkeypatch.setattr(env_ops.shutil, "copytree", copytree)
+
+        def fake_run(*a, **k):
+            live.add(merged)
+            return MagicMock(returncode=0, stderr=b"")
+
+        monkeypatch.setattr(env_ops.subprocess, "run", fake_run)
+
+        env_ops._mount_filestore(
+            MagicMock(),
+            Settings(base_data_dir=str(tmp_path)),
+            team,
+            "env1",
+            "db1",
+            "odoo:19.0",
+            {},
+            template_name="tpl",
+            force_overlay=True,
+        )
+
+        copytree.assert_not_called()
+        assert merged in live
+
+
+class TestStaleOverlayPaths:
+    def test_finds_stale_mounts_across_teams(self, tmp_path, stale):
+        team_dir = tmp_path / "team_1"
+        workspaces = team_dir / "workspaces"
+        for name in ("broken", "healthy"):
+            (workspaces / name).mkdir(parents=True)
+            (workspaces / name / "filestore").mkdir()
+        broken = str(workspaces / "broken" / "filestore")
+        stale.add(broken)
+
+        settings = Settings(
+            base_data_dir=str(tmp_path),
+            teams={"1": TeamSettings(team_id="1", data_dir=str(team_dir))},
+        )
+
+        assert env_ops.stale_overlay_paths(settings) == [broken]
+
+    def test_empty_when_team_never_initialized(self, tmp_path):
+        settings = Settings(
+            base_data_dir=str(tmp_path),
+            teams={"1": TeamSettings(team_id="1", data_dir=str(tmp_path / "gone"))},
+        )
+        assert env_ops.stale_overlay_paths(settings) == []
+
+    def test_ignores_non_workspace_files(self, tmp_path):
+        team_dir = tmp_path / "team_1"
+        workspaces = team_dir / "workspaces"
+        workspaces.mkdir(parents=True)
+        (workspaces / ".DS_Store").write_text("not an environment")
+        settings = Settings(
+            base_data_dir=str(tmp_path),
+            teams={"1": TeamSettings(team_id="1", data_dir=str(team_dir))},
+        )
+
+        assert env_ops.overlay_mount_issues(settings) == []
+
+    def test_missing_expected_overlay_is_an_issue(self, tmp_path):
+        team_dir = tmp_path / "team_1"
+        workspaces = team_dir / "workspaces"
+        paths = get_filestore_paths("missing", str(workspaces))
+        os.makedirs(paths["upper"])
+        os.makedirs(paths["work"])
+        settings = Settings(
+            base_data_dir=str(tmp_path),
+            teams={"1": TeamSettings(team_id="1", data_dir=str(team_dir))},
+        )
+
+        assert env_ops.overlay_mount_issues(settings) == [
+            {
+                "team_id": "1",
+                "env_name": "missing",
+                "state": env_ops.MOUNT_ABSENT,
+                "path": paths["merged"],
+            }
+        ]
+
+    def test_unreadable_team_directory_is_reported(self, tmp_path, monkeypatch):
+        team_dir = tmp_path / "team_1"
+        settings = Settings(
+            base_data_dir=str(tmp_path),
+            teams={"1": TeamSettings(team_id="1", data_dir=str(team_dir))},
+        )
+        monkeypatch.setattr(
+            env_ops.os,
+            "scandir",
+            lambda *a, **k: (_ for _ in ()).throw(PermissionError("denied")),
+        )
+
+        with pytest.raises(PermissionError, match="denied"):
+            env_ops.overlay_mount_issues(settings)
+
+
+class TestReconcileOverlayMounts:
+    @pytest.fixture
+    def wired(self, tmp_path, monkeypatch, stale):
+        """Reconciliation with its Docker and mount side effects stubbed out."""
+        team_dir = tmp_path / "team_1"
+        (team_dir / "workspaces").mkdir(parents=True)
+        settings = Settings(
+            base_data_dir=str(tmp_path),
+            teams={"1": TeamSettings(team_id="1", data_dir=str(team_dir))},
+        )
+        # The lower layer a repair remounts against.
+        os.makedirs(
+            settings.teams["1"].get_template_filestore_path("tpl"), exist_ok=True
+        )
+        container = MagicMock()
+        container.status = "running"
+        container.image.tags = ["odoo:19.0"]
+        container.stop.side_effect = lambda **kw: setattr(container, "status", "exited")
+        container.start.side_effect = lambda: setattr(container, "status", "running")
+        client = MagicMock()
+        client.containers.get.return_value = container
+
+        monkeypatch.setattr(env_ops, "get_client", lambda: client)
+        unmounted: list[str] = []
+        live: set[str] = set()
+
+        def fake_unmount(name, selected_team):
+            merged = get_filestore_paths(name, selected_team.workspaces_dir)["merged"]
+            unmounted.append(name)
+            stale.discard(merged)
+            live.discard(merged)
+
+        monkeypatch.setattr(env_ops, "_unmount_filestore", fake_unmount)
+        monkeypatch.setattr(env_ops, "_wait_unmounted", lambda *a, **k: None)
+        monkeypatch.setattr(env_ops.os.path, "ismount", lambda path: str(path) in live)
+        mounted: list = []
+
+        def fake_mount(*a, **k):
+            # A successful remount is what stops the mountpoint being stale.
+            assert k["force_overlay"] is True
+            mounted.append((a[3], k["template_name"]))
+            merged = get_filestore_paths(a[3], a[2].workspaces_dir)["merged"]
+            os.makedirs(merged, exist_ok=True)
+            stale.discard(merged)
+            live.add(merged)
+
+        monkeypatch.setattr(env_ops, "_mount_filestore", fake_mount)
+        return SimpleNamespace(
+            settings=settings,
+            client=client,
+            container=container,
+            mounted=mounted,
+            unmounted=unmounted,
+            live=live,
+        )
+
+    def _envs(self, monkeypatch, *envs):
+        def listed(settings, team):
+            for env in envs:
+                paths = get_filestore_paths(env["env_name"], team.workspaces_dir)
+                os.makedirs(paths["upper"], exist_ok=True)
+            return list(envs)
+
+        monkeypatch.setattr(env_ops, "list_environments", listed)
+
+    def test_repairs_a_stale_environment(self, wired, stale, monkeypatch):
+        settings, container, mounted = wired.settings, wired.container, wired.mounted
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch,
+            {
+                "env_name": "wise-moth",
+                "template_name": "tpl",
+                "odoo_image": "odoo:19.0",
+            },
+        )
+        stale.add(get_filestore_paths("wise-moth", team.workspaces_dir)["merged"])
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result == [
+            {"team_id": "1", "env_name": "wise-moth", "repaired": True, "detail": ""}
+        ]
+        assert mounted == [("wise-moth", "tpl")]
+        # The container has to be cycled: its bind mount still points at the
+        # dead mount, so a host-side remount alone would not reach it.
+        container.stop.assert_called_once()
+        container.start.assert_called_once()
+
+    def test_leaves_healthy_environments_alone(self, wired, monkeypatch):
+        settings, container, mounted = wired.settings, wired.container, wired.mounted
+        self._envs(
+            monkeypatch, {"env_name": "fine", "template_name": "tpl", "odoo_image": ""}
+        )
+        merged = get_filestore_paths("fine", settings.teams["1"].workspaces_dir)[
+            "merged"
+        ]
+        os.makedirs(merged, exist_ok=True)
+        wired.live.add(merged)
+
+        assert env_ops.reconcile_overlay_mounts(settings) == []
+        assert mounted == []
+        container.stop.assert_not_called()
+
+    def test_repairs_an_expected_overlay_that_is_absent(self, wired, monkeypatch):
+        settings, mounted = wired.settings, wired.mounted
+        team = settings.teams["1"]
+        paths = get_filestore_paths("missing", team.workspaces_dir)
+        os.makedirs(paths["upper"], exist_ok=True)
+        os.makedirs(paths["work"], exist_ok=True)
+        self._envs(
+            monkeypatch,
+            {"env_name": "missing", "template_name": "tpl", "odoo_image": ""},
+        )
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is True
+        assert mounted == [("missing", "tpl")]
+
+    def test_reports_stale_environment_without_a_template(
+        self, wired, stale, monkeypatch
+    ):
+        settings, container, mounted = wired.settings, wired.container, wired.mounted
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch,
+            {"env_name": "orphan", "template_name": "none", "odoo_image": ""},
+        )
+        stale.add(get_filestore_paths("orphan", team.workspaces_dir)["merged"])
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        # No lower layer to remount against — flagged for an operator, not
+        # silently "repaired".
+        assert result == [
+            {
+                "team_id": "1",
+                "env_name": "orphan",
+                "repaired": False,
+                "detail": "no template to remount against",
+            }
+        ]
+        assert mounted == []
+        container.stop.assert_not_called()
+
+    def test_missing_upper_layer_is_not_detached(self, wired, stale, monkeypatch):
+        settings = wired.settings
+        team = settings.teams["1"]
+        monkeypatch.setattr(
+            env_ops,
+            "list_environments",
+            lambda *a: [
+                {"env_name": "lost-upper", "template_name": "tpl", "odoo_image": ""}
+            ],
+        )
+        merged = get_filestore_paths("lost-upper", team.workspaces_dir)["merged"]
+        stale.add(merged)
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is False
+        assert result[0]["detail"] == "overlay upper layer is missing"
+        assert wired.unmounted == []
+        wired.container.stop.assert_not_called()
+
+    def test_a_failed_repair_does_not_stop_the_pass(self, wired, stale, monkeypatch):
+        settings, mounted, live = wired.settings, wired.mounted, wired.live
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch,
+            {"env_name": "a", "template_name": "tpl", "odoo_image": ""},
+            {"env_name": "b", "template_name": "tpl", "odoo_image": ""},
+        )
+        for name in ("a", "b"):
+            stale.add(get_filestore_paths(name, team.workspaces_dir)["merged"])
+
+        def _mount(*a, **k):
+            if a[3] == "a":
+                # The fixture uses one mock object for both names; reset it to
+                # model b's distinct running container before continuing.
+                wired.container.status = "running"
+                raise RuntimeError("mount refused")
+            mounted.append(a[3])
+            merged = get_filestore_paths(a[3], team.workspaces_dir)["merged"]
+            os.makedirs(merged, exist_ok=True)
+            stale.discard(merged)
+            live.add(merged)
+
+        monkeypatch.setattr(env_ops, "_mount_filestore", _mount)
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert [(r["env_name"], r["repaired"]) for r in result] == [
+            ("a", False),
+            ("b", True),
+        ]
+        assert result[0]["detail"] == "mount refused"
+        assert mounted == ["b"]
+        # The failed environment stays stopped rather than starting on an
+        # absent filestore.
+        assert wired.container.start.call_count == 1
+
+    def test_missing_container_is_not_an_error(self, wired, stale, monkeypatch):
+        settings, mounted = wired.settings, wired.mounted
+        team = settings.teams["1"]
+        wired.client.containers.get.side_effect = docker.errors.NotFound("gone")
+        self._envs(
+            monkeypatch,
+            {"env_name": "c", "template_name": "tpl", "odoo_image": "odoo:19.0"},
+        )
+        stale.add(get_filestore_paths("c", team.workspaces_dir)["merged"])
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is True
+        assert mounted == [("c", "tpl")]
+
+    def test_missing_template_filestore_is_not_touched(self, wired, stale, monkeypatch):
+        settings, mounted = wired.settings, wired.mounted
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch,
+            {"env_name": "lost", "template_name": "vanished", "odoo_image": ""},
+        )
+        stale.add(get_filestore_paths("lost", team.workspaces_dir)["merged"])
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        # Detaching here would trade a stale mount for an empty filestore and
+        # still report success, so the environment is left for an operator.
+        assert result[0]["repaired"] is False
+        assert "template filestore missing" in result[0]["detail"]
+        assert wired.unmounted == []
+        assert mounted == []
+
+    def test_a_mount_that_stayed_stale_is_not_called_a_repair(
+        self, wired, stale, monkeypatch
+    ):
+        settings = wired.settings
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch, {"env_name": "stuck", "template_name": "tpl", "odoo_image": ""}
+        )
+        merged = get_filestore_paths("stuck", team.workspaces_dir)["merged"]
+        stale.add(merged)
+        mount = MagicMock()
+        monkeypatch.setattr(env_ops, "_unmount_filestore", lambda *a, **k: None)
+        monkeypatch.setattr(env_ops, "_mount_filestore", mount)
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is False
+        assert result[0]["detail"] == "mount did not detach"
+        mount.assert_not_called()
+        wired.container.start.assert_not_called()
+
+    def test_stop_failure_does_not_touch_the_mount(self, wired, stale, monkeypatch):
+        settings = wired.settings
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch, {"env_name": "busy", "template_name": "tpl", "odoo_image": ""}
+        )
+        stale.add(get_filestore_paths("busy", team.workspaces_dir)["merged"])
+        wired.container.stop.side_effect = RuntimeError("timeout")
+        mount = MagicMock()
+        monkeypatch.setattr(env_ops, "_mount_filestore", mount)
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is False
+        assert result[0]["detail"] == "stop failed: timeout"
+        assert wired.unmounted == []
+        mount.assert_not_called()
+        wired.container.start.assert_not_called()
+
+    def test_restart_failure_is_reported(self, wired, stale, monkeypatch):
+        settings = wired.settings
+        team = settings.teams["1"]
+        self._envs(
+            monkeypatch,
+            {"env_name": "restart", "template_name": "tpl", "odoo_image": ""},
+        )
+        stale.add(get_filestore_paths("restart", team.workspaces_dir)["merged"])
+        wired.container.start.side_effect = RuntimeError("start refused")
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is False
+        assert result[0]["detail"] == "restart failed: start refused"
+
+    def test_uses_team_scoped_database_name(self, tmp_path, monkeypatch, stale):
+        team_dir = tmp_path / "team_2"
+        (team_dir / "workspaces").mkdir(parents=True)
+        team = TeamSettings(team_id="2", data_dir=str(team_dir))
+        settings = Settings(base_data_dir=str(tmp_path), teams={"2": team})
+        os.makedirs(team.get_template_filestore_path("tpl"), exist_ok=True)
+        merged = get_filestore_paths("same-name", team.workspaces_dir)["merged"]
+        os.makedirs(get_filestore_paths("same-name", team.workspaces_dir)["upper"])
+        stale.add(merged)
+        client = MagicMock()
+        client.containers.get.side_effect = docker.errors.NotFound("gone")
+        monkeypatch.setattr(env_ops, "get_client", lambda: client)
+        monkeypatch.setattr(
+            env_ops,
+            "list_environments",
+            lambda *a: [
+                {"env_name": "same-name", "template_name": "tpl", "odoo_image": ""}
+            ],
+        )
+        monkeypatch.setattr(
+            env_ops,
+            "_unmount_filestore",
+            lambda *a: stale.discard(merged),
+        )
+        monkeypatch.setattr(env_ops, "_wait_unmounted", lambda *a: None)
+        live: set[str] = set()
+        monkeypatch.setattr(env_ops.os.path, "ismount", lambda path: str(path) in live)
+        captured: dict[str, str] = {}
+
+        def mount(*args, **kwargs):
+            captured["db"] = args[4]
+            os.makedirs(merged, exist_ok=True)
+            live.add(merged)
+
+        monkeypatch.setattr(env_ops, "_mount_filestore", mount)
+
+        result = env_ops.reconcile_overlay_mounts(settings)
+
+        assert result[0]["repaired"] is True
+        assert captured["db"] == "oduflow_2_same-name"

--- a/tests/test_template_update.py
+++ b/tests/test_template_update.py
@@ -76,6 +76,10 @@ def _build(tmp_path, envs, mounted_envs, statuses=None):
         paths = get_filestore_paths(env_name, team.workspaces_dir)
         os.makedirs(paths["upper"], exist_ok=True)
         os.makedirs(paths["work"], exist_ok=True)
+        # The mountpoint has to exist: overlay liveness is decided by stat'ing
+        # it (a stale FUSE mount is the case where that stat fails), not by
+        # ``ismount`` alone.
+        os.makedirs(paths["merged"], exist_ok=True)
         with open(os.path.join(paths["upper"], "marker.txt"), "w") as f:
             f.write("delta")
         env_dicts.append(
@@ -134,6 +138,9 @@ class TestRemountTemplateOverlays:
         # Each env unmounted + remounted.
         assert unmount_mock.call_count == 2
         assert mount_mock.call_count == 2
+        assert all(
+            call.kwargs["force_overlay"] is True for call in mount_mock.call_args_list
+        )
         # Containers cycled.
         for c in mapping.values():
             assert c.stop_calls == 1


### PR DESCRIPTION
## Summary

- detect stale and unexpectedly absent fuse-overlayfs mounts at startup
- recover overlays fail-closed while preserving each environment upper layer
- expose path-safe overlay health through /healthz and the dashboard
- document recovery behavior and add lifecycle, failure, and multi-team coverage

## Validation

- 65 focused tests passed
- 2,513 broader unit tests passed (24 environment-dependent cases deselected)
- Ruff lint and format checks passed
- mypy passed for 76 source files
- git diff --check passed