### PR TITLE
Surface environment reuse metadata in list_environments and get_environment_info

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,25 @@
   through the line-based create field. In template Settings, such values are
   shown read-only and pointed at the raw JSON editor.
 
+### Fixes
+
+- **Environment listings now carry the evidence needed for safe slot reuse** —
+  the MCP `list_environments` output previously discarded lifecycle metadata
+  that the backend already tracked and the dashboard already showed. It now
+  reports the current git branch, creation and last-activity timestamps,
+  stopped time and source, protection, Stack ownership and operator note;
+  legacy records explicitly say `Last Activity: unknown`. The same lifecycle
+  metadata is available from `get_environment_info`, and the agent guide no
+  longer treats an empty GitHub PR result as proof that a slot is reusable.
+
+- **Translation instructions start with Odoo's exporter** — agents are now told
+  to run `export_module_translations` before creating a `.po`, never invent
+  `#.`/`#:` metadata by hand, and verify the loaded result with
+  `translation_status` after the module upgrade. The guide also warns that
+  re-exporting over a catalogue that has not been imported overwrites it with
+  the database's contents. This makes the existing silent-zero-import detector
+  preventive instead of merely diagnostic.
+
 ## v1.71.0
 
 ### Features

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -200,6 +200,16 @@ scoped MCP endpoint and token. This matters twice over — provisioning is skipp
 (no fresh clone, no template database copy), and the MCP client you already
 pointed at `/mcp/dev1` keeps working, because the address never changed.
 
+`list_environments` prints the evidence needed to choose a reusable slot:
+current git branch, creation and last-activity timestamps, stopped time and
+source, protection, Stack ownership and the operator note. Prefer an exact
+branch match. Otherwise do not switch a running, protected, Stack-managed or
+noted-as-reserved environment. If repository policy permits reclaiming idle
+slots, rank the remaining stopped candidates by oldest activity; `unknown` is
+not proof that a legacy slot is abandoned. GitHub returning no PR for a branch
+is also inconclusive — confirm completion from a merged PR/branch or an explicit
+operator instruction, and create a new environment when ownership is unclear.
+
 #### Renaming While Switching
 
 The environment name is a slot label, not a description of what the slot

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -186,7 +186,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `reset_admin_password` — reset the admin user password (default: "test")
 - `connect_as_user` — mint a passwordless Odoo login session for a user and return the `session_id` cookie + URL (Playwright-ready; skips the login form, supports any role incl. portal)
 - `read_output` — read from a cached tool output by ID (paginate, grep, errors, tail)
-- `list_environments` / `get_environment_info` — inspect environments
+- `list_environments` / `get_environment_info` — inspect environments, including current branch, last activity, stopped time/source, protection, Stack ownership and operator notes used for safe slot reuse
 - `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_info` / `get_service_logs` / `run_service_command` — manage auxiliary services
   - In Traefik TLS mode every service implicitly receives the exact `oduflow-traefik-acme:/etc/traefik:ro` mount; do not pass or override that system volume
 - `create_volume` / `list_volumes` / `inspect_volume` / `delete_volume` — manage Docker volumes
@@ -1794,6 +1794,16 @@ scoped MCP endpoint and token. This matters twice over — provisioning is skipp
 (no fresh clone, no template database copy), and the MCP client you already
 pointed at `/mcp/dev1` keeps working, because the address never changed.
 
+`list_environments` prints the evidence needed to choose a reusable slot:
+current git branch, creation and last-activity timestamps, stopped time and
+source, protection, Stack ownership and the operator note. Prefer an exact
+branch match. Otherwise do not switch a running, protected, Stack-managed or
+noted-as-reserved environment. If repository policy permits reclaiming idle
+slots, rank the remaining stopped candidates by oldest activity; `unknown` is
+not proof that a legacy slot is abandoned. GitHub returning no PR for a branch
+is also inconclusive — confirm completion from a merged PR/branch or an explicit
+operator instruction, and create a new environment when ownership is unclear.
+
 #### Renaming While Switching
 
 The environment name is a slot label, not a description of what the slot
@@ -3201,8 +3211,8 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Environment Management** | | |
 | `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables, merged per key over any recorded on the template |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
-| `list_environments` | | List all managed environments with status and URLs |
-| `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
+| `list_environments` | | List all managed environments with status, URL, current git branch, creation/last-activity/stopped timestamps, stop source, protection, Stack ownership and operator note |
+| `get_environment_info` | | Full environment details: lifecycle/reuse metadata, DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
 | `start_environment` | | Start a stopped environment |
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -186,7 +186,7 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `reset_admin_password` — reset the admin user password (default: "test")
 - `connect_as_user` — mint a passwordless Odoo login session for a user and return the `session_id` cookie + URL (Playwright-ready; skips the login form, supports any role incl. portal)
 - `read_output` — read from a cached tool output by ID (paginate, grep, errors, tail)
-- `list_environments` / `get_environment_info` — inspect environments
+- `list_environments` / `get_environment_info` — inspect environments, including current branch, last activity, stopped time/source, protection, Stack ownership and operator notes used for safe slot reuse
 - `create_service` / `delete_service` / `restart_service` / `update_service` / `list_services` / `get_service_info` / `get_service_logs` / `run_service_command` — manage auxiliary services
   - In Traefik TLS mode every service implicitly receives the exact `oduflow-traefik-acme:/etc/traefik:ro` mount; do not pass or override that system volume
 - `create_volume` / `list_volumes` / `inspect_volume` / `delete_volume` — manage Docker volumes

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -9,8 +9,8 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | **Environment Management** | | |
 | `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables, merged per key over any recorded on the template |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
-| `list_environments` | | List all managed environments with status and URLs |
-| `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
+| `list_environments` | | List all managed environments with status, URL, current git branch, creation/last-activity/stopped timestamps, stop source, protection, Stack ownership and operator note |
+| `get_environment_info` | | Full environment details: lifecycle/reuse metadata, DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
 | `start_environment` | | Start a stopped environment |
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -2874,6 +2874,7 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
         rec = records.get(env_name, {})
         env["last_activity"] = rec.get("last_activity", "")
         env["stopped_at"] = rec.get("stopped_at", "")
+        env["stopped_by"] = rec.get("stopped_by", "")
         env["auto_stopped"] = rec.get("stopped_by") == "auto"
 
     return list(envs.values())
@@ -3164,6 +3165,13 @@ def get_environment_info(
             result["odoo"]["mem_percent"] = stats["mem_percent"]
     except docker.errors.NotFound:
         pass
+
+    rec = activity.get_all(team).get(env_name, {})
+    result["protected"] = is_protected(settings, team, env_name)
+    result["last_activity"] = rec.get("last_activity", "")
+    result["stopped_at"] = rec.get("stopped_at", "")
+    result["stopped_by"] = rec.get("stopped_by", "")
+    result["auto_stopped"] = rec.get("stopped_by") == "auto"
 
     try:
         db_container = client.containers.get(settings.shared_db_container)

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -1406,9 +1406,21 @@ def list_environments(ctx: Context | None = None) -> str:
         if env.get("url"):
             status_line += f" - {env['url']}"
         output += status_line + "\n"
-        git_branch = env.get("git_branch", "")
-        if git_branch and git_branch != env["env_name"]:
-            output += f"  Git Branch: {git_branch}\n"
+        output += f"  Git Branch: {env.get('git_branch') or env['env_name']}\n"
+        if env.get("created_at"):
+            output += f"  Created: {env['created_at']}\n"
+        output += f"  Last Activity: {env.get('last_activity') or 'unknown'}\n"
+        if env["status"] == "stopped" or env.get("stopped_at"):
+            stopped_at = env.get("stopped_at") or "unknown"
+            stopped_by = env.get("stopped_by") or "unknown"
+            output += f"  Stopped At: {stopped_at} ({stopped_by})\n"
+        output += f"  Protected: {'yes' if env.get('protected') else 'no'}\n"
+        if env.get("stack"):
+            output += f"  Stack: {env['stack']}\n"
+        note = str(env.get("note") or "").strip()
+        if note:
+            note = note.replace("\n", "\n        ")
+            output += f"  Note: {note}\n"
         if env.get("db_name"):
             output += f"  Database: {env['db_name']}\n"
         if env.get("odoo_image"):
@@ -1618,9 +1630,24 @@ def get_environment_info(env_name: str, ctx: Context | None = None) -> str:
         else "Some containers not running"
     )
     lines = [f"Environment Info for '{env_name}': {overall}"]
-    git_branch = info.get("git_branch", "")
-    if git_branch and git_branch != env_name:
-        lines.append(f"Git Branch: {git_branch}")
+    lines.append(f"Git Branch: {info.get('git_branch') or env_name}")
+    if info.get("created_at"):
+        lines.append(f"Created: {info['created_at']}")
+    lines.append(f"Last Activity: {info.get('last_activity') or 'unknown'}")
+    odoo_status = info.get("odoo", {})
+    if info.get("stopped_at") or (
+        not odoo_status.get("running") and odoo_status.get("status") != "not found"
+    ):
+        stopped_at = info.get("stopped_at") or "unknown"
+        stopped_by = info.get("stopped_by") or "unknown"
+        lines.append(f"Stopped At: {stopped_at} ({stopped_by})")
+    lines.append(f"Protected: {'yes' if info.get('protected') else 'no'}")
+    if info.get("stack"):
+        lines.append(f"Stack: {info['stack']}")
+    note = str(info.get("note") or "").strip()
+    if note:
+        note = note.replace("\n", "\n      ")
+        lines.append(f"Note: {note}")
     lines.append(f"Database: {info['db_name']}")
     if info.get("url"):
         lines.append(f"URL: {info['url']}")

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 6
+Version: 7
 
 ## Purpose
 
@@ -60,6 +60,16 @@ target branch must exist on origin; live-mounted environments are rejected
 (switch the branch in the mounted checkout and call `pull_and_apply`). If the
 target branch does not carry a module installed in that database, the response
 warns; create a separate environment when that matters.
+
+Treat the reuse metadata in `list_environments` as evidence, not decoration.
+Never switch a running, protected, Stack-managed, or explicitly reserved
+(`Note:`) environment. When the repository's own instructions allow reclaiming
+idle slots, choose among eligible stopped environments by `Last Activity` and
+`Stopped At`, oldest first; `unknown` is not evidence that a slot is abandoned.
+Confirm that its previous work is finished from an affirmative signal such as a
+merged PR, a branch merged into the target branch, or the user's instruction.
+An empty `gh pr list` result proves neither completion nor continued use. If the
+safe choice cannot be established, create a new environment.
 
 The environment name is a slot label, not a description of the branch, so a
 mismatch is normal — no need to rename on every switch. When the user asks for
@@ -186,10 +196,20 @@ errors. Never recreate the environment as a substitute for the upgrade.
 
 ## Translations
 
-After loading translation changes, call `translation_status`. It compares the
-module catalogue, committed `.po`, and database, then returns a verdict and a
-`Next:` action. Follow that action instead of deriving a diagnosis from raw
-counts. Use `export_module_translations` when it asks for a fresh catalogue.
+Before creating a new `i18n/<lang>.po`, call
+`export_module_translations(env_name, module, lang)` and edit the generated
+catalogue. Never invent `#.` or `#:` metadata: Odoo derives the translation
+target from it, and a malformed reference can import as zero translations
+without a warning. Do not run that export over a catalogue you have already
+written: it overwrites `i18n/<lang>.po` with what the database holds, so
+translations that never imported are lost. When repairing an existing
+hand-written catalogue, follow `translation_status`'s `Next:` action; it may
+ask for a sibling `<module>.pot` whose generated metadata Odoo merges into the
+`.po` during import.
+
+After upgrading the module, call `translation_status`. It compares the module
+catalogue, committed `.po`, and database, then returns a verdict and a `Next:`
+action. Follow that action instead of deriving a diagnosis from raw counts.
 
 Write English source strings; localized text belongs in `i18n/*.po`.
 

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -1816,7 +1816,21 @@ class TestGetEnvironmentInfo:
 
         mock_docker_client.containers.get.side_effect = get_container
 
-        result = env_ops.get_environment_info(TEST_SETTINGS, TEST_TEAM, "main")
+        with (
+            patch.object(
+                env_ops.activity,
+                "get_all",
+                return_value={
+                    "main": {
+                        "last_activity": "2026-08-27T10:00:00+00:00",
+                        "stopped_at": "2026-08-27T11:00:00+00:00",
+                        "stopped_by": "manual",
+                    }
+                },
+            ),
+            patch.object(env_ops, "is_protected", return_value=True),
+        ):
+            result = env_ops.get_environment_info(TEST_SETTINGS, TEST_TEAM, "main")
 
         assert result["all_running"] is True
         assert result["db"]["name"] == "oduflow-db"
@@ -1826,6 +1840,10 @@ class TestGetEnvironmentInfo:
         assert result["local_path"] == ""
         assert result["odoo_image"] == "odoo:17.0"
         assert result["template_name"] == "default"
+        assert result["last_activity"] == "2026-08-27T10:00:00+00:00"
+        assert result["stopped_at"] == "2026-08-27T11:00:00+00:00"
+        assert result["stopped_by"] == "manual"
+        assert result["protected"] is True
 
     @patch(
         "oduflow.docker_ops.env_ops.load_credentials",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -505,6 +505,53 @@ class TestListEnvironmentsTool:
         assert "Live-mount: /Users/dev/addons" in result
         assert "Repo:" not in result
 
+    @patch("oduflow.docker_ops.env_ops.list_environments")
+    def test_list_shows_reuse_metadata(self, mock_list):
+        mock_list.return_value = [
+            {
+                "env_name": "dev1",
+                "git_branch": "feature/finished",
+                "status": "stopped",
+                "url": None,
+                "created_at": "2026-08-20T08:00:00+00:00",
+                "last_activity": "2026-08-26T09:30:00+00:00",
+                "stopped_at": "2026-08-27T09:30:00+00:00",
+                "stopped_by": "auto",
+                "protected": True,
+                "note": "Reserved for QA\nDo not reuse",
+                "stack": "demo",
+                "containers": [],
+            }
+        ]
+
+        result = _call_tool("list_environments")
+
+        assert "Git Branch: feature/finished" in result
+        assert "Created: 2026-08-20T08:00:00+00:00" in result
+        assert "Last Activity: 2026-08-26T09:30:00+00:00" in result
+        assert "Stopped At: 2026-08-27T09:30:00+00:00 (auto)" in result
+        assert "Protected: yes" in result
+        assert "Stack: demo" in result
+        assert "Note: Reserved for QA" in result
+        assert "Do not reuse" in result
+
+    @patch("oduflow.docker_ops.env_ops.list_environments")
+    def test_list_marks_missing_activity_as_unknown(self, mock_list):
+        mock_list.return_value = [
+            {
+                "env_name": "legacy",
+                "status": "stopped",
+                "containers": [],
+            }
+        ]
+
+        result = _call_tool("list_environments")
+
+        assert "Git Branch: legacy" in result
+        assert "Last Activity: unknown" in result
+        assert "Stopped At: unknown (unknown)" in result
+        assert "Protected: no" in result
+
 
 class TestAgentInstructionsTool:
     def test_bundled_guide_is_compact_and_workflow_focused(self):
@@ -520,7 +567,9 @@ class TestAgentInstructionsTool:
 
         assert len(guide) < 16_000
         assert "Per-environment Odoo configuration" in guide
-        assert "Version: 6" in guide
+        assert "Version: 7" in guide
+        assert "Never invent `#.` or `#:` metadata" in guide
+        assert "An empty `gh pr list` result proves neither" in guide
         assert "git push -u origin HEAD" in guide
         assert "cannot see a local-only branch" in guide
         assert "db_maxconn" in guide
@@ -588,6 +637,10 @@ class TestInfoTool:
             "repo_url": "https://github.com/example/repo.git",
             "odoo_image": "odoo:17.0",
             "template_name": "default",
+            "created_at": "2026-08-20T08:00:00+00:00",
+            "last_activity": "2026-08-27T10:00:00+00:00",
+            "protected": True,
+            "note": "Reserved for QA",
             "extra_addons": {},
             "git_user": "",
             "odoo": {"status": "running", "running": True},
@@ -595,6 +648,11 @@ class TestInfoTool:
         }
         result = _call_tool("get_environment_info", env_name="main")
         assert "All containers running" in result
+        assert "Git Branch: main" in result
+        assert "Created: 2026-08-20T08:00:00+00:00" in result
+        assert "Last Activity: 2026-08-27T10:00:00+00:00" in result
+        assert "Protected: yes" in result
+        assert "Note: Reserved for QA" in result
         assert "Database: oduflow_1_main" in result
         assert "DB (shared)" in result
 


### PR DESCRIPTION
## What

MCP `list_environments` discarded lifecycle metadata that the backend already tracked and the dashboard already showed, so an agent picking a slot to reuse had nothing to reason from. It now reports the current git branch, creation and last-activity timestamps, stopped time and source, protection, Stack ownership and the operator note; legacy records read `Last Activity: unknown` rather than being omitted. `get_environment_info` carries the same fields, backed by new `protected`/activity keys in `env_ops.get_environment_info`.

The bundled agent guide (version 6 → 7) gains two rules:

- **Slot reuse** — never switch a running, protected, Stack-managed or explicitly reserved (`Note:`) environment; rank eligible stopped candidates by `Last Activity`/`Stopped At`; `unknown` is not evidence of abandonment and an empty `gh pr list` proves neither completion nor continued use.
- **Translations** — start from `export_module_translations` instead of hand-written `#.`/`#:` metadata, and verify with `translation_status` after the upgrade. The guide explicitly warns that re-exporting over a catalogue that has not been imported overwrites it with the database's contents (`export_module_translations` writes `i18n/<lang>.po` through `put_archive`, which does not check for an existing file), so the export-first step is scoped to *creating* a new catalogue.

Docs (`environments.md`, `mcp-tools.md`, `llms.txt`, regenerated `llms-full.txt`) updated to match. Changelog entries go under a new `## Unreleased` heading, since `v1.71.0` is already tagged and published.

## Verification

- `ruff check src/oduflow tests` — clean
- `mypy src/oduflow` — clean
- `pytest -m "not integration and not heavyweight"` — 2493 passed
- `python scripts/build_llms_full.py --check` — in sync