### PR TITLE
Quiet summary_only responses for pull_and_apply and run_odoo_tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@
 
 ### Features
 
+- **Token-safe summaries for apply and test calls** — `pull_and_apply` and
+  `run_odoo_tests` now accept `summary_only=True`, keeping verbose Odoo command
+  logs server-side instead of injecting them into the calling agent's context.
+  Test runs return the final `N failed, M error(s) of K tests` result; applies
+  return one line with the action, changed-file count and exit status. Both
+  include an `output_id` when detailed output is available, so failures can be
+  inspected selectively through `read_output`. The existing verbose responses
+  remain the default for backward compatibility.
+
 - **Custom environment names, decoupled from the git branch** — an environment
   can now carry a name of its own instead of inheriting the branch name, so one
   branch can back several isolated environments. The dashboard's create form
@@ -27,6 +36,13 @@
   and the MCP tools are unchanged. (#204)
 
 ### Fixes
+
+- **A failed install is no longer masked by a later successful upgrade** — when
+  a single `pull_and_apply` both installed and upgraded modules, the reported
+  exit code was the last command's, so a broken install followed by a clean
+  upgrade came back as a success. The apply now keeps the first non-zero exit
+  code, which is what the compact `summary_only` status line and the live-mount
+  snapshot both key off.
 
 - **PostgreSQL access follows the real Docker networks** — on every startup,
   Oduflow now reads the actual IPAM subnets of its shared and per-team networks

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -341,6 +341,17 @@ oduflow call upgrade_odoo_modules feature-login sale,crm
 oduflow call run_odoo_tests feature-login sale,crm
 ```
 
+For agent loops, pass `summary_only=true` to keep the complete Odoo log out of
+the MCP response:
+
+```bash
+oduflow call run_odoo_tests '{"env_name":"feature-login","modules":"sale,crm","summary_only":true}'
+```
+
+The response is one `N failed, M error(s) of K tests` line plus an `output_id`.
+The full log remains server-side and can be inspected with `read_output` only
+when the summary reports a failure or Odoo aborts before producing a test count.
+
 This runs `odoo --test-enable --stop-after-init --workers 0 --http-port 8089 --gevent-port 8090 -u
 <modules>` inside the container. The module must already be installed — tests run via an upgrade
 (`-u`); `-i` on an already-installed module is a no-op that never enters the test phase ("0 of 0
@@ -358,6 +369,11 @@ The `pull_and_apply` tool is one of Oduflow's most powerful features. It pulls t
 ```bash
 oduflow call pull_and_apply feature-login
 ```
+
+`summary_only=true` suppresses install/upgrade logs and changed-file names from
+the MCP response. It returns one line containing the applied action, changed
+file count and exit status; when command output exists, the line includes an
+`output_id` for targeted inspection with `read_output`.
 
 ### How it works
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -171,8 +171,8 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `upgrade_odoo_modules` — upgrade Odoo modules
 - `export_module_translations` — export a module's .pot/.po translation catalogue
 - `translation_status` — check what translations actually loaded, and lint the .po files
-- `run_odoo_tests` — run Odoo tests for specific modules (`test_tags` narrows to one class/method; `upgrade=False` skips the `-u`, collects `post_install` tests only, and requires module-scoped positive tags)
-- `pull_and_apply` — pull latest code and auto-install/upgrade/restart as needed
+- `run_odoo_tests` — run Odoo tests for specific modules (`summary_only=True` returns only the final test count plus an `output_id`; `test_tags` narrows to one class/method; `upgrade=False` skips the `-u`, collects `post_install` tests only, and requires module-scoped positive tags)
+- `pull_and_apply` — pull latest code and auto-install/upgrade/restart as needed (`summary_only=True` returns one action/status line and caches command logs for `read_output`)
 - `get_environment_logs` — retrieve container logs
 - `run_odoo_command` — execute shell commands inside the Odoo container (through `sh -c`, so pipes and redirections work; `shell=False` for exact argv)
 - `run_odoo_shell` — execute Python code in the Odoo shell with full ORM access
@@ -228,8 +228,8 @@ sanitization scripts followed by project scripts from
 
 1. Call `list_environments` to check if an environment for the branch exists
 2. If not, call `create_environment` with `branch`, `template_name`, `repo_url`, and `odoo_image`
-3. Write code, `git push`, then call `pull_and_apply` (auto-detects what to do); read its response for install/upgrade errors
-4. Use `install_odoo_modules` / `run_odoo_tests` and read their direct responses; use `get_environment_logs` only for errors from the running Odoo server
+3. Write code, `git push`, then call `pull_and_apply(summary_only=True)` (auto-detects what to do); inspect its `output_id` only when the compact status reports a failure
+4. Use `install_odoo_modules` / `run_odoo_tests(summary_only=True)`; inspect the cached output on failure, and use `get_environment_logs` only for errors from the running Odoo server
 5. Inspect and manipulate data with the `odoo_*` ORM tools — `odoo_schema` first to get the real field names, then `odoo_search_read`; add `as_user` to check what a given role can actually see or change
 6. Call `delete_environment` when the task is done
 
@@ -1914,6 +1914,17 @@ oduflow call upgrade_odoo_modules feature-login sale,crm
 oduflow call run_odoo_tests feature-login sale,crm
 ```
 
+For agent loops, pass `summary_only=true` to keep the complete Odoo log out of
+the MCP response:
+
+```bash
+oduflow call run_odoo_tests '{"env_name":"feature-login","modules":"sale,crm","summary_only":true}'
+```
+
+The response is one `N failed, M error(s) of K tests` line plus an `output_id`.
+The full log remains server-side and can be inspected with `read_output` only
+when the summary reports a failure or Odoo aborts before producing a test count.
+
 This runs `odoo --test-enable --stop-after-init --workers 0 --http-port 8089 --gevent-port 8090 -u
 <modules>` inside the container. The module must already be installed — tests run via an upgrade
 (`-u`); `-i` on an already-installed module is a no-op that never enters the test phase ("0 of 0
@@ -1931,6 +1942,11 @@ The `pull_and_apply` tool is one of Oduflow's most powerful features. It pulls t
 ```bash
 oduflow call pull_and_apply feature-login
 ```
+
+`summary_only=true` suppresses install/upgrade logs and changed-file names from
+the MCP response. It returns one line containing the applied action, changed
+file count and exit status; when command output exists, the line includes an
+`output_id` for targeted inspection with `read_output`.
 
 ### How it works
 
@@ -3188,12 +3204,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
 | `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
 | **Odoo Operations** | | |
-| `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
+| `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart; `summary_only=True` returns one action/status line and caches command logs for `read_output` |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
 | `upgrade_odoo_modules` | ✓ | Upgrade Odoo modules (`-u`) |
 | `export_module_translations` | ✓ | Export a module's `.pot`/`.po` with Odoo's own exporter, write it into the module's `i18n/`, and return a summary plus an HTTP download URL or local temporary path |
 | `translation_status` | ✓ | Verdict per language (OK, PARTIAL, NOT LOADED, NOT TRANSLATED, IMPORT SILENTLY DROPPED, IMPORT ABORTS, NO FILE, NOT ACTIVATED) from the module's terms, the database and the committed `.po` files, including the sibling-POT metadata merge Odoo performs before import, plus the call that fixes it |
-| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `test_tags` narrows the run to one class or method, `upgrade=False` skips the `-u` for a fast re-run (collects `post_install` tests only and requires module-scoped positive tags) |
+| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `summary_only=True` returns the final `N failed, M error(s) of K tests` line and an `output_id`; `test_tags` narrows the run, while `upgrade=False` skips `-u` for a fast `post_install` re-run |
 | `get_environment_logs` | | Retrieve recent container logs |
 | `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |
 | `run_odoo_shell` | ✓ | Execute Python code in the Odoo shell context with full ORM access; `auto_commit=True` commits successful writes, while `False` leaves the shell transaction uncommitted |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -171,8 +171,8 @@ For OAuth-based MCP clients like Claude.ai Remote MCP, Oduflow runs its own OAut
 - `upgrade_odoo_modules` — upgrade Odoo modules
 - `export_module_translations` — export a module's .pot/.po translation catalogue
 - `translation_status` — check what translations actually loaded, and lint the .po files
-- `run_odoo_tests` — run Odoo tests for specific modules (`test_tags` narrows to one class/method; `upgrade=False` skips the `-u`, collects `post_install` tests only, and requires module-scoped positive tags)
-- `pull_and_apply` — pull latest code and auto-install/upgrade/restart as needed
+- `run_odoo_tests` — run Odoo tests for specific modules (`summary_only=True` returns only the final test count plus an `output_id`; `test_tags` narrows to one class/method; `upgrade=False` skips the `-u`, collects `post_install` tests only, and requires module-scoped positive tags)
+- `pull_and_apply` — pull latest code and auto-install/upgrade/restart as needed (`summary_only=True` returns one action/status line and caches command logs for `read_output`)
 - `get_environment_logs` — retrieve container logs
 - `run_odoo_command` — execute shell commands inside the Odoo container (through `sh -c`, so pipes and redirections work; `shell=False` for exact argv)
 - `run_odoo_shell` — execute Python code in the Odoo shell with full ORM access
@@ -228,8 +228,8 @@ sanitization scripts followed by project scripts from
 
 1. Call `list_environments` to check if an environment for the branch exists
 2. If not, call `create_environment` with `branch`, `template_name`, `repo_url`, and `odoo_image`
-3. Write code, `git push`, then call `pull_and_apply` (auto-detects what to do); read its response for install/upgrade errors
-4. Use `install_odoo_modules` / `run_odoo_tests` and read their direct responses; use `get_environment_logs` only for errors from the running Odoo server
+3. Write code, `git push`, then call `pull_and_apply(summary_only=True)` (auto-detects what to do); inspect its `output_id` only when the compact status reports a failure
+4. Use `install_odoo_modules` / `run_odoo_tests(summary_only=True)`; inspect the cached output on failure, and use `get_environment_logs` only for errors from the running Odoo server
 5. Inspect and manipulate data with the `odoo_*` ORM tools — `odoo_schema` first to get the real field names, then `odoo_search_read`; add `as_user` to check what a given role can actually see or change
 6. Call `delete_environment` when the task is done
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -17,12 +17,12 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
 | `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
 | **Odoo Operations** | | |
-| `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
+| `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart; `summary_only=True` returns one action/status line and caches command logs for `read_output` |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |
 | `upgrade_odoo_modules` | ✓ | Upgrade Odoo modules (`-u`) |
 | `export_module_translations` | ✓ | Export a module's `.pot`/`.po` with Odoo's own exporter, write it into the module's `i18n/`, and return a summary plus an HTTP download URL or local temporary path |
 | `translation_status` | ✓ | Verdict per language (OK, PARTIAL, NOT LOADED, NOT TRANSLATED, IMPORT SILENTLY DROPPED, IMPORT ABORTS, NO FILE, NOT ACTIVATED) from the module's terms, the database and the committed `.po` files, including the sibling-POT metadata merge Odoo performs before import, plus the call that fixes it |
-| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `test_tags` narrows the run to one class or method, `upgrade=False` skips the `-u` for a fast re-run (collects `post_install` tests only and requires module-scoped positive tags) |
+| `run_odoo_tests` | ✓ | Run Odoo tests for specific modules; `summary_only=True` returns the final `N failed, M error(s) of K tests` line and an `output_id`; `test_tags` narrows the run, while `upgrade=False` skips `-u` for a fast `post_install` re-run |
 | `get_environment_logs` | | Retrieve recent container logs |
 | `run_odoo_command` | ✓ | Execute an arbitrary shell command inside the Odoo container (runs through `sh -c`, so pipes, redirections and `&&` work; `shell=False` for exact argv) |
 | `run_odoo_shell` | ✓ | Execute Python code in the Odoo shell context with full ORM access; `auto_commit=True` commits successful writes, while `False` leaves the shell transaction uncommitted |

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -3042,16 +3042,21 @@ def _apply_actions(
     if to_install or to_upgrade:
         messages: list[str] = []
         odoo_output_parts: list[str] = []
-        last_exit_code = 0
+        # Keep the FIRST non-zero code: a failed install followed by a
+        # successful upgrade must still report failure. Callers treat this as
+        # the whole apply's status (the compact pull_and_apply summary hides the
+        # log behind an output_id, and the live-mount snapshot is only written
+        # on 0), so a later success must not overwrite an earlier failure.
+        apply_exit_code = 0
         if to_install:
             res = install_odoo_modules(settings, team, env_name, *to_install)
-            last_exit_code = res["exit_code"]
+            apply_exit_code = apply_exit_code or res["exit_code"]
             messages.append(f"Installed modules: {','.join(to_install)}")
             if res.get("output"):
                 odoo_output_parts.append(res["output"])
         if to_upgrade:
             res = upgrade_odoo_modules(settings, team, env_name, *to_upgrade)
-            last_exit_code = res["exit_code"]
+            apply_exit_code = apply_exit_code or res["exit_code"]
             messages.append(f"Upgraded modules: {','.join(to_upgrade)}")
             if res.get("output"):
                 odoo_output_parts.append(res["output"])
@@ -3069,7 +3074,7 @@ def _apply_actions(
             "action": "install" if to_install else "upgrade",
             "modules_installed": to_install,
             "modules_upgraded": to_upgrade,
-            "exit_code": last_exit_code or dep_exit,
+            "exit_code": apply_exit_code or dep_exit,
             "changed_files": changed_files,
             "message": " ".join(messages),
             "output": "\n".join(dep_logs + odoo_output_parts),

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -73,6 +73,9 @@ _CACHE_THRESHOLD = 5_000  # chars — outputs above this are cached + summarized
 _SUMMARY_HEAD_LINES = 200
 _SUMMARY_TAIL_LINES = 100
 _SUMMARY_ERROR_CONTEXT = 5
+_ODOO_TEST_SUMMARY_RE = re.compile(
+    r"\b\d+ failed, \d+ error\(s\) of \d+ tests\b", re.IGNORECASE
+)
 
 _output_cache = OutputCache()
 
@@ -208,6 +211,46 @@ def _maybe_cache(output: str, header: str, source_tool: str, source_args: str) -
         )
         return f"{header}\n\n{_make_summary(cached)}"
     return f"{header}\n\nOutput:\n{output}"
+
+
+def _cache_output(output: str, source_tool: str, source_args: str) -> CachedOutput:
+    """Store command output when the caller explicitly requested a terse response."""
+    return _output_cache.store(output, source_tool=source_tool, source_args=source_args)
+
+
+def _odoo_test_summary(output: str) -> str | None:
+    """Return Odoo's final aggregate test result without its log prefix."""
+    matches = list(_ODOO_TEST_SUMMARY_RE.finditer(output))
+    return matches[-1].group(0) if matches else None
+
+
+def _compact_pull_result(
+    result: dict[str, Any], woke_note: str, output: str, env_name: str
+) -> str:
+    """Build a one-line apply result while keeping raw command output server-side."""
+    parts = [" ".join((woke_note + str(result["message"])).split())]
+    if result.get("modules_installed"):
+        parts.append(f"Installed: {', '.join(result['modules_installed'])}")
+    if result.get("modules_upgraded"):
+        parts.append(f"Upgraded: {', '.join(result['modules_upgraded'])}")
+    parts.append(f"Changed files: {len(result.get('changed_files', []))}")
+
+    exit_code = int(result.get("exit_code", 0) or 0)
+    parts.append(f"Status: {'failed' if exit_code else 'ok'} (exit_code={exit_code})")
+
+    warnings = result.get("warnings") or []
+    if warnings:
+        compact_warnings = [" ".join(str(warning).split()) for warning in warnings]
+        parts.append(f"Guardrail warnings: {' | '.join(compact_warnings)}")
+
+    if output:
+        cached = _cache_output(
+            output,
+            source_tool="pull_and_apply",
+            source_args=f"env={env_name}, summary_only=True",
+        )
+        parts.append(f"output_id={cached.output_id}")
+    return "; ".join(parts)
 
 
 def _artifact_url(settings: Settings, team: TeamSettings, token: str) -> str | None:
@@ -1421,6 +1464,7 @@ def run_odoo_tests(
     modules: str,
     test_tags: str = "",
     upgrade: bool = True,
+    summary_only: bool = False,
     ctx: Context | None = None,
 ) -> str:
     """
@@ -1450,6 +1494,9 @@ def run_odoo_tests(
             upgrade Odoo only collects **post_install** tests, so classes at the
             default at_install position (plain TransactionCase/TestCase) will report
             "0 tests". If a class you expect does not run, re-run with upgrade=True.
+        summary_only: Return only Odoo's aggregate test result and an output_id
+            instead of command logs. The complete output remains available through
+            read_output. Default False preserves the verbose response.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -1457,12 +1504,27 @@ def run_odoo_tests(
     output = odoo_ops.run_environment_tests(
         settings, team, env_name, modules, test_tags=test_tags, upgrade=upgrade
     )
+    source_args = (
+        f"env={env_name}, modules={modules}, test_tags={test_tags}, upgrade={upgrade}"
+    )
+    if summary_only:
+        cached = _cache_output(
+            output, "run_odoo_tests", f"{source_args}, summary_only=True"
+        )
+        summary = _odoo_test_summary(output) or "Test summary not found"
+        # Keep the wake note (whitespace-collapsed, so the response stays one
+        # line): the caller still has to know the environment was stopped and
+        # started by this call.
+        note = " ".join(woke.split())
+        prefix = f"{note} " if note else ""
+        return f"{prefix}{summary} [output_id={cached.output_id}]"
+
     header = woke + f"Test Results for {env_name}:"
     return _maybe_cache(
         output,
         header,
         "run_odoo_tests",
-        f"env={env_name}, modules={modules}, test_tags={test_tags}, upgrade={upgrade}",
+        source_args,
     )
 
 
@@ -1703,6 +1765,7 @@ def pull_and_apply(
     upgrade: str = "",
     restart: bool = False,
     strict: bool = False,
+    summary_only: bool = False,
     ctx: Context | None = None,
 ) -> str:
     """
@@ -1739,7 +1802,9 @@ def pull_and_apply(
       update_environment.)
 
     Errors and tracebacks are returned directly in this response — do NOT call
-    get_environment_logs to check for them.
+    get_environment_logs to check for them. With summary_only=True they are not
+    inlined: the response reports the exit status and an `output_id`, and the
+    full log is read with read_output.
 
     Args:
         env_name: The environment to apply changes to.
@@ -1748,6 +1813,10 @@ def pull_and_apply(
         restart: Restart the Odoo container (for Python-only changes).
         strict: If True, refuse to apply when the guardrail finds a likely
             missing action (default False: warn but apply anyway).
+        summary_only: Return a compact one-line action/status summary instead of
+            command logs and changed-file names. Raw output is cached and remains
+            available through read_output. Default False preserves the verbose
+            response.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -1792,6 +1861,8 @@ def pull_and_apply(
 
     header = "\n".join(header_lines)
     output = result.get("output", "")
+    if summary_only:
+        return _compact_pull_result(result, woke_note, output, env_name)
     if output:
         return _maybe_cache(output, header, "pull_and_apply", f"env={env_name}")
     return header

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 6
+Version: 7
 
 ## Purpose
 
@@ -45,9 +45,9 @@ Call `create_environment` with the branch, correct Odoo image, and either
 3. get_odoo_development_guide before module code changes
 4. edit code locally
 5. repo_url: commit + push; local_path: no delivery step
-6. pull_and_apply with the action required by the edit
+6. pull_and_apply with the action required by the edit and summary_only=true
 7. read that response; if it failed, fix and repeat from step 4
-8. run_odoo_tests for the changed modules
+8. run_odoo_tests with summary_only=true for the changed modules
 9. leave the environment for the next branch, or delete_environment when
    nobody still needs the URL or its test data
 ```
@@ -99,9 +99,15 @@ command output, errors, and tracebacks. Read that response. Do not call
 Odoo server process and is appropriate for failures during HTTP requests or
 after a restart.
 
-Large command responses are cached automatically. The response includes an
-`output_id`; use `read_output` with `errors`, `grep`, `lines`, or `tail` only
-when the returned summary does not answer the question.
+Pass `summary_only=true` to `pull_and_apply` and `run_odoo_tests` during the
+normal development loop. Test runs then return the final
+`N failed, M error(s) of K tests` result, while applies return one compact line
+with the action, changed-file count and exit status. The complete command log
+stays server-side and the response includes an `output_id`; use `read_output`
+with `errors`, `grep`, `lines`, or `tail` only when that compact result reports
+a failure or does not answer the question. Without `summary_only`, command
+responses keep their verbose backward-compatible format and large ones are
+cached automatically.
 
 Use the most specific inspection surface:
 

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -2582,6 +2582,72 @@ class TestApplyActionsConf:
         container.restart.assert_not_called()
 
 
+class TestApplyActionsExitCode:
+    """A failed install must not be masked by a later successful upgrade.
+
+    ``exit_code`` is the whole apply's status: the compact ``pull_and_apply``
+    response derives "Status: ok/failed" from it and keeps the log server-side,
+    and the live-mount snapshot is only written when it is 0.
+    """
+
+    @staticmethod
+    def _client_with_container():
+        client = MagicMock()
+        container = MagicMock()
+        client.containers.get.return_value = container
+        return client, container
+
+    def _apply(self):
+        client, _ = self._client_with_container()
+        return env_ops._apply_actions(
+            client,
+            TEST_SETTINGS,
+            TEST_TEAM,
+            "feature/x",
+            "oduflow-1-feature-x-odoo",
+            to_install=["new_module"],
+            to_upgrade=["sale"],
+            do_restart=False,
+            changed_files=["new_module/__manifest__.py", "sale/models/sale.py"],
+        )
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.upgrade_odoo_modules",
+        return_value={"exit_code": 0, "output": "upgraded"},
+    )
+    @patch(
+        "oduflow.docker_ops.odoo_ops.install_odoo_modules",
+        return_value={"exit_code": 1, "output": "install traceback"},
+    )
+    def test_failed_install_survives_successful_upgrade(self, mock_install, mock_up):
+        result = self._apply()
+
+        assert result["exit_code"] == 1
+        assert "install traceback" in result["output"]
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.upgrade_odoo_modules",
+        return_value={"exit_code": 2, "output": "upgrade traceback"},
+    )
+    @patch(
+        "oduflow.docker_ops.odoo_ops.install_odoo_modules",
+        return_value={"exit_code": 0, "output": "installed"},
+    )
+    def test_failed_upgrade_is_reported(self, mock_install, mock_up):
+        assert self._apply()["exit_code"] == 2
+
+    @patch(
+        "oduflow.docker_ops.odoo_ops.upgrade_odoo_modules",
+        return_value={"exit_code": 0, "output": "upgraded"},
+    )
+    @patch(
+        "oduflow.docker_ops.odoo_ops.install_odoo_modules",
+        return_value={"exit_code": 0, "output": "installed"},
+    )
+    def test_all_successful_reports_zero(self, mock_install, mock_up):
+        assert self._apply()["exit_code"] == 0
+
+
 class TestApplyActionsDeps:
     """A changed dependency descriptor must reinstall apt/pip deps into the
     running container and restart it — not fall through to an XML/JS refresh."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -520,7 +520,7 @@ class TestAgentInstructionsTool:
 
         assert len(guide) < 16_000
         assert "Per-environment Odoo configuration" in guide
-        assert "Version: 6" in guide
+        assert "Version: 7" in guide
         assert "git push -u origin HEAD" in guide
         assert "cannot see a local-only branch" in guide
         assert "db_maxconn" in guide
@@ -630,6 +630,144 @@ class TestErrorHandling:
         mock_restart.side_effect = NotFoundError("container not found")
         with pytest.raises(ToolError, match="container not found"):
             _call_tool("restart_environment", env_name="main")
+
+
+def _compact_output_id(response: str) -> str:
+    return response.rsplit("output_id=", 1)[1].rstrip("]")
+
+
+class TestCompactCommandResponses:
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_ops.run_environment_tests")
+    def test_run_odoo_tests_returns_only_the_last_aggregate_summary(
+        self, mock_run, mock_ensure
+    ):
+        mock_run.return_value = "\n".join(
+            [
+                "2026-01-01 INFO 2 failed, 0 error(s) of 10 tests",
+                *(f"2026-01-01 WARNING noisy line {i}" for i in range(2_000)),
+                "unique full-log detail",
+                "2026-01-01 INFO 1 failed, 2 error(s) of 30 tests when loading database",
+            ]
+        )
+
+        result = _call_tool(
+            "run_odoo_tests",
+            env_name="main",
+            modules="sale",
+            summary_only=True,
+        )
+
+        assert result.startswith("1 failed, 2 error(s) of 30 tests [output_id=")
+        assert "\n" not in result
+        assert "noisy line" not in result
+
+        output_id = _compact_output_id(result)
+        cached = _call_tool(
+            "read_output", output_id=output_id, mode="grep", grep="unique full-log"
+        )
+        assert "unique full-log detail" in cached
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_ops.run_environment_tests")
+    def test_run_odoo_tests_has_a_short_fallback_when_odoo_aborts_early(
+        self, mock_run, mock_ensure
+    ):
+        mock_run.return_value = "Traceback\nImportError: broken module"
+
+        result = _call_tool(
+            "run_odoo_tests",
+            env_name="main",
+            modules="sale",
+            summary_only=True,
+        )
+
+        assert result.startswith("Test summary not found [output_id=")
+        assert "Traceback" not in result
+        output_id = _compact_output_id(result)
+        assert "ImportError: broken module" in _call_tool(
+            "read_output", output_id=output_id, mode="tail"
+        )
+
+    @patch(
+        "oduflow.server._wake_for_work",
+        return_value="Note: environment was stopped; started it for this call.\n",
+    )
+    @patch("oduflow.docker_ops.odoo_ops.run_environment_tests")
+    def test_run_odoo_tests_summary_keeps_the_wake_note(self, mock_run, mock_wake):
+        mock_run.return_value = "INFO 0 failed, 0 error(s) of 7 tests"
+
+        result = _call_tool(
+            "run_odoo_tests",
+            env_name="main",
+            modules="sale",
+            summary_only=True,
+        )
+
+        assert result.startswith("Note: environment was stopped; started it for ")
+        assert "0 failed, 0 error(s) of 7 tests [output_id=" in result
+        assert "\n" not in result
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.odoo_ops.run_environment_tests")
+    def test_run_odoo_tests_is_verbose_by_default(self, mock_run, mock_ensure):
+        mock_run.return_value = "complete Odoo command output"
+
+        result = _call_tool("run_odoo_tests", env_name="main", modules="sale")
+
+        assert "Test Results for main:" in result
+        assert "complete Odoo command output" in result
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.env_ops.pull_environment")
+    def test_pull_and_apply_suppresses_logs_and_file_names(
+        self, mock_pull, mock_ensure
+    ):
+        mock_pull.return_value = {
+            "action": "upgrade",
+            "message": "Upgraded modules: sale. Container restarted.",
+            "modules_installed": [],
+            "modules_upgraded": ["sale"],
+            "changed_files": ["sale/models/order.py", "sale/security/rules.xml"],
+            "warnings": ["restart is also\nrecommended"],
+            "exit_code": 1,
+            "output": "RAW ODOO LOG\nunique apply failure",
+        }
+
+        result = _call_tool(
+            "pull_and_apply",
+            env_name="main",
+            upgrade="sale",
+            summary_only=True,
+        )
+
+        assert "\n" not in result
+        assert "Changed files: 2" in result
+        assert "Status: failed (exit_code=1)" in result
+        assert "Guardrail warnings: restart is also recommended" in result
+        assert "sale/models/order.py" not in result
+        assert "RAW ODOO LOG" not in result
+
+        output_id = _compact_output_id(result)
+        assert "unique apply failure" in _call_tool(
+            "read_output", output_id=output_id, mode="tail"
+        )
+
+    @patch("oduflow.docker_ops.env_ops.ensure_running", return_value=False)
+    @patch("oduflow.docker_ops.env_ops.pull_environment")
+    def test_pull_and_apply_is_verbose_by_default(self, mock_pull, mock_ensure):
+        mock_pull.return_value = {
+            "action": "restart",
+            "message": "Container restarted.",
+            "changed_files": ["sale/models/order.py"],
+            "exit_code": 0,
+            "output": "complete apply output",
+        }
+
+        result = _call_tool("pull_and_apply", env_name="main", restart=True)
+
+        assert "sale/models/order.py" in result
+        assert "complete apply output" in result
 
 
 class TestProductionFeatureGate:


### PR DESCRIPTION
## What

Adds a `summary_only` flag to `pull_and_apply` and `run_odoo_tests` so verbose Odoo command logs stay server-side instead of being injected into the calling agent's context.

- `run_odoo_tests(summary_only=True)` returns Odoo's final `N failed, M error(s) of K tests` line (or `Test summary not found` when Odoo aborts before the test phase) plus an `output_id`.
- `pull_and_apply(summary_only=True)` returns one line with the applied action, module lists, changed-file count, exit status and guardrail warnings, plus an `output_id` when command output exists.
- Both keep the full output in the output cache, so `read_output` still gives `errors`, `grep`, `lines` and `tail` access.
- The verbose responses remain the default; nothing changes for existing callers.

Docs, the MCP tool reference, `llms.txt`/`llms-full.txt` and the agent guide (bumped to Version 7) are updated to recommend `summary_only=true` in the normal development loop.

## Fix included

The apply exit code was the *last* command's: a `pull_and_apply` that both installed and upgraded modules reported success when the install failed and the upgrade succeeded. `_apply_actions` now keeps the first non-zero exit code. This matters more with `summary_only`, where `Status:` is the only failure signal the agent sees, and it also affects the live-mount snapshot, which is only written when the code is 0.

## Testing

`pytest -m "not integration and not heavyweight"` (2500 passed), `ruff check`, `ruff format --check`, `mypy src/oduflow` — all clean.
