### PR TITLE
fix: make auto-installed modules part of atomic environment provisioning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,6 +28,17 @@
 
 ### Fixes
 
+- **Auto-installed modules are now part of atomic environment provisioning** —
+  creation no longer reports success when the serving Odoo registry misses its
+  120-second readiness deadline or the requested module install fails. The
+  readiness probe now preserves its last error and includes a bounded Odoo log
+  tail, required setup failures stop before sanitization and roll back the new
+  environment, and a final database-bound registry check runs after the
+  post-sanitization restart. This prevents an environment from surviving with
+  requested modules missing or with their neutralization SQL skipped. Module
+  names are validated up front, so a typo is rejected before anything is
+  provisioned instead of after the rollback discards it.
+
 - **PostgreSQL access follows the real Docker networks** — on every startup,
   Oduflow now reads the actual IPAM subnets of its shared and per-team networks
   and reconciles a marked block in the active `pg_hba.conf` for both development

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any
 
 import docker
@@ -790,22 +791,42 @@ def _install_pip_requirements(
 
 def _odoo_registry_probe(env_db: str) -> list[str]:
     """Build an in-container probe that forces the target registry to load."""
-    script = (
-        "import http.cookiejar,sys,urllib.parse,urllib.request;"
-        f"db={env_db!r};"
-        "jar=http.cookiejar.CookieJar();"
-        "opener=urllib.request.build_opener("
-        "urllib.request.HTTPCookieProcessor(jar));"
-        "url='http://127.0.0.1:8069/web/login?'+urllib.parse.urlencode({'db':db});"
-        "response=opener.open(url,timeout=5);"
-        "sys.exit(0 if response.status==200 else 1)"
+    script = "\n".join(
+        [
+            "import http.cookiejar",
+            "import sys",
+            "import urllib.parse",
+            "import urllib.request",
+            f"db = {env_db!r}",
+            "jar = http.cookiejar.CookieJar()",
+            "opener = urllib.request.build_opener(",
+            "    urllib.request.HTTPCookieProcessor(jar)",
+            ")",
+            "url = 'http://127.0.0.1:8069/web/login?' + urllib.parse.urlencode({'db': db})",
+            "try:",
+            "    response = opener.open(url, timeout=5)",
+            "    if response.status != 200:",
+            "        raise RuntimeError(f'HTTP {response.status}')",
+            "except Exception as exc:",
+            "    print(f'{type(exc).__name__}: {exc}', file=sys.stderr)",
+            "    sys.exit(1)",
+        ]
     )
     return ["python3", "-c", script]
 
 
+@dataclass(frozen=True)
+class _OdooReadinessResult:
+    ready: bool
+    elapsed_seconds: float
+    attempts: int
+    timeout_seconds: int
+    last_error: str = ""
+
+
 def _wait_for_container_odoo_ready(
     container: Any, env_db: str, timeout: int = 120
-) -> bool:
+) -> _OdooReadinessResult:
     """Wait until the serving Odoo process has finished registry startup.
 
     The probe runs inside the container so readiness does not depend on public
@@ -818,36 +839,113 @@ def _wait_for_container_odoo_ready(
     database-independent and can respond before registry preloading completes.
     """
     probe = _odoo_registry_probe(env_db)
-    deadline = time.monotonic() + timeout
+    started = time.monotonic()
+    deadline = started + timeout
+    attempts = 0
+    last_error = "readiness probe has not run"
+    next_progress_log = 30.0
     while True:
+        attempts += 1
         try:
-            if container.exec_run(probe)[0] == 0:
-                return True
-        except docker.errors.APIError:
+            exit_code, output = container.exec_run(probe)
+            output_str = (
+                output.decode("utf-8", errors="replace")
+                if isinstance(output, bytes)
+                else str(output)
+            ).strip()
+            if exit_code == 0:
+                return _OdooReadinessResult(
+                    ready=True,
+                    elapsed_seconds=round(time.monotonic() - started, 1),
+                    attempts=attempts,
+                    timeout_seconds=timeout,
+                )
+            last_error = output_str or f"probe exited with code {exit_code}"
+        except docker.errors.APIError as exc:
             # The container may briefly reject execs while restarting after a
             # dependency install. Treat that exactly like a failed probe.
-            pass
-        if time.monotonic() >= deadline:
-            return False
+            last_error = f"Docker exec failed: {exc}"
+        now = time.monotonic()
+        elapsed = now - started
+        if now >= deadline:
+            return _OdooReadinessResult(
+                ready=False,
+                elapsed_seconds=round(elapsed, 1),
+                attempts=attempts,
+                timeout_seconds=timeout,
+                last_error=last_error[-2000:],
+            )
+        if elapsed >= next_progress_log:
+            logger.info(
+                "Still waiting for serving Odoo registry for '%s' after %.0f seconds: %s",
+                env_db,
+                elapsed,
+                last_error[-500:],
+            )
+            next_progress_log += 30.0
         time.sleep(2)
 
 
+def _recent_container_logs(container: Any, tail: int = 200) -> str:
+    """Return a bounded log tail without masking the readiness failure."""
+    try:
+        output = container.logs(tail=tail, stdout=True, stderr=True)
+    except Exception as exc:
+        return f"Could not read container logs: {exc}"
+    output_str = (
+        output.decode("utf-8", errors="replace")
+        if isinstance(output, bytes)
+        else str(output)
+    ).strip()
+    return output_str[-20_000:] or "(container produced no logs)"
+
+
+def _readiness_error(
+    container: Any,
+    env_db: str,
+    result: _OdooReadinessResult,
+    *,
+    action: str,
+) -> PrerequisiteNotMetError:
+    logs = _recent_container_logs(container)
+    return PrerequisiteNotMetError(
+        f"{action}: serving Odoo did not load registry for database '{env_db}' "
+        f"within {result.timeout_seconds} seconds ({result.attempts} probes). "
+        f"Last readiness error: {result.last_error}\n\n"
+        f"Recent Odoo container logs:\n{logs}"
+    )
+
+
 def _auto_install_modules(
-    container: Any, env_db: str, modules: list[str], env_name: str = ""
+    container: Any,
+    settings: Settings,
+    team: TeamSettings,
+    env_db: str,
+    modules: list[str],
+    env_name: str,
 ) -> str:
     """Install modules after the serving registry is ready and return its log."""
+    from oduflow.docker_ops.odoo_ops import (
+        _require_installed_modules,
+        _validate_module_names,
+    )
+
+    _validate_module_names(modules)
     modules_str = ",".join(modules)
     logger.info(
         "Waiting for serving Odoo before auto-installing modules",
         extra={"env_name": env_name},
     )
-    if not _wait_for_container_odoo_ready(container, env_db):
-        message = (
-            f"[AUTO-INSTALL] odoo -i {modules_str} FAILED: serving Odoo did not "
-            "become ready within 120 seconds; installation was not attempted"
+    readiness = _wait_for_container_odoo_ready(container, env_db)
+    if not readiness.ready:
+        error = _readiness_error(
+            container,
+            env_db,
+            readiness,
+            action=f"Auto-install of modules {modules_str} was not attempted",
         )
-        logger.error(message, extra={"env_name": env_name})
-        return message
+        logger.error(str(error), extra={"env_name": env_name})
+        raise error
 
     install_cmd = (
         f"/entrypoint.sh odoo -d {env_db} -i {modules_str} --stop-after-init --no-http"
@@ -861,11 +959,79 @@ def _auto_install_modules(
             output_str,
             extra={"env_name": env_name},
         )
-        return (
-            f"[AUTO-INSTALL] odoo -i {modules_str} FAILED (exit {exit_code}):\n"
-            f"{output_str}"
-        )
+        raise ExternalCommandError(install_cmd, exit_code, output_str[-20_000:])
+    _require_installed_modules(settings, team, env_name, tuple(modules))
     return f"[AUTO-INSTALL] odoo -i {modules_str} completed successfully"
+
+
+def _configure_serving_environment(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    container: Any,
+    repo_path: str,
+    env_db: str,
+    env_name: str,
+    template_name: str | None,
+    sanitize: bool,
+    auto_install_modules: list[str] | None,
+    odoo_conf_to_copy: str | None,
+) -> list[str]:
+    """Run required post-start setup before the environment is declared ready."""
+    setup_logs: list[str] = []
+    if odoo_conf_to_copy:
+        _copy_file_to_container(container, odoo_conf_to_copy, "/etc/odoo")
+
+    apt_log = _install_apt_packages(container, repo_path)
+    if apt_log:
+        setup_logs.append(apt_log)
+    _, pip_log = _install_pip_requirements(container, repo_path)
+    if pip_log:
+        setup_logs.append(pip_log)
+
+    # Install first so neutralization includes SQL shipped by the new modules.
+    if auto_install_modules:
+        modules_str = ",".join(auto_install_modules)
+        logger.info(
+            "Auto-installing modules: %s",
+            modules_str,
+            extra={"env_name": env_name},
+        )
+        setup_logs.append(
+            _auto_install_modules(
+                container,
+                settings,
+                team,
+                env_db,
+                auto_install_modules,
+                env_name,
+            )
+        )
+
+    if sanitize and template_name is not None:
+        from oduflow.sanitizer import neutralize_environment, sanitize_environment
+
+        setup_logs.extend(neutralize_environment(client, settings, team, env_name))
+        setup_logs.extend(sanitize_environment(client, settings, team, env_name))
+
+    if auto_install_modules:
+        # Reload only after sanitization has disabled the newly-installed
+        # modules' crons and external credentials.
+        container.restart()
+        logger.info(
+            "Waiting for serving Odoo after auto-install setup",
+            extra={"env_name": env_name},
+        )
+        readiness = _wait_for_container_odoo_ready(container, env_db)
+        if not readiness.ready:
+            raise _readiness_error(
+                container,
+                env_db,
+                readiness,
+                action="Environment setup did not complete",
+            )
+
+    return setup_logs
 
 
 def _cleanup_old_environment(
@@ -913,6 +1079,24 @@ def _cleanup_old_environment(
     if os.path.exists(workspace_path):
         _unmount_filestore(env_name, team)
         shutil.rmtree(workspace_path)
+
+
+def _rollback_partial_environment(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+) -> None:
+    """Best-effort rollback that preserves the original provisioning error."""
+    if settings.routing_mode == "port":
+        try:
+            release_port(team.port_registry_path, env_name)
+        except Exception:
+            logger.exception("Failed to release port while rolling back '%s'", env_name)
+    try:
+        _cleanup_old_environment(client, settings, team, env_name)
+    except Exception:
+        logger.exception("Failed to fully roll back environment '%s'", env_name)
 
 
 def _init_empty_database(
@@ -1191,6 +1375,14 @@ def _create_environment_impl(
             f"Environment names starting with '{PROD_ENV_PREFIX}' are reserved "
             "for production environments. Use create_production instead."
         )
+    if auto_install_modules:
+        # Fail before anything is provisioned: a malformed module name would
+        # otherwise only surface at the auto-install step, after the clone,
+        # template restore, container start and dependency installs — all of
+        # which the setup rollback then discards.
+        from oduflow.docker_ops.odoo_ops import _validate_module_names
+
+        _validate_module_names(auto_install_modules)
     start_time = time.time()
     try:
         client = get_client()
@@ -1564,66 +1756,32 @@ def _create_environment_impl(
             "containers.run failed for '%s'; rolling back partial environment",
             env_name,
         )
-        if settings.routing_mode == "port":
-            release_port(team.port_registry_path, env_name)
-        _cleanup_old_environment(client, settings, team, env_name)
+        _rollback_partial_environment(client, settings, team, env_name)
         raise
 
-    if odoo_conf_to_copy:
-        _copy_file_to_container(container, odoo_conf_to_copy, "/etc/odoo")
-
-    # Install repo apt/pip dependencies onto the serving container (both paths).
-    # base needs no custom deps, so this runs after the DB is ready.
-    apt_log = _install_apt_packages(container, repo_path)
-    if apt_log:
-        setup_logs.append(apt_log)
-    _, pip_log = _install_pip_requirements(container, repo_path)
-    if pip_log:
-        setup_logs.append(pip_log)
-
-    # --- Auto-install modules ---
-    # MUST run before sanitization below: Odoo's native neutralization gathers
-    # SQL only from already-installed modules, so any `data/neutralize.sql`
-    # shipped by an auto-installed module — and the crons, payment providers, or
-    # connector credentials those modules create — would be missed if neutralize
-    # ran first. Install now, neutralize after.
-    if auto_install_modules:
-        modules_str = ",".join(auto_install_modules)
-        logger.info(
-            "Auto-installing modules: %s",
-            modules_str,
-            extra={"env_name": env_name},
-        )
-        setup_logs.append(
-            _auto_install_modules(
-                container, env_db, auto_install_modules, env_name=env_name
+    try:
+        setup_logs.extend(
+            _configure_serving_environment(
+                client,
+                settings,
+                team,
+                container,
+                repo_path,
+                env_db,
+                env_name,
+                template_name,
+                sanitize,
+                auto_install_modules,
+                odoo_conf_to_copy,
             )
         )
-        # NOTE: the serving container is restarted further down, AFTER
-        # sanitization, so the newly-installed modules' crons are already
-        # deactivated in the DB before PID1 reloads them into a live registry.
-
-    # --- Sanitize environment database ---
-    # Runs AFTER auto-install so Odoo's native neutralization sees the final set
-    # of installed modules (see the auto-install note above).
-    if sanitize and template_name is not None:
-        from oduflow.sanitizer import neutralize_environment, sanitize_environment
-
-        # Layer 1: Odoo's native neutralization — the baseline safety net that
-        # blocks anything going out (mail off, crons off, payment providers off,
-        # third-party credentials scrubbed, database.is_neutralized=true). Runs
-        # in the serving container so it sees the full addons_path.
-        setup_logs.extend(neutralize_environment(client, settings, team, env_name))
-        # Layer 2: custom team/repo sanitization scripts (e.g. PII scrubbing)
-        # run on top of the neutralized database. Project scripts live under
-        # .oduflow/odoo_sanitize in the active checkout.
-        sanitize_logs = sanitize_environment(client, settings, team, env_name)
-        setup_logs.extend(sanitize_logs)
-
-    # Reload any auto-installed modules into the serving registry — done after
-    # sanitization so their crons/credentials are neutralized in the DB first.
-    if auto_install_modules:
-        container.restart()
+    except Exception:
+        logger.error(
+            "Environment setup failed for '%s'; rolling back partial environment",
+            env_name,
+        )
+        _rollback_partial_environment(client, settings, team, env_name)
+        raise
 
     if settings.routing_mode == "traefik":
         url = f"https://{get_env_hostname(env_name, team.hostname, hostname)}"

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import tarfile
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 from unittest.mock import call as mock_call
 from urllib.parse import urlsplit
@@ -331,7 +332,10 @@ class TestCreateEnvironment:
         instance_conf.exists.return_value = False
         setup_error = PrerequisiteNotMetError("registry not ready")
 
-        with (
+        # Entered through an ExitStack rather than a parenthesized `with` group:
+        # CPython 3.10 caps a function at 20 statically nested blocks, and the
+        # patches needed to reach the serving container exceed it.
+        provisioning_patches = [
             patch("oduflow.docker_ops.env_ops._db_exists", return_value=True),
             patch("oduflow.docker_ops.env_ops._ensure_system_ready"),
             patch("oduflow.docker_ops.env_ops.ensure_team_network"),
@@ -366,10 +370,14 @@ class TestCreateEnvironment:
                 "oduflow.docker_ops.env_ops._configure_serving_environment",
                 side_effect=setup_error,
             ),
-            patch(
-                "oduflow.docker_ops.env_ops._rollback_partial_environment"
-            ) as mock_rollback,
-        ):
+        ]
+
+        with ExitStack() as stack:
+            for provisioning_patch in provisioning_patches:
+                stack.enter_context(provisioning_patch)
+            mock_rollback = stack.enter_context(
+                patch("oduflow.docker_ops.env_ops._rollback_partial_environment")
+            )
             with pytest.raises(PrerequisiteNotMetError, match="registry not ready"):
                 env_ops.create_environment(
                     TEST_SETTINGS,

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -13,6 +13,7 @@ from oduflow import po_tools
 from oduflow.docker_ops import env_ops, odoo_ops, system_ops
 from oduflow.errors import (
     ConflictError,
+    ExternalCommandError,
     FlowError,
     NotFoundError,
     PrerequisiteNotMetError,
@@ -318,6 +319,90 @@ class TestCreateEnvironment:
             TEST_TEAM.port_registry_path, "feature/payments"
         )
         assert mock_cleanup.call_count == 2
+
+    def test_create_rolls_back_on_required_setup_failure(
+        self, mock_docker_client, tmp_path
+    ):
+        container = MagicMock()
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.list.return_value = []
+        mock_docker_client.containers.run.return_value = container
+        instance_conf = MagicMock()
+        instance_conf.exists.return_value = False
+        setup_error = PrerequisiteNotMetError("registry not ready")
+
+        with (
+            patch("oduflow.docker_ops.env_ops._db_exists", return_value=True),
+            patch("oduflow.docker_ops.env_ops._ensure_system_ready"),
+            patch("oduflow.docker_ops.env_ops.ensure_team_network"),
+            patch("oduflow.docker_ops.env_ops._cleanup_old_environment"),
+            patch("oduflow.docker_ops.env_ops._write_local_snapshot"),
+            patch(
+                "oduflow.docker_ops.env_ops._template_code_lineage",
+                return_value={},
+            ),
+            patch("oduflow.docker_ops.env_ops._exec_sql"),
+            patch(
+                "oduflow.docker_ops.env_ops.create_credentials",
+                return_value={"pg_user": "u_1_feature", "pg_password": "pw"},
+            ),
+            patch("oduflow.docker_ops.env_ops._create_pg_role"),
+            patch("oduflow.docker_ops.env_ops.reassign_db_ownership"),
+            patch("oduflow.docker_ops.env_ops.drop_signaling_sequences"),
+            patch("oduflow.docker_ops.env_ops._mount_filestore"),
+            patch("oduflow.docker_ops.env_ops._get_used_ports", return_value=set()),
+            patch("oduflow.docker_ops.env_ops.allocate_port", return_value=50000),
+            patch("oduflow.docker_ops.env_ops.os.makedirs"),
+            patch("oduflow.docker_ops.env_ops.os.chmod"),
+            patch(
+                "oduflow.docker_ops.env_ops.get_odoo_uid_gid",
+                return_value="100:101",
+            ),
+            patch(
+                "oduflow.docker_ops.env_ops._resolve_instance_conf",
+                return_value=instance_conf,
+            ),
+            patch(
+                "oduflow.docker_ops.env_ops._configure_serving_environment",
+                side_effect=setup_error,
+            ),
+            patch(
+                "oduflow.docker_ops.env_ops._rollback_partial_environment"
+            ) as mock_rollback,
+        ):
+            with pytest.raises(PrerequisiteNotMetError, match="registry not ready"):
+                env_ops.create_environment(
+                    TEST_SETTINGS,
+                    TEST_TEAM,
+                    "feature",
+                    "",
+                    "odoo:15.0",
+                    template_name="base",
+                    auto_install_modules=["red_border"],
+                    local_path=str(tmp_path),
+                )
+
+        mock_rollback.assert_called_once_with(
+            mock_docker_client, TEST_SETTINGS, TEST_TEAM, "feature"
+        )
+
+    def test_create_rejects_invalid_auto_install_module_before_provisioning(
+        self, mock_docker_client
+    ):
+        # An unusable module name must fail before the clone, template restore
+        # and container start that the setup rollback would otherwise discard.
+        with pytest.raises(ValueError, match="Invalid module name"):
+            env_ops.create_environment(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "feature",
+                "https://github.com/org/repo.git",
+                "odoo:15.0",
+                template_name="base",
+                auto_install_modules=["sale-management"],
+            )
+
+        mock_docker_client.containers.run.assert_not_called()
 
     @patch("oduflow.docker_ops.env_ops._cleanup_old_environment")
     @patch("oduflow.docker_ops.env_ops._ensure_system_ready")
@@ -1596,11 +1681,13 @@ class TestAutoInstallReadiness:
         ]
 
         with patch("oduflow.docker_ops.env_ops.time.sleep") as mock_sleep:
-            assert (
-                env_ops._wait_for_container_odoo_ready(container, "oduflow_1_feature")
-                is True
+            result = env_ops._wait_for_container_odoo_ready(
+                container, "oduflow_1_feature"
             )
 
+        assert result.ready is True
+        assert result.attempts == 3
+        assert result.timeout_seconds == 120
         assert container.exec_run.call_count == 3
         expected_probe = env_ops._odoo_registry_probe("oduflow_1_feature")
         assert all(
@@ -1619,23 +1706,27 @@ class TestAutoInstallReadiness:
             ),
             patch("oduflow.docker_ops.env_ops.time.sleep") as mock_sleep,
         ):
-            assert (
-                env_ops._wait_for_container_odoo_ready(
-                    container, "oduflow_1_feature", timeout=1
-                )
-                is False
+            result = env_ops._wait_for_container_odoo_ready(
+                container, "oduflow_1_feature", timeout=1
             )
 
+        assert result.ready is False
+        assert result.attempts == 1
+        assert result.timeout_seconds == 1
+        assert result.last_error == "not ready"
         container.exec_run.assert_called_once_with(
             env_ops._odoo_registry_probe("oduflow_1_feature")
         )
         mock_sleep.assert_not_called()
 
+    @patch("oduflow.docker_ops.odoo_ops._require_installed_modules")
     @patch(
         "oduflow.docker_ops.env_ops._wait_for_container_odoo_ready",
-        return_value=True,
+        return_value=env_ops._OdooReadinessResult(True, 2.0, 2, 120),
     )
-    def test_auto_install_waits_before_starting_second_odoo(self, mock_wait):
+    def test_auto_install_waits_before_starting_second_odoo(
+        self, mock_wait, mock_require_installed
+    ):
         container = MagicMock()
         container.exec_run.return_value = (0, b"installed")
         calls = MagicMock()
@@ -1644,31 +1735,240 @@ class TestAutoInstallReadiness:
 
         result = env_ops._auto_install_modules(
             container,
+            TEST_SETTINGS,
+            TEST_TEAM,
             "oduflow_1_feature",
             ["red_border"],
-            env_name="feature",
+            "feature",
         )
 
         assert [call[0] for call in calls.mock_calls] == ["wait", "install"]
         mock_wait.assert_called_once_with(container, "oduflow_1_feature")
         install_cmd = container.exec_run.call_args.args[0]
         assert "-d oduflow_1_feature -i red_border" in install_cmd
+        mock_require_installed.assert_called_once_with(
+            TEST_SETTINGS, TEST_TEAM, "feature", ("red_border",)
+        )
         assert "completed successfully" in result
 
     @patch(
         "oduflow.docker_ops.env_ops._wait_for_container_odoo_ready",
-        return_value=False,
+        return_value=env_ops._OdooReadinessResult(
+            False, 120.0, 60, 120, "URLError: connection refused"
+        ),
     )
     def test_auto_install_is_not_attempted_before_readiness(self, mock_wait):
         container = MagicMock()
+        container.logs.return_value = b"Failed to load registry\ntraceback"
 
-        result = env_ops._auto_install_modules(
-            container, "oduflow_1_feature", ["red_border"]
-        )
+        with pytest.raises(PrerequisiteNotMetError) as exc_info:
+            env_ops._auto_install_modules(
+                container,
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "oduflow_1_feature",
+                ["red_border"],
+                "feature",
+            )
 
         mock_wait.assert_called_once_with(container, "oduflow_1_feature")
         container.exec_run.assert_not_called()
-        assert "installation was not attempted" in result
+        message = str(exc_info.value)
+        assert "was not attempted" in message
+        assert "URLError: connection refused" in message
+        assert "Failed to load registry" in message
+
+    @patch(
+        "oduflow.docker_ops.env_ops._wait_for_container_odoo_ready",
+        return_value=env_ops._OdooReadinessResult(True, 2.0, 2, 120),
+    )
+    def test_auto_install_command_failure_is_fatal(self, mock_wait):
+        container = MagicMock()
+        container.exec_run.return_value = (1, b"module import failed")
+
+        with pytest.raises(ExternalCommandError, match="module import failed"):
+            env_ops._auto_install_modules(
+                container,
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "oduflow_1_feature",
+                ["red_border"],
+                "feature",
+            )
+
+    def test_auto_install_validates_module_names_before_exec(self):
+        container = MagicMock()
+
+        with pytest.raises(ValueError, match="Invalid module name"):
+            env_ops._auto_install_modules(
+                container,
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "oduflow_1_feature",
+                ["red_border --stop-after-init"],
+                "feature",
+            )
+
+        container.exec_run.assert_not_called()
+
+
+class TestProvisioningSetup:
+    @patch("oduflow.sanitizer.sanitize_environment")
+    @patch("oduflow.sanitizer.neutralize_environment")
+    @patch(
+        "oduflow.docker_ops.env_ops._auto_install_modules",
+        side_effect=PrerequisiteNotMetError("registry not ready"),
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements",
+        return_value=(False, ""),
+    )
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value="")
+    def test_failed_auto_install_stops_before_sanitization(
+        self,
+        mock_apt,
+        mock_pip,
+        mock_install,
+        mock_neutralize,
+        mock_sanitize,
+    ):
+        container = MagicMock()
+
+        with pytest.raises(PrerequisiteNotMetError, match="registry not ready"):
+            env_ops._configure_serving_environment(
+                MagicMock(),
+                TEST_SETTINGS,
+                TEST_TEAM,
+                container,
+                "/repo",
+                "oduflow_1_feature",
+                "feature",
+                "template",
+                True,
+                ["red_border"],
+                None,
+            )
+
+        mock_neutralize.assert_not_called()
+        mock_sanitize.assert_not_called()
+        container.restart.assert_not_called()
+
+    @patch("oduflow.sanitizer.sanitize_environment", return_value=["sanitize"])
+    @patch("oduflow.sanitizer.neutralize_environment", return_value=["neutralize"])
+    @patch(
+        "oduflow.docker_ops.env_ops._wait_for_container_odoo_ready",
+        return_value=env_ops._OdooReadinessResult(True, 1.0, 1, 120),
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._auto_install_modules",
+        return_value="auto-install",
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements",
+        return_value=(False, ""),
+    )
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value="")
+    def test_successful_setup_sanitizes_before_final_readiness(
+        self,
+        mock_apt,
+        mock_pip,
+        mock_install,
+        mock_wait,
+        mock_neutralize,
+        mock_sanitize,
+    ):
+        container = MagicMock()
+        calls = MagicMock()
+        calls.attach_mock(mock_install, "install")
+        calls.attach_mock(mock_neutralize, "neutralize")
+        calls.attach_mock(mock_sanitize, "sanitize")
+        calls.attach_mock(container.restart, "restart")
+        calls.attach_mock(mock_wait, "wait")
+
+        result = env_ops._configure_serving_environment(
+            MagicMock(),
+            TEST_SETTINGS,
+            TEST_TEAM,
+            container,
+            "/repo",
+            "oduflow_1_feature",
+            "feature",
+            "template",
+            True,
+            ["red_border"],
+            None,
+        )
+
+        assert [entry[0] for entry in calls.mock_calls] == [
+            "install",
+            "neutralize",
+            "sanitize",
+            "restart",
+            "wait",
+        ]
+        assert result == ["auto-install", "neutralize", "sanitize"]
+
+    @patch("oduflow.sanitizer.sanitize_environment", return_value=[])
+    @patch("oduflow.sanitizer.neutralize_environment", return_value=[])
+    @patch(
+        "oduflow.docker_ops.env_ops._wait_for_container_odoo_ready",
+        return_value=env_ops._OdooReadinessResult(
+            False, 120.0, 60, 120, "HTTPError: HTTP 500"
+        ),
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._auto_install_modules",
+        return_value="auto-install",
+    )
+    @patch(
+        "oduflow.docker_ops.env_ops._install_pip_requirements",
+        return_value=(False, ""),
+    )
+    @patch("oduflow.docker_ops.env_ops._install_apt_packages", return_value="")
+    def test_final_registry_failure_is_fatal(
+        self,
+        mock_apt,
+        mock_pip,
+        mock_install,
+        mock_wait,
+        mock_neutralize,
+        mock_sanitize,
+    ):
+        container = MagicMock()
+        container.logs.return_value = b"registry traceback"
+
+        with pytest.raises(PrerequisiteNotMetError) as exc_info:
+            env_ops._configure_serving_environment(
+                MagicMock(),
+                TEST_SETTINGS,
+                TEST_TEAM,
+                container,
+                "/repo",
+                "oduflow_1_feature",
+                "feature",
+                "template",
+                True,
+                ["red_border"],
+                None,
+            )
+
+        assert "Environment setup did not complete" in str(exc_info.value)
+        assert "HTTPError: HTTP 500" in str(exc_info.value)
+        assert "registry traceback" in str(exc_info.value)
+
+    @patch("oduflow.docker_ops.env_ops._cleanup_old_environment")
+    @patch("oduflow.docker_ops.env_ops.release_port")
+    def test_partial_environment_rollback_releases_all_resources(
+        self, mock_release_port, mock_cleanup
+    ):
+        env_ops._rollback_partial_environment(
+            MagicMock(), TEST_SETTINGS, TEST_TEAM, "feature"
+        )
+
+        mock_release_port.assert_called_once_with(
+            TEST_TEAM.port_registry_path, "feature"
+        )
+        mock_cleanup.assert_called_once()
 
 
 class TestDeleteEnvironment:


### PR DESCRIPTION
## Problem

`create_environment` reported success even when auto-install never happened. Both failure paths — the serving Odoo registry missing its 120-second readiness deadline, and a non-zero `odoo -i` exit — only appended a `[AUTO-INSTALL] ... FAILED` line to `setup_logs`.

The environment then survived in a state the caller did not ask for: requested modules missing, and — because sanitization still ran against the pre-install module set — without the `data/neutralize.sql`, crons, payment providers and connector credentials those modules ship. The readiness probe also discarded its last error, so a timeout left nothing to diagnose from.

## Change

- Required post-start setup moved into `_configure_serving_environment`, which raises instead of logging. A failure stops **before** sanitization and rolls the new environment back via `_rollback_partial_environment` (which also releases the allocated port).
- A final database-bound registry check runs after the post-sanitization restart, so creation returns only once the serving process has reloaded the installed modules.
- The readiness probe keeps its last error, logs progress every 30 seconds, and the resulting `PrerequisiteNotMetError` carries a bounded tail of the Odoo container logs — diagnosable after the rollback removed the container.
- An exit-code-0 install is verified against `ir_module_module` through the existing `_require_installed_modules` check.
- Module names are validated at the top of `_create_environment_impl`. This closes the argument-injection hole in the `odoo -i <modules>` command string, and rejects a typo before the clone, template restore, container start and dependency installs that the rollback would otherwise discard.

## Notes

Rollback is safe for pre-existing state: `_create_environment_impl` refuses when the target environment already exists, so only resources created by this call are torn down. `apt`/`pip` dependency installs stay best-effort and non-fatal, as before.

## Testing

- `pytest -m "not integration and not heavyweight"` — 2499 passed
- `ruff check`, `ruff format --check`, `mypy src/oduflow` — clean

New coverage: rollback on required-setup failure, install-command failure is fatal, readiness failure carries probe error plus container logs, setup stops before sanitization, the successful order `install → neutralize → sanitize → restart → wait`, and early module-name rejection before `containers.run`.