### PR TITLE
Skip Markdown-only pulls and return the existing environment on create

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -23,6 +23,16 @@ oduflow call create_environment '{"branch":"feature-login","template_name":"mypr
 
 `env_vars` are added on top of the database connection variables (`HOST`/`USER`/`PASSWORD`). They are stored on the container and can later be replaced with [`update_environment`](#lifecycle-management).
 
+Creating an environment that already exists is not an error over MCP: the call
+returns that environment's URL and details right away, starts it when it was
+stopped, and provisions nothing. So an agent can call `create_environment`
+first, with no `list_environments` lookup before it. The one refusal is a
+**branch mismatch** — an existing environment tracking another branch is left
+alone, because its database and URL are in use; move it deliberately with
+[`switch_branch`](#reusing-an-environment-for-the-next-branch), pick another
+`env_name`, or delete it. The dashboard and the REST API keep the strict
+behaviour and report the conflict instead.
+
 In Traefik mode, a team with `environment_slots = N` numbers the first label of
 its hostname. For `dev.example.com`, the reusable pool is `dev1.example.com`
 through `devN.example.com`. The assignment survives stops and container updates
@@ -187,7 +197,13 @@ oduflow call delete_environment feature-login
 
 An environment is not tied for life to the branch it was created from. When a
 branch is finished — PR merged, worktree gone — point the same environment at the
-next branch instead of deleting it and provisioning a new one:
+next branch instead of deleting it and provisioning a new one.
+
+This is the answer to a **full slot pool**, not the default way to start a task.
+While the team still has free `environment_slots`, create a new environment; it
+costs a clone and a template copy and keeps the branches independent. Reuse when
+`create_environment` reports "No free environment slots", or when that specific
+database and URL are worth carrying over:
 
 ```bash
 # Same environment, next branch. The branch must already exist on origin.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -374,12 +374,13 @@ After `git pull --rebase`, Oduflow compares `HEAD` before and after, then classi
 | `i18n/*.po` | Translation terms, loaded into the database on upgrade | **Upgrade** the module |
 | `*.xml` (not in security/) | Views, actions, data | **Refresh** (hot-reloaded via `--dev=xml`) |
 | `*.js` | Frontend assets | **Refresh** (hot-reloaded via `--dev=xml`) |
+| `*.md` (nothing else changed) | Documentation, never loaded by Odoo | **None** — nothing is applied |
 
 ### Action priority
 
-`install` > `upgrade` > `restart` > `refresh`
+`install` > `upgrade` > `restart` > `refresh` > `none`
 
-If any module needs installation, all pending upgrades are also executed. If only Python files changed (without field modifications), a container restart is sufficient. If only XML/JS changed, no server-side action is needed — just refresh the browser.
+If any module needs installation, all pending upgrades are also executed. If only Python files changed (without field modifications), a container restart is sufficient. If only XML/JS changed, no server-side action is needed — just refresh the browser. If the pull brought Markdown files only, nothing is applied at all — in development and in production alike, since the container is not restarted either.
 
 !!! note
     `pull_and_apply` updates only the **main project repository**. Extra addons repositories are pinned to the commit they were deployed with and are not affected. See [Extra Addons — Updating](extra-addons.md#updating-extra-repos) for details.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1939,12 +1939,13 @@ After `git pull --rebase`, Oduflow compares `HEAD` before and after, then classi
 | `i18n/*.po` | Translation terms, loaded into the database on upgrade | **Upgrade** the module |
 | `*.xml` (not in security/) | Views, actions, data | **Refresh** (hot-reloaded via `--dev=xml`) |
 | `*.js` | Frontend assets | **Refresh** (hot-reloaded via `--dev=xml`) |
+| `*.md` (nothing else changed) | Documentation, never loaded by Odoo | **None** — nothing is applied |
 
 ### Action priority
 
-`install` > `upgrade` > `restart` > `refresh`
+`install` > `upgrade` > `restart` > `refresh` > `none`
 
-If any module needs installation, all pending upgrades are also executed. If only Python files changed (without field modifications), a container restart is sufficient. If only XML/JS changed, no server-side action is needed — just refresh the browser.
+If any module needs installation, all pending upgrades are also executed. If only Python files changed (without field modifications), a container restart is sufficient. If only XML/JS changed, no server-side action is needed — just refresh the browser. If the pull brought Markdown files only, nothing is applied at all — in development and in production alike, since the container is not restarted either.
 
 !!! note
     `pull_and_apply` updates only the **main project repository**. Extra addons repositories are pinned to the commit they were deployed with and are not affected. See [Extra Addons — Updating](extra-addons.md#updating-extra-repos) for details.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1588,6 +1588,16 @@ oduflow call create_environment '{"branch":"feature-login","template_name":"mypr
 
 `env_vars` are added on top of the database connection variables (`HOST`/`USER`/`PASSWORD`). They are stored on the container and can later be replaced with [`update_environment`](#lifecycle-management).
 
+Creating an environment that already exists is not an error over MCP: the call
+returns that environment's URL and details right away, starts it when it was
+stopped, and provisions nothing. So an agent can call `create_environment`
+first, with no `list_environments` lookup before it. The one refusal is a
+**branch mismatch** — an existing environment tracking another branch is left
+alone, because its database and URL are in use; move it deliberately with
+[`switch_branch`](#reusing-an-environment-for-the-next-branch), pick another
+`env_name`, or delete it. The dashboard and the REST API keep the strict
+behaviour and report the conflict instead.
+
 In Traefik mode, a team with `environment_slots = N` numbers the first label of
 its hostname. For `dev.example.com`, the reusable pool is `dev1.example.com`
 through `devN.example.com`. The assignment survives stops and container updates
@@ -1752,7 +1762,13 @@ oduflow call delete_environment feature-login
 
 An environment is not tied for life to the branch it was created from. When a
 branch is finished — PR merged, worktree gone — point the same environment at the
-next branch instead of deleting it and provisioning a new one:
+next branch instead of deleting it and provisioning a new one.
+
+This is the answer to a **full slot pool**, not the default way to start a task.
+While the team still has free `environment_slots`, create a new environment; it
+costs a clone and a template copy and keeps the branches independent. Reuse when
+`create_environment` reports "No free environment slots", or when that specific
+database and URL are worth carrying over:
 
 ```bash
 # Same environment, next branch. The branch must already exist on origin.
@@ -3171,7 +3187,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); an environment that already exists is returned as is (started if stopped) instead of raising, unless it tracks another branch; optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
@@ -3179,7 +3195,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
-| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
+| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — the way to work when the team is out of environment slots; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -7,7 +7,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | Tool | Lock | Description |
 |---|:---:|---|
 | **Environment Management** | | |
-| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
+| `create_environment` | ✓ | Provision an Odoo environment for a branch (clone, DB, container, filestore); an environment that already exists is returned as is (started if stopped) instead of raising, unless it tracks another branch; optional `hostname` selects a short Traefik hostname and `env_vars` injects container environment variables |
 | `delete_environment` | ✓ | Tear down all resources for a branch |
 | `list_environments` | | List all managed environments with status and URLs |
 | `get_environment_info` | | Full environment details: DB name, URL, repo, image, template, extra addons, workspace, container status, CPU/RAM stats |
@@ -15,7 +15,7 @@ All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI 
 | `stop_environment` | | Stop a running environment |
 | `restart_environment` | | Restart the Odoo container |
 | `update_environment` | ✓ | Re-create the container, preserving DB and filestore; optional `odoo_image` switches the image and `env_vars` replaces the container environment variables |
-| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — reuse instead of delete-and-create; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
+| `switch_branch` | ✓ | Point an existing environment at another branch and apply the difference, keeping its database, filestore, hostname and URL — the way to work when the team is out of environment slots; optional `new_name` renames the environment in the same operation (its scoped MCP endpoint moves with the name) |
 | **Odoo Operations** | | |
 | `pull_and_apply` | ✓ | Git pull + smart analysis → auto install/upgrade/restart |
 | `install_odoo_modules` | ✓ | Install Odoo modules (`-i`) |

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -3008,6 +3008,7 @@ def _apply_actions(
     to_upgrade: list[str],
     do_restart: bool,
     changed_files: list[str],
+    do_refresh: bool = False,
     config_changed: bool = False,
     deps_changed: bool = False,
     repo_path: str = "",
@@ -3101,7 +3102,7 @@ def _apply_actions(
             "exit_code": dep_exit,
         }
 
-    if changed_files:
+    if do_refresh:
         return {
             "action": "refresh",
             "changed_files": changed_files,
@@ -3110,7 +3111,15 @@ def _apply_actions(
                 "(--dev=xml is active)."
             ),
         }
-    return {"action": "none", "message": "No changes detected."}
+    return {
+        "action": "none",
+        "changed_files": changed_files,
+        "message": (
+            "Only Markdown files changed. No Odoo action required."
+            if changed_files
+            else "No changes detected."
+        ),
+    }
 
 
 def pull_environment(
@@ -3304,6 +3313,7 @@ def pull_environment(
     deps_changed = any(_is_active_dep_file(f, repo_path) for f in main_changed_files)
 
     warnings: list[str] = []
+    do_refresh = False
     if explicit:
         to_install = list(install or [])
         to_upgrade = list(upgrade or [])
@@ -3355,6 +3365,7 @@ def pull_environment(
         to_install = list(recommended.get("modules_to_install", []))
         to_upgrade = list(recommended.get("modules_to_upgrade", []))
         do_restart = recommended.get("action") == "restart"
+        do_refresh = recommended.get("action") == "refresh"
 
     # --- 3. Switch immutable mounts, then execute ---
     # Do this only after strict guardrails have accepted the requested action.
@@ -3381,6 +3392,7 @@ def pull_environment(
         to_install=to_install,
         to_upgrade=to_upgrade,
         do_restart=do_restart,
+        do_refresh=do_refresh,
         changed_files=all_changed,
         config_changed=config_changed,
         deps_changed=deps_changed,

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1078,6 +1078,80 @@ def build_env_traefik_labels(
     return labels
 
 
+def adopt_existing_environment(
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    *,
+    branch: str = "",
+) -> dict[str, Any] | None:
+    """Describe an environment that already exists, starting it when stopped.
+
+    The agent-facing create path calls this first, so asking for an environment
+    that is already provisioned is a fast successful answer ("here is its URL")
+    instead of an error the agent has to recover from — no `list_environments`
+    round-trip needed before every create.
+
+    Returns ``None`` when nothing is provisioned under *env_name*, so the caller
+    goes on to create it for real. A **different git branch is never adopted**:
+    the database, the URL and the running code are shared state, and moving them
+    onto another branch is a decision for the person driving the task
+    (``switch_branch``), not a side effect of a create call.
+    """
+    try:
+        client = get_client()
+    except PrerequisiteNotMetError:
+        # This lookup is an optimisation, not the place to report a dead Docker
+        # daemon — the creation path right after it says that properly.
+        return None
+    odoo_container_name = get_resource_name(
+        env_name, "odoo", settings.prefix, team.team_id
+    )
+    try:
+        container = client.containers.get(odoo_container_name)
+    except docker.errors.NotFound:
+        return None
+    _assert_team_owns(container, settings, team, env_name)
+
+    labels = container.labels
+    current_branch = labels.get("oduflow.git_branch", env_name)
+    if branch and branch != current_branch:
+        raise ConflictError(
+            f"Environment '{env_name}' already exists and tracks branch "
+            f"'{current_branch}', not '{branch}'. Move it with switch_branch "
+            f"(env_name='{env_name}', branch='{branch}'), which keeps its "
+            "database and URL, or delete it first if you want a fresh one."
+        )
+
+    started = container.status != "running"
+    if started:
+        start_environment(settings, env_name, team)
+        container.reload()
+
+    if settings.routing_mode == "traefik":
+        url = f"https://{get_env_hostname(env_name, team.hostname, labels.get(ENV_HOSTNAME_LABEL, ''))}"
+    else:
+        ports = container.ports.get("8069/tcp")
+        url = f"http://{team.hostname}:{ports[0]['HostPort']}" if ports else ""
+
+    return {
+        "env_name": env_name,
+        "url": url,
+        "git_branch": current_branch,
+        "odoo_image": labels.get(settings.image_label, ""),
+        "template_name": labels.get("oduflow.template", "none"),
+        "hostname": get_env_short_hostname(
+            env_name, labels.get(ENV_HOSTNAME_LABEL, "")
+        ),
+        "odoo_container": odoo_container_name,
+        "database": get_db_name(env_name, team.team_id),
+        "workspace": get_workspace_path(env_name, team.workspaces_dir),
+        "local_path": labels.get("oduflow.local_path", ""),
+        "status": container.status,
+        "started": started,
+    }
+
+
 def create_environment(
     settings: Settings,
     team: TeamSettings,

--- a/src/oduflow/docker_ops/production_ops.py
+++ b/src/oduflow/docker_ops/production_ops.py
@@ -942,7 +942,9 @@ def update_production(
     (:func:`env_ops.pull_environment`), with production semantics on top:
 
     - ``refresh`` is promoted to ``restart`` (no ``--dev=xml`` in prod —
-      any changed file requires at least a container restart);
+      any changed file Odoo loads requires at least a container restart).
+      A ``none`` outcome (Markdown-only changes) is left alone: there is
+      nothing for the server to pick up;
     - the deploy is verified (module exit codes + in-container health
       poll); on failure the checkout (and extra worktrees) are reset to
       the pre-update commits, the conf is re-applied and the container

--- a/src/oduflow/git_analysis.py
+++ b/src/oduflow/git_analysis.py
@@ -178,6 +178,10 @@ def _is_translation_file(file_path: str) -> bool:
     return os.path.splitext(file_path)[1].lower() == ".po"
 
 
+def _is_markdown_file(file_path: str) -> bool:
+    return os.path.splitext(file_path)[1].lower() == ".md"
+
+
 def _is_active_dep_file(file_path: str, repo_path: str) -> bool:
     """Whether a changed dependency file is the one Oduflow actually reads."""
     normalized = file_path.replace(os.sep, "/")
@@ -215,6 +219,15 @@ def classify_changes(
 
     if not changed_files:
         _trace("classify_changes: no changed files -> action=none")
+        return {
+            "action": "none",
+            "modules_to_upgrade": [],
+            "modules_to_install": [],
+            "details": {},
+        }
+
+    if all(_is_markdown_file(f) for f in changed_files):
+        _trace("classify_changes: only Markdown files changed -> action=none")
         return {
             "action": "none",
             "modules_to_upgrade": [],
@@ -437,6 +450,14 @@ def shallow_classify(changed_files: list[str], repo_path: str = "") -> dict[str,
     ``__manifest__.py`` is treated as *upgrade*). Returns the same dict shape.
     """
     if not changed_files:
+        return {
+            "action": "none",
+            "modules_to_upgrade": [],
+            "modules_to_install": [],
+            "details": {},
+        }
+
+    if all(_is_markdown_file(f) for f in changed_files):
         return {
             "action": "none",
             "modules_to_upgrade": [],

--- a/src/oduflow/hostname_registry.py
+++ b/src/oduflow/hostname_registry.py
@@ -99,7 +99,8 @@ def allocate_hostname(
         if slot_count > 0 and len(occupied_envs) >= slot_count:
             raise FlowError(
                 f"No free environment slots (configured: {slot_count}). "
-                "Delete an unused environment to free a slot."
+                "Move a finished environment onto your branch with "
+                "switch_branch, or delete an unused one to free a slot."
             )
 
         occupied_hostnames = {
@@ -137,7 +138,8 @@ def allocate_hostname(
     raise FlowError(
         f"No free environment hostnames in {hostname_prefix}1-"
         f"{hostname_prefix}{slot_count}. "
-        "Delete an unused environment to free a slot."
+        "Move a finished environment onto your branch with switch_branch, or "
+        "delete an unused one to free a slot."
     )
 
 

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -583,6 +583,73 @@ def _parse_extra_addons(raw: str) -> dict[str, str]:
     return result
 
 
+def _odoo_guide_reminder(odoo_image: str) -> str:
+    """The "load the version guide before writing code" line, if the image says
+    which Odoo version this is."""
+    import re
+
+    match = re.search(r"odoo[:/](\d+)(?:\.0)?", odoo_image)
+    if not match:
+        return ""
+    version = match.group(1)
+    return (
+        f"\n⚠️ Immediately call "
+        f'get_odoo_development_guide(version="{version}") to load Odoo {version} '
+        "development standards and constraints. Do not wait for the user to ask "
+        "— these guidelines must be loaded before writing any code."
+    )
+
+
+def _existing_environment_message(
+    existing: dict[str, Any],
+    *,
+    requested_image: str,
+    requested_template: str,
+) -> str:
+    """Report an environment that create_environment found already provisioned."""
+    lines = [
+        "Environment already exists — reusing it. Nothing was recreated.",
+        f"Environment: {existing['env_name']}",
+        f"URL: {existing['url']}",
+        f"Git Branch: {existing['git_branch']}",
+        f"Hostname: {existing['hostname']}",
+        f"Odoo Container: {existing['odoo_container']}",
+        f"Database: {existing['database']}",
+        f"Workspace: {existing['workspace']}",
+        f"Odoo Image: {existing['odoo_image']}",
+        f"Template: {existing['template_name']}",
+    ]
+    if existing.get("local_path"):
+        lines.append(
+            f"Live-mount: {existing['local_path']} "
+            "(edit files directly; call pull_and_apply to apply)"
+        )
+    if existing.get("started"):
+        lines.append("It was stopped and has been started for you.")
+    if requested_image and requested_image != existing["odoo_image"]:
+        lines.append(
+            f"Note: you asked for image '{requested_image}', but this "
+            f"environment runs '{existing['odoo_image']}'. Change it with "
+            "update_environment, or delete and create it again."
+        )
+    if (
+        requested_template
+        and requested_template.lower() != "none"
+        and requested_template != existing["template_name"]
+    ):
+        lines.append(
+            f"Note: you asked for template '{requested_template}', but this "
+            f"environment was created from '{existing['template_name']}'. Its "
+            "database is the one that already exists; delete and create the "
+            "environment again to start from another template."
+        )
+    lines.append("Apply your code with pull_and_apply.")
+    reminder = _odoo_guide_reminder(existing["odoo_image"])
+    if reminder:
+        lines.append(reminder)
+    return "\n".join(lines)
+
+
 # =============================================================================
 # MCP Tools — Environments
 # =============================================================================
@@ -607,6 +674,14 @@ def create_environment(
     """
     Provision a new ephemeral Odoo environment.
 
+    Safe to call first, without listing environments: if one already exists
+    under this name it is returned as is — with its URL, and started when it
+    was stopped — and nothing is recreated. The single refusal is a branch
+    mismatch: an environment tracking another branch is left alone, since its
+    database and URL are in use. Move it with switch_branch, pass a different
+    env_name, or delete it first. When the team runs out of environment slots,
+    switch_branch onto a finished (merged) environment is the way forward.
+
     Args:
         branch: The git branch to clone (e.g. "19.0", "feature/my-feature").
         env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="19.0").
@@ -629,6 +704,19 @@ def create_environment(
     team = _resolve_team(ctx)
     _locks.acquire_env(resolved_env_name, team.team_id, operation="create_environment")
     try:
+        # Creating an environment that already exists is not a mistake worth an
+        # error: the agent wanted one for this branch and there is one. Answer
+        # with its URL before doing any of the expensive work below, so calling
+        # create first — without a list_environments round-trip — is the cheap,
+        # correct default. A branch mismatch still raises (see the helper).
+        existing = env_ops.adopt_existing_environment(
+            settings, team, resolved_env_name, branch=branch
+        )
+        if existing is not None:
+            return _existing_environment_message(
+                existing, requested_image=odoo_image, requested_template=template_name
+            )
+
         resolved_template: str | None
         if not template_name or template_name.lower() == "none":
             resolved_template = None
@@ -788,14 +876,9 @@ def create_environment(
         if setup_logs:
             lines.append("\n--- Setup Log ---")
             lines.extend(setup_logs)
-        import re
-
-        _ver_match = re.search(r"odoo[:/](\d+)(?:\.0)?", effective_odoo_image)
-        if _ver_match:
-            _odoo_ver = _ver_match.group(1)
-            lines.append(
-                f'\n⚠️ After creating an environment, immediately call get_odoo_development_guide(version="{_odoo_ver}") to load Odoo {_odoo_ver} development standards and constraints. Do not wait for the user to ask — these guidelines must be loaded before writing any code.'
-            )
+        reminder = _odoo_guide_reminder(effective_odoo_image)
+        if reminder:
+            lines.append(reminder)
         return "\n".join(lines)
     finally:
         _locks.release_env(resolved_env_name)
@@ -1812,14 +1895,15 @@ def switch_branch(
     ctx: Context | None = None,
 ) -> str:
     """
-    Move an existing environment onto another git branch — reuse it instead of
-    creating a new one.
+    Move an existing environment onto another git branch.
 
     Everything except the code stays: the database, filestore, URL / hostname,
-    ports, database credentials and the scoped MCP token. Use this at the start
-    of a task when a previous branch is finished (merged) — it replaces "delete
-    the old environment, create a fresh one", which re-clones the repository and
-    re-copies the template database.
+    ports, database credentials and the scoped MCP token. Reach for this when
+    the team has no free environment slots left and a previous branch is
+    finished (merged), or when that database and URL are worth keeping — it
+    replaces "delete the old environment, create a fresh one", which re-clones
+    the repository and re-copies the template database. With slots still free,
+    create_environment is the simpler path.
 
     The branch must already exist on origin, so push it first. Oduflow then
     diffs the old and new tips and applies exactly the logic of pull_and_apply:

--- a/src/oduflow/templates/agent_guides/agent_instructions.md
+++ b/src/oduflow/templates/agent_guides/agent_instructions.md
@@ -1,5 +1,5 @@
 # Oduflow — Agentic Odoo Development
-Version: 6
+Version: 7
 
 ## Purpose
 
@@ -20,9 +20,10 @@ version (15–19).
   directly; no push is required. Git commits are optional and do not control
   what Oduflow applies.
 
-Use `list_environments` before creating anything. Reuse the environment for
-the current branch when it exists. If none exists, prepare the selected
-delivery mode before calling `create_environment`:
+Call `create_environment` first, without looking anything up: if an environment
+with that name already exists, the call returns its URL immediately, starts it
+when it was stopped, and creates nothing. Prepare the selected delivery mode
+before that call:
 
 - **`repo_url`: first run `git push -u origin HEAD`** so the current branch
   exists in the remote repository, then create the environment. Oduflow can
@@ -37,11 +38,11 @@ Call `create_environment` with the branch, correct Odoo image, and either
 ## Core workflow
 
 ```text
-1. list_environments
-2. if an existing environment's branch is finished (merged), reuse it:
-   git push -u origin HEAD, then switch_branch to your branch;
-   otherwise create_environment (repo_url must be pushed first;
-   local_path needs no push)
+1. create_environment for your branch (repo_url must be pushed first;
+   local_path needs no push). An environment that already exists is
+   returned as is, so this is safe to call first
+2. if the team is out of environment slots, take a finished (merged)
+   environment instead: git push -u origin HEAD, then switch_branch
 3. get_odoo_development_guide before module code changes
 4. edit code locally
 5. repo_url: commit + push; local_path: no delivery step
@@ -52,14 +53,20 @@ Call `create_environment` with the branch, correct Odoo image, and either
    nobody still needs the URL or its test data
 ```
 
-Prefer step 2's reuse over a new environment. `switch_branch` keeps the
-database, filestore, URL and scoped MCP endpoint and only changes the code, so
-it is much faster than provisioning — and the address you are already using
-stays valid. It applies the branch difference exactly like `pull_and_apply`. The
-target branch must exist on origin; live-mounted environments are rejected
-(switch the branch in the mounted checkout and call `pull_and_apply`). If the
-target branch does not carry a module installed in that database, the response
-warns; create a separate environment when that matters.
+Create a fresh environment while the team still has free slots — that is the
+normal path, and there is no need to hunt for an environment to take over.
+`create_environment` fails with "No free environment slots" when they run out;
+that is when step 2 applies. `switch_branch` keeps the database, filestore, URL
+and scoped MCP endpoint and only changes the code, and it applies the branch
+difference exactly like `pull_and_apply`. The target branch must exist on
+origin; live-mounted environments are rejected (switch the branch in the
+mounted checkout and call `pull_and_apply`). If the target branch does not
+carry a module installed in that database, the response warns.
+
+`create_environment` refuses an existing environment only when it tracks a
+different branch: that environment's database and URL are in use, so moving it
+is the user's call. Report the conflict and let them choose `switch_branch`, a
+different `env_name`, or deleting the old environment.
 
 The environment name is a slot label, not a description of the branch, so a
 mismatch is normal — no need to rename on every switch. When the user asks for

--- a/tests/test_git_analysis.py
+++ b/tests/test_git_analysis.py
@@ -100,6 +100,17 @@ class TestClassifyChanges:
         result = classify_changes([], "/tmp")
         assert result["action"] == "none"
 
+    def test_only_markdown_needs_no_action(self):
+        files = ["README.md", "docs/deployment.MD"]
+        result = classify_changes(files, "/tmp")
+        assert result["action"] == "none"
+        assert result["modules_to_upgrade"] == []
+
+    def test_markdown_does_not_hide_refresh_changes(self):
+        files = ["README.md", "sale/views/sale_order.xml"]
+        result = classify_changes(files, "/tmp")
+        assert result["action"] == "refresh"
+
     def test_only_xml_not_security(self):
         files = ["sale/views/sale_order.xml", "crm/views/crm_lead.xml"]
         result = classify_changes(files, "/tmp")
@@ -705,6 +716,11 @@ class TestExtractFieldLines:
 
 
 class TestShallowClassify:
+    def test_only_markdown_needs_no_action(self):
+        result = shallow_classify(["README.md", "docs/setup.MD"], "/tmp")
+        assert result["action"] == "none"
+        assert result["modules_to_upgrade"] == []
+
     def test_lone_requirements_txt_restart(self):
         result = shallow_classify(["requirements.txt"], "/tmp")
         assert result["action"] == "restart"

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -166,6 +166,76 @@ class TestDestroySystem:
         net.remove.assert_called_once()
 
 
+class TestAdoptExistingEnvironment:
+    """create_environment answers with the existing environment instead of an
+    error, so an agent can call it first without listing environments."""
+
+    @staticmethod
+    def _container(status="running", branch="main"):
+        container = MagicMock()
+        container.status = status
+        container.labels = {
+            "oduflow.git_branch": branch,
+            "oduflow.template": "myproject",
+            TEST_SETTINGS.image_label: "odoo:17.0",
+            TEST_SETTINGS.team_label: "1",
+        }
+        container.ports = {"8069/tcp": [{"HostPort": "50000"}]}
+        return container
+
+    def test_missing_environment_returns_none(self, mock_docker_client):
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nope")
+        assert (
+            env_ops.adopt_existing_environment(TEST_SETTINGS, TEST_TEAM, "main") is None
+        )
+
+    def test_running_environment_is_described(self, mock_docker_client):
+        mock_docker_client.containers.get.return_value = self._container()
+
+        result = env_ops.adopt_existing_environment(
+            TEST_SETTINGS, TEST_TEAM, "main", branch="main"
+        )
+
+        assert result is not None
+        assert result["url"] == "http://localhost:50000"
+        assert result["git_branch"] == "main"
+        assert result["odoo_image"] == "odoo:17.0"
+        assert result["template_name"] == "myproject"
+        assert result["started"] is False
+
+    @patch("oduflow.docker_ops.env_ops.start_environment")
+    def test_stopped_environment_is_started(self, mock_start, mock_docker_client):
+        mock_docker_client.containers.get.return_value = self._container(
+            status="exited"
+        )
+
+        result = env_ops.adopt_existing_environment(
+            TEST_SETTINGS, TEST_TEAM, "main", branch="main"
+        )
+
+        mock_start.assert_called_once_with(TEST_SETTINGS, "main", TEST_TEAM)
+        assert result is not None
+        assert result["started"] is True
+
+    def test_other_branch_is_refused(self, mock_docker_client):
+        mock_docker_client.containers.get.return_value = self._container(branch="main")
+
+        with pytest.raises(ConflictError, match="switch_branch"):
+            env_ops.adopt_existing_environment(
+                TEST_SETTINGS, TEST_TEAM, "main", branch="feature/x"
+            )
+
+    def test_unreachable_docker_defers_to_the_creation_path(self):
+        with patch(
+            "oduflow.docker_ops.env_ops.get_client",
+            side_effect=PrerequisiteNotMetError("no docker"),
+        ):
+            assert (
+                env_ops.adopt_existing_environment(TEST_SETTINGS, TEST_TEAM, "main")
+                is None
+            )
+
+
 class TestCreateEnvironment:
     @patch(
         "oduflow.extra_addons.generate_odoo_conf",

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -977,6 +977,28 @@ class TestPullEnvironmentLocalAndSharedExtraCheckouts:
         assert mock_apply.call_args.kwargs["do_restart"] is True
         assert env_ops._detect_local_changes(str(repo), "env", team)[1] == []
 
+    def test_git_markdown_only_needs_no_odoo_action(self, mock_docker_client, tmp_path):
+        team = TeamSettings(team_id="1", data_dir=str(tmp_path / "team"))
+        settings = Settings(teams={"1": team})
+        repo = tmp_path / "team" / "workspaces" / "env" / "repo"
+        repo.mkdir(parents=True)
+
+        container = MagicMock()
+        container.labels = {"oduflow.git_branch": "main"}
+        mock_docker_client.containers.get.return_value = container
+
+        with patch(
+            "oduflow.git_ops.pull_repo", return_value=("old-head", ["README.md"])
+        ):
+            result = env_ops.pull_environment(settings, team, "env")
+
+        assert result["action"] == "none"
+        assert result["changed_files"] == ["README.md"]
+        assert result["message"] == (
+            "Only Markdown files changed. No Odoo action required."
+        )
+        container.restart.assert_not_called()
+
     @patch("oduflow.docker_ops.env_ops._apply_actions")
     def test_local_requirements_change_passes_deps_changed(
         self, mock_apply, mock_docker_client, tmp_path
@@ -2695,6 +2717,7 @@ class TestApplyActionsDeps:
             to_upgrade=[],
             do_restart=False,
             changed_files=["sale/views/sale_order.xml"],
+            do_refresh=True,
             deps_changed=False,
             repo_path="/repo",
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -304,8 +304,12 @@ class TestImportTemplateFromOdoo:
 
 
 class TestCreateEnvironmentTool:
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_create(self, mock_create):
+    def test_create(self, mock_create, mock_adopt):
         mock_create.return_value = {
             "url": "http://localhost:50000",
             "odoo_container": "oduflow-main-odoo",
@@ -323,8 +327,12 @@ class TestCreateEnvironmentTool:
         assert "Database: oduflow_1_main" in result
         assert "Template: none (init from scratch)" in result
 
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_create_with_env_vars(self, mock_create):
+    def test_create_with_env_vars(self, mock_create, mock_adopt):
         mock_create.return_value = {
             "url": "http://localhost:50000",
             "odoo_container": "oduflow-main-odoo",
@@ -345,8 +353,12 @@ class TestCreateEnvironmentTool:
         }
         assert "Env vars: FOO=bar, BAZ=qux" in result
 
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_create_without_env_vars(self, mock_create):
+    def test_create_without_env_vars(self, mock_create, mock_adopt):
         mock_create.return_value = {
             "url": "http://localhost:50000",
             "odoo_container": "oduflow-main-odoo",
@@ -362,8 +374,12 @@ class TestCreateEnvironmentTool:
         )
         assert mock_create.call_args.kwargs["env_vars"] is None
 
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_create_with_short_hostname(self, mock_create):
+    def test_create_with_short_hostname(self, mock_create, mock_adopt):
         mock_create.return_value = {
             "url": "https://dev3.example.com",
             "hostname": "dev3",
@@ -383,6 +399,73 @@ class TestCreateEnvironmentTool:
 
         assert mock_create.call_args.kwargs["hostname"] == "dev3"
         assert "Hostname: dev3" in result
+
+
+class TestCreateEnvironmentAdoptsExisting:
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    @patch("oduflow.docker_ops.env_ops.adopt_existing_environment")
+    def test_existing_environment_is_returned_without_provisioning(
+        self, mock_adopt, mock_create
+    ):
+        mock_adopt.return_value = {
+            "env_name": "main",
+            "url": "https://dev1.example.com",
+            "git_branch": "main",
+            "odoo_image": "odoo:17.0",
+            "template_name": "myproject",
+            "hostname": "dev1",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+            "local_path": "",
+            "status": "exited",
+            "started": True,
+        }
+
+        result = _call_tool(
+            "create_environment",
+            branch="main",
+            template_name="myproject",
+            repo_url="https://8.8.8.8/repo.git",
+            odoo_image="odoo:17.0",
+        )
+
+        mock_create.assert_not_called()
+        assert "Environment already exists" in result
+        assert "URL: https://dev1.example.com" in result
+        assert "It was stopped and has been started for you." in result
+        assert 'get_odoo_development_guide(version="17")' in result
+
+    @patch("oduflow.docker_ops.env_ops.create_environment")
+    @patch("oduflow.docker_ops.env_ops.adopt_existing_environment")
+    def test_mismatched_image_and_template_are_reported(self, mock_adopt, mock_create):
+        mock_adopt.return_value = {
+            "env_name": "main",
+            "url": "https://dev1.example.com",
+            "git_branch": "main",
+            "odoo_image": "odoo:17.0",
+            "template_name": "myproject",
+            "hostname": "dev1",
+            "odoo_container": "oduflow-main-odoo",
+            "database": "oduflow_1_main",
+            "workspace": "/tmp/ws",
+            "local_path": "",
+            "status": "running",
+            "started": False,
+        }
+
+        result = _call_tool(
+            "create_environment",
+            branch="main",
+            template_name="other",
+            repo_url="https://8.8.8.8/repo.git",
+            odoo_image="odoo:18.0",
+        )
+
+        mock_create.assert_not_called()
+        assert "you asked for image 'odoo:18.0'" in result
+        assert "you asked for template 'other'" in result
+        assert "It was stopped" not in result
 
 
 class TestUpdateEnvironmentTool:
@@ -520,7 +603,7 @@ class TestAgentInstructionsTool:
 
         assert len(guide) < 16_000
         assert "Per-environment Odoo configuration" in guide
-        assert "Version: 6" in guide
+        assert "Version: 7" in guide
         assert "git push -u origin HEAD" in guide
         assert "cannot see a local-only branch" in guide
         assert "db_maxconn" in guide

--- a/tests/test_template_provenance.py
+++ b/tests/test_template_provenance.py
@@ -302,9 +302,13 @@ class TestTemplateCodeLineage:
 
 
 class TestCreateEnvironmentReportsLineage:
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
     def test_diverged_branch_is_reported_with_the_remedy(
-        self, mock_create, tool_env, tmp_path
+        self, mock_create, mock_adopt, tool_env, tmp_path
     ):
         settings, team = tool_env
         _write_template(
@@ -329,8 +333,14 @@ class TestCreateEnvironmentReportsLineage:
         assert "Code is behind the template database" in result
         assert "Merge prod into this branch" in result
 
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_aligned_branch_says_nothing(self, mock_create, tool_env, tmp_path):
+    def test_aligned_branch_says_nothing(
+        self, mock_create, mock_adopt, tool_env, tmp_path
+    ):
         settings, team = tool_env
         _write_template(
             team,
@@ -353,8 +363,14 @@ class TestCreateEnvironmentReportsLineage:
 
         assert "template database" not in result
 
+    @patch(
+        "oduflow.docker_ops.env_ops.adopt_existing_environment",
+        return_value=None,
+    )
     @patch("oduflow.docker_ops.env_ops.create_environment")
-    def test_ahead_branch_gets_the_upgrade_list(self, mock_create, tool_env, tmp_path):
+    def test_ahead_branch_gets_the_upgrade_list(
+        self, mock_create, mock_adopt, tool_env, tmp_path
+    ):
         settings, team = tool_env
         _write_template(
             team,


### PR DESCRIPTION
Two changes to how Oduflow reacts to an agent's routine calls.

## Markdown-only pulls apply nothing

A pull carrying documentation only used to be classified as `refresh` — harmless in development, but the production deploy engine promotes `refresh` to a container restart, so a docs commit bounced the Odoo container for nothing.

`classify_changes` and `shallow_classify` now return `action="none"` when every changed file is Markdown, and `_apply_actions` takes an explicit `do_refresh` flag instead of inferring `refresh` from a non-empty `changed_files` list. The `none` result keeps `changed_files`, so callers still report what was pulled.

## create_environment returns an environment that already exists

Agents were told to call `list_environments` before every create, because `create_environment` raised `ConflictError` when the environment existed. That round-trip bought nothing.

`create_environment` now answers with the existing environment — URL, database, image, template — starting it when it was stopped, and provisions nothing. The lookup runs under the env lock before any template metadata or repo validation, so the fast path stays fast; an unreachable Docker daemon is reported by the real creation path rather than by this optimisation. A branch mismatch is still refused: that database and URL are in use, so moving them is the user's decision (`switch_branch`). The dashboard and REST API keep the strict behaviour.

The agent guide drops "list_environments before creating anything" and "prefer reuse over a new environment". Reuse through `switch_branch` is now documented as the answer to an exhausted slot pool — which is also what the slot-exhaustion errors suggest.

## Notes

Docs and the classification table are updated, `docs/llms-full.txt` regenerated, and the bundled guide is at Version 9.

`tests/test_overlay_stale_mount.py::TestMountFilestoreClearsStale::test_forced_recovery_ignores_copy_metadata` fails on this machine, but it fails identically on a clean `origin/main` checkout — it is not caused by this branch. Everything else passes: 2574 tests, plus `ruff check`, `ruff format --check` and `mypy`.