### PR TITLE
Separate environment capacity from Traefik hostname policy

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,16 @@
 
 ### Fixes
 
+- **Environment limits no longer rewrite existing Traefik hostnames** —
+  `environment_slots` is now only a concurrency-safe team capacity limit and
+  applies in both port and Traefik modes. The new explicit
+  `environment_hostname_mode = "slots"` opt-in enables reusable `dev1`, `dev2`,
+  ... routes; the default `branch` mode preserves established addresses such as
+  `feature.dev.example.com`, including across `update_environment`. Explicit
+  custom hostnames remain stable. Environments that were automatically moved
+  to a numbered hostname by v1.69-v1.71 return to their branch-derived route on
+  their next update in branch mode, while their capacity reservation remains.
+
 - **A failed install is no longer masked by a later successful upgrade** — when
   a single `pull_and_apply` both installed and upgraded modules, the reported
   exit code was the last command's, so a broken install followed by a clean

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -14,7 +14,7 @@ oduflow call create_environment feature-login "" none https://github.com/owner/r
 # Create with JSON arguments (more explicit)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0"}'
 
-# Override the numbered Traefik prefix (dev.example.com -> qa.example.com)
+# Override the Traefik hostname prefix (dev.example.com -> qa.example.com)
 oduflow call create_environment '{"branch":"feature-login","hostname":"qa","template_name":"myproject"}'
 
 # Inject container environment variables (comma-separated KEY=VALUE)
@@ -33,13 +33,18 @@ alone, because its database and URL are in use; move it deliberately with
 `env_name`, or delete it. The dashboard and the REST API keep the strict
 behaviour and report the conflict instead.
 
-In Traefik mode, a team with `environment_slots = N` numbers the first label of
-its hostname. For `dev.example.com`, the reusable pool is `dev1.example.com`
-through `devN.example.com`. The assignment survives stops and container updates
-and is released only when the environment is deleted. Pass `hostname` to replace
-the numbered prefix: `hostname="qa"` produces `qa.example.com`. The default is
-20 concurrent environment slots; set `environment_slots = 0` to retain legacy
-branch-derived hostnames.
+`environment_slots = N` caps concurrent environments without changing their
+public names. The default Traefik strategy is
+`environment_hostname_mode = "branch"`, so `feature-login` remains available at
+`feature-login.dev.example.com` and continues to work with
+`*.dev.example.com` DNS or wildcard certificates.
+
+Set `environment_hostname_mode = "slots"` explicitly when Let's Encrypt
+certificate reuse is more important than descriptive URLs. For
+`hostname = "dev.example.com"`, that mode allocates `dev1.example.com` through
+`devN.example.com`; assignments survive stops and updates and return to the
+pool on deletion. Pass `hostname="qa"` to request `qa.example.com` in either
+mode. Explicit hostnames still consume environment capacity.
 
 When creating an environment, Oduflow:
 
@@ -242,9 +247,9 @@ with it, so the browser tab you have open keeps working. Two things to know:
 - **The scoped MCP endpoint moves too**, from `/mcp/dev1` to `/mcp/next-task`
   (the token itself is unchanged). Re-point any MCP client configured against
   the old path.
-- **Environments without a pooled hostname slot** — created before
-  `environment_slots` was configured, so their hostname is derived from their
-  name — get a new URL, since the hostname follows the name.
+- **Environments using branch-derived hostnames** get a new URL because the
+  hostname follows the environment name. Pooled and explicit hostnames remain
+  stable across the rename.
 
 The name must be free: a rename onto a name that already has an environment,
 workspace directory or database is refused before anything is touched.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -249,7 +249,8 @@ auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 di
 
 [team.1]
 hostname = "localhost"               # port mode: http://{hostname}:{port}, traefik mode: https://{slug}.{hostname}
-environment_slots = 20               # traefik: dev.example.com + N => dev1.example.com..devN.example.com; 0 = legacy hostnames
+environment_slots = 20               # maximum concurrent environments; 0 = unlimited
+environment_hostname_mode = "branch" # "branch": feature.dev.example.com; "slots": dev1.example.com..devN.example.com
 service_slots = 10                   # maximum managed auxiliary services; 0 = unlimited
 auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Bearer token
 ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
@@ -357,7 +358,8 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | Key | Default | Description |
 |---|---|---|
 | `hostname` | `localhost` | Team hostname. In port mode: `http://{hostname}:{port}`. In traefik mode: `https://{slug}.{hostname}` |
-| `environment_slots` | `20` | Traefik reusable hostname pool and concurrent environment cap. `0` keeps branch-derived hostnames; with `dev.example.com`, `N` allocates `dev1.example.com` through `devN.example.com` |
+| `environment_slots` | `20` | Maximum concurrent development environments for the team in port or Traefik mode. Stopped environments count; deleting one frees its reservation. `0` disables the cap |
+| `environment_hostname_mode` | `branch` | Traefik public hostname strategy. `branch` keeps environment-derived names such as `feature.dev.example.com`; `slots` reuses `dev1.example.com` through `devN.example.com` and requires `environment_slots > 0` |
 | `service_slots` | `10` | Maximum number of managed auxiliary services for the team. Stopped services count; deleting a service frees its slot. `0` disables the cap |
 | `auth_token` | *(generated in fresh config)* | Bearer token for MCP HTTP auth and OAuth client secret. Empty disables MCP auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
@@ -368,9 +370,11 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
 | `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
 
-`environment_slots > 0` requires a hostname with a distinct host prefix and
-parent domain, such as `dev.example.com`. A bare registrable domain such as
-`example.com` has no prefix to number and is rejected.
+`environment_hostname_mode = "slots"` requires Traefik and a hostname with a
+distinct host prefix and parent domain, such as `dev.example.com`. A bare
+registrable domain such as `example.com` has no prefix to number and is
+rejected. The default `branch` mode works with the existing
+`*.dev.example.com` DNS and wildcard-certificate layout.
 
 Team data is stored at `{data_dir}/team_{ID}/`:
 
@@ -380,7 +384,7 @@ team_{ID}/
 ├── templates/            # Reusable database snapshots
 ├── shared_repos/         # Extra addon repositories (bare clones)
 ├── ports.json            # Port registry
-├── hostnames.json        # Reusable Traefik hostname reservations
+├── hostnames.json        # Environment capacity reservations and optional reusable hostnames
 ├── .git-credentials      # Git credentials for this team
 └── agent_guides/         # AI agent guides (markdown)
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -806,7 +806,8 @@ auto_delete_hours = 0       # auto-delete environments stopped for N hours; 0 di
 
 [team.1]
 hostname = "localhost"               # port mode: http://{hostname}:{port}, traefik mode: https://{slug}.{hostname}
-environment_slots = 20               # traefik: dev.example.com + N => dev1.example.com..devN.example.com; 0 = legacy hostnames
+environment_slots = 20               # maximum concurrent environments; 0 = unlimited
+environment_hostname_mode = "branch" # "branch": feature.dev.example.com; "slots": dev1.example.com..devN.example.com
 service_slots = 10                   # maximum managed auxiliary services; 0 = unlimited
 auth_token = ""                      # auto-filled in fresh configs; HTTP MCP Bearer token
 ui_password = ""                     # auto-filled in fresh configs; Web UI password for admin
@@ -914,7 +915,8 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | Key | Default | Description |
 |---|---|---|
 | `hostname` | `localhost` | Team hostname. In port mode: `http://{hostname}:{port}`. In traefik mode: `https://{slug}.{hostname}` |
-| `environment_slots` | `20` | Traefik reusable hostname pool and concurrent environment cap. `0` keeps branch-derived hostnames; with `dev.example.com`, `N` allocates `dev1.example.com` through `devN.example.com` |
+| `environment_slots` | `20` | Maximum concurrent development environments for the team in port or Traefik mode. Stopped environments count; deleting one frees its reservation. `0` disables the cap |
+| `environment_hostname_mode` | `branch` | Traefik public hostname strategy. `branch` keeps environment-derived names such as `feature.dev.example.com`; `slots` reuses `dev1.example.com` through `devN.example.com` and requires `environment_slots > 0` |
 | `service_slots` | `10` | Maximum number of managed auxiliary services for the team. Stopped services count; deleting a service frees its slot. `0` disables the cap |
 | `auth_token` | *(generated in fresh config)* | Bearer token for MCP HTTP auth and OAuth client secret. Empty disables MCP auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
 | `ui_password` | *(generated in fresh config)* | Password for Web UI login (user: `admin`). Separate from MCP auth token. Empty disables UI auth only when explicitly allowed with `[server].allow_insecure_http = true`; otherwise HTTP startup refuses it |
@@ -925,9 +927,11 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
 | `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
 
-`environment_slots > 0` requires a hostname with a distinct host prefix and
-parent domain, such as `dev.example.com`. A bare registrable domain such as
-`example.com` has no prefix to number and is rejected.
+`environment_hostname_mode = "slots"` requires Traefik and a hostname with a
+distinct host prefix and parent domain, such as `dev.example.com`. A bare
+registrable domain such as `example.com` has no prefix to number and is
+rejected. The default `branch` mode works with the existing
+`*.dev.example.com` DNS and wildcard-certificate layout.
 
 Team data is stored at `{data_dir}/team_{ID}/`:
 
@@ -937,7 +941,7 @@ team_{ID}/
 ├── templates/            # Reusable database snapshots
 ├── shared_repos/         # Extra addon repositories (bare clones)
 ├── ports.json            # Port registry
-├── hostnames.json        # Reusable Traefik hostname reservations
+├── hostnames.json        # Environment capacity reservations and optional reusable hostnames
 ├── .git-credentials      # Git credentials for this team
 └── agent_guides/         # AI agent guides (markdown)
 ```
@@ -1608,7 +1612,7 @@ oduflow call create_environment feature-login "" none https://github.com/owner/r
 # Create with JSON arguments (more explicit)
 oduflow call create_environment '{"branch":"feature-login","template_name":"myproject","repo_url":"https://github.com/owner/repo.git","odoo_image":"odoo:19.0"}'
 
-# Override the numbered Traefik prefix (dev.example.com -> qa.example.com)
+# Override the Traefik hostname prefix (dev.example.com -> qa.example.com)
 oduflow call create_environment '{"branch":"feature-login","hostname":"qa","template_name":"myproject"}'
 
 # Inject container environment variables (comma-separated KEY=VALUE)
@@ -1627,13 +1631,18 @@ alone, because its database and URL are in use; move it deliberately with
 `env_name`, or delete it. The dashboard and the REST API keep the strict
 behaviour and report the conflict instead.
 
-In Traefik mode, a team with `environment_slots = N` numbers the first label of
-its hostname. For `dev.example.com`, the reusable pool is `dev1.example.com`
-through `devN.example.com`. The assignment survives stops and container updates
-and is released only when the environment is deleted. Pass `hostname` to replace
-the numbered prefix: `hostname="qa"` produces `qa.example.com`. The default is
-20 concurrent environment slots; set `environment_slots = 0` to retain legacy
-branch-derived hostnames.
+`environment_slots = N` caps concurrent environments without changing their
+public names. The default Traefik strategy is
+`environment_hostname_mode = "branch"`, so `feature-login` remains available at
+`feature-login.dev.example.com` and continues to work with
+`*.dev.example.com` DNS or wildcard certificates.
+
+Set `environment_hostname_mode = "slots"` explicitly when Let's Encrypt
+certificate reuse is more important than descriptive URLs. For
+`hostname = "dev.example.com"`, that mode allocates `dev1.example.com` through
+`devN.example.com`; assignments survive stops and updates and return to the
+pool on deletion. Pass `hostname="qa"` to request `qa.example.com` in either
+mode. Explicit hostnames still consume environment capacity.
 
 When creating an environment, Oduflow:
 
@@ -1836,9 +1845,9 @@ with it, so the browser tab you have open keeps working. Two things to know:
 - **The scoped MCP endpoint moves too**, from `/mcp/dev1` to `/mcp/next-task`
   (the token itself is unchanged). Re-point any MCP client configured against
   the old path.
-- **Environments without a pooled hostname slot** — created before
-  `environment_slots` was configured, so their hostname is derived from their
-  name — get a new URL, since the hostname follows the name.
+- **Environments using branch-derived hostnames** get a new URL because the
+  hostname follows the environment name. Pooled and explicit hostnames remain
+  stable across the rename.
 
 The name must be free: a rename onto a name that already has an environment,
 workspace directory or database is refused before anything is touched.
@@ -3603,29 +3612,44 @@ For production-like access with HTTPS, Oduflow can deploy a **Traefik** reverse 
    [team.1]
    hostname = "dev.example.com"
    environment_slots = 20
+   environment_hostname_mode = "branch"
    ```
 
 3. **Start (or restart) Oduflow.** On startup, Oduflow will create a Traefik v3 container that:
    - Listens on ports 80 and 443
    - Automatically redirects HTTP to HTTPS
-   - Obtains a separate TLS certificate from Let's Encrypt for each reusable environment hostname via HTTP-01 challenge
+   - Obtains a TLS certificate from Let's Encrypt for each routed hostname via HTTP-01 challenge
    - Routes requests to the correct Odoo container based on the subdomain
    - Also routes the Oduflow server itself via the team `hostname`
 
-## How certificates work
+## Hostname and certificate strategies
 
-With `hostname = "dev.example.com"` and `environment_slots = 20`, Oduflow
-allocates `dev1.example.com` through `dev20.example.com`: it removes the first
-hostname label, adds the slot number to it, and keeps the parent domain.
-Deleting an environment returns its hostname to the pool, so later environments
-reuse the same certificates from Traefik's persistent ACME store instead of
-continuously issuing certificates for branch names.
-`create_environment(hostname="qa")` requests `qa.example.com`. Set
-`environment_slots = 0` to retain the legacy branch-derived hostname behavior.
-The configured hostname must include a distinct prefix (`dev.example.com`, not
-bare `example.com`) so Oduflow has a label to number.
+The default `environment_hostname_mode = "branch"` keeps descriptive and
+backward-compatible routes: `feature-login.dev.example.com`,
+`fix-invoice.dev.example.com`, and so on. `environment_slots = 20` limits how
+many environments may exist but does not change those names. This mode matches
+the `*.dev.example.com` DNS record shown above and works with a Cloudflare or
+other wildcard certificate for `*.dev.example.com`.
 
-Wildcard certificates (`*.dev.example.com`) via DNS-01 validation are also possible but require additional Traefik configuration with a provider-specific plugin.
+For Traefik HTTP-01 installations that need to bound Let's Encrypt issuance,
+opt into a reusable pool:
+
+```toml
+[team.1]
+hostname = "dev.example.com"
+environment_slots = 20
+environment_hostname_mode = "slots"
+```
+
+Oduflow then allocates `dev1.example.com` through `dev20.example.com` and
+returns names to the pool on deletion. These names are one DNS level higher
+than branch-derived routes: configure individual `dev1`…`dev20` records or a
+wildcard record for `*.example.com`. A `*.dev.example.com` record or certificate
+does not cover `dev1.example.com`.
+
+`create_environment(hostname="qa")` requests `qa.example.com` in either mode.
+The configured team hostname must include a distinct prefix
+(`dev.example.com`, not bare `example.com`) for pooled or explicit short names.
 
 ## OAuth on each team's hostname
 

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -24,29 +24,44 @@ For production-like access with HTTPS, Oduflow can deploy a **Traefik** reverse 
    [team.1]
    hostname = "dev.example.com"
    environment_slots = 20
+   environment_hostname_mode = "branch"
    ```
 
 3. **Start (or restart) Oduflow.** On startup, Oduflow will create a Traefik v3 container that:
    - Listens on ports 80 and 443
    - Automatically redirects HTTP to HTTPS
-   - Obtains a separate TLS certificate from Let's Encrypt for each reusable environment hostname via HTTP-01 challenge
+   - Obtains a TLS certificate from Let's Encrypt for each routed hostname via HTTP-01 challenge
    - Routes requests to the correct Odoo container based on the subdomain
    - Also routes the Oduflow server itself via the team `hostname`
 
-## How certificates work
+## Hostname and certificate strategies
 
-With `hostname = "dev.example.com"` and `environment_slots = 20`, Oduflow
-allocates `dev1.example.com` through `dev20.example.com`: it removes the first
-hostname label, adds the slot number to it, and keeps the parent domain.
-Deleting an environment returns its hostname to the pool, so later environments
-reuse the same certificates from Traefik's persistent ACME store instead of
-continuously issuing certificates for branch names.
-`create_environment(hostname="qa")` requests `qa.example.com`. Set
-`environment_slots = 0` to retain the legacy branch-derived hostname behavior.
-The configured hostname must include a distinct prefix (`dev.example.com`, not
-bare `example.com`) so Oduflow has a label to number.
+The default `environment_hostname_mode = "branch"` keeps descriptive and
+backward-compatible routes: `feature-login.dev.example.com`,
+`fix-invoice.dev.example.com`, and so on. `environment_slots = 20` limits how
+many environments may exist but does not change those names. This mode matches
+the `*.dev.example.com` DNS record shown above and works with a Cloudflare or
+other wildcard certificate for `*.dev.example.com`.
 
-Wildcard certificates (`*.dev.example.com`) via DNS-01 validation are also possible but require additional Traefik configuration with a provider-specific plugin.
+For Traefik HTTP-01 installations that need to bound Let's Encrypt issuance,
+opt into a reusable pool:
+
+```toml
+[team.1]
+hostname = "dev.example.com"
+environment_slots = 20
+environment_hostname_mode = "slots"
+```
+
+Oduflow then allocates `dev1.example.com` through `dev20.example.com` and
+returns names to the pool on deletion. These names are one DNS level higher
+than branch-derived routes: configure individual `dev1`…`dev20` records or a
+wildcard record for `*.example.com`. A `*.dev.example.com` record or certificate
+does not cover `dev1.example.com`.
+
+`create_environment(hostname="qa")` requests `qa.example.com` in either mode.
+The configured team hostname must include a distinct prefix
+(`dev.example.com`, not bare `example.com`) for pooled or explicit short names.
 
 ## OAuth on each team's hostname
 

--- a/specs/0048-reusable-environment-hostname-slots.md
+++ b/specs/0048-reusable-environment-hostname-slots.md
@@ -20,25 +20,28 @@ identity. It does not need to be the public routing identity.
 
 ## Decision
 
-Make the public environment hostname an independently persisted, reusable team
-resource. A team can configure `environment_slots = N`; Oduflow then numbers
-the first label of the team hostname. For `dev.example.com`, the reusable pool
-is `dev1.example.com` through `devN.example.com` instead of unbounded
-branch-derived names.
+Treat environment capacity and public hostname allocation as independent team
+choices. `environment_slots = N` is a hard concurrent-environment cap in every
+routing mode. Public names remain branch-derived by default. A team explicitly
+configures `environment_hostname_mode = "slots"` when it wants Oduflow to
+number the first label of its hostname: for `dev.example.com`, the reusable
+pool is `dev1.example.com` through `devN.example.com`.
 
 `create_environment` also accepts an explicit short `hostname` that replaces
 the numbered prefix: `hostname="qa"` under `dev.example.com` produces
 `qa.example.com`. Explicit names are useful for controlled integrations but
 still consume one of the team's configured concurrent environment slots. The
-configured default is 20 slots; a zero slot count preserves the legacy
-branch-derived behavior for compatibility.
+configured default is 20 capacity slots with branch-derived hostnames; zero
+disables the capacity cap, while numbered hostname mode requires a positive
+limit.
 
 ## How it works (macro)
 
-- A per-team `hostnames.json` registry maps environment identity to its short
-  routing hostname. Read-modify-write operations use a thread mutex, process
-  `flock`, and atomic replacement, matching the concurrency requirements of the
-  persistent port registry.
+- A per-team `hostnames.json` registry reserves environment capacity and, when
+  requested, maps environment identity to its short routing hostname.
+  Read-modify-write operations use a thread mutex, process `flock`, and atomic
+  replacement, matching the concurrency requirements of the persistent port
+  registry.
 - Automatic allocation splits the team hostname into a reusable prefix and
   parent domain, then selects the first unused numbered prefix (`dev1`, `dev2`,
   ...). Active legacy environments and in-flight reservations both count toward
@@ -49,18 +52,19 @@ branch-derived behavior for compatibility.
   updates read that label instead of recomputing the route from the branch.
 - Stops and updates preserve the reservation. Deletion releases it. A failed
   create releases a reservation when no serving container was created.
-- Existing unlabeled environments keep their branch-derived hostname until an
-  update migrates them into the configured pool, avoiding a surprise URL change
-  merely from restarting the Oduflow server.
+- Existing unlabeled environments keep their branch-derived hostname across
+  restarts and updates. A persisted explicit hostname always wins. Numbered
+  assignments are created only in explicit slot mode.
 
 ## Consequences
 
 - Certificate cardinality is bounded by the configured numbered hostname pool
   during normal automatic operation; once the pool has been issued, later
   environments reuse the same Traefik ACME certificates.
-- Environment identity and public address are no longer the same concept. All
-  routing consumers must use the persisted hostname label, while database,
-  workspace and locking code continues to use the environment name.
+- In slot mode or with an explicit override, environment identity and public
+  address are separate concepts. Routing consumers use the persisted hostname
+  label when present; branch mode continues deriving the route from the
+  environment name.
 - A positive slot count is also a hard cap on concurrent development
   environments for the team. Capacity exhaustion is reported before
   provisioning starts.
@@ -68,8 +72,22 @@ branch-derived behavior for compatibility.
   time; that is an intentional operator override rather than the automatic
   lifecycle default.
 
+## Evolution
+
+The original v1.69 implementation overloaded `environment_slots`: any positive
+limit also enabled numbered hostnames, including for existing configurations
+that had never opted into a routing change. Updating an old container then
+rewrote `feature.dev.example.com` to `dev1.example.com`, which is outside a
+`*.dev.example.com` DNS or wildcard-certificate scope. In August 2026 the
+capacity limit was separated from the explicit hostname strategy. Branch mode
+became the compatibility-safe default, the cap was extended to port mode, and
+legacy automatic assignments became recoverable without disturbing explicit
+custom hostnames.
+
 ## History
 
 - `litnimax/reusable-hostname-slots` (2026-08-16) — reusable per-team hostname
   pool, explicit short hostname override, persisted routing identity and
   lifecycle integration.
+- `litnimax/review-hostname-limits` (2026-08-28) — separate capacity from
+  hostname policy and preserve existing wildcard-backed routes by default.

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -50,8 +50,12 @@ from oduflow.errors import (
 )
 from oduflow.git_ops import RepoAuthError, git_env_for_team
 from oduflow.hostname_registry import (
+    CAPACITY_RESERVATION,
     allocate_hostname,
+    clear_hostname_assignment,
+    get_hostname,
     release_hostname,
+    reserve_environment_slot,
 )
 from oduflow.hostname_registry import rename_env as rename_hostname_env
 from oduflow.locking import env_wake_key, keyed_mutex
@@ -85,6 +89,9 @@ logger = logging.getLogger("oduflow")
 AGENT_USER = "agent"
 AGENT_HOME = "/home/agent"
 ENV_HOSTNAME_LABEL = "oduflow.hostname"
+ENV_HOSTNAME_SOURCE_LABEL = "oduflow.hostname_source"
+HOSTNAME_SOURCE_CUSTOM = "custom"
+HOSTNAME_SOURCE_SLOT = "slot"
 
 
 def _hostname_registry_path(team: TeamSettings) -> str:
@@ -226,6 +233,27 @@ def _get_used_ports(
     return used
 
 
+def _active_environment_names(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    *,
+    exclude_env: str = "",
+) -> set[str]:
+    active_envs: set[str] = set()
+    filters = {
+        "label": [
+            f"{settings.managed_label}=true",
+            f"{settings.team_label}={team.team_id}",
+        ]
+    }
+    for container in client.containers.list(all=True, filters=filters):
+        env_name = container.labels.get(settings.branch_label, "")
+        if env_name and env_name != exclude_env:
+            active_envs.add(env_name)
+    return active_envs
+
+
 def _environment_hostname_usage(
     client: DockerClient,
     settings: Settings,
@@ -233,7 +261,12 @@ def _environment_hostname_usage(
     *,
     exclude_env: str = "",
 ) -> tuple[set[str], set[str]]:
-    """Return active environment names and their short routing hostnames."""
+    """Return active environment names and their short routing hostnames.
+
+    Both sets come from one container listing: allocation runs on every create
+    and update, so a second pass over the same containers would only double the
+    Docker round trips.
+    """
     active_envs: set[str] = set()
     used_hostnames: set[str] = set()
     _hostname_prefix, parent_domain = split_team_hostname(team.hostname)
@@ -260,15 +293,87 @@ def _environment_hostname_usage(
             for fqdn in re.findall(r"Host\(`([^`]+)`\)", value):
                 if fqdn.endswith(suffix):
                     used_hostnames.add(fqdn[: -len(suffix)])
-        if not env_name:
-            continue
-        active_envs.add(env_name)
-        used_hostnames.add(
-            get_env_short_hostname(
-                env_name, container.labels.get(ENV_HOSTNAME_LABEL, "")
+        if env_name:
+            active_envs.add(env_name)
+            used_hostnames.add(
+                get_env_short_hostname(
+                    env_name, container.labels.get(ENV_HOSTNAME_LABEL, "")
+                )
             )
-        )
     return active_envs, used_hostnames
+
+
+def _legacy_hostname_is_automatic(
+    team: TeamSettings, env_name: str, route_hostname: str
+) -> bool:
+    """Recognize hostname slots created before source labels were introduced."""
+    if not route_hostname:
+        return False
+    try:
+        registered = get_hostname(_hostname_registry_path(team), env_name)
+        hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
+    except (OSError, ValueError):
+        return False
+    return registered == route_hostname and bool(
+        re.fullmatch(rf"{re.escape(hostname_prefix)}[1-9][0-9]*", route_hostname)
+    )
+
+
+def _reconcile_environment_hostname_for_update(
+    client: DockerClient,
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    labels: dict[str, str],
+) -> bool:
+    """Apply hostname policy before a recreate; return whether assignment clears."""
+    route_hostname = labels.get(ENV_HOSTNAME_LABEL, "")
+    source = labels.get(ENV_HOSTNAME_SOURCE_LABEL, "")
+
+    if team.environment_hostname_mode == "slots":
+        if route_hostname:
+            if not source:
+                labels[ENV_HOSTNAME_SOURCE_LABEL] = (
+                    HOSTNAME_SOURCE_SLOT
+                    if _legacy_hostname_is_automatic(team, env_name, route_hostname)
+                    else HOSTNAME_SOURCE_CUSTOM
+                )
+            return False
+
+        hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
+        active_envs, used_hostnames = _environment_hostname_usage(
+            client, settings, team, exclude_env=env_name
+        )
+        labels[ENV_HOSTNAME_LABEL] = allocate_hostname(
+            _hostname_registry_path(team),
+            env_name,
+            team.environment_slots,
+            hostname_prefix=hostname_prefix,
+            active_envs=active_envs,
+            used_hostnames=used_hostnames,
+        )
+        labels[ENV_HOSTNAME_SOURCE_LABEL] = HOSTNAME_SOURCE_SLOT
+        return False
+
+    if route_hostname and (
+        source == HOSTNAME_SOURCE_SLOT
+        or (
+            not source and _legacy_hostname_is_automatic(team, env_name, route_hostname)
+        )
+    ):
+        labels.pop(ENV_HOSTNAME_LABEL, None)
+        labels.pop(ENV_HOSTNAME_SOURCE_LABEL, None)
+        return True
+    if route_hostname and not source:
+        labels[ENV_HOSTNAME_SOURCE_LABEL] = HOSTNAME_SOURCE_CUSTOM
+    elif not route_hostname:
+        labels.pop(ENV_HOSTNAME_SOURCE_LABEL, None)
+        try:
+            registered = get_hostname(_hostname_registry_path(team), env_name)
+        except ValueError:
+            return False
+        return bool(registered and registered != CAPACITY_RESERVATION)
+    return False
 
 
 def _ensure_system_ready(
@@ -1697,6 +1802,7 @@ def create_environment(
     local_path: str = "",
     stack_labels: dict[str, str] | None = None,
     hostname: str = "",
+    hostname_source: str = "",
 ) -> dict[str, Any]:
     """Allocate routing state, then provision the environment itself."""
     resolved_env_name = env_name or branch
@@ -1705,10 +1811,10 @@ def create_environment(
         raise ValueError("hostname is supported only when routing.mode = 'traefik'.")
 
     assigned_hostname = ""
-    if settings.routing_mode == "traefik" and (
-        requested_hostname or team.environment_slots > 0
-    ):
-        hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
+    assigned_hostname_source = ""
+    reservation_active = False
+    needs_docker_state = team.environment_slots > 0 or bool(requested_hostname)
+    if needs_docker_state:
         try:
             client = get_client()
         except Exception as exc:
@@ -1721,18 +1827,59 @@ def create_environment(
         try:
             client.containers.get(container_name)
         except docker.errors.NotFound:
-            active_envs, used_hostnames = _environment_hostname_usage(
-                client, settings, team, exclude_env=resolved_env_name
+            # Read the team's Docker state once; both the capacity reservation
+            # and the hostname allocation below are driven from this snapshot.
+            wants_hostname = bool(requested_hostname) or (
+                team.environment_hostname_mode == "slots"
             )
-            assigned_hostname = allocate_hostname(
-                _hostname_registry_path(team),
-                resolved_env_name,
-                team.environment_slots,
-                requested_hostname=requested_hostname,
-                hostname_prefix=hostname_prefix,
-                active_envs=active_envs,
-                used_hostnames=used_hostnames,
-            )
+            hostname_prefix = ""
+            used_hostnames: set[str] = set()
+            if wants_hostname:
+                hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
+                active_envs, used_hostnames = _environment_hostname_usage(
+                    client, settings, team, exclude_env=resolved_env_name
+                )
+            else:
+                active_envs = _active_environment_names(
+                    client, settings, team, exclude_env=resolved_env_name
+                )
+            if team.environment_slots > 0:
+                reserve_environment_slot(
+                    _hostname_registry_path(team),
+                    resolved_env_name,
+                    team.environment_slots,
+                    active_envs=active_envs,
+                )
+                reservation_active = True
+            if wants_hostname:
+                try:
+                    assigned_hostname = allocate_hostname(
+                        _hostname_registry_path(team),
+                        resolved_env_name,
+                        team.environment_slots,
+                        requested_hostname=requested_hostname,
+                        hostname_prefix=hostname_prefix,
+                        active_envs=active_envs,
+                        used_hostnames=used_hostnames,
+                    )
+                    reservation_active = True
+                    assigned_hostname_source = (
+                        hostname_source
+                        if requested_hostname
+                        and hostname_source
+                        in (HOSTNAME_SOURCE_CUSTOM, HOSTNAME_SOURCE_SLOT)
+                        else (
+                            HOSTNAME_SOURCE_CUSTOM
+                            if requested_hostname
+                            else HOSTNAME_SOURCE_SLOT
+                        )
+                    )
+                except Exception:
+                    if reservation_active:
+                        release_hostname(
+                            _hostname_registry_path(team), resolved_env_name
+                        )
+                    raise
 
     try:
         return _create_environment_impl(
@@ -1751,9 +1898,10 @@ def create_environment(
             local_path=local_path,
             stack_labels=stack_labels,
             hostname=assigned_hostname,
+            hostname_source=assigned_hostname_source,
         )
     except Exception:
-        if assigned_hostname:
+        if reservation_active:
             try:
                 get_client().containers.get(
                     get_resource_name(
@@ -1785,6 +1933,7 @@ def _create_environment_impl(
     local_path: str = "",
     stack_labels: dict[str, str] | None = None,
     hostname: str = "",
+    hostname_source: str = "",
 ) -> dict[str, Any]:
     env_name = env_name or branch
     from oduflow.naming import PROD_ENV_PREFIX
@@ -1935,6 +2084,7 @@ def _create_environment_impl(
         labels.update(stack_labels)
     if hostname:
         labels[ENV_HOSTNAME_LABEL] = hostname
+        labels[ENV_HOSTNAME_SOURCE_LABEL] = hostname_source or HOSTNAME_SOURCE_CUSTOM
 
     labels.update(build_env_traefik_labels(settings, team, env_name, hostname))
 
@@ -4683,23 +4833,9 @@ def update_environment(
                     "locally; leaving the existing environment untouched."
                 ) from exc
 
-    if (
-        settings.routing_mode == "traefik"
-        and team.environment_slots > 0
-        and not labels.get(ENV_HOSTNAME_LABEL)
-    ):
-        hostname_prefix, _parent_domain = split_team_hostname(team.hostname)
-        active_envs, used_hostnames = _environment_hostname_usage(
-            client, settings, team, exclude_env=env_name
-        )
-        labels[ENV_HOSTNAME_LABEL] = allocate_hostname(
-            _hostname_registry_path(team),
-            env_name,
-            team.environment_slots,
-            hostname_prefix=hostname_prefix,
-            active_envs=active_envs,
-            used_hostnames=used_hostnames,
-        )
+    clear_hostname_after_update = _reconcile_environment_hostname_for_update(
+        client, settings, team, env_name, labels
+    )
 
     logger.info(
         "Updating environment – stopping old container",
@@ -4889,6 +5025,22 @@ def update_environment(
         if port_newly_allocated:
             release_port(team.port_registry_path, env_name)
         raise
+
+    if clear_hostname_after_update:
+        try:
+            clear_hostname_assignment(
+                _hostname_registry_path(team),
+                env_name,
+                retain_slot=team.environment_slots > 0,
+            )
+        except OSError as exc:
+            # The serving container already has the correct route. Keep the
+            # update successful and retry registry normalization next time.
+            logger.warning(
+                "Could not clear stale hostname assignment for '%s': %s",
+                env_name,
+                exc,
+            )
 
     # Regenerate and copy odoo.conf into the new container (repo .oduflow/ takes
     # priority over the instance conf; extra-addons paths merged from labels).

--- a/src/oduflow/hostname_registry.py
+++ b/src/oduflow/hostname_registry.py
@@ -13,6 +13,10 @@ from oduflow.errors import ConflictError, FlowError
 
 logger = logging.getLogger("oduflow")
 
+# A team slot can be reserved without assigning a reusable public hostname.
+# This keeps the environment cap concurrency-safe in branch and port modes.
+CAPACITY_RESERVATION = "@reserved"
+
 _locks_guard = threading.Lock()
 _path_locks: dict[str, threading.Lock] = {}
 
@@ -118,7 +122,11 @@ def allocate_hostname(
                 _save_registry(registry_path, registry)
             return requested_hostname
 
-        if current and current not in occupied_hostnames:
+        if (
+            current
+            and current != CAPACITY_RESERVATION
+            and current not in occupied_hostnames
+        ):
             return current
         if slot_count <= 0:
             raise FlowError(
@@ -143,6 +151,32 @@ def allocate_hostname(
     )
 
 
+def reserve_environment_slot(
+    registry_path: str,
+    env_name: str,
+    slot_count: int,
+    *,
+    active_envs: set[str] | None = None,
+) -> None:
+    """Reserve capacity for an environment without changing its public hostname."""
+    if slot_count <= 0:
+        return
+
+    active_envs = active_envs or set()
+    with _registry_lock(registry_path):
+        registry = _load_registry(registry_path)
+        if env_name in registry:
+            return
+        occupied_envs = set(registry) | (active_envs - {env_name})
+        if len(occupied_envs) >= slot_count:
+            raise FlowError(
+                f"No free environment slots (configured: {slot_count}). "
+                "Delete an unused environment to free a slot."
+            )
+        registry[env_name] = CAPACITY_RESERVATION
+        _save_registry(registry_path, registry)
+
+
 def release_hostname(registry_path: str, env_name: str) -> None:
     with _registry_lock(registry_path):
         registry = _load_registry(registry_path)
@@ -150,6 +184,30 @@ def release_hostname(registry_path: str, env_name: str) -> None:
         if hostname is not None:
             _save_registry(registry_path, registry)
             logger.info("Released hostname %s for environment '%s'", hostname, env_name)
+
+
+def clear_hostname_assignment(
+    registry_path: str, env_name: str, *, retain_slot: bool
+) -> None:
+    """Drop a reusable hostname while optionally retaining environment capacity."""
+    with _registry_lock(registry_path):
+        registry = _load_registry(registry_path)
+        hostname = registry.get(env_name)
+        if hostname is None:
+            if not retain_slot:
+                return
+            registry[env_name] = CAPACITY_RESERVATION
+        elif retain_slot:
+            registry[env_name] = CAPACITY_RESERVATION
+        else:
+            registry.pop(env_name, None)
+        _save_registry(registry_path, registry)
+        logger.info(
+            "Cleared hostname %s for environment '%s' (retain_slot=%s)",
+            hostname,
+            env_name,
+            retain_slot,
+        )
 
 
 def rename_env(registry_path: str, old_name: str, new_name: str) -> None:

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -728,7 +728,7 @@ def create_environment(
     Args:
         branch: The git branch to clone (e.g. "19.0", "feature/my-feature").
         env_name: Optional environment name. If empty, defaults to the branch name. Use this to create multiple environments from the same branch (e.g. env_name="client-a" with branch="19.0").
-        hostname: Optional short Traefik hostname (for example "qa"). If omitted and the team configures environment_slots, Oduflow numbers the team hostname prefix: dev.example.com produces dev1.example.com through devN.example.com. An explicit value replaces that prefix, so hostname="qa" produces qa.example.com.
+        hostname: Optional short Traefik hostname (for example "qa"). By default public hostnames remain environment-derived (feature.dev.example.com). Teams that explicitly set environment_hostname_mode="slots" reuse dev1.example.com through devN.example.com. An explicit value replaces the team prefix in either mode, so hostname="qa" produces qa.example.com.
         template_name: Name of the template profile to use as database template. Pass "none" to skip template and initialise Odoo from scratch with -i base. When a template is specified, repo_url and odoo_image are loaded from template metadata (but can be overridden). A template saved from a live-mounted environment supplies local_path instead of repo_url and recreates the live-mount when allow_local_path is enabled.
         repo_url: URL of the git repository to clone. Optional when template_name is specified (loaded from template metadata).
         odoo_image: Full Docker image name with tag (e.g. "odoo:19.0"). Optional when template_name is specified (loaded from template metadata).

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -51,10 +51,11 @@ class TeamSettings:
     data_dir: str = ""
     port_registry_path: str = ""
     hostname_registry_path: str = ""
-    # Traefik-only reusable hostname pool. 0 keeps legacy branch-derived
-    # hostnames; for dev.example.com a positive value allocates
-    # dev1.example.com..devN.example.com and caps active environments.
+    # Hard cap on managed development environments. 0 disables the cap.
     environment_slots: int = 20
+    # Public hostname strategy: "branch" keeps feature.dev.example.com;
+    # "slots" allocates dev1.example.com..devN.example.com in Traefik mode.
+    environment_hostname_mode: str = "branch"
     # Hard cap on managed auxiliary service containers. 0 disables the cap.
     service_slots: int = 10
     # Quotas; 0 disables. db_quota_gb caps the combined size of the team's
@@ -379,19 +380,34 @@ class Settings:
                     f"Team '{team.team_id}': environment_slots must be >= 0 "
                     "(0 disables)"
                 )
+            if team.environment_hostname_mode not in ("branch", "slots"):
+                raise ValueError(
+                    f"Team '{team.team_id}': environment_hostname_mode must be "
+                    "'branch' or 'slots'"
+                )
             if team.service_slots < 0:
                 raise ValueError(
                     f"Team '{team.team_id}': service_slots must be >= 0 (0 disables)"
                 )
-            if self.routing_mode == "traefik" and team.environment_slots > 0:
+            if team.environment_hostname_mode == "slots":
+                if self.routing_mode != "traefik":
+                    raise ValueError(
+                        f"Team '{team.team_id}': environment_hostname_mode='slots' "
+                        "requires routing_mode=traefik"
+                    )
+                if team.environment_slots <= 0:
+                    raise ValueError(
+                        f"Team '{team.team_id}': environment_hostname_mode='slots' "
+                        "requires environment_slots > 0"
+                    )
                 from oduflow.naming import split_team_hostname
 
                 try:
                     split_team_hostname(team.hostname)
                 except ValueError as exc:
                     raise ValueError(
-                        f"Team '{team.team_id}': environment_slots requires a "
-                        "hostname such as 'dev.example.com'"
+                        f"Team '{team.team_id}': environment_hostname_mode='slots' "
+                        "requires a hostname such as 'dev.example.com'"
                     ) from exc
 
         # Validate static extra routes ([route.*]). They only make sense in
@@ -568,6 +584,12 @@ class Settings:
                 port_registry_path=os.path.join(team_data_dir, "ports.json"),
                 hostname_registry_path=os.path.join(team_data_dir, "hostnames.json"),
                 environment_slots=int(team_cfg.get("environment_slots", 20)),
+                environment_hostname_mode=str(
+                    team_cfg.get("environment_hostname_mode", "branch")
+                )
+                .strip()
+                .lower()
+                or "branch",
                 service_slots=int(team_cfg.get("service_slots", 10)),
                 db_quota_gb=int(team_cfg.get("db_quota_gb", 50)),
                 disk_quota_gb=int(team_cfg.get("disk_quota_gb", 0)),

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -113,7 +113,8 @@ auto_delete_hours = 0             # delete stopped environments after N hours (D
 
 [team.1]
 hostname = "localhost"            # port: http://{hostname}:{port}, traefik: https://{slug}.{hostname}
-environment_slots = 20            # traefik: dev.example.com + N => dev1.example.com..devN.example.com; 0 = legacy hostnames
+environment_slots = 20            # maximum concurrent environments; 0 = unlimited
+environment_hostname_mode = "branch" # "branch": feature.dev.example.com; "slots": dev1.example.com..devN.example.com
 service_slots = 10                # maximum managed auxiliary services; 0 = unlimited
 auth_token = ""                   # MCP bearer token / OAuth client_id+secret (auto-generated on first run; HTTP refuses to start if empty)
 ui_password = ""                  # Web UI password (auto-generated on first run; HTTP refuses to start if empty unless allow_insecure_http)

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -1123,7 +1123,12 @@ def _build_routes(
             # (several environments off one branch), so recreate from the
             # recorded branch label rather than from the environment name.
             git_branch = labels.get("oduflow.git_branch", branch)
-            hostname = labels.get(env_ops.ENV_HOSTNAME_LABEL, "")
+            recreate_labels = dict(labels)
+            env_ops._reconcile_environment_hostname_for_update(
+                client, settings, team, branch, recreate_labels
+            )
+            hostname = recreate_labels.get(env_ops.ENV_HOSTNAME_LABEL, "")
+            hostname_source = recreate_labels.get(env_ops.ENV_HOSTNAME_SOURCE_LABEL, "")
 
             # Check disk space BEFORE deleting the old environment: refusing
             # here loses nothing, while failing after delete_environment would
@@ -1158,6 +1163,7 @@ def _build_routes(
                 env_vars=env_vars,
                 local_path=local_path,
                 hostname=hostname,
+                hostname_source=hostname_source,
             )
             return JSONResponse({"ok": True, "result": result})
         except FlowError as e:

--- a/tests/test_hostname_registry.py
+++ b/tests/test_hostname_registry.py
@@ -7,9 +7,12 @@ import docker
 from oduflow.docker_ops import env_ops
 from oduflow.errors import ConflictError, FlowError
 from oduflow.hostname_registry import (
+    CAPACITY_RESERVATION,
     allocate_hostname,
+    clear_hostname_assignment,
     get_hostname,
     release_hostname,
+    reserve_environment_slot,
 )
 from oduflow.settings import Settings, TeamSettings
 
@@ -87,7 +90,34 @@ def test_parallel_allocations_never_share_a_slot(tmp_path):
     assert set(hostnames) == {f"dev{number}" for number in range(1, 21)}
 
 
-def _traefik_settings(tmp_path, slots=2):
+def test_capacity_reservations_are_concurrency_safe_without_hostname_changes(tmp_path):
+    path = _path(tmp_path)
+    envs = [f"feature-{number}" for number in range(10)]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(
+            pool.map(
+                lambda env: reserve_environment_slot(path, env, len(envs)),
+                envs,
+            )
+        )
+
+    assert {get_hostname(path, env) for env in envs} == {CAPACITY_RESERVATION}
+    with pytest.raises(FlowError, match="No free environment slots"):
+        reserve_environment_slot(path, "overflow", len(envs))
+
+
+def test_hostname_assignment_can_return_to_capacity_only(tmp_path):
+    path = _path(tmp_path)
+    reserve_environment_slot(path, "feature-a", 2)
+    assert allocate_hostname(path, "feature-a", 2, hostname_prefix="dev") == "dev1"
+
+    clear_hostname_assignment(path, "feature-a", retain_slot=True)
+
+    assert get_hostname(path, "feature-a") == CAPACITY_RESERVATION
+
+
+def _traefik_settings(tmp_path, slots=2, hostname_mode="slots"):
     data_dir = tmp_path / "team_1"
     team = TeamSettings(
         team_id="1",
@@ -95,6 +125,7 @@ def _traefik_settings(tmp_path, slots=2):
         data_dir=str(data_dir),
         hostname_registry_path=str(data_dir / "hostnames.json"),
         environment_slots=slots,
+        environment_hostname_mode=hostname_mode,
     )
     return Settings(
         routing_mode="traefik",
@@ -122,7 +153,10 @@ def test_create_wrapper_assigns_short_hostname(tmp_path):
 
     assert result["url"] == "https://dev1.example.com"
     assert provision.call_args.kwargs["hostname"] == "dev1"
+    assert provision.call_args.kwargs["hostname_source"] == "slot"
     assert get_hostname(team.hostname_registry_path, "feature-a") == "dev1"
+    # Capacity and hostname usage come from one container listing.
+    assert client.containers.list.call_count == 1
 
 
 def test_create_wrapper_accepts_explicit_parent_domain_prefix(tmp_path):
@@ -148,7 +182,34 @@ def test_create_wrapper_accepts_explicit_parent_domain_prefix(tmp_path):
         )
 
     assert provision.call_args.kwargs["hostname"] == "qa"
+    assert provision.call_args.kwargs["hostname_source"] == "custom"
     assert get_hostname(team.hostname_registry_path, "feature-a") == "qa"
+
+
+def test_internal_recreate_preserves_slot_hostname_source(tmp_path):
+    settings, team = _traefik_settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    client.containers.list.return_value = []
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.env_ops._create_environment_impl",
+            return_value={"url": "https://dev1.example.com"},
+        ) as provision,
+    ):
+        env_ops.create_environment(
+            settings,
+            team,
+            "feature-a",
+            "repo",
+            "odoo:19.0",
+            hostname="dev1",
+            hostname_source="slot",
+        )
+
+    assert provision.call_args.kwargs["hostname_source"] == "slot"
 
 
 def test_automatic_allocation_skips_hostname_used_by_service(tmp_path):
@@ -194,6 +255,132 @@ def test_failed_create_releases_hostname_before_container_exists(tmp_path):
         env_ops.create_environment(settings, team, "feature-a", "repo", "odoo:19.0")
 
     assert get_hostname(team.hostname_registry_path, "feature-a") is None
+
+
+def test_branch_mode_keeps_legacy_hostname_while_enforcing_capacity(tmp_path):
+    settings, team = _traefik_settings(tmp_path, slots=1, hostname_mode="branch")
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    client.containers.list.return_value = []
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.env_ops._create_environment_impl",
+            return_value={"url": "https://feature-a.dev.example.com"},
+        ) as provision,
+    ):
+        env_ops.create_environment(settings, team, "feature-a", "repo", "odoo:19.0")
+
+    assert provision.call_args.kwargs["hostname"] == ""
+    assert get_hostname(team.hostname_registry_path, "feature-a") == (
+        CAPACITY_RESERVATION
+    )
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        pytest.raises(FlowError, match="No free environment slots"),
+    ):
+        env_ops.create_environment(settings, team, "feature-b", "repo", "odoo:19.0")
+
+
+def test_port_mode_enforces_environment_capacity(tmp_path):
+    data_dir = tmp_path / "team_1"
+    team = TeamSettings(
+        team_id="1",
+        data_dir=str(data_dir),
+        hostname_registry_path=str(data_dir / "hostnames.json"),
+        environment_slots=1,
+    )
+    settings = Settings(routing_mode="port", teams={"1": team})
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    existing = MagicMock()
+    existing.labels = {
+        settings.managed_label: "true",
+        settings.team_label: "1",
+        settings.branch_label: "feature-a",
+    }
+    client.containers.list.return_value = [existing]
+
+    with (
+        patch("oduflow.docker_ops.env_ops.get_client", return_value=client),
+        pytest.raises(FlowError, match="No free environment slots"),
+    ):
+        env_ops.create_environment(settings, team, "feature-b", "repo", "odoo:19.0")
+
+
+def test_update_keeps_unlabeled_legacy_hostname_in_branch_mode(tmp_path):
+    settings, team = _traefik_settings(tmp_path, hostname_mode="branch")
+    labels = {}
+
+    clear_after_update = env_ops._reconcile_environment_hostname_for_update(
+        MagicMock(), settings, team, "feature-a", labels
+    )
+
+    assert clear_after_update is False
+    assert env_ops.ENV_HOSTNAME_LABEL not in labels
+    assert env_ops.ENV_HOSTNAME_SOURCE_LABEL not in labels
+
+
+def test_update_clears_stale_registry_assignment_for_unlabeled_hostname(tmp_path):
+    settings, team = _traefik_settings(tmp_path, hostname_mode="branch")
+    reserve_environment_slot(team.hostname_registry_path, "feature-a", 2)
+    allocate_hostname(
+        team.hostname_registry_path, "feature-a", 2, hostname_prefix="dev"
+    )
+    labels = {}
+
+    clear_after_update = env_ops._reconcile_environment_hostname_for_update(
+        MagicMock(), settings, team, "feature-a", labels
+    )
+
+    assert clear_after_update is True
+
+
+def test_update_returns_legacy_automatic_slot_to_branch_hostname(tmp_path):
+    settings, team = _traefik_settings(tmp_path, hostname_mode="branch")
+    reserve_environment_slot(team.hostname_registry_path, "feature-a", 2)
+    allocate_hostname(
+        team.hostname_registry_path, "feature-a", 2, hostname_prefix="dev"
+    )
+    labels = {env_ops.ENV_HOSTNAME_LABEL: "dev1"}
+
+    clear_after_update = env_ops._reconcile_environment_hostname_for_update(
+        MagicMock(), settings, team, "feature-a", labels
+    )
+
+    assert clear_after_update is True
+    assert env_ops.ENV_HOSTNAME_LABEL not in labels
+    assert env_ops.ENV_HOSTNAME_SOURCE_LABEL not in labels
+
+
+def test_update_preserves_legacy_custom_hostname_in_branch_mode(tmp_path):
+    settings, team = _traefik_settings(tmp_path, hostname_mode="branch")
+    labels = {env_ops.ENV_HOSTNAME_LABEL: "qa"}
+
+    clear_after_update = env_ops._reconcile_environment_hostname_for_update(
+        MagicMock(), settings, team, "feature-a", labels
+    )
+
+    assert clear_after_update is False
+    assert labels[env_ops.ENV_HOSTNAME_LABEL] == "qa"
+    assert labels[env_ops.ENV_HOSTNAME_SOURCE_LABEL] == "custom"
+
+
+def test_update_assigns_slot_only_when_slot_mode_is_explicit(tmp_path):
+    settings, team = _traefik_settings(tmp_path, hostname_mode="slots")
+    client = MagicMock()
+    client.containers.list.return_value = []
+    labels = {}
+
+    clear_after_update = env_ops._reconcile_environment_hostname_for_update(
+        client, settings, team, "feature-a", labels
+    )
+
+    assert clear_after_update is False
+    assert labels[env_ops.ENV_HOSTNAME_LABEL] == "dev1"
+    assert labels[env_ops.ENV_HOSTNAME_SOURCE_LABEL] == "slot"
 
 
 def test_base_url_reads_persisted_short_hostname(tmp_path):

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -42,6 +42,20 @@ TEST_SETTINGS = Settings(
 
 
 @pytest.fixture(autouse=True)
+def _isolated_hostname_registry(tmp_path, monkeypatch):
+    # create_environment reserves an environment slot in the team's
+    # hostnames.json before provisioning. Keep that registry per-test: the
+    # shared /tmp data dir would carry reservations across runs, and several
+    # tests below patch ``env_ops.os.makedirs``, which resolves to the shared
+    # ``os`` module and so also disables the registry's directory creation.
+    monkeypatch.setattr(
+        env_ops,
+        "_hostname_registry_path",
+        lambda team: str(tmp_path / "hostnames.json"),
+    )
+
+
+@pytest.fixture(autouse=True)
 def _no_db_quota(monkeypatch):
     # Quota enforcement is covered by tests/test_db_quota.py; here it would
     # only add a psql exec to every mocked create_environment call chain.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -124,12 +124,15 @@ class TestSettings:
         toml.write_text(
             '[routing]\nmode = "traefik"\ntls = false\n'
             '[team.1]\nhostname = "dev.example.com"\n'
-            "environment_slots = 7\nservice_slots = 3\n"
+            "environment_slots = 7\n"
+            'environment_hostname_mode = "slots"\n'
+            "service_slots = 3\n"
         )
 
         team = Settings.from_toml(str(toml)).get_team("1")
 
         assert team.environment_slots == 7
+        assert team.environment_hostname_mode == "slots"
         assert team.service_slots == 3
         assert team.hostname_registry_path.endswith("team_1/hostnames.json")
 
@@ -140,6 +143,7 @@ class TestSettings:
         team = Settings.from_toml(str(toml)).get_team("1")
 
         assert team.environment_slots == 20
+        assert team.environment_hostname_mode == "branch"
         assert team.service_slots == 10
 
     def test_negative_environment_slots_rejected(self):
@@ -156,8 +160,41 @@ class TestSettings:
         with pytest.raises(ValueError, match="service_slots"):
             settings.validate()
 
-    def test_environment_slots_require_prefixed_domain(self):
-        team = TeamSettings(team_id="1", hostname="localhost", environment_slots=2)
+    def test_invalid_environment_hostname_mode_rejected(self):
+        team = TeamSettings(team_id="1", environment_hostname_mode="magic")
+
+        with pytest.raises(ValueError, match="environment_hostname_mode"):
+            Settings(teams={"1": team}).validate()
+
+    def test_hostname_slots_require_traefik(self):
+        team = TeamSettings(team_id="1", environment_hostname_mode="slots")
+
+        with pytest.raises(ValueError, match="requires routing_mode=traefik"):
+            Settings(teams={"1": team}).validate()
+
+    def test_hostname_slots_require_positive_environment_limit(self):
+        team = TeamSettings(
+            team_id="1",
+            hostname="dev.example.com",
+            environment_slots=0,
+            environment_hostname_mode="slots",
+        )
+        settings = Settings(
+            routing_mode="traefik",
+            routing_tls=False,
+            teams={"1": team},
+        )
+
+        with pytest.raises(ValueError, match="environment_slots > 0"):
+            settings.validate()
+
+    def test_hostname_slots_require_prefixed_domain(self):
+        team = TeamSettings(
+            team_id="1",
+            hostname="localhost",
+            environment_slots=2,
+            environment_hostname_mode="slots",
+        )
         settings = Settings(
             routing_mode="traefik",
             routing_tls=False,

--- a/tests/test_web_ui_create_lock.py
+++ b/tests/test_web_ui_create_lock.py
@@ -14,6 +14,7 @@ from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from oduflow.errors import BusyError
+from oduflow.hostname_registry import allocate_hostname, reserve_environment_slot
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import mount_web_ui
@@ -196,3 +197,57 @@ def test_api_recreate_uses_recorded_git_branch(tmp_path):
     assert resp.status_code == 200
     assert create.call_args.args[2] == "staging"
     assert create.call_args.kwargs["env_name"] == "oldstaging"
+
+
+def test_api_recreate_restores_legacy_slot_to_branch_hostname(tmp_path):
+    from unittest.mock import MagicMock
+
+    data_dir = tmp_path / "team_1"
+    team = TeamSettings(
+        team_id="1",
+        hostname="dev.example.com",
+        data_dir=str(data_dir),
+        hostname_registry_path=str(data_dir / "hostnames.json"),
+        environment_slots=2,
+        environment_hostname_mode="branch",
+    )
+    settings = Settings(
+        routing_mode="traefik",
+        routing_tls=False,
+        base_data_dir=str(tmp_path),
+        teams={"1": team},
+    )
+    reserve_environment_slot(team.hostname_registry_path, "feature-a", 2)
+    allocate_hostname(
+        team.hostname_registry_path, "feature-a", 2, hostname_prefix="dev"
+    )
+
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app)
+    container = MagicMock()
+    container.labels = {
+        settings.repo_label: "https://github.com/x/y.git",
+        settings.image_label: "odoo:19.0",
+        settings.branch_label: "feature-a",
+        "oduflow.template": "none",
+        "oduflow.git_branch": "feature-a",
+        "oduflow.hostname": "dev1",
+    }
+
+    with (
+        patch("oduflow.docker_ops.client.get_client") as mock_client,
+        patch("oduflow.docker_ops.system_ops.check_disk_space"),
+        patch("oduflow.docker_ops.system_ops.estimate_new_db_bytes", return_value=0),
+        patch("oduflow.docker_ops.env_ops.delete_environment"),
+        patch(
+            "oduflow.docker_ops.env_ops.create_environment",
+            return_value={"url": "https://feature-a.dev.example.com"},
+        ) as create,
+    ):
+        mock_client.return_value.containers.get.return_value = container
+        resp = client.post("/api/environments/feature-a/recreate")
+
+    assert resp.status_code == 200
+    assert create.call_args.kwargs["hostname"] == ""
+    assert create.call_args.kwargs["hostname_source"] == ""


### PR DESCRIPTION
## Problem

`environment_slots` overloaded two unrelated decisions: how many environments a team may run, and how their public addresses are formed. Because the default is `20`, every Traefik team was implicitly opted into numbered hostnames. Updating an existing container then rewrote `feature.dev.example.com` to `dev1.example.com` — one DNS level higher, so outside the scope of a `*.dev.example.com` record or wildcard certificate.

## Change

- `environment_slots` is now a capacity cap only, and it applies in **both** port and Traefik modes. Capacity is held as a `@reserved` entry in the per-team `hostnames.json`, so the cap stays concurrency-safe even when no hostname is allocated.
- Numbered hostnames require the explicit opt-in `environment_hostname_mode = "slots"`. The default `"branch"` preserves environment-derived routes, including across `update_environment`.
- Environments carry an `oduflow.hostname_source` label (`slot` / `custom`) so a recreate can tell an automatic assignment from an operator's explicit hostname.
- Slot assignments made by v1.69–v1.71 are recognised from the registry and returned to their branch-derived route on the next update; explicit custom hostnames are left untouched.
- `environment_hostname_mode = "slots"` is validated at startup: it requires `routing_mode = "traefik"`, `environment_slots > 0`, and a team hostname with a distinct prefix (`dev.example.com`).

## Behaviour changes for existing installations

- **Port mode** previously ignored `environment_slots` entirely; the default cap of 20 now applies there. Existing environments are counted from their containers, so the cap is correct from the first start.
- Environments that v1.69–v1.71 moved onto a numbered hostname go back to their branch-derived URL on their next update or recreate. Their capacity reservation is kept.

## Verification

- `ruff check`, `ruff format`, `mypy src/oduflow` — clean.
- Unit suite: 2569 passed. The single failure, `test_overlay_stale_mount.py::TestMountFilestoreClearsStale::test_forced_recovery_ignores_copy_metadata`, is pre-existing on `main` (verified by stashing this branch's changes).
- `docs/llms-full.txt` regenerated via `scripts/build_llms_full.py`; no drift.
- Decision record `specs/0048-reusable-environment-hostname-slots.md` updated with an Evolution section covering why the original design was revised.
