### PR TITLE
Built-in remote MCP CLI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ oduflow -t http
 **HTTP (remote)** — point your MCP client to `http://<host>:8000/mcp` and send
 `Authorization: Bearer <auth_token>` using the token from `oduflow.toml`.
 
+The bundled CLI can call that remote MCP server without a separate agent or MCP
+client configuration:
+
+```bash
+export ODUFLOW_MCP_URL="http://<host>:8000/mcp"
+export ODUFLOW_MCP_TOKEN="<auth_token>"
+oduflow client list_environments
+```
+
 The Web Dashboard is available at `http://<host>:8000/`. Sign in as `admin`
 with the `ui_password` from `oduflow.toml`; this is separate from the MCP Bearer
 token.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,16 @@
 
 ### Features
 
+- **Built-in remote MCP CLI** — `oduflow client <tool>` now calls a running
+  Oduflow server through FastMCP using `ODUFLOW_MCP_URL` and
+  `ODUFLOW_MCP_TOKEN`. It discovers the live tool schemas, accepts named flags
+  or a JSON argument object, derives a required environment target from an
+  explicit override or the current Git branch (and the `create_environment`
+  branch from the current checkout), supports full team and scoped
+  `/mcp/<env>` endpoints, emits machine-readable JSON for automation, and
+  preserves server-side tool errors and output-cache summaries. The existing
+  `oduflow call <tool>` remains the local in-process path.
+
 - **Token-safe summaries for apply and test calls** — `pull_and_apply` and
   `run_odoo_tests` now accept `summary_only=True`, keeping verbose Odoo command
   logs server-side instead of injecting them into the calling agent's context.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -223,3 +223,88 @@ oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port
 # Type coercion is automatic: int, bool, and float parameters are cast from strings
 oduflow call get_environment_logs dev 500
 ```
+
+## Remote Tool Invocation
+
+`oduflow client` calls the same registered tools on a running Oduflow HTTP
+server through FastMCP. Unlike `oduflow call`, it does not load the local
+`oduflow.toml`, access local Docker, or execute server functions in the client
+process.
+
+Configure the exact full or scoped MCP endpoint and its Bearer credential:
+
+```bash
+export ODUFLOW_MCP_URL="https://oduflow.example.com/mcp"
+export ODUFLOW_MCP_TOKEN="<team-auth-token>"
+
+# Tools advertised by this endpoint
+oduflow client list
+oduflow client list --verbose
+
+# Read live help generated from a tool's input schema
+oduflow client create_environment --help
+
+# Call team-wide tools
+oduflow client list_environments
+oduflow client create_environment \
+  --repo-url https://github.com/owner/addons.git \
+  --odoo-image odoo:19.0 \
+  --template-name myproject
+```
+
+The client reads the live `tools/list` response, converts kebab-case flags to
+MCP parameter names, validates basic scalar/JSON types, and then calls the tool.
+A single JSON object is also accepted for complex arguments:
+
+```bash
+oduflow client create_service '{
+  "name": "redis",
+  "image": "redis:7",
+  "port": 6379
+}'
+```
+
+Client options must appear before the tool name:
+
+```bash
+oduflow client --timeout 1200 --json list_environments
+oduflow client --env demo pull_and_apply --upgrade sale_custom --strict
+```
+
+When a remote schema requires `env_name`, the client uses `--env`, then
+`ODUFLOW_ENV_NAME`, then the current Git branch. When `create_environment`
+requires `branch`, it uses the current Git branch unless `--branch` is supplied;
+other tools that take a required branch, such as `create_production`, always
+need it spelled out.
+An explicit environment override is useful when an environment name differs
+from its source branch.
+
+For confined development access, use the environment's scoped endpoint and
+Secret Key from **More → MCP Access**:
+
+```bash
+export ODUFLOW_MCP_URL="https://oduflow.example.com/mcp/feature-x"
+export ODUFLOW_MCP_TOKEN="<environment-secret-key>"
+
+# env_name is absent from the scoped schema and injected by the server
+oduflow client get_environment_info
+oduflow client pull_and_apply --upgrade sale_custom --strict
+oduflow client run_odoo_tests --modules sale_custom
+```
+
+The scoped server advertises only its allowlisted single-environment tools, so
+team-wide commands such as `list_environments` and `create_environment` are not
+available. The client does not maintain a second authorization list; the live
+server schema remains authoritative.
+
+For scripts and CI, `--json` emits the complete MCP result and tool failures
+return a non-zero exit code. To avoid storing a token in the environment, pass
+it on standard input:
+
+```bash
+printf '%s\n' "$TOKEN_FROM_SECRET_STORE" | \
+  oduflow client --token-stdin --json list_environments
+```
+
+In summary, `oduflow call <tool>` is local in-process execution, while
+`oduflow client <tool>` is remote authenticated MCP execution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,8 @@ hide:
 
     ---
 
-    Every MCP tool is one `oduflow call` away from your terminal and CI pipelines.
+    Use `oduflow call` for local in-process execution or `oduflow client` for a
+    remote authenticated server from terminals, scripts, and CI pipelines.
 
     [:octicons-arrow-right-24: CLI Reference](cli.md)
 
@@ -143,5 +144,6 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 - **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex / OpenCode) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
 - **Web dashboard** — a built-in HTML dashboard for managing environments from a browser
 - **REST API** — full JSON API for programmatic control from any HTTP client
-- **CLI tools** — every MCP tool can be called directly from the command line via `oduflow call`
+- **CLI tools** — call every MCP tool locally via `oduflow call` or remotely via
+  the schema-driven `oduflow client`
 - **Dual transport** — stdio (default, for local MCP clients) and HTTP (Streamable HTTP, for remote/multi-user)

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -303,7 +303,8 @@ sanitization scripts followed by project scripts from
 
     ---
 
-    Every MCP tool is one `oduflow call` away from your terminal and CI pipelines.
+    Use `oduflow call` for local in-process execution or `oduflow client` for a
+    remote authenticated server from terminals, scripts, and CI pipelines.
 
     [:octicons-arrow-right-24: CLI Reference](cli.md)
 
@@ -381,7 +382,8 @@ The agent writes code, installs the module, reads the traceback, fixes the error
 - **Hosted coding agent** — an opt-in, per-team AI agent (Claude Code / OpenAI Codex / OpenCode) with a browser **Agent Chat** and **Agent CLI**, driving environments through MCP (see [Coding Agent](agent.md))
 - **Web dashboard** — a built-in HTML dashboard for managing environments from a browser
 - **REST API** — full JSON API for programmatic control from any HTTP client
-- **CLI tools** — every MCP tool can be called directly from the command line via `oduflow call`
+- **CLI tools** — call every MCP tool locally via `oduflow call` or remotely via
+  the schema-driven `oduflow client`
 - **Dual transport** — stdio (default, for local MCP clients) and HTTP (Streamable HTTP, for remote/multi-user)
 
 ---
@@ -3246,7 +3248,9 @@ semantics.
 
 ![Agent Instructions](img/agent_instructions.png)
 
-All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI (`oduflow call`). A subset is also available via the [REST API](web-api.md).
+All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.), locally via
+`oduflow call`, and on a remote Oduflow server via `oduflow client`. A subset is
+also available via the [REST API](web-api.md).
 
 | Tool | Lock | Description |
 |---|:---:|---|
@@ -3583,6 +3587,91 @@ oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port
 # Type coercion is automatic: int, bool, and float parameters are cast from strings
 oduflow call get_environment_logs dev 500
 ```
+
+## Remote Tool Invocation
+
+`oduflow client` calls the same registered tools on a running Oduflow HTTP
+server through FastMCP. Unlike `oduflow call`, it does not load the local
+`oduflow.toml`, access local Docker, or execute server functions in the client
+process.
+
+Configure the exact full or scoped MCP endpoint and its Bearer credential:
+
+```bash
+export ODUFLOW_MCP_URL="https://oduflow.example.com/mcp"
+export ODUFLOW_MCP_TOKEN="<team-auth-token>"
+
+# Tools advertised by this endpoint
+oduflow client list
+oduflow client list --verbose
+
+# Read live help generated from a tool's input schema
+oduflow client create_environment --help
+
+# Call team-wide tools
+oduflow client list_environments
+oduflow client create_environment \
+  --repo-url https://github.com/owner/addons.git \
+  --odoo-image odoo:19.0 \
+  --template-name myproject
+```
+
+The client reads the live `tools/list` response, converts kebab-case flags to
+MCP parameter names, validates basic scalar/JSON types, and then calls the tool.
+A single JSON object is also accepted for complex arguments:
+
+```bash
+oduflow client create_service '{
+  "name": "redis",
+  "image": "redis:7",
+  "port": 6379
+}'
+```
+
+Client options must appear before the tool name:
+
+```bash
+oduflow client --timeout 1200 --json list_environments
+oduflow client --env demo pull_and_apply --upgrade sale_custom --strict
+```
+
+When a remote schema requires `env_name`, the client uses `--env`, then
+`ODUFLOW_ENV_NAME`, then the current Git branch. When `create_environment`
+requires `branch`, it uses the current Git branch unless `--branch` is supplied;
+other tools that take a required branch, such as `create_production`, always
+need it spelled out.
+An explicit environment override is useful when an environment name differs
+from its source branch.
+
+For confined development access, use the environment's scoped endpoint and
+Secret Key from **More → MCP Access**:
+
+```bash
+export ODUFLOW_MCP_URL="https://oduflow.example.com/mcp/feature-x"
+export ODUFLOW_MCP_TOKEN="<environment-secret-key>"
+
+# env_name is absent from the scoped schema and injected by the server
+oduflow client get_environment_info
+oduflow client pull_and_apply --upgrade sale_custom --strict
+oduflow client run_odoo_tests --modules sale_custom
+```
+
+The scoped server advertises only its allowlisted single-environment tools, so
+team-wide commands such as `list_environments` and `create_environment` are not
+available. The client does not maintain a second authorization list; the live
+server schema remains authoritative.
+
+For scripts and CI, `--json` emits the complete MCP result and tool failures
+return a non-zero exit code. To avoid storing a token in the environment, pass
+it on standard input:
+
+```bash
+printf '%s\n' "$TOKEN_FROM_SECRET_STORE" | \
+  oduflow client --token-stdin --json list_environments
+```
+
+In summary, `oduflow call <tool>` is local in-process execution, while
+`oduflow client <tool>` is remote authenticated MCP execution.
 
 ---
 
@@ -4024,6 +4113,21 @@ Authorization: Bearer secret-token-team-1
 
 This works whether or not `oauth_base_url` is configured.
 
+The built-in remote CLI uses the same Bearer authentication and live MCP tool
+schemas:
+
+```bash
+export ODUFLOW_MCP_URL="https://your-server.com/mcp"
+export ODUFLOW_MCP_TOKEN="secret-token-team-1"
+
+oduflow client list_environments
+```
+
+`oduflow client` does not use the dashboard's `ui_password`. For an automation
+that needs only one development environment, prefer its scoped `/mcp/<env>` URL
+and per-environment Secret Key instead of the team token. The server then hides
+team-wide tools and injects the environment target itself.
+
 ## Scoped single-environment access (`/mcp/<env>`)
 
 The team `auth_token` unlocks the **full** tool surface — create, delete, and stop
@@ -4063,7 +4167,13 @@ environment's URL, so the credential itself is the boundary.
 
 In the web dashboard, open an environment's **More → MCP Access**. The dialog
 shows the `/mcp/<env>` URL and the Secret Key (with copy buttons) ready to paste
-into an agent's MCP configuration.
+into an agent's MCP configuration or the built-in remote CLI:
+
+```bash
+export ODUFLOW_MCP_URL="https://your-server.com/mcp/<env>"
+export ODUFLOW_MCP_TOKEN="<environment-secret-key>"
+oduflow client get_environment_info
+```
 
 Environments created before this feature carry no Secret Key (Docker labels can't
 be added to a live container); recreate the environment to issue one. Recreating

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,7 +2,9 @@
 
 ![Agent Instructions](img/agent_instructions.png)
 
-All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.) and the CLI (`oduflow call`). A subset is also available via the [REST API](web-api.md).
+All tools are accessible via MCP clients (Cursor, Cline, Amp, etc.), locally via
+`oduflow call`, and on a remote Oduflow server via `oduflow client`. A subset is
+also available via the [REST API](web-api.md).
 
 | Tool | Lock | Description |
 |---|:---:|---|

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,6 +88,21 @@ Authorization: Bearer secret-token-team-1
 
 This works whether or not `oauth_base_url` is configured.
 
+The built-in remote CLI uses the same Bearer authentication and live MCP tool
+schemas:
+
+```bash
+export ODUFLOW_MCP_URL="https://your-server.com/mcp"
+export ODUFLOW_MCP_TOKEN="secret-token-team-1"
+
+oduflow client list_environments
+```
+
+`oduflow client` does not use the dashboard's `ui_password`. For an automation
+that needs only one development environment, prefer its scoped `/mcp/<env>` URL
+and per-environment Secret Key instead of the team token. The server then hides
+team-wide tools and injects the environment target itself.
+
 ## Scoped single-environment access (`/mcp/<env>`)
 
 The team `auth_token` unlocks the **full** tool surface — create, delete, and stop
@@ -127,7 +142,13 @@ environment's URL, so the credential itself is the boundary.
 
 In the web dashboard, open an environment's **More → MCP Access**. The dialog
 shows the `/mcp/<env>` URL and the Secret Key (with copy buttons) ready to paste
-into an agent's MCP configuration.
+into an agent's MCP configuration or the built-in remote CLI:
+
+```bash
+export ODUFLOW_MCP_URL="https://your-server.com/mcp/<env>"
+export ODUFLOW_MCP_TOKEN="<environment-secret-key>"
+oduflow client get_environment_info
+```
 
 Environments created before this feature carry no Secret Key (Docker labels can't
 be added to a live container); recreate the environment to issue one. Recreating

--- a/specs/0051-remote-mcp-cli-client.md
+++ b/specs/0051-remote-mcp-cli-client.md
@@ -1,0 +1,84 @@
+# 0051 — Built-in remote CLI over the live FastMCP tool surface
+
+**Status:** Adopted
+**Type:** Architecture — delivery mode / significant CLI capability
+**First introduced:** this change (2026-08-29)
+**Key code today:** `client.py` (remote schema-driven FastMCP client), `server.py` (`oduflow client` dispatch), `scoped_access.py` (server-authoritative single-environment policy)
+
+## Context
+
+Oduflow had two ways to execute a registered tool. Native MCP clients connected
+to the HTTP or stdio transport, while `oduflow call` invoked the tool function
+locally in the server package. The local command is useful on the Docker host,
+but it loads local configuration and cannot operate a remote Oduflow instance.
+Shell scripts, CI jobs, operators, and coding-agent skills therefore had to
+configure a full MCP integration or use the dashboard's partial REST API.
+
+The REST API is intentionally shaped around dashboard workflows and does not
+mirror the complete development tool surface. Reimplementing every MCP tool as
+a second REST contract would duplicate argument schemas, error semantics,
+scoped authorization, and future tool additions. It would also encourage agents
+to receive the dashboard `ui_password` instead of the narrower per-environment
+credential introduced by [[0028-scoped-environment-mcp-access]].
+
+## Decision
+
+Add `oduflow client <tool>` as an official remote CLI. It connects through
+FastMCP to the exact endpoint supplied in `ODUFLOW_MCP_URL`, authenticates with
+the Bearer credential in `ODUFLOW_MCP_TOKEN`, discovers the endpoint's live
+`tools/list` schemas, and calls the selected tool. `oduflow call <tool>` remains
+the separate local in-process path.
+
+The remote CLI does not carry a hard-coded copy of the tool catalogue. It uses
+the server schema for visibility, argument names, basic types, required fields,
+and help output. Consequently a full `/mcp` endpoint exposes team-wide tools,
+while `/mcp/<env>` exposes only the default-deny scoped allowlist and omits
+`env_name`; the client does not duplicate or weaken that policy.
+
+## How it works
+
+The client accepts either kebab-case named flags or one JSON argument object.
+It converts scalar and JSON values according to the advertised schema and sends
+the resulting dictionary through `FastMCP.Client.call_tool`. Required
+`env_name` defaults to an explicit client override, `ODUFLOW_ENV_NAME`, or the
+current Git branch. `create_environment` additionally defaults its required
+`branch` to the current Git branch; tools that deploy long-lived targets, such
+as `create_production`, always require the branch explicitly. On a
+scoped endpoint the server removes `env_name` from the schema and injects the
+URL-bound environment after authorization, so the client performs no target
+selection.
+
+Connection options are parsed before the tool name; everything after the tool
+name belongs to its live schema. The command is dispatched before Oduflow loads
+local Settings, so a client installation needs neither the remote server's TOML
+nor Docker access. Human output preserves returned text and cached-output hints;
+`--json` emits the complete MCP result for automation. Authentication,
+transport, schema, and tool failures produce non-zero process exits.
+
+## Consequences
+
+- Operators and CI can drive any current Oduflow tool remotely with the same
+  package and semantics as native MCP clients, without a parallel REST API.
+- Coding-agent skills can use one deterministic CLI and avoid loading the full
+  Oduflow tool catalogue into the model context; they can refresh workflow
+  guidance through `oduflow client get_agent_instructions`.
+- Scoped URLs and per-environment tokens remain the preferred agent credential:
+  tool visibility and target injection are enforced by the server exactly as
+  described in [[0028-scoped-environment-mcp-access]].
+- Every CLI invocation performs MCP initialization and live tool discovery.
+  This adds a small round trip but prevents stale client schemas and makes new
+  tools available without a client release.
+- The Oduflow Python package remains larger than a minimal standalone client,
+  but keeping client and server on the same FastMCP dependency avoids another
+  package, release process, and compatibility matrix.
+
+## Evolution
+
+Schema caching or generated shell completion may be added later if repeated
+discovery becomes measurable. They must remain advisory: the authenticated
+server response is always the source of truth for available tools and scope.
+
+## History
+
+- 2026-08-29 — built-in schema-driven FastMCP client and `oduflow client`
+  command introduced.

--- a/specs/README.md
+++ b/specs/README.md
@@ -69,6 +69,7 @@ precursors).
 | [0048](0048-reusable-environment-hostname-slots.md) | 2026-08-16 | Reusable environment hostname slots decouple public routing from branch identity |
 | [0049](0049-environment-reuse-by-branch-switch.md) | 2026-08-17 | Environment reuse: the branch becomes a mutable property switched in place |
 | [0050](0050-granular-resource-locks.md) | 2026-08-17 | Resource-scoped locks: the team lock stops being the catch-all |
+| [0051](0051-remote-mcp-cli-client.md) | 2026-08-29 | Built-in remote CLI over the live FastMCP tool surface |
 
 ## Design docs
 

--- a/src/oduflow/client.py
+++ b/src/oduflow/client.py
@@ -1,0 +1,485 @@
+"""Remote Oduflow CLI backed by the server's FastMCP tool surface."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import warnings
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TextIO
+
+try:
+    from authlib.deprecate import AuthlibDeprecationWarning
+
+    warnings.filterwarnings("ignore", category=AuthlibDeprecationWarning)
+except Exception:  # pragma: no cover - authlib internals may change
+    pass
+
+
+class ClientUsageError(ValueError):
+    """Invalid remote-client configuration or command arguments."""
+
+
+@dataclass(frozen=True)
+class ClientOptions:
+    url: str
+    token: str
+    env_name: str
+    timeout: float
+    json_output: bool
+    tool_name: str
+    tool_args: list[str]
+
+
+ClientFactory = Callable[[str, str, float], Any]
+BranchGetter = Callable[[], str]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="oduflow client",
+        description="Call tools on a remote Oduflow MCP server",
+    )
+    parser.add_argument(
+        "--url",
+        default="",
+        help="MCP endpoint (default: ODUFLOW_MCP_URL)",
+    )
+    parser.add_argument(
+        "--env",
+        default="",
+        help="environment override (default: ODUFLOW_ENV_NAME or current branch)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=600.0,
+        help="tool timeout in seconds (default: 600)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="emit the complete MCP result as JSON",
+    )
+    parser.add_argument(
+        "--token-stdin",
+        action="store_true",
+        help="read the Bearer token from stdin instead of ODUFLOW_MCP_TOKEN",
+    )
+    parser.add_argument(
+        "tool_name",
+        nargs="?",
+        default="list",
+        help="remote MCP tool name, or 'list'",
+    )
+    parser.add_argument("tool_args", nargs=argparse.REMAINDER)
+    return parser
+
+
+def _parse_options(
+    argv: Sequence[str],
+    environ: Mapping[str, str],
+    stdin: TextIO,
+) -> ClientOptions:
+    args = _parser().parse_args(list(argv))
+    url = (args.url or environ.get("ODUFLOW_MCP_URL", "")).strip()
+    if not url:
+        raise ClientUsageError(
+            "MCP URL is required; set ODUFLOW_MCP_URL or pass --url."
+        )
+    if args.timeout <= 0:
+        raise ClientUsageError("--timeout must be greater than zero.")
+
+    if args.token_stdin:
+        token = stdin.readline().strip()
+    else:
+        token = environ.get("ODUFLOW_MCP_TOKEN", "").strip()
+
+    return ClientOptions(
+        url=url,
+        token=token,
+        env_name=(args.env or environ.get("ODUFLOW_ENV_NAME", "")).strip(),
+        timeout=args.timeout,
+        json_output=args.json_output,
+        tool_name=args.tool_name,
+        tool_args=list(args.tool_args),
+    )
+
+
+def _git_branch() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ClientUsageError(f"Cannot determine the current git branch: {exc}")
+    branch = result.stdout.strip()
+    if result.returncode != 0 or not branch:
+        raise ClientUsageError(
+            "Cannot determine the current git branch; pass --env or the required "
+            "--branch argument explicitly."
+        )
+    return branch
+
+
+def _default_client_factory(url: str, token: str, timeout: float) -> Any:
+    from fastmcp import Client
+
+    return Client(url, auth=token or None, timeout=timeout)
+
+
+def _tool_schema(tool: Any) -> dict[str, Any]:
+    schema = getattr(tool, "inputSchema", None)
+    if schema is None:
+        schema = getattr(tool, "input_schema", None)
+    return schema if isinstance(schema, dict) else {}
+
+
+def _tool_description(tool: Any) -> str:
+    return str(getattr(tool, "description", "") or "").strip()
+
+
+def _parameter_type(parameter: Mapping[str, Any]) -> Any:
+    """Return the effective JSON Schema type of a parameter.
+
+    Optional tool arguments (``bool | None``, ``list[...] | None``) reach the
+    client as an ``anyOf`` union with a ``null`` branch, so the concrete type
+    has to be unwrapped before flags can be parsed and coerced.
+    """
+    value_type = parameter.get("type")
+    if value_type is not None:
+        return value_type
+    variants = parameter.get("anyOf")
+    if isinstance(variants, list):
+        for variant in variants:
+            if not isinstance(variant, dict):
+                continue
+            variant_type = variant.get("type")
+            if variant_type is not None and variant_type != "null":
+                return variant_type
+    return None
+
+
+def _coerce_value(raw: str, parameter: Mapping[str, Any]) -> Any:
+    value_type = _parameter_type(parameter)
+    if value_type == "string" or value_type is None:
+        return raw
+    if value_type == "boolean":
+        normalized = raw.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+        raise ClientUsageError(f"Expected a boolean value, got {raw!r}.")
+    if value_type == "integer":
+        try:
+            return int(raw)
+        except ValueError as exc:
+            raise ClientUsageError(f"Expected an integer value, got {raw!r}.") from exc
+    if value_type == "number":
+        try:
+            return float(raw)
+        except ValueError as exc:
+            raise ClientUsageError(f"Expected a numeric value, got {raw!r}.") from exc
+    if value_type in {"array", "object"}:
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ClientUsageError(
+                f"Expected JSON for {value_type} value, got {raw!r}."
+            ) from exc
+        expected = list if value_type == "array" else dict
+        if not isinstance(value, expected):
+            raise ClientUsageError(f"Expected a JSON {value_type}, got {raw!r}.")
+        return value
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _parse_json_arguments(tokens: Sequence[str]) -> dict[str, Any] | None:
+    if not tokens or not tokens[0].lstrip().startswith("{"):
+        return None
+    if len(tokens) != 1:
+        raise ClientUsageError(
+            "A JSON argument object cannot be combined with named flags."
+        )
+    try:
+        value = json.loads(tokens[0])
+    except json.JSONDecodeError as exc:
+        raise ClientUsageError(f"Invalid JSON argument object: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ClientUsageError("Tool arguments must be a JSON object.")
+    return value
+
+
+def _parse_named_arguments(
+    tokens: Sequence[str], schema: Mapping[str, Any]
+) -> dict[str, Any]:
+    properties = schema.get("properties", {})
+    if not isinstance(properties, dict):
+        properties = {}
+    result: dict[str, Any] = {}
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if not token.startswith("--"):
+            raise ClientUsageError(
+                f"Unexpected positional argument {token!r}; use named flags or one "
+                "JSON object."
+            )
+        raw_name, separator, inline_value = token[2:].partition("=")
+        negated = raw_name.startswith("no-")
+        if negated:
+            raw_name = raw_name[3:]
+        name = raw_name.replace("-", "_")
+        parameter = properties.get(name)
+        if not isinstance(parameter, dict):
+            available = ", ".join(sorted(properties)) or "none"
+            raise ClientUsageError(
+                f"Unknown argument --{raw_name}; available parameters: {available}."
+            )
+        parameter_type = _parameter_type(parameter)
+        if negated and parameter_type != "boolean":
+            raise ClientUsageError(f"--no-{raw_name} is valid only for booleans.")
+
+        if separator:
+            if negated:
+                raise ClientUsageError(f"--no-{raw_name} does not take a value.")
+            raw_value = inline_value
+        elif parameter_type == "boolean":
+            if negated:
+                raw_value = "false"
+            elif index + 1 < len(tokens) and not tokens[index + 1].startswith("--"):
+                index += 1
+                raw_value = tokens[index]
+            else:
+                raw_value = "true"
+        else:
+            if negated:
+                raise ClientUsageError(f"--no-{raw_name} is valid only for booleans.")
+            if index + 1 >= len(tokens) or tokens[index + 1].startswith("--"):
+                raise ClientUsageError(f"--{raw_name} requires a value.")
+            index += 1
+            raw_value = tokens[index]
+
+        result[name] = _coerce_value(raw_value, parameter)
+        index += 1
+    return result
+
+
+def _resolve_arguments(
+    tokens: Sequence[str],
+    tool: Any,
+    env_override: str,
+    branch_getter: BranchGetter,
+) -> dict[str, Any]:
+    schema = _tool_schema(tool)
+    arguments = _parse_json_arguments(tokens)
+    if arguments is None:
+        arguments = _parse_named_arguments(tokens, schema)
+
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+    if not isinstance(properties, dict):
+        properties = {}
+    if not isinstance(required, list):
+        required = []
+
+    if "env_name" in required and "env_name" not in arguments:
+        arguments["env_name"] = env_override or branch_getter()
+    elif env_override and "env_name" in properties and "env_name" not in arguments:
+        arguments["env_name"] = env_override
+
+    # Only environment creation infers the branch from the working copy. Other
+    # tools that require a branch (create_production) target long-lived
+    # deployments, where a silent default from the operator's checkout would be
+    # the wrong target.
+    if (
+        str(getattr(tool, "name", "")) == "create_environment"
+        and "branch" in required
+        and "branch" not in arguments
+    ):
+        arguments["branch"] = branch_getter()
+
+    missing = [name for name in required if name not in arguments]
+    if missing:
+        rendered = ", ".join(f"--{name.replace('_', '-')}" for name in missing)
+        raise ClientUsageError(f"Missing required arguments: {rendered}.")
+    return arguments
+
+
+def _print_tools(tools: Sequence[Any], *, verbose: bool, stdout: TextIO) -> None:
+    for tool in sorted(tools, key=lambda item: str(getattr(item, "name", ""))):
+        name = str(getattr(tool, "name", ""))
+        if not name:
+            continue
+        print(name, file=stdout)
+        if verbose:
+            description = _tool_description(tool).splitlines()[0:1]
+            if description:
+                print(f"  {description[0]}", file=stdout)
+
+
+def _print_tool_help(tool: Any, stdout: TextIO) -> None:
+    name = str(getattr(tool, "name", ""))
+    description = _tool_description(tool)
+    schema = _tool_schema(tool)
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+    if not isinstance(properties, dict):
+        properties = {}
+    if not isinstance(required, list):
+        required = []
+
+    print(f"Usage: oduflow client {name} [JSON_OBJECT | --name VALUE ...]", file=stdout)
+    if description:
+        print(f"\n{description}", file=stdout)
+    if not properties:
+        print("\nThis tool takes no arguments.", file=stdout)
+        return
+    print("\nArguments:", file=stdout)
+    for parameter_name, parameter in properties.items():
+        if not isinstance(parameter, dict):
+            parameter = {}
+        flag = parameter_name.replace("_", "-")
+        value_type = _parameter_type(parameter) or "value"
+        suffix = "required" if parameter_name in required else "optional"
+        if "default" in parameter:
+            suffix += f", default={parameter['default']!r}"
+        print(f"  --{flag} <{value_type}>  {suffix}", file=stdout)
+
+
+def _jsonable(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json", by_alias=True)
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _print_result(result: Any, *, as_json: bool, stdout: TextIO) -> None:
+    if as_json:
+        payload = {
+            "content": _jsonable(getattr(result, "content", [])),
+            "structured_content": _jsonable(
+                getattr(result, "structured_content", None)
+            ),
+            "data": _jsonable(getattr(result, "data", None)),
+            "meta": _jsonable(getattr(result, "meta", None)),
+            "is_error": bool(getattr(result, "is_error", False)),
+        }
+        print(json.dumps(payload, ensure_ascii=True), file=stdout)
+        return
+
+    printed = False
+    for block in getattr(result, "content", []):
+        text = getattr(block, "text", None)
+        if text is not None:
+            print(text, file=stdout)
+            printed = True
+        else:
+            print(json.dumps(_jsonable(block), ensure_ascii=True), file=stdout)
+            printed = True
+    if not printed and getattr(result, "data", None) is not None:
+        data = getattr(result, "data")
+        if isinstance(data, str):
+            print(data, file=stdout)
+        else:
+            print(json.dumps(_jsonable(data), ensure_ascii=True), file=stdout)
+
+
+async def _run_client_async(
+    argv: Sequence[str],
+    *,
+    environ: Mapping[str, str],
+    stdin: TextIO,
+    stdout: TextIO,
+    client_factory: ClientFactory,
+    branch_getter: BranchGetter,
+) -> int:
+    options = _parse_options(argv, environ, stdin)
+    async with client_factory(options.url, options.token, options.timeout) as client:
+        tools = await client.list_tools()
+        if options.tool_name == "list":
+            verbose = options.tool_args == ["--verbose"]
+            if options.tool_args and not verbose:
+                raise ClientUsageError("Usage: oduflow client list [--verbose]")
+            _print_tools(tools, verbose=verbose, stdout=stdout)
+            return 0
+
+        by_name = {str(getattr(tool, "name", "")): tool for tool in tools}
+        tool = by_name.get(options.tool_name)
+        if tool is None:
+            scope_hint = " The endpoint may be scoped to one environment."
+            raise ClientUsageError(
+                f"Tool {options.tool_name!r} is not available on this Oduflow "
+                f"endpoint.{scope_hint}"
+            )
+        if options.tool_args == ["--help"]:
+            _print_tool_help(tool, stdout)
+            return 0
+
+        arguments = _resolve_arguments(
+            options.tool_args, tool, options.env_name, branch_getter
+        )
+        result = await client.call_tool(
+            options.tool_name,
+            arguments,
+            timeout=options.timeout,
+            raise_on_error=False,
+        )
+        _print_result(result, as_json=options.json_output, stdout=stdout)
+        return 1 if bool(getattr(result, "is_error", False)) else 0
+
+
+def run_client(
+    argv: Sequence[str],
+    *,
+    environ: Mapping[str, str] | None = None,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    client_factory: ClientFactory | None = None,
+    branch_getter: BranchGetter | None = None,
+) -> int:
+    """Run ``oduflow client`` and return a process-compatible exit code."""
+    environ = os.environ if environ is None else environ
+    stdin = sys.stdin if stdin is None else stdin
+    stdout = sys.stdout if stdout is None else stdout
+    stderr = sys.stderr if stderr is None else stderr
+    client_factory = client_factory or _default_client_factory
+    branch_getter = branch_getter or _git_branch
+    try:
+        return asyncio.run(
+            _run_client_async(
+                argv,
+                environ=environ,
+                stdin=stdin,
+                stdout=stdout,
+                client_factory=client_factory,
+                branch_getter=branch_getter,
+            )
+        )
+    except ClientUsageError as exc:
+        print(f"ERROR: {exc}", file=stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("ERROR: interrupted", file=stderr)
+        return 130
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=stderr)
+        return 1

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -9,7 +9,7 @@ import pathlib
 import re
 import sys
 import warnings
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, ParamSpec, TypeVar, cast
 
 # Suppress a third-party deprecation warning emitted at import time by fastmcp's
@@ -6005,8 +6005,23 @@ def _get_version() -> str:
 # =============================================================================
 
 
+def _dispatch_client(argv: Sequence[str]) -> None:
+    """Run the remote MCP client and turn its exit code into a process exit."""
+    from oduflow.client import run_client
+
+    exit_code = run_client(list(argv))
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
 def _run_cli() -> None:
     """Entry point for the Oduflow MCP server."""
+    # The remote client accepts flags defined by the live server's tool schemas,
+    # so the static top-level parser must not try to interpret them first.
+    if len(sys.argv) > 1 and sys.argv[1] == "client":
+        _dispatch_client(sys.argv[2:])
+        return
+
     parser = argparse.ArgumentParser(
         prog="oduflow", description="Oduflow — Odoo dev environment manager"
     )
@@ -6221,6 +6236,17 @@ def _run_cli() -> None:
         "call_args", nargs="*", default=[], help="Tool name and arguments"
     )
 
+    p_client = sub.add_parser(
+        "client",
+        help="Call tools on a remote Oduflow MCP server",
+        add_help=False,
+    )
+    p_client.add_argument(
+        "client_args",
+        nargs=argparse.REMAINDER,
+        help="client options, remote tool name, and tool arguments",
+    )
+
     # --- Declarative stacks ---
     p_stack = sub.add_parser(
         "stack", help="Validate, plan, apply, or inspect a declarative Stack"
@@ -6255,6 +6281,13 @@ def _run_cli() -> None:
 
     if args.command == "call":
         _run_call(args.call_args)
+        return
+
+    # Reached only when a global option precedes the subcommand, as in
+    # "oduflow -t http client list"; the fast path at the top of _run_cli
+    # handles the plain "oduflow client ..." form.
+    if args.command == "client":
+        _dispatch_client(args.client_args)
         return
 
     if args.command == "stack" and args.stack_command == "validate":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from oduflow.client import run_client
+
+
+def _tool(
+    name: str,
+    properties: dict[str, dict[str, Any]] | None = None,
+    required: list[str] | None = None,
+    description: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        inputSchema={
+            "type": "object",
+            "properties": properties or {},
+            "required": required or [],
+        },
+    )
+
+
+class FakeClient:
+    def __init__(self, tools: list[Any], result: Any | None = None) -> None:
+        self.tools = tools
+        self.result = result or SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            structured_content=None,
+            data=None,
+            meta=None,
+            is_error=False,
+        )
+        self.calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    async def __aenter__(self) -> FakeClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def list_tools(self) -> list[Any]:
+        return self.tools
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any], **kwargs: Any
+    ) -> Any:
+        self.calls.append((name, arguments, kwargs))
+        return self.result
+
+
+class Factory:
+    def __init__(self, client: FakeClient) -> None:
+        self.client = client
+        self.calls: list[tuple[str, str, float]] = []
+
+    def __call__(self, url: str, token: str, timeout: float) -> FakeClient:
+        self.calls.append((url, token, timeout))
+        return self.client
+
+
+def _run(
+    argv: list[str],
+    client: FakeClient,
+    *,
+    environ: dict[str, str] | None = None,
+    branch: str = "feature/test",
+    stdin: str = "",
+) -> tuple[int, str, str, Factory]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    factory = Factory(client)
+    code = run_client(
+        argv,
+        environ=environ
+        or {
+            "ODUFLOW_MCP_URL": "https://oduflow.example/mcp",
+            "ODUFLOW_MCP_TOKEN": "secret",
+        },
+        stdin=io.StringIO(stdin),
+        stdout=stdout,
+        stderr=stderr,
+        client_factory=factory,
+        branch_getter=lambda: branch,
+    )
+    return code, stdout.getvalue(), stderr.getvalue(), factory
+
+
+def test_list_tools_uses_remote_url_and_token() -> None:
+    client = FakeClient(
+        [_tool("z_tool"), _tool("a_tool", description="First line\nMore")]
+    )
+
+    code, stdout, stderr, factory = _run(["list", "--verbose"], client)
+
+    assert code == 0
+    assert stdout == "a_tool\n  First line\nz_tool\n"
+    assert stderr == ""
+    assert factory.calls == [("https://oduflow.example/mcp", "secret", 600.0)]
+
+
+def test_required_env_name_defaults_to_current_branch() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "pull_and_apply",
+                {
+                    "env_name": {"type": "string"},
+                    "upgrade": {"type": "string", "default": ""},
+                    "restart": {"type": "boolean", "default": False},
+                    "strict": {"type": "boolean", "default": False},
+                },
+                ["env_name"],
+            )
+        ]
+    )
+
+    code, stdout, stderr, _factory = _run(
+        ["pull_and_apply", "--upgrade", "sale_custom", "--strict"], client
+    )
+
+    assert code == 0
+    assert stdout == "ok\n"
+    assert stderr == ""
+    assert client.calls[0][0:2] == (
+        "pull_and_apply",
+        {
+            "env_name": "feature/test",
+            "upgrade": "sale_custom",
+            "strict": True,
+        },
+    )
+    assert client.calls[0][2]["raise_on_error"] is False
+
+
+def test_env_override_wins_and_boolean_can_be_negated() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "pull_and_apply",
+                {
+                    "env_name": {"type": "string"},
+                    "restart": {"type": "boolean"},
+                },
+                ["env_name"],
+            )
+        ]
+    )
+
+    code, _stdout, _stderr, _factory = _run(
+        ["--env", "demo", "pull_and_apply", "--no-restart"], client
+    )
+
+    assert code == 0
+    assert client.calls[0][1] == {"env_name": "demo", "restart": False}
+
+
+def test_scoped_schema_does_not_read_current_branch() -> None:
+    client = FakeClient(
+        [_tool("run_odoo_tests", {"modules": {"type": "string"}}, ["modules"])]
+    )
+
+    code = run_client(
+        ["run_odoo_tests", "--modules", "sale_custom"],
+        environ={"ODUFLOW_MCP_URL": "https://host/mcp/demo"},
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        client_factory=Factory(client),
+        branch_getter=lambda: (_ for _ in ()).throw(AssertionError("branch read")),
+    )
+
+    assert code == 0
+    assert client.calls[0][1] == {"modules": "sale_custom"}
+
+
+def test_create_environment_injects_branch_and_optional_env_override() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "create_environment",
+                {
+                    "branch": {"type": "string"},
+                    "env_name": {"type": "string", "default": ""},
+                    "odoo_image": {"type": "string", "default": ""},
+                },
+                ["branch"],
+            )
+        ]
+    )
+
+    code, _stdout, _stderr, _factory = _run(
+        ["--env", "demo", "create_environment", "--odoo-image", "odoo:19.0"],
+        client,
+        branch="feature/client",
+    )
+
+    assert code == 0
+    assert client.calls[0][1] == {
+        "branch": "feature/client",
+        "env_name": "demo",
+        "odoo_image": "odoo:19.0",
+    }
+
+
+def test_json_arguments_are_passed_through() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "odoo_search_read",
+                {
+                    "env_name": {"type": "string"},
+                    "model": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+                ["env_name", "model"],
+            )
+        ]
+    )
+
+    code, _stdout, _stderr, _factory = _run(
+        ["odoo_search_read", '{"model":"res.partner","limit":20}'], client
+    )
+
+    assert code == 0
+    assert client.calls[0][1] == {
+        "env_name": "feature/test",
+        "model": "res.partner",
+        "limit": 20,
+    }
+
+
+def test_named_values_follow_tool_schema_types() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "typed",
+                {
+                    "count": {"type": "integer"},
+                    "ratio": {"type": "number"},
+                    "enabled": {"type": "boolean"},
+                    "items": {"type": "array"},
+                },
+            )
+        ]
+    )
+
+    code, _stdout, _stderr, _factory = _run(
+        [
+            "typed",
+            "--count",
+            "20",
+            "--ratio=1.5",
+            "--enabled",
+            "false",
+            "--items",
+            '["a","b"]',
+        ],
+        client,
+    )
+
+    assert code == 0
+    assert client.calls[0][1] == {
+        "count": 20,
+        "ratio": 1.5,
+        "enabled": False,
+        "items": ["a", "b"],
+    }
+
+
+def test_tool_help_comes_from_live_schema() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "logs",
+                {"n_lines": {"type": "integer", "default": 100}},
+                description="Read logs.",
+            )
+        ]
+    )
+
+    code, stdout, stderr, _factory = _run(["logs", "--help"], client)
+
+    assert code == 0
+    assert "Usage: oduflow client logs" in stdout
+    assert "--n-lines <integer>" in stdout
+    assert "Read logs." in stdout
+    assert stderr == ""
+    assert client.calls == []
+
+
+def test_unavailable_tool_mentions_scoped_endpoint() -> None:
+    code, _stdout, stderr, _factory = _run(
+        ["list_environments"], FakeClient([_tool("run_odoo_tests")])
+    )
+
+    assert code == 2
+    assert "not available" in stderr
+    assert "scoped" in stderr
+
+
+def test_tool_error_is_printed_and_returns_nonzero() -> None:
+    result = SimpleNamespace(
+        content=[SimpleNamespace(text="upgrade failed")],
+        structured_content=None,
+        data=None,
+        meta=None,
+        is_error=True,
+    )
+    client = FakeClient([_tool("upgrade")], result=result)
+
+    code, stdout, stderr, _factory = _run(["upgrade"], client)
+
+    assert code == 1
+    assert stdout == "upgrade failed\n"
+    assert stderr == ""
+
+
+def test_json_output_is_machine_readable() -> None:
+    result = SimpleNamespace(
+        content=[
+            SimpleNamespace(model_dump=lambda **_kwargs: {"type": "text", "text": "ok"})
+        ],
+        structured_content={"answer": 42},
+        data="ok",
+        meta={"request": "1"},
+        is_error=False,
+    )
+    client = FakeClient([_tool("answer")], result=result)
+
+    code, stdout, _stderr, _factory = _run(["--json", "answer"], client)
+
+    assert code == 0
+    assert json.loads(stdout) == {
+        "content": [{"type": "text", "text": "ok"}],
+        "structured_content": {"answer": 42},
+        "data": "ok",
+        "meta": {"request": "1"},
+        "is_error": False,
+    }
+
+
+def test_missing_url_fails_before_connecting() -> None:
+    client = FakeClient([])
+
+    code, _stdout, stderr, factory = _run(
+        ["list"], client, environ={"ODUFLOW_MCP_TOKEN": "secret"}
+    )
+
+    assert code == 2
+    assert "ODUFLOW_MCP_URL" in stderr
+    assert factory.calls == []
+
+
+def test_token_can_be_read_from_stdin() -> None:
+    client = FakeClient([])
+
+    code, _stdout, _stderr, factory = _run(
+        ["--token-stdin", "list"],
+        client,
+        environ={"ODUFLOW_MCP_URL": "https://host/mcp"},
+        stdin="from-stdin\n",
+    )
+
+    assert code == 0
+    assert factory.calls == [("https://host/mcp", "from-stdin", 600.0)]
+
+
+def test_real_fastmcp_client_round_trip() -> None:
+    from fastmcp import Client, FastMCP
+
+    server = FastMCP("test")
+
+    @server.tool()
+    def identify(env_name: str, count: int = 1) -> str:
+        return f"{env_name}:{count}"
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = run_client(
+        ["identify", "--count", "2"],
+        environ={"ODUFLOW_MCP_URL": "https://unused.example/mcp"},
+        stdout=stdout,
+        stderr=stderr,
+        client_factory=lambda _url, _token, _timeout: Client(server),
+        branch_getter=lambda: "feature/round-trip",
+    )
+
+    assert code == 0
+    assert stdout.getvalue() == "feature/round-trip:2\n"
+    assert stderr.getvalue() == ""
+
+
+def test_optional_boolean_union_supports_bare_and_negated_flags() -> None:
+    optional_bool = {"anyOf": [{"type": "boolean"}, {"type": "null"}], "default": None}
+    client = FakeClient(
+        [
+            _tool(
+                "update_service",
+                {
+                    "name": {"type": "string"},
+                    "host_mode": optional_bool,
+                    "privileged": optional_bool,
+                },
+                ["name"],
+            )
+        ]
+    )
+
+    code, _stdout, _stderr, _factory = _run(
+        ["update_service", "--name", "fs", "--host-mode", "--no-privileged"], client
+    )
+
+    assert code == 0
+    assert client.calls[0][1] == {
+        "name": "fs",
+        "host_mode": True,
+        "privileged": False,
+    }
+
+
+def test_optional_union_help_shows_concrete_type() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "update_service",
+                {
+                    "host_mode": {
+                        "anyOf": [{"type": "boolean"}, {"type": "null"}],
+                        "default": None,
+                    }
+                },
+            )
+        ]
+    )
+
+    code, stdout, _stderr, _factory = _run(["update_service", "--help"], client)
+
+    assert code == 0
+    assert "--host-mode <boolean>" in stdout
+
+
+def test_required_branch_is_not_inferred_outside_create_environment() -> None:
+    client = FakeClient(
+        [
+            _tool(
+                "create_production",
+                {
+                    "name": {"type": "string"},
+                    "branch": {"type": "string"},
+                    "domain": {"type": "string"},
+                },
+                ["name", "branch", "domain"],
+            )
+        ]
+    )
+
+    code, _stdout, stderr, _factory = _run(
+        ["create_production", "--name", "acme", "--domain", "acme.example"], client
+    )
+
+    assert code == 2
+    assert "--branch" in stderr
+    assert client.calls == []

--- a/tests/test_client_cli.py
+++ b/tests/test_client_cli.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+
+def test_client_cli_dispatches_without_loading_settings() -> None:
+    from oduflow import server
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            ["oduflow", "client", "--url", "https://host/mcp", "list"],
+        ),
+        patch("oduflow.client.run_client", return_value=0) as run_client,
+        patch.object(
+            server, "find_toml", side_effect=AssertionError("settings loaded")
+        ),
+    ):
+        server._run_cli()
+
+    run_client.assert_called_once_with(["--url", "https://host/mcp", "list"])
+
+
+def test_client_cli_propagates_nonzero_exit_code() -> None:
+    from oduflow import server
+
+    with (
+        patch.object(sys, "argv", ["oduflow", "client", "list"]),
+        patch("oduflow.client.run_client", return_value=2),
+        patch.object(
+            server, "find_toml", side_effect=AssertionError("settings loaded")
+        ),
+        patch("builtins.print"),
+    ):
+        try:
+            server._run_cli()
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError("SystemExit was not raised")
+
+
+def test_client_cli_dispatches_after_a_global_option() -> None:
+    from oduflow import server
+
+    with (
+        patch.object(sys, "argv", ["oduflow", "-t", "http", "client", "list"]),
+        patch("oduflow.client.run_client", return_value=0) as run_client,
+        patch.object(
+            server, "find_toml", side_effect=AssertionError("settings loaded")
+        ),
+    ):
+        server._run_cli()
+
+    run_client.assert_called_once_with(["list"])


### PR DESCRIPTION
## Summary

Adds `oduflow client <tool>` — a schema-driven remote CLI that calls a running Oduflow server through FastMCP, instead of executing tools in-process the way `oduflow call` does.

- Connects to the endpoint in `ODUFLOW_MCP_URL` with the Bearer credential in `ODUFLOW_MCP_TOKEN` (or `--token-stdin`), reads the live `tools/list` schemas, and calls the selected tool.
- Accepts kebab-case named flags or one JSON argument object; values are coerced from the advertised schema types, including optional `anyOf` unions such as `bool | None` (`--host-mode` / `--no-host-mode`).
- Dispatched before local Settings load, so a client install needs neither the server's `oduflow.toml` nor Docker. The subcommand is handled both on the fast path and after the top-level parser, so `oduflow -t http client list` works too.
- A required `env_name` defaults to `--env`, `ODUFLOW_ENV_NAME`, or the current Git branch. `create_environment` also defaults its `branch` to the current checkout; long-lived targets such as `create_production` require `--branch` explicitly.
- Scoped `/mcp/<env>` endpoints are unchanged: the server hides team-wide tools and injects the environment target; the client keeps no second authorization list.
- `--json` emits the complete MCP result; tool errors and usage errors exit non-zero.

Decision record: `specs/0051-remote-mcp-cli-client.md`. Docs updated in `docs/cli.md`, `docs/security.md`, `docs/index.md`, `docs/mcp-tools.md`, `README.md`, and the changelog.

## Test plan

- `pytest -m "not integration and not heavyweight"` — 2608 passed, 1 pre-existing unrelated failure (`test_overlay_stale_mount.py::test_forced_recovery_ignores_copy_metadata`, also fails on `main`)
- `ruff check src/oduflow tests`, `ruff format --check`, `mypy src/oduflow`
- New tests cover flag/JSON argument parsing, type coercion (including optional unions), env/branch defaulting, scoped endpoints, `--json` output, error exit codes, a real FastMCP round trip, and CLI dispatch with and without a preceding global option.
