### PR TITLE
Scrub external command output from dashboard errors

### DIFF
--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -63,7 +63,13 @@ from oduflow.docker_ops.stats import (
     refresh_env_storage,
     refresh_team_storage,
 )
-from oduflow.errors import BusyError, ConflictError, FlowError, NotFoundError
+from oduflow.errors import (
+    BusyError,
+    ConflictError,
+    ExternalCommandError,
+    FlowError,
+    NotFoundError,
+)
 from oduflow.licensing import get_license_info, install_license_from_text
 from oduflow.locking import LockManager
 from oduflow.naming import validate_template_name
@@ -347,14 +353,33 @@ async def _read_login_password(request: Request) -> str:
     return (parsed.get("password", [""])[0]).strip()
 
 
-def _error_response(e: FlowError) -> JSONResponse:
+_EXTERNAL_COMMAND_UI_ERROR = "Operation failed. Check server logs for details."
+
+
+def _flow_error_status(e: FlowError) -> int:
     if isinstance(e, NotFoundError):
-        status = 404
-    elif isinstance(e, BusyError):
-        status = 409
-    else:
-        status = 400
-    return JSONResponse({"ok": False, "error": str(e)}, status_code=status)
+        return 404
+    if isinstance(e, BusyError):
+        return 409
+    if isinstance(e, ExternalCommandError):
+        return 500
+    return 400
+
+
+def _public_flow_error(e: FlowError, *, context: str = "Dashboard operation") -> str:
+    if isinstance(e, ExternalCommandError):
+        # Command output can contain tracebacks, filesystem paths, or connection
+        # details. Keep it in the server log instead of returning it to browsers.
+        logger.error("%s failed: %s", context, e)
+        return _EXTERNAL_COMMAND_UI_ERROR
+    return str(e)
+
+
+def _error_response(e: FlowError) -> JSONResponse:
+    return JSONResponse(
+        {"ok": False, "error": _public_flow_error(e)},
+        status_code=_flow_error_status(e),
+    )
 
 
 async def _offload(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
@@ -3176,11 +3201,18 @@ def _build_routes(
 
     async def api_connect_as(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
+        lock_acquired = False
         try:
             settings = get_settings()
             team = _get_ui_team(request)
+            # Read the body before taking the env lock (same order as
+            # api_update): a client that stalls mid-body would otherwise hold
+            # the branch lock for as long as it likes, 409-ing every other
+            # operation on the branch and blocking team-level ones.
             body = await request.json()
             user = (body.get("user") or "admin").strip() or "admin"
+            locks.acquire_env(branch, team.team_id, operation="connect_as_user")
+            lock_acquired = True
             activity.touch(team, branch)
             result = await _offload(
                 odoo_ops.connect_as_user, settings, team, branch, user
@@ -3209,6 +3241,9 @@ def _build_routes(
             return JSONResponse(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
+        finally:
+            if lock_acquired:
+                locks.release_env(branch)
 
     async def api_connect_open(request: Request) -> Response:
         """ "Open": mint a session and land the browser in the env already
@@ -3231,9 +3266,12 @@ def _build_routes(
         host-only there.
         """
         branch = request.path_params["branch"]
+        lock_acquired = False
         try:
             settings = get_settings()
             team = _get_ui_team(request)
+            locks.acquire_env(branch, team.team_id, operation="connect_as_user")
+            lock_acquired = True
             user = (request.query_params.get("user") or "admin").strip() or "admin"
             activity.touch(team, branch)
             result = await _offload(
@@ -3258,13 +3296,20 @@ def _build_routes(
             return response
         except FlowError as e:
             return Response(
-                f"Connect failed: {e}", status_code=400, media_type="text/plain"
+                f"Connect failed: {_public_flow_error(e, context='Connect As')}",
+                status_code=_flow_error_status(e),
+                media_type="text/plain",
             )
-        except Exception as e:
+        except Exception:
             logger.exception("Unexpected error in api_connect_open")
             return Response(
-                f"Connect failed: {e}", status_code=500, media_type="text/plain"
+                "Connect failed: Internal server error.",
+                status_code=500,
+                media_type="text/plain",
             )
+        finally:
+            if lock_acquired:
+                locks.release_env(branch)
 
     async def api_connect_land(request: Request) -> Response:
         """Traefik cross-subdomain Connect As landing, served ON the env host.

--- a/tests/test_web_ui_connect_as.py
+++ b/tests/test_web_ui_connect_as.py
@@ -11,9 +11,10 @@ mirroring test_web_ui_create_lock's TestClient harness.
 from unittest.mock import patch
 
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.testclient import TestClient
 
-from oduflow.errors import NotFoundError
+from oduflow.errors import ExternalCommandError, NotFoundError
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import mount_web_ui
@@ -28,9 +29,9 @@ def _open_settings(tmp_path):
     )
 
 
-def _client(settings):
+def _client(settings, locks=None):
     app = Starlette()
-    mount_web_ui(app, lambda: settings, LockManager())
+    mount_web_ui(app, lambda: settings, locks or LockManager())
     return TestClient(app)
 
 
@@ -99,6 +100,63 @@ def test_connect_as_error_surfaced(tmp_path):
     assert data.get("error")
 
 
+def test_connect_as_external_command_error_is_scrubbed(tmp_path, caplog):
+    client = _client(_open_settings(tmp_path))
+    internal_detail = "/srv/oduflow/private/path\nTraceback: registry failed"
+    caplog.set_level("ERROR", logger="oduflow")
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user",
+            side_effect=ExternalCommandError(
+                "odoo shell (connect_as_user)", 1, internal_detail
+            ),
+        ),
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        resp = client.post("/api/environments/18.0/connect-as", json={})
+
+    assert resp.status_code == 500
+    assert resp.json() == {
+        "ok": False,
+        "error": "Operation failed. Check server logs for details.",
+    }
+    assert internal_detail not in resp.text
+    assert internal_detail in caplog.text
+
+
+def test_connect_as_reads_body_before_locking(tmp_path):
+    """The env lock must not be held while the request body is being read.
+
+    request.json() waits on a client-controlled stream with no read timeout, so
+    acquiring the branch lock first would let a stalled client 409 every other
+    operation on the branch (and BusyError the whole team) for as long as it
+    keeps the socket open.
+    """
+    order = []
+
+    class _RecordingLocks(LockManager):
+        def acquire_env(self, env_name, team_id=None, operation=""):
+            order.append("lock")
+            super().acquire_env(env_name, team_id, operation)
+
+    client = _client(_open_settings(tmp_path), _RecordingLocks())
+    real_json = Request.json
+
+    async def _spy_json(self):
+        order.append("body")
+        return await real_json(self)
+
+    with (
+        patch("oduflow.web_ui.odoo_ops.connect_as_user", return_value=dict(_MINT)),
+        patch("oduflow.web_ui.activity.touch"),
+        patch.object(Request, "json", _spy_json),
+    ):
+        resp = client.post("/api/environments/18.0/connect-as", json={})
+
+    assert resp.json()["ok"] is True
+    assert order == ["body", "lock"]
+
+
 def test_connect_open_redirects_and_sets_cookie(tmp_path):
     client = _client(_open_settings(tmp_path))
     with (
@@ -134,6 +192,64 @@ def test_connect_open_defaults_to_admin(tmp_path):
     ):
         client.get("/api/environments/18.0/connect-open", follow_redirects=False)
     assert mock.call_args.args[3] == "admin"
+
+
+def test_connect_open_external_command_error_is_scrubbed(tmp_path, caplog):
+    client = _client(_open_settings(tmp_path))
+    internal_detail = "/mnt/extra-addons/private_module.py\nTraceback: registry failed"
+    caplog.set_level("ERROR", logger="oduflow")
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user",
+            side_effect=ExternalCommandError(
+                "odoo shell (connect_as_user)", 1, internal_detail
+            ),
+        ),
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        resp = client.get("/api/environments/18.0/connect-open", follow_redirects=False)
+
+    assert resp.status_code == 500
+    assert (
+        resp.text == "Connect failed: Operation failed. Check server logs for details."
+    )
+    assert internal_detail not in resp.text
+    assert internal_detail in caplog.text
+
+
+def test_connect_open_unexpected_error_is_scrubbed(tmp_path):
+    client = _client(_open_settings(tmp_path))
+    internal_detail = "/srv/oduflow/private/unexpected"
+    with (
+        patch(
+            "oduflow.web_ui.odoo_ops.connect_as_user",
+            side_effect=RuntimeError(internal_detail),
+        ),
+        patch("oduflow.web_ui.activity.touch"),
+    ):
+        resp = client.get("/api/environments/18.0/connect-open", follow_redirects=False)
+
+    assert resp.status_code == 500
+    assert resp.text == "Connect failed: Internal server error."
+    assert internal_detail not in resp.text
+
+
+def test_connect_open_rejects_lifecycle_race(tmp_path):
+    locks = LockManager()
+    locks.acquire_env("18.0", "1", operation="delete_environment")
+    client = _client(_open_settings(tmp_path), locks)
+    try:
+        with patch("oduflow.web_ui.odoo_ops.connect_as_user") as connect:
+            resp = client.get(
+                "/api/environments/18.0/connect-open", follow_redirects=False
+            )
+    finally:
+        locks.release_env("18.0")
+
+    assert resp.status_code == 409
+    assert "Another operation on environment '18.0'" in resp.text
+    assert "delete_environment" in resp.text
+    connect.assert_not_called()
 
 
 def _traefik_settings(tmp_path):

--- a/tests/test_web_ui_error_scrub.py
+++ b/tests/test_web_ui_error_scrub.py
@@ -1,8 +1,10 @@
-"""Regression test for issue #84 (item 2).
+"""Regression tests for errors returned by the dashboard API.
 
 The dashboard's HTTP-500 handlers returned ``str(e)`` in the JSON body, which
 could leak absolute paths / Docker internals to the browser. The handlers must
 now return a generic message and keep the detail server-side (logged only).
+The same rule applies to ``ExternalCommandError`` even though it is a FlowError:
+its message contains the external process's complete output.
 
 MCP tool responses are intentionally left verbose and are out of scope here.
 """
@@ -12,6 +14,7 @@ from unittest.mock import patch
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+from oduflow.errors import ExternalCommandError
 from oduflow.locking import LockManager
 from oduflow.settings import Settings, TeamSettings
 from oduflow.web_ui import mount_web_ui
@@ -47,3 +50,26 @@ def test_unexpected_500_does_not_leak_exception_text(tmp_path):
     # Generic message only — the internal detail must not reach the browser.
     assert body["error"] == "Internal server error."
     assert secret not in resp.text
+
+
+def test_delete_external_command_error_does_not_leak_output(tmp_path, caplog):
+    settings = _open_settings(tmp_path)
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    client = TestClient(app, raise_server_exceptions=False)
+
+    secret = "/srv/oduflow/data/team-1/private-delete-detail"
+    caplog.set_level("ERROR", logger="oduflow")
+    with patch(
+        "oduflow.web_ui.env_ops.delete_environment",
+        side_effect=ExternalCommandError("docker remove", 1, secret),
+    ):
+        resp = client.post("/api/environments/feature%2Fcleanup/delete")
+
+    assert resp.status_code == 500
+    assert resp.json() == {
+        "ok": False,
+        "error": "Operation failed. Check server logs for details.",
+    }
+    assert secret not in resp.text
+    assert secret in caplog.text


### PR DESCRIPTION
## What

`ExternalCommandError` carries the failed process's complete output — Docker internals, absolute filesystem paths, Python tracebacks. The dashboard's `FlowError` handler returned `str(e)` verbatim, so a failed delete (or any other environment operation) rendered that straight into the browser.

The dashboard now returns a generic `Operation failed. Check server logs for details.` for `ExternalCommandError` and keeps the detail in the server log, matching what the HTTP-500 handlers already do for unexpected exceptions. MCP tool responses stay verbose and are unaffected.

## Details

- `_public_flow_error()` / `_flow_error_status()` split out of `_error_response()`, so both the JSON API and the plain-text Connect As bridge share one rule.
- Status code for `ExternalCommandError` moves from 400 to 500: a failed external command is a server-side failure, not a bad request.
- `api_connect_open` no longer interpolates the raw exception into its plain-text response (both the `FlowError` and the unexpected-exception path).
- Both Connect As endpoints now take the environment lock, so minting a session cannot race a delete or recreate of the same branch. The lock is taken *after* the request body is read, so a client that stalls mid-body cannot hold the branch lock open and 409 every other operation on that branch.

## Tests

New cases in `tests/test_web_ui_error_scrub.py` and `tests/test_web_ui_connect_as.py` cover: delete and both Connect As endpoints scrubbing the command output while logging it, the unexpected-exception path on `connect-open`, the lifecycle-race rejection, and the body-read-before-lock ordering.

`pytest -m "not integration and not heavyweight"` — 2328 passed. `ruff check`, `ruff format --check`, `mypy` all clean.
