### PR TITLE
Return 400, not 500, for an invalid environment hostname

### DIFF
--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -85,6 +85,7 @@ from oduflow.naming import (
     PROD_ENV_PREFIX,
     parse_env_vars,
     slugify_branch,
+    validate_env_hostname,
     validate_env_name,
     validate_template_name,
 )
@@ -1448,10 +1449,13 @@ def _build_routes(
                 {"ok": False, "error": "branch is required."},
                 status_code=400,
             )
-        from oduflow.naming import validate_env_name
-
         try:
             env_name = validate_env_name(env_name)
+            # Validated here as well as in create_environment: rejecting a bad
+            # DNS label before the lock is taken keeps the message immediate
+            # and starts no work that has to be unwound.
+            if hostname:
+                hostname = validate_env_hostname(hostname)
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
 
@@ -1565,6 +1569,14 @@ def _build_routes(
             # in the server journal.
             logger.warning("create_environment failed for %s: %s", env_name, e)
             return _error_response(e)
+        except ValueError as e:
+            # Deliberate input validation raised deeper in the create path
+            # (unsupported hostname for the routing mode, malformed team
+            # hostname, …). Same policy as the MCP tools' handle_errors: these
+            # messages are authored for the user, so surface them as 400
+            # instead of masking them behind a 500.
+            logger.warning("create_environment rejected %s: %s", env_name, e)
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except Exception:
             logger.exception("Unexpected error in api_create")
             return JSONResponse(

--- a/tests/test_web_ui_create_lock.py
+++ b/tests/test_web_ui_create_lock.py
@@ -251,3 +251,66 @@ def test_api_recreate_restores_legacy_slot_to_branch_hostname(tmp_path):
     assert resp.status_code == 200
     assert create.call_args.kwargs["hostname"] == ""
     assert create.call_args.kwargs["hostname_source"] == ""
+
+
+def test_api_create_rejects_invalid_hostname(tmp_path):
+    """A hostname that is not a DNS label is a 400 with the reason, not a 500.
+
+    The dashboard shows the API error verbatim, so an underscore typed into the
+    Hostname field must come back explained ("expected one DNS label") instead
+    of as an opaque "Internal server error."
+    """
+    settings = _open_settings(tmp_path)
+    locks = LockManager()
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, locks)
+    client = TestClient(app)
+
+    with patch("oduflow.web_ui.env_ops.create_environment") as create:
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "env_name": "oldstaging",
+                "hostname": "old_staging",
+                "repo_url": "r",
+                "odoo_image": "i",
+            },
+        )
+        # Rejected before any provisioning starts.
+        create.assert_not_called()
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["ok"] is False
+    assert "old_staging" in body["error"]
+    assert "DNS label" in body["error"]
+    # Rejecting before the lock is taken must leave the env free.
+    locks.acquire_env("oldstaging")
+
+
+def test_api_create_surfaces_value_error_from_create(tmp_path):
+    """Input validation raised inside create_environment is a 400, not a 500."""
+    settings = _open_settings(tmp_path)
+    locks = LockManager()
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, locks)
+    client = TestClient(app)
+
+    message = "hostname is supported only when routing.mode = 'traefik'."
+    with patch(
+        "oduflow.web_ui.env_ops.create_environment", side_effect=ValueError(message)
+    ):
+        resp = client.post(
+            "/api/environments/create",
+            json={
+                "env_name": "main",
+                "hostname": "dev2",
+                "repo_url": "r",
+                "odoo_image": "i",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.json() == {"ok": False, "error": message}
+    # The finally must still have released the lock this request acquired.
+    locks.acquire_env("main")


### PR DESCRIPTION
## Problem

Creating an environment from the dashboard with a hostname that is not a DNS label — e.g. `old_staging` typed into the *Hostname* field — failed with an opaque **"Internal server error."** The reason was only in the server log:

```
ValueError: Invalid environment hostname 'old_staging': expected one DNS label
such as 'dev1' (letters, digits and internal hyphens only).
INFO: "POST /api/environments/create HTTP/1.1" 500 Internal Server Error
```

`create_environment` raises `ValueError` from `validate_env_hostname`, but `api_create` caught `ValueError` only around `validate_env_name`; everything raised by the create call itself fell through to the generic `except Exception` → 500.

## Fix

- Validate the hostname up front, next to the env name and **before** the env lock is taken — immediate message, no work started that has to be unwound.
- Catch `ValueError` from the create call as a **400**, so validation raised deeper in the path (unsupported hostname for the routing mode, malformed team hostname, …) surfaces instead of being masked.

This is the policy `handle_errors` (`server.py`) already applies to the MCP tools — these messages are developer-authored for the user and safe to surface, while every other exception stays masked — and what `api_service_create` / `api_service_restore` already do. Environment create is the only env endpoint taking a user-supplied hostname (recreate reuses the container label), so the gap doesn't exist elsewhere.

No dashboard change needed: `submitCreate()` already renders `data.error`, so the dialog now shows the explanation instead of an internal error.

## Tests

Two added to `tests/test_web_ui_create_lock.py` — the `old_staging` case (400, message names the hostname, `create_environment` never called, lock left free) and a `ValueError` raised from inside `create_environment` (400, lock released). Both fail on the pre-fix code and pass after.

`ruff check`, `ruff format --check`, `mypy src/oduflow` clean. Unit suite: 2677 passed; the 4 failures (`test_server::test_reset_not_found`, `test_stack_cli::test_startup_stack_is_applied_before_server`, `test_template_metadata_web::test_template_list_reads_during_a_team_operation`, `test_template_provenance::test_source_line_includes_branch_and_short_commit`) are pre-existing on `main` and fail identically without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)