### PR TITLE
Custom start commands for auxiliary services

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Custom start command for auxiliary services** — `create_service` and
+  `update_service` accept an optional `command` that replaces the image `CMD`,
+  so images whose entrypoint expects arguments (`minio/minio server /data`)
+  no longer need a repackaged or legacy variant. The shell-quoted string is
+  split into argv once and stored that way in the service preset; the image
+  `ENTRYPOINT` is untouched. `get_service_info` reports the effective command
+  (and the image default when it is not overridden), the dashboard exposes it
+  in the Create/Restore service forms and on the service card, and declarative
+  Stacks gained a `command` field that participates in drift detection. On
+  update the parameter is tri-state: omitted keeps the current command, a
+  string replaces it, and an empty string drops the override.
+
 ## v1.72.1
 
 ### Bug Fixes

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2550,6 +2550,9 @@ oduflow call create_service meilisearch getmeili/meilisearch:v1.6 7700 "" "MEILI
 # Elasticsearch
 oduflow call create_service elasticsearch docker.elastic.co/elasticsearch/elasticsearch:8.11.0 9200 "" "discovery.type=single-node,ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
+# MinIO — the image expects its start arguments as the container command
+oduflow call create_service '{"name":"minio","image":"minio/minio","port":9000,"command":"server /data"}'
+
 # WireGuard VPN — needs NET_ADMIN to manage tun/iptables
 oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
 
@@ -2635,6 +2638,42 @@ readable to every service container. Use only trusted service images and grant
 service-management access only to trusted operators. Read-only protects the
 store from modification, not from disclosure.
 
+### Start Command
+
+Some images ship an `ENTRYPOINT` that expects arguments, and their default
+`CMD` is not what you want (`minio/minio` needs `server /data`, for example).
+The optional `command` replaces the image `CMD`:
+
+```bash
+oduflow call create_service '{
+  "name":"minio",
+  "image":"minio/minio",
+  "port":9000,
+  "command":"server /data --console-address :9001"
+}'
+```
+
+The string is split with shell quoting rules, so `--address ":9001"` stays one
+argument; the resulting argv is what `get_service_info` reports and what the
+preset stores. The image `ENTRYPOINT` is never changed. Leave `command` out to
+run the image's own `CMD`.
+
+On `update_service` the parameter is tri-state: omitted keeps the current
+command, a new string replaces it, and an **empty string drops the override**
+so the container falls back to the image `CMD`. (This differs from `env_vars`
+and `image`, where an empty value means "keep".)
+
+```bash
+# Change the command
+oduflow call update_service '{
+  "name":"minio",
+  "command":"server /data --console-address :9090"
+}'
+
+# Drop it and use the image default again
+oduflow call update_service '{"name":"minio","command":""}'
+```
+
 ### Linux Capabilities
 
 Two optional flags grant additional container privileges:
@@ -2651,7 +2690,8 @@ Both can be enabled at the same time; on the Docker side, `privileged` implies a
 oduflow call list_services
 
 # Full state of a single service — image + digest, port/routes, hostname,
-# host_mode, volumes, env vars, capabilities, restart count, started_at, preset
+# host_mode, command, volumes, env vars, capabilities, restart count,
+# started_at, preset
 oduflow call get_service_info redis
 
 # View service logs
@@ -2682,16 +2722,16 @@ oduflow call run_service_command redis "redis-cli ping"
 
 ### Changing a Service
 
-`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
+`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `command`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
 
-If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
+If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `command`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
 
 ## Service Update Flow
 
 The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
-2. Applies any overrides passed in (`env_vars`, `image`, `port`/`routes`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
+2. Applies any overrides passed in (`env_vars`, `image`, `port`/`routes`, `hostname`, `host_mode`, `command`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
 3. Resolves the complete candidate volume configuration before touching the running container; invalid or missing volumes fail without stopping it
 4. Pulls the target image (the override, or the current one)
 5. Decides whether to recreate:
@@ -2703,7 +2743,7 @@ Overrides are optional: calling `update_service` with only `name` pulls the curr
 
 ## Service Presets
 
-Every time a service is created, its configuration (image, port or routes, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
+Every time a service is created, its configuration (image, port or routes, hostname, environment variables, volumes, `host_mode`, `command`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
 
 ```bash
 # List saved presets
@@ -2937,6 +2977,10 @@ spec:
       image: oduist/freeswitch:1.4.0
       port: 8080
       hostMode: true
+
+      # Optional: replaces the image CMD. A shell-quoted string
+      # ("server /data") is accepted and split into the same argv.
+      command: ["freeswitch", "-nonat"]
 
       volumes:
         - source: fs-sounds
@@ -3178,8 +3222,8 @@ Odoo.sh ingest endpoints accept the import token only in
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/services` | List services |
-| `POST` | `/api/services/create` | Create a service with either catch-all `port` or restricted Traefik `routes`, plus optional image/runtime settings |
-| `POST` | `/api/services/{name}/update` | Pull/change settings and recreate safely; `env_vars`, `volumes`, and `routes` are full replacements when supplied |
+| `POST` | `/api/services/create` | Create a service with either catch-all `port` or restricted Traefik `routes`, plus optional image/runtime settings. `command` accepts a shell-quoted string or an argv array and replaces the image `CMD` |
+| `POST` | `/api/services/{name}/update` | Pull/change settings and recreate safely; `env_vars`, `volumes`, and `routes` are full replacements when supplied. Omit `command` to keep it, send `""`/`[]` to fall back to the image `CMD` |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
 | `GET` | `/api/services/{name}/logs?n=200` | Read service logs |
@@ -3339,12 +3383,12 @@ also available via the [REST API](web-api.md).
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik |
+| `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik. Optional `command` (shell-quoted string) replaces the image `CMD` |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | ✓ | Restart a service container |
-| `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode |
+| `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode. `command` is tri-state: omitted keeps it, a string replaces it, an empty string falls back to the image `CMD` |
 | `list_services` | | List all managed service containers |
-| `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
+| `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, command, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | ✓ | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
 | **Service PostgreSQL Databases** | | |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -52,12 +52,12 @@ also available via the [REST API](web-api.md).
 | `refresh_template` | ✓ | ⚠️ Re-apply a template's filestore to live overlay environments (preserves env changes by default; `reset_env_changes=True` discards them — destructive) |
 | `attach_filestore` | ✓ | Attach or replace a template filestore from a local directory, archive, `rsync://` URL, or SSH rsync source; normalizes wrapper paths and preserves live env changes by default |
 | **Auxiliary Services** | | |
-| `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik |
+| `create_service` | ✓ | Create a managed service with exactly one exposure model: catch-all `port`, or restricted Traefik `routes` (`path`, backend `port`, optional `strip_prefix`). The two parameters are mutually exclusive; `port` remains required outside Traefik. Optional `command` (shell-quoted string) replaces the image `CMD` |
 | `delete_service` | ✓ | Stop and remove a service container |
 | `restart_service` | ✓ | Restart a service container |
-| `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode |
+| `update_service` | ✓ | Preflight configuration, pull the latest image and/or change settings. `routes` replaces the complete allowlist; use `routes=[]` with `port` only when switching back to catch-all mode. `command` is tri-state: omitted keeps it, a string replaces it, an empty string falls back to the image `CMD` |
 | `list_services` | | List all managed service containers |
-| `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, volumes, env, capabilities, restart count, preset). Call before recreating it |
+| `get_service_info` | | Full live state of a single service (image+digest, port/routes, hostname, host_mode, command, volumes, env, capabilities, restart count, preset). Call before recreating it |
 | `get_service_logs` | | Retrieve service container logs |
 | `run_service_command` | ✓ | Execute a shell command inside a service container (through `sh -c`; `shell=False` for exact argv) |
 | **Service PostgreSQL Databases** | | |

--- a/docs/services.md
+++ b/docs/services.md
@@ -16,6 +16,9 @@ oduflow call create_service meilisearch getmeili/meilisearch:v1.6 7700 "" "MEILI
 # Elasticsearch
 oduflow call create_service elasticsearch docker.elastic.co/elasticsearch/elasticsearch:8.11.0 9200 "" "discovery.type=single-node,ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
+# MinIO — the image expects its start arguments as the container command
+oduflow call create_service '{"name":"minio","image":"minio/minio","port":9000,"command":"server /data"}'
+
 # WireGuard VPN — needs NET_ADMIN to manage tun/iptables
 oduflow call create_service '{"name":"vpn","image":"linuxserver/wireguard","port":51820,"net_admin":true}'
 
@@ -101,6 +104,42 @@ readable to every service container. Use only trusted service images and grant
 service-management access only to trusted operators. Read-only protects the
 store from modification, not from disclosure.
 
+### Start Command
+
+Some images ship an `ENTRYPOINT` that expects arguments, and their default
+`CMD` is not what you want (`minio/minio` needs `server /data`, for example).
+The optional `command` replaces the image `CMD`:
+
+```bash
+oduflow call create_service '{
+  "name":"minio",
+  "image":"minio/minio",
+  "port":9000,
+  "command":"server /data --console-address :9001"
+}'
+```
+
+The string is split with shell quoting rules, so `--address ":9001"` stays one
+argument; the resulting argv is what `get_service_info` reports and what the
+preset stores. The image `ENTRYPOINT` is never changed. Leave `command` out to
+run the image's own `CMD`.
+
+On `update_service` the parameter is tri-state: omitted keeps the current
+command, a new string replaces it, and an **empty string drops the override**
+so the container falls back to the image `CMD`. (This differs from `env_vars`
+and `image`, where an empty value means "keep".)
+
+```bash
+# Change the command
+oduflow call update_service '{
+  "name":"minio",
+  "command":"server /data --console-address :9090"
+}'
+
+# Drop it and use the image default again
+oduflow call update_service '{"name":"minio","command":""}'
+```
+
 ### Linux Capabilities
 
 Two optional flags grant additional container privileges:
@@ -117,7 +156,8 @@ Both can be enabled at the same time; on the Docker side, `privileged` implies a
 oduflow call list_services
 
 # Full state of a single service — image + digest, port/routes, hostname,
-# host_mode, volumes, env vars, capabilities, restart count, started_at, preset
+# host_mode, command, volumes, env vars, capabilities, restart count,
+# started_at, preset
 oduflow call get_service_info redis
 
 # View service logs
@@ -148,16 +188,16 @@ oduflow call run_service_command redis "redis-cli ping"
 
 ### Changing a Service
 
-`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
+`update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `command`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
 
-If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
+If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `command`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
 
 ## Service Update Flow
 
 The `update_service` operation:
 
 1. Reads the saved preset (authoritative source) or inspects the running container as a legacy fallback
-2. Applies any overrides passed in (`env_vars`, `image`, `port`/`routes`, `hostname`, `host_mode`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
+2. Applies any overrides passed in (`env_vars`, `image`, `port`/`routes`, `hostname`, `host_mode`, `command`, `volumes`, `privileged`, `net_admin`) — each override **fully replaces** the current value
 3. Resolves the complete candidate volume configuration before touching the running container; invalid or missing volumes fail without stopping it
 4. Pulls the target image (the override, or the current one)
 5. Decides whether to recreate:
@@ -169,7 +209,7 @@ Overrides are optional: calling `update_service` with only `name` pulls the curr
 
 ## Service Presets
 
-Every time a service is created, its configuration (image, port or routes, hostname, environment variables, volumes, `host_mode`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
+Every time a service is created, its configuration (image, port or routes, hostname, environment variables, volumes, `host_mode`, `command`, `cap_add`, `privileged`) is automatically saved as a **preset** in `{team_data_dir}/service_presets.json`. This allows you to restore a service after deletion without re-entering its configuration.
 
 ```bash
 # List saved presets

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -86,6 +86,10 @@ spec:
       port: 8080
       hostMode: true
 
+      # Optional: replaces the image CMD. A shell-quoted string
+      # ("server /data") is accepted and split into the same argv.
+      command: ["freeswitch", "-nonat"]
+
       volumes:
         - source: fs-sounds
           target: /usr/share/freeswitch/sounds

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -111,8 +111,8 @@ Odoo.sh ingest endpoints accept the import token only in
 | Method | Endpoint | Description |
 |---|---|---|
 | `GET` | `/api/services` | List services |
-| `POST` | `/api/services/create` | Create a service with either catch-all `port` or restricted Traefik `routes`, plus optional image/runtime settings |
-| `POST` | `/api/services/{name}/update` | Pull/change settings and recreate safely; `env_vars`, `volumes`, and `routes` are full replacements when supplied |
+| `POST` | `/api/services/create` | Create a service with either catch-all `port` or restricted Traefik `routes`, plus optional image/runtime settings. `command` accepts a shell-quoted string or an argv array and replaces the image `CMD` |
+| `POST` | `/api/services/{name}/update` | Pull/change settings and recreate safely; `env_vars`, `volumes`, and `routes` are full replacements when supplied. Omit `command` to keep it, send `""`/`[]` to fall back to the image `CMD` |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |
 | `GET` | `/api/services/{name}/logs?n=200` | Read service logs |

--- a/specs/0053-explicit-start-commands-for-auxiliary-services.md
+++ b/specs/0053-explicit-start-commands-for-auxiliary-services.md
@@ -1,0 +1,75 @@
+# 0053 — Explicit start commands for auxiliary services
+
+**Status:** Adopted
+**Type:** Architecture / Service lifecycle
+**First introduced:** 2026-08-31
+**Key code today:** `docker_ops/service_ops.py`, `docker_ops/service_presets.py`, `stack_models.py`, `stack_ops.py`, MCP tools in `server.py`, REST/dashboard controls in `web_ui.py` and `templates/dashboard.html`
+
+## Context
+
+Auxiliary services ([[0007-auxiliary-services-and-volumes]]) originally always
+started with the Docker image's default `CMD`. That works for self-starting
+images such as Redis, but many official images intentionally provide only an
+`ENTRYPOINT` and expect deployment-specific arguments. MinIO, for example,
+needs a storage path and may need a separate console address. Rebuilding such
+images merely to supply arguments creates unnecessary image variants and moves
+ordinary runtime configuration outside Oduflow.
+
+The command must survive service update and restore, remain inspectable, and
+participate in declarative Stack convergence ([[0046-declarative-oduflow-stacks]]).
+At the same time, accepting a shell program would add expansion and injection
+semantics that Docker does not require and would make a displayed command
+ambiguous to reproduce.
+
+## Decision
+
+Make an explicit argv-style Docker `CMD` override part of the managed auxiliary
+service configuration while always preserving the image `ENTRYPOINT`.
+
+- Operators may enter a shell-quoted string for convenience or provide an argv
+  array directly. Oduflow parses the string once and passes the resulting array
+  to Docker without invoking a shell.
+- The override is available consistently through MCP, REST, the dashboard,
+  saved presets, and declarative Stacks.
+- Updates use tri-state semantics: omission preserves the current command, a
+  non-empty value replaces it, and an explicit empty value removes the override
+  so the image `CMD` becomes effective again.
+- Presets store argv rather than the original spelling. Live inspection reports
+  the configured override and the image default separately; Stack planning
+  compares effective argv so an explicit command equal to the image default is
+  already converged.
+
+## How it works (macro)
+
+All human-oriented string inputs pass through one POSIX shell-word parser, but
+the parsed result is data, not a shell script. The service runtime gives Docker
+the array as its `command` option and persists the same array in the automatic
+preset. Recreate and image-update paths read the preset as their authoritative
+configuration; legacy services without a preset recover an override by
+comparing the container command with the image default.
+
+REST accepts only a string or an array of strings and rejects other JSON shapes.
+The Stack model accepts those same two input forms, normalizes both to argv, and
+publishes both forms in the generated JSON Schema. Command state participates
+in resource hashing, plan drift, and apply alongside image, environment,
+volumes, capabilities, and routes.
+
+## Consequences
+
+- Official images whose entrypoint expects arguments can run directly without
+  wrapper images or manual container management.
+- Commands round-trip without losing argument boundaries, including arguments
+  containing spaces; shell operators and variable expansion are deliberately
+  unavailable unless the configured command or image entrypoint explicitly
+  invokes a shell.
+- Clearing an override is explicit and distinguishable from leaving it
+  unchanged, at the cost of command update semantics differing from older
+  string options where an empty value means “keep”.
+- Docker does not record whether a container command identical to the image
+  default was supplied explicitly. Runtime convergence therefore uses effective
+  argv, while presets preserve the operator's intent for later image updates.
+
+## History
+
+- 2026-08-31 — decision introduced with command support across service
+  orchestration, presets, MCP, REST, dashboard, declarative Stacks, and docs.

--- a/specs/README.md
+++ b/specs/README.md
@@ -71,6 +71,7 @@ precursors).
 | [0050](0050-granular-resource-locks.md) | 2026-08-17 | Resource-scoped locks: the team lock stops being the catch-all |
 | [0051](0051-remote-mcp-cli-client.md) | 2026-08-29 | Built-in remote CLI over the live FastMCP tool surface |
 | [0052](0052-managed-postgresql-databases-for-auxiliary-services.md) | 2026-08-29 | Managed PostgreSQL databases for auxiliary services |
+| [0053](0053-explicit-start-commands-for-auxiliary-services.md) | 2026-08-31 | Explicit Docker CMD overrides for auxiliary services |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -254,6 +254,26 @@ def _needs_traefik_acme_mount(settings: Settings, container: Any) -> bool:
     return True
 
 
+def _image_command(container: Any) -> list[str]:
+    """The CMD baked into the container's image, or [] when it has none."""
+    try:
+        cmd = container.image.attrs.get("Config", {}).get("Cmd")
+    except Exception:
+        return []
+    return list(cmd) if isinstance(cmd, list) else []
+
+
+def _command_override(container: Any) -> list[str]:
+    """The container's CMD when it overrides the image default, else [].
+
+    Docker copies the image CMD into ``Config.Cmd`` when the container does not
+    set one, so an override is only visible as a difference between the two.
+    """
+    cmd = container.attrs.get("Config", {}).get("Cmd")
+    command = list(cmd) if isinstance(cmd, list) else []
+    return [] if command == _image_command(container) else command
+
+
 def _assert_free_service_slot(
     settings: Settings, team: TeamSettings, client: Any
 ) -> None:
@@ -290,6 +310,7 @@ def create_service(
     cap_add: list[str] | None = None,
     privileged: bool = False,
     routes: list[dict[str, object]] | None = None,
+    command: list[str] | None = None,
     stack_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     container_name = get_service_container_name(name, settings.prefix, team.team_id)
@@ -413,6 +434,9 @@ def create_service(
     if env_vars:
         run_kwargs["environment"] = env_vars
 
+    if command:
+        run_kwargs["command"] = list(command)
+
     # Reject a missing or reserved volume before the image pull; the binds that
     # are actually used are resolved again under the registry lock below.
     _resolve_service_volume_binds(settings, team, volumes, client=client)
@@ -458,6 +482,7 @@ def create_service(
             cap_add=cap_add,
             privileged=privileged,
             routes=routes,
+            command=command,
         )
     except Exception:
         logger.warning("Failed to save service preset for %s", name, exc_info=True)
@@ -468,6 +493,7 @@ def create_service(
         "image": image,
         "url": url,
         "host_mode": host_mode,
+        "command": list(command or []),
         "routes": _routes_with_urls(routes, hostname),
     }
 
@@ -633,6 +659,8 @@ def _describe_service_container(
     host_config = container.attrs.get("HostConfig", {}) or {}
     svc_cap_add = list(host_config.get("CapAdd") or [])
     svc_privileged = bool(host_config.get("Privileged", False))
+    svc_command = _command_override(container)
+    svc_image_command = _image_command(container)
 
     return {
         "name": svc_name,
@@ -649,6 +677,8 @@ def _describe_service_container(
         "volumes": svc_volumes,
         "cap_add": svc_cap_add,
         "privileged": svc_privileged,
+        "command": svc_command,
+        "image_command": svc_image_command,
         "created_at": container.labels.get("oduflow.created_at", "")
         or container.attrs.get("Created", ""),
         "stack": container.labels.get("oduflow.stack", ""),
@@ -733,6 +763,7 @@ def update_service(
     cap_add_override: list[str] | None = None,
     privileged_override: bool | None = None,
     routes_override: list[dict[str, object]] | None = None,
+    command_override: list[str] | None = None,
     stack_labels: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Pull the latest image for a service and re-create it with the same settings.
@@ -781,6 +812,7 @@ def update_service(
         cap_add = preset.get("cap_add") or None
         privileged = preset.get("privileged", False)
         routes = normalize_http_routes(preset.get("routes"))
+        command = list(preset.get("command") or [])
     else:
         # Legacy fallback: extract from running container
         raw_env = container.attrs.get("Config", {}).get("Env", [])
@@ -797,6 +829,7 @@ def update_service(
         host_config = container.attrs.get("HostConfig", {}) or {}
         cap_add = list(host_config.get("CapAdd") or []) or None
         privileged = bool(host_config.get("Privileged", False))
+        command = _command_override(container)
 
         port = None
         hostname = None
@@ -901,6 +934,9 @@ def update_service(
     if privileged_override is not None and privileged_override != privileged:
         privileged = privileged_override
         config_changed = True
+    if command_override is not None and list(command_override) != command:
+        command = list(command_override)
+        config_changed = True
     if routes_override is not None:
         normalized_override = normalize_http_routes(routes_override)
         if normalized_override:
@@ -963,6 +999,7 @@ def update_service(
             "image": target_image,
             "url": url,
             "host_mode": is_host_mode,
+            "command": list(command),
             "image_updated": False,
             "config_updated": False,
             "old_digest": old_digest,
@@ -1006,6 +1043,7 @@ def update_service(
             cap_add=cap_add,
             privileged=privileged,
             routes=routes,
+            command=command or None,
             stack_labels=effective_stack_labels,
         )
 

--- a/src/oduflow/docker_ops/service_presets.py
+++ b/src/oduflow/docker_ops/service_presets.py
@@ -67,6 +67,7 @@ def save_preset(
     cap_add: list[str] | None = None,
     privileged: bool = False,
     routes: list[dict[str, object]] | None = None,
+    command: list[str] | None = None,
 ) -> dict[str, Any]:
     """Save (or overwrite) a single service preset and return it."""
     short_hostname = hostname or ""
@@ -90,6 +91,8 @@ def save_preset(
         preset["privileged"] = True
     if routes:
         preset["routes"] = routes
+    if command:
+        preset["command"] = list(command)
     data = _load_presets(team)
     data[name] = preset
     _save_presets(team, data)

--- a/src/oduflow/naming.py
+++ b/src/oduflow/naming.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import re
+import shlex
 from typing import Any
 from urllib.parse import urlparse, urlunparse
 
@@ -406,6 +407,21 @@ def parse_env_vars(raw: str) -> dict[str, str]:
     """
     items = re.split(r"\r?\n|,(?=\s*[A-Za-z_][A-Za-z0-9_]*=)", raw)
     return dict(item.strip().split("=", 1) for item in items if "=" in item)
+
+
+def parse_service_command(raw: str) -> list[str]:
+    """Split a start-command string into the argv list Docker expects.
+
+    Shell quoting rules apply, so ``server /data --address ":9001"`` becomes
+    four arguments. An empty (or whitespace-only) string means "no override" —
+    the image's own CMD is used.
+    """
+    if not raw or not raw.strip():
+        return []
+    try:
+        return shlex.split(raw)
+    except ValueError as exc:
+        raise ValueError(f"Invalid command {raw!r}: {exc}") from None
 
 
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")

--- a/src/oduflow/schemas/oduflow-stack-v1alpha1.json
+++ b/src/oduflow/schemas/oduflow-stack-v1alpha1.json
@@ -215,6 +215,21 @@
           },
           "title": "Routes",
           "type": "array"
+        },
+        "command": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "title": "Command"
         }
       },
       "required": [

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pathlib
 import re
+import shlex
 import sys
 import warnings
 from collections.abc import Awaitable, Callable, Sequence
@@ -61,7 +62,7 @@ from oduflow.locking import (
     service_preset_lock_key,
     volume_lock_key,
 )
-from oduflow.naming import normalize_env_vars, parse_env_vars
+from oduflow.naming import normalize_env_vars, parse_env_vars, parse_service_command
 from oduflow.output_cache import CachedOutput, OutputCache
 from oduflow.po_tools import PoEntry
 from oduflow.settings import Settings, TeamSettings, find_toml
@@ -3722,6 +3723,7 @@ def create_service(
     privileged: bool = False,
     net_admin: bool = False,
     routes: list[dict[str, object]] | None = None,
+    command: str = "",
     ctx: Context | None = None,
 ) -> str:
     """
@@ -3738,6 +3740,7 @@ def create_service(
         privileged: Run the container in privileged mode (full host access). Use with care — implies all Linux capabilities. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
         net_admin: Add the NET_ADMIN Linux capability. Required for VPN/WireGuard, tun/tap devices, and iptables manipulation inside the container.
         routes: Alternative Traefik exposure mode. Each object has path, backend port, and optional strip_prefix. Routes target this same service and unlisted paths return Traefik 404. Mutually exclusive with the top-level port.
+        command: Start command overriding the image CMD, written as a shell-quoted string (e.g. "server /data --console-address :9001" for minio/minio). Leave empty to use the image default. The image ENTRYPOINT is not affected.
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -3746,6 +3749,7 @@ def create_service(
         parsed_env = parse_env_vars(env_vars)
     parsed_volumes = volume_ops.parse_volume_mounts(volumes) if volumes else None
     cap_add = ["NET_ADMIN"] if net_admin else None
+    parsed_command = parse_service_command(command)
     result = service_ops.create_service(
         settings,
         team,
@@ -3759,6 +3763,7 @@ def create_service(
         cap_add=cap_add,
         privileged=privileged,
         routes=routes,
+        command=parsed_command or None,
     )
     vol_info = ""
     if parsed_volumes:
@@ -3772,6 +3777,9 @@ def create_service(
             f"{' (strip prefix)' if route.get('strip_prefix') else ''}"
             for route in result["routes"]
         )
+    cmd_info = ""
+    if result.get("command"):
+        cmd_info = "\nCommand: " + shlex.join(result["command"])
     return (
         f"Service created successfully!\n"
         f"Name: {result['name']}\n"
@@ -3779,6 +3787,7 @@ def create_service(
         f"{_service_internal_host_line(result['container_name'], host_mode)}\n"
         f"Image: {result['image']}\n"
         f"URL: {result['url']}"
+        f"{cmd_info}"
         f"{vol_info}"
         f"{route_info}"
     )
@@ -3798,12 +3807,13 @@ def update_service(
     privileged: bool | None = None,
     net_admin: bool | None = None,
     routes: list[dict[str, object]] | None = None,
+    command: str | None = None,
     ctx: Context | None = None,
 ) -> str:
     """
     Update a managed auxiliary service container. Pulls the latest image and
     optionally changes any setting (env vars, image, port, hostname, host_mode,
-    volumes, privileged, net_admin, routes). The container is recreated when the image or
+    volumes, privileged, net_admin, routes, command). The container is recreated when the image or
     any setting changes; settings that are not overridden are preserved. This is
     the preferred way to change a service — you do not need to delete and
     recreate it manually.
@@ -3819,6 +3829,7 @@ def update_service(
         privileged: Run the container in privileged mode (full host access). Leave unset (null) to keep current mode. Mutually exclusive with net_admin (privileged already grants NET_ADMIN).
         net_admin: Add (True) or remove (False) the NET_ADMIN Linux capability — required for VPN/WireGuard, tun/tap, and iptables. Leave unset (null) to keep current capabilities.
         routes: Full replacement HTTP route list. Leave unset to preserve it. Pass [] together with port to return to a single catch-all port.
+        command: New start command overriding the image CMD, as a shell-quoted string (e.g. "server /data"). Leave unset (null) to keep the current command; pass an empty string to drop the override and fall back to the image CMD. Note this differs from env_vars/image, where an empty string means "keep".
     """
     settings = _get_settings()
     team = _resolve_team(ctx)
@@ -3836,6 +3847,8 @@ def update_service(
     if net_admin is not None:
         cap_add_override = ["NET_ADMIN"] if net_admin else []
 
+    command_override = parse_service_command(command) if command is not None else None
+
     result = service_ops.update_service(
         settings,
         team,
@@ -3849,6 +3862,7 @@ def update_service(
         cap_add_override=cap_add_override,
         privileged_override=privileged,
         routes_override=routes,
+        command_override=command_override,
     )
 
     if result.get("image_updated"):
@@ -3859,6 +3873,9 @@ def update_service(
         status = "Already up-to-date (no changes)"
 
     digest_short = (result.get("new_digest") or "")[:19]
+    cmd_info = ""
+    if result.get("command"):
+        cmd_info = "\nCommand: " + shlex.join(result["command"])
     return (
         f"Service updated successfully!\n"
         f"Status: {status}\n"
@@ -3868,6 +3885,7 @@ def update_service(
         f"Image: {result['image']}\n"
         f"Digest: {digest_short}\n"
         f"URL: {result['url']}"
+        f"{cmd_info}"
     )
 
 
@@ -3906,10 +3924,10 @@ def get_service_info(name: str, ctx: Context | None = None) -> str:
     Get full state and configuration of a managed auxiliary service.
 
     Returns image (with digest), runtime status, port, hostname, URL, host_mode,
-    volumes, environment variables, capabilities, privileged flag, restart count,
-    started_at, and whether a saved preset exists. Use this before recreating or
-    updating a service so all current options (volumes, host_mode, cap_add, env)
-    are preserved.
+    start command, volumes, environment variables, capabilities, privileged flag,
+    restart count, started_at, and whether a saved preset exists. Use this before
+    recreating or updating a service so all current options (volumes, host_mode,
+    cap_add, command, env) are preserved.
 
     Args:
         name: The name of the service to inspect (e.g. "redis", "fs").
@@ -3947,6 +3965,12 @@ def get_service_info(name: str, ctx: Context | None = None) -> str:
         lines.append("Privileged: true")
     if info.get("cap_add"):
         lines.append(f"Capabilities: {','.join(info['cap_add'])}")
+    if info.get("command"):
+        lines.append(f"Command: {shlex.join(info['command'])}")
+    elif info.get("image_command"):
+        lines.append(
+            f"Command: {shlex.join(info['image_command'])} (image default, not overridden)"
+        )
     user_volumes = []
     system_volumes = []
     for volume in info.get("volumes") or []:
@@ -4008,6 +4032,8 @@ def list_service_presets(ctx: Context | None = None) -> str:
             output += ", privileged=true"
         if p.get("cap_add"):
             output += f", cap_add=[{','.join(p['cap_add'])}]"
+        if p.get("command"):
+            output += f", command={shlex.join(p['command'])!r}"
         if p.get("volumes"):
             vol_str = ",".join(
                 f"{v['volume']}:{v['mount_path']}:{v.get('mode', 'rw')}"
@@ -4039,6 +4065,7 @@ def restore_service(name: str, ctx: Context | None = None) -> str:
     preset_volumes = preset.get("volumes") or None
     preset_cap_add = preset.get("cap_add") or None
     preset_privileged = preset.get("privileged", False)
+    preset_command = preset.get("command") or None
     result = service_ops.create_service(
         settings,
         team,
@@ -4052,6 +4079,7 @@ def restore_service(name: str, ctx: Context | None = None) -> str:
         cap_add=preset_cap_add,
         privileged=preset_privileged,
         routes=preset.get("routes") or None,
+        command=preset_command,
     )
     extra = ""
     if preset_volumes:
@@ -4063,6 +4091,8 @@ def restore_service(name: str, ctx: Context | None = None) -> str:
         extra += "\nPrivileged: true"
     elif preset_cap_add:
         extra += f"\nCapabilities: {','.join(preset_cap_add)}"
+    if preset_command:
+        extra += f"\nCommand: {shlex.join(preset_command)}"
     if result.get("routes"):
         extra += "\nRoutes: " + ", ".join(
             f"{route['path']}->{route['port']}" for route in result["routes"]

--- a/src/oduflow/stack_models.py
+++ b/src/oduflow/stack_models.py
@@ -16,6 +16,7 @@ from pydantic import (
 )
 
 from oduflow.naming import (
+    parse_service_command,
     validate_env_hostname,
     validate_env_name,
     validate_template_name,
@@ -234,6 +235,17 @@ class Service(StackModel):
     privileged: bool = False
     net_admin: bool = False
     routes: list[ServiceRoute] = Field(default_factory=list)
+    command: list[NonEmptyString] = Field(default_factory=list)
+
+    @field_validator(
+        "command",
+        mode="before",
+        json_schema_input_type=str | list[NonEmptyString],
+    )
+    @classmethod
+    def split_command_string(cls, value: object) -> object:
+        """Accept the shell-quoted string form as well as an explicit argv list."""
+        return parse_service_command(value) if isinstance(value, str) else value
 
     @model_validator(mode="after")
     def one_exposure_mode(self) -> Service:

--- a/src/oduflow/stack_models.py
+++ b/src/oduflow/stack_models.py
@@ -46,6 +46,10 @@ EnvironmentVariableName = Annotated[
     StringConstraints(pattern=r"^[A-Za-z_][A-Za-z0-9_]*$"),
 ]
 NonEmptyString = Annotated[str, StringConstraints(min_length=1)]
+CommandArgument = Annotated[
+    str,
+    StringConstraints(strip_whitespace=False, min_length=1),
+]
 
 
 def _to_camel(value: str) -> str:
@@ -235,12 +239,12 @@ class Service(StackModel):
     privileged: bool = False
     net_admin: bool = False
     routes: list[ServiceRoute] = Field(default_factory=list)
-    command: list[NonEmptyString] = Field(default_factory=list)
+    command: list[CommandArgument] = Field(default_factory=list)
 
     @field_validator(
         "command",
         mode="before",
-        json_schema_input_type=str | list[NonEmptyString],
+        json_schema_input_type=str | list[CommandArgument],
     )
     @classmethod
     def split_command_string(cls, value: object) -> object:

--- a/src/oduflow/stack_ops.py
+++ b/src/oduflow/stack_ops.py
@@ -519,6 +519,15 @@ def build_plan(
             ),
             ("capabilities", sorted(actual.get("cap_add", [])), desired_caps),
             (
+                "command",
+                list(
+                    actual.get("command")
+                    or (actual.get("image_command") if desired_service.command else [])
+                    or []
+                ),
+                desired_service.command,
+            ),
+            (
                 "privileged",
                 bool(actual.get("privileged")),
                 desired_service.privileged,
@@ -606,6 +615,7 @@ def _service_kwargs(
         else None,
         "privileged": desired.privileged,
         "routes": _desired_routes(desired) or None,
+        "command": list(desired.command) or None,
         "stack_labels": _stack_labels(
             manifest.metadata.name, f"services.{name}", desired
         ),
@@ -742,6 +752,7 @@ def apply_stack(
                     cap_add_override=kwargs["cap_add"] or [],
                     privileged_override=kwargs["privileged"],
                     routes_override=kwargs["routes"] or [],
+                    command_override=kwargs["command"] or [],
                     stack_labels=kwargs["stack_labels"],
                 )
 

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1687,6 +1687,10 @@
         <input type="text" id="svc-image" placeholder="e.g. redis:7, getmeili/meilisearch:v1.6">
       </div>
       <div class="form-group">
+        <label for="svc-command">Command (optional) <span class="label-hint">— overrides the image CMD</span></label>
+        <input type="text" id="svc-command" placeholder="e.g. server /data --console-address :9001">
+      </div>
+      <div class="form-group">
         <label for="svc-exposure">Public exposure</label>
         <select id="svc-exposure" onchange="toggleServiceExposure('svc')">
           <option value="port">Single port (all paths)</option>
@@ -1758,6 +1762,10 @@
       <div class="form-group">
         <label for="restore-svc-image">Docker image</label>
         <input type="text" id="restore-svc-image" placeholder="e.g. redis:7">
+      </div>
+      <div class="form-group">
+        <label for="restore-svc-command">Command (optional) <span class="label-hint">— overrides the image CMD</span></label>
+        <input type="text" id="restore-svc-command" placeholder="e.g. server /data --console-address :9001">
       </div>
       <div class="form-group">
         <label for="restore-svc-exposure">Public exposure</label>
@@ -5275,6 +5283,10 @@ function renderServices(services) {
       var volStr = svc.volumes.map(function(v) { return esc(v.volume) + ':' + esc(v.mount_path) + (v.mode === 'ro' ? ':ro' : ''); }).join(', ');
       volHtml = '<div class="svc-meta"><span>Volumes: <strong>' + volStr + '</strong></span></div>';
     }
+    var cmdHtml = '';
+    if (svc.command && svc.command.length > 0) {
+      cmdHtml = '<div class="svc-meta"><span>Command: <strong>' + esc(shellJoin(svc.command)) + '</strong></span></div>';
+    }
     var capBadges = '';
     if (svc.privileged) {
       capBadges += '<span class="badge badge-privileged" title="Privileged container (full host access)">privileged</span>';
@@ -5304,10 +5316,18 @@ function renderServices(services) {
       '</div>' +
       urlHtml +
       routesHtml +
+      cmdHtml +
       volHtml +
     '</div>';
   }).join('');
   applyStats();
+}
+
+function shellJoin(argv) {
+  return (argv || []).map(function(arg) {
+    var text = String(arg);
+    return /^[A-Za-z0-9_@%+=:,.\/-]+$/.test(text) ? text : "'" + text.replace(/'/g, "'\\''") + "'";
+  }).join(' ');
 }
 
 function showServiceInfo(name) {
@@ -5418,6 +5438,7 @@ async function showServiceLogs(name) {
 function openCreateServiceModal() {
    document.getElementById('svc-name').value = '';
    document.getElementById('svc-image').value = '';
+   document.getElementById('svc-command').value = '';
    document.getElementById('svc-port').value = '';
    document.getElementById('svc-exposure').value = 'port';
    setServiceRoutes('svc', []);
@@ -5466,7 +5487,9 @@ async function submitCreateService() {
     var svcVolumes = document.getElementById('svc-volumes').value.trim();
     var privileged = document.getElementById('svc-privileged').checked;
     var netAdmin = document.getElementById('svc-net-admin').checked;
+    var command = document.getElementById('svc-command').value.trim();
     var payload = { name: name, image: image, host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
+    if (command) payload.command = command;
     if (routeMode) payload.routes = collectServiceRoutes('svc');
     else payload.port = parseInt(port, 10);
     if (hostname) payload.hostname = hostname;
@@ -5593,6 +5616,7 @@ function _fillRestoreFields(p) {
    document.getElementById('restore-svc-volumes').value = volStr;
    document.getElementById('restore-svc-privileged').checked = !!p.privileged;
    document.getElementById('restore-svc-net-admin').checked = !!(p.cap_add && p.cap_add.indexOf('NET_ADMIN') !== -1);
+   document.getElementById('restore-svc-command').value = shellJoin(p.command);
 }
 
 function openRestoreServiceModal(preselect) {
@@ -5602,6 +5626,7 @@ function openRestoreServiceModal(preselect) {
    document.getElementById('restore-svc-submit').disabled = false;
    document.getElementById('restore-svc-name').value = '';
    document.getElementById('restore-svc-image').value = '';
+   document.getElementById('restore-svc-command').value = '';
    document.getElementById('restore-svc-port').value = '';
    document.getElementById('restore-svc-exposure').value = 'port';
    setServiceRoutes('restore-svc', []);
@@ -5670,7 +5695,9 @@ async function submitRestoreService() {
     var restoreVolumes = document.getElementById('restore-svc-volumes').value.trim();
     var privileged = document.getElementById('restore-svc-privileged').checked;
     var netAdmin = document.getElementById('restore-svc-net-admin').checked;
+    var command = document.getElementById('restore-svc-command').value.trim();
     var payload = { name: name, image: image, host_mode: hostMode, privileged: privileged, net_admin: netAdmin };
+    if (command) payload.command = command;
     if (routeMode) payload.routes = collectServiceRoutes('restore-svc');
     else payload.port = parseInt(port, 10);
     if (hostname) payload.hostname = hostname;

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -84,6 +84,7 @@ from oduflow.locking import (
 from oduflow.naming import (
     PROD_ENV_PREFIX,
     parse_env_vars,
+    parse_service_command,
     slugify_branch,
     validate_env_hostname,
     validate_env_name,
@@ -437,6 +438,21 @@ def _env_vars_from_body(raw: object) -> dict[str, str]:
     if isinstance(raw, dict):
         return {str(k).strip(): str(v) for k, v in raw.items() if str(k).strip()}
     return parse_env_vars(str(raw or "").strip())
+
+
+def _command_from_body(raw: object) -> list[str]:
+    """Read a "command" request field in either supported shape.
+
+    A list is taken verbatim as argv (no re-splitting, so an argument may hold
+    spaces); the shell-quoted string form is parsed like the MCP tool does.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return parse_service_command(raw)
+    if isinstance(raw, list) and all(isinstance(item, str) for item in raw):
+        return list(raw)
+    raise ValueError("command must be a shell-quoted string or an array of strings")
 
 
 def _parse_extra_addons(raw: str) -> dict[str, str]:
@@ -2732,6 +2748,7 @@ def _build_routes(
             privileged = bool(body.get("privileged", False))
             net_admin = bool(body.get("net_admin", False))
             cap_add = ["NET_ADMIN"] if net_admin else None
+            command = _command_from_body(body.get("command")) or None
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
@@ -2761,6 +2778,7 @@ def _build_routes(
                 cap_add=cap_add,
                 privileged=privileged,
                 routes=routes,
+                command=command,
             )
             return JSONResponse({"ok": True, "result": result})
         except ValueError as e:
@@ -2820,6 +2838,10 @@ def _build_routes(
             if body and "net_admin" in body and body["net_admin"] is not None:
                 cap_add_override = ["NET_ADMIN"] if bool(body["net_admin"]) else []
 
+            command_override = None
+            if body and "command" in body and body["command"] is not None:
+                command_override = _command_from_body(body["command"])
+
             result = await _offload(
                 service_ops.update_service,
                 get_settings(),
@@ -2834,6 +2856,7 @@ def _build_routes(
                 cap_add_override=cap_add_override,
                 privileged_override=privileged_override,
                 routes_override=routes_override,
+                command_override=command_override,
             )
             return JSONResponse({"ok": True, "result": result})
         except ValueError as e:
@@ -2948,6 +2971,7 @@ def _build_routes(
             privileged = bool(body.get("privileged", False))
             net_admin = bool(body.get("net_admin", False))
             cap_add = ["NET_ADMIN"] if net_admin else None
+            command = _command_from_body(body.get("command")) or None
         except ValueError as e:
             return JSONResponse({"ok": False, "error": str(e)}, status_code=400)
         except FlowError as e:
@@ -2977,6 +3001,7 @@ def _build_routes(
                 cap_add=cap_add,
                 privileged=privileged,
                 routes=routes,
+                command=command,
             )
             return JSONResponse({"ok": True, "result": result})
         except ValueError as e:

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -11,6 +11,7 @@ from oduflow.naming import (
     get_service_database_role,
     get_template_db_name,
     get_workspace_path,
+    parse_service_command,
     slugify_branch,
     split_team_hostname,
     validate_env_hostname,
@@ -465,3 +466,21 @@ class TestRedactUrlCredentials:
         from oduflow.naming import redact_url_credentials
 
         assert redact_url_credentials("") == ""
+
+
+class TestParseServiceCommand:
+    def test_splits_with_shell_quoting(self):
+        assert parse_service_command('server /data --address ":9001"') == [
+            "server",
+            "/data",
+            "--address",
+            ":9001",
+        ]
+
+    def test_empty_means_no_override(self):
+        assert parse_service_command("") == []
+        assert parse_service_command("   ") == []
+
+    def test_unbalanced_quote_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid command"):
+            parse_service_command("server '/data")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1102,6 +1102,40 @@ class TestCreateServiceTool:
         assert mock_create.call_args.kwargs["routes"] == routes
         assert "- /RPC2 -> 8080" in result
 
+    @patch("oduflow.docker_ops.service_ops.create_service")
+    def test_create_splits_command_into_argv(self, mock_create):
+        command = ["server", "/data", "--console-address", ":9001"]
+        mock_create.return_value = {
+            "name": "minio",
+            "container_name": "oduflow-1-svc-minio",
+            "url": "http://localhost:9000",
+            "image": "minio/minio:latest",
+            "command": command,
+        }
+
+        result = _get_tool_fn("create_service")(
+            name="minio",
+            image="minio/minio:latest",
+            port=9000,
+            command='server /data --console-address ":9001"',
+        )
+
+        assert mock_create.call_args.kwargs["command"] == command
+        assert "Command: server /data --console-address :9001" in result
+
+    @patch("oduflow.docker_ops.service_ops.create_service")
+    def test_create_without_command_passes_none(self, mock_create):
+        mock_create.return_value = {
+            "name": "redis",
+            "container_name": "oduflow-1-svc-redis",
+            "url": "http://localhost:6379",
+            "image": "redis:7",
+        }
+
+        _get_tool_fn("create_service")(name="redis", image="redis:7", port=6379)
+
+        assert mock_create.call_args.kwargs["command"] is None
+
 
 class TestUpdateServiceTool:
     @patch("oduflow.docker_ops.service_ops.update_service")
@@ -1129,6 +1163,7 @@ class TestUpdateServiceTool:
             cap_add_override=None,
             privileged_override=None,
             routes_override=None,
+            command_override=None,
         )
 
     @patch("oduflow.docker_ops.service_ops.update_service")
@@ -1181,6 +1216,37 @@ class TestUpdateServiceTool:
         routes = [{"path": "/RPC2", "port": 8080, "strip_prefix": False}]
         _get_tool_fn("update_service")(name="fs", routes=routes)
         assert mock_update.call_args.kwargs["routes_override"] == routes
+
+    @patch("oduflow.docker_ops.service_ops.update_service")
+    def test_update_command_string_is_split(self, mock_update):
+        mock_update.return_value = {
+            "name": "minio",
+            "container_name": "oduflow-1-svc-minio",
+            "url": "http://localhost:9000",
+            "image": "minio/minio:latest",
+            "command": ["server", "/data"],
+            "config_updated": True,
+        }
+
+        result = _get_tool_fn("update_service")(name="minio", command="server /data")
+
+        assert mock_update.call_args.kwargs["command_override"] == ["server", "/data"]
+        assert "Command: server /data" in result
+
+    @patch("oduflow.docker_ops.service_ops.update_service")
+    def test_update_empty_command_clears_the_override(self, mock_update):
+        """An empty string means "drop it", unlike env_vars where it means "keep"."""
+        mock_update.return_value = {
+            "name": "minio",
+            "container_name": "oduflow-1-svc-minio",
+            "url": "http://localhost:9000",
+            "image": "minio/minio:latest",
+            "config_updated": True,
+        }
+
+        _get_tool_fn("update_service")(name="minio", command="")
+
+        assert mock_update.call_args.kwargs["command_override"] == []
 
     @patch("oduflow.docker_ops.service_ops.update_service")
     def test_update_net_admin_and_privileged_mapping(self, mock_update):

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -482,6 +482,38 @@ class TestCreateService:
         run_kwargs = mock_docker_client.containers.run.call_args
         assert run_kwargs[1]["environment"] == env
 
+    def test_create_with_command(self, mock_docker_client):
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.save_preset"
+        ) as mock_save:
+            result = service_ops.create_service(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "minio",
+                "minio/minio:latest",
+                9000,
+                command=["server", "/data"],
+            )
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["command"] == ["server", "/data"]
+        assert result["command"] == ["server", "/data"]
+        assert mock_save.call_args[1]["command"] == ["server", "/data"]
+
+    def test_create_without_command(self, mock_docker_client):
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        service_ops.create_service(TEST_SETTINGS, TEST_TEAM, "redis", "redis:7", 6379)
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert "command" not in run_kwargs[1]
+
     def test_create_without_env_vars(self, mock_docker_client):
         mock_docker_client.networks.get.return_value = MagicMock()
         mock_docker_client.containers.get.side_effect = docker.errors.NotFound("nf")
@@ -581,6 +613,42 @@ class TestListServices:
         svc = result[0]
         assert svc["url"] == "https://meili.example.com"
         assert svc["port"] == 7700
+
+    def test_list_reports_command_override(self, mock_docker_client):
+        container = MagicMock()
+        container.labels = {"oduflow.managed": "true", "oduflow.service": "minio"}
+        container.name = "oduflow-1-svc-minio"
+        container.status = "running"
+        container.image.tags = ["minio/minio:latest"]
+        container.image.attrs = {"Config": {"Cmd": ["minio"], "Env": []}}
+        container.attrs = {
+            "NetworkSettings": {"Ports": {}},
+            "Config": {"Cmd": ["server", "/data"], "Env": []},
+        }
+        mock_docker_client.containers.list.return_value = [container]
+
+        svc = service_ops.list_services(TEST_SETTINGS, TEST_TEAM)[0]
+
+        assert svc["command"] == ["server", "/data"]
+        assert svc["image_command"] == ["minio"]
+
+    def test_list_image_default_command_is_not_an_override(self, mock_docker_client):
+        container = MagicMock()
+        container.labels = {"oduflow.managed": "true", "oduflow.service": "redis"}
+        container.name = "oduflow-1-svc-redis"
+        container.status = "running"
+        container.image.tags = ["redis:7"]
+        container.image.attrs = {"Config": {"Cmd": ["redis-server"], "Env": []}}
+        container.attrs = {
+            "NetworkSettings": {"Ports": {}},
+            "Config": {"Cmd": ["redis-server"], "Env": []},
+        }
+        mock_docker_client.containers.list.return_value = [container]
+
+        svc = service_ops.list_services(TEST_SETTINGS, TEST_TEAM)[0]
+
+        assert svc["command"] == []
+        assert svc["image_command"] == ["redis-server"]
 
     def test_list_empty(self, mock_docker_client):
         mock_docker_client.containers.list.return_value = []
@@ -794,6 +862,158 @@ class TestUpdateService:
             # image pull) and re-resolves under the service-registry lock.
             assert mock_resolve.call_count == 3
             mock_resolve.assert_any_call(TEST_TEAM, volumes)
+
+    def test_update_preserves_preset_command(self, mock_docker_client):
+        """An update with no command override keeps the preset's command."""
+        container = self._make_container(
+            image_tags=["minio/minio:latest"],
+            labels={"oduflow.managed": "true", "oduflow.service": "minio"},
+            attrs={"Config": {"Env": []}},
+        )
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "minio",
+            "image": "minio/minio:latest",
+            "port": 9000,
+            "hostname": "",
+            "env_vars": {},
+            "command": ["server", "/data"],
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "minio")
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["command"] == ["server", "/data"]
+
+    def test_update_command_override_recreates_container(self, mock_docker_client):
+        """A changed command recreates the container even on an unchanged digest."""
+        container = self._make_container(
+            image_tags=["minio/minio:latest"],
+            labels={"oduflow.managed": "true", "oduflow.service": "minio"},
+            attrs={"Config": {"Env": []}},
+        )
+        container.image.id = "sha256:same"
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        new_image = MagicMock()
+        new_image.id = "sha256:same"
+        mock_docker_client.images.pull.return_value = new_image
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "minio",
+            "image": "minio/minio:latest",
+            "port": 9000,
+            "hostname": "",
+            "env_vars": {},
+            "command": ["server", "/data"],
+        }
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value=preset,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS,
+                TEST_TEAM,
+                "minio",
+                command_override=["server", "/data", "--console-address", ":9001"],
+            )
+
+        assert result["config_updated"] is True
+        assert result["image_updated"] is False
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["command"] == [
+            "server",
+            "/data",
+            "--console-address",
+            ":9001",
+        ]
+
+    def test_update_empty_command_override_clears_it(self, mock_docker_client):
+        """An empty override drops the command back to the image default."""
+        container = self._make_container(
+            image_tags=["minio/minio:latest"],
+            labels={"oduflow.managed": "true", "oduflow.service": "minio"},
+            attrs={"Config": {"Env": []}},
+        )
+        container.image.id = "sha256:same"
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        new_image = MagicMock()
+        new_image.id = "sha256:same"
+        mock_docker_client.images.pull.return_value = new_image
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        preset = {
+            "name": "minio",
+            "image": "minio/minio:latest",
+            "port": 9000,
+            "hostname": "",
+            "env_vars": {},
+            "command": ["server", "/data"],
+        }
+
+        with (
+            patch(
+                "oduflow.docker_ops.service_ops.service_presets.get_preset",
+                return_value=preset,
+            ),
+            patch(
+                "oduflow.docker_ops.service_ops.service_presets.save_preset"
+            ) as mock_save,
+        ):
+            result = service_ops.update_service(
+                TEST_SETTINGS, TEST_TEAM, "minio", command_override=[]
+            )
+
+        assert result["config_updated"] is True
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert "command" not in run_kwargs[1]
+        assert mock_save.call_args[1]["command"] is None
+
+    def test_update_legacy_no_preset_keeps_command_override(self, mock_docker_client):
+        """Without a preset the override is read back from the container's Cmd."""
+        container = self._make_container(
+            image_tags=["minio/minio:latest"],
+            labels={"oduflow.managed": "true", "oduflow.service": "minio"},
+            attrs={
+                "Config": {"Env": [], "Cmd": ["server", "/data"]},
+                "NetworkSettings": {"Ports": {"9000/tcp": []}},
+            },
+        )
+        container.image.attrs = {"Config": {"Cmd": ["minio"], "Env": []}}
+        mock_docker_client.containers.get.side_effect = [
+            container,
+            docker.errors.NotFound("nf"),
+        ]
+        mock_docker_client.networks.get.return_value = MagicMock()
+        mock_docker_client.containers.run.return_value = MagicMock()
+
+        with patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=NotFoundError("no preset"),
+        ):
+            service_ops.update_service(TEST_SETTINGS, TEST_TEAM, "minio")
+
+        run_kwargs = mock_docker_client.containers.run.call_args
+        assert run_kwargs[1]["command"] == ["server", "/data"]
 
     def test_update_port_mode_legacy_no_preset(self, mock_docker_client):
         """Legacy fallback: extract settings from container when no preset exists."""

--- a/tests/test_service_routes_web.py
+++ b/tests/test_service_routes_web.py
@@ -81,3 +81,85 @@ def test_update_service_distinguishes_missing_and_empty_routes(tmp_path):
     assert response.status_code == 200
     assert update.call_args.kwargs["routes_override"] == []
     assert update.call_args.kwargs["port_override"] == 8080
+
+
+def test_create_service_accepts_command_as_string_or_argv(tmp_path):
+    client = _client(tmp_path)
+    result = {
+        "name": "minio",
+        "container_name": "oduflow-1-svc-minio",
+        "image": "minio/minio:latest",
+        "url": "https://minio.example.com",
+    }
+    with patch(
+        "oduflow.web_ui.service_ops.create_service", return_value=result
+    ) as create:
+        client.post(
+            "/api/services/create",
+            json={
+                "name": "minio",
+                "image": "minio/minio:latest",
+                "port": 9000,
+                "command": "server /data",
+            },
+        )
+        assert create.call_args.kwargs["command"] == ["server", "/data"]
+
+        client.post(
+            "/api/services/create",
+            json={
+                "name": "minio",
+                "image": "minio/minio:latest",
+                "port": 9000,
+                # A list is argv already — an element may hold spaces.
+                "command": ["server", "/data dir"],
+            },
+        )
+        assert create.call_args.kwargs["command"] == ["server", "/data dir"]
+
+
+def test_create_service_rejects_invalid_command_shapes(tmp_path):
+    client = _client(tmp_path)
+
+    with patch("oduflow.web_ui.service_ops.create_service") as create:
+        for command in (True, 123, {"executable": "server"}, ["server", None]):
+            response = client.post(
+                "/api/services/create",
+                json={
+                    "name": "minio",
+                    "image": "minio/minio:latest",
+                    "port": 9000,
+                    "command": command,
+                },
+            )
+
+            assert response.status_code == 400
+            assert response.json() == {
+                "ok": False,
+                "error": (
+                    "command must be a shell-quoted string or an array of strings"
+                ),
+            }
+
+    create.assert_not_called()
+
+
+def test_update_service_distinguishes_missing_and_empty_command(tmp_path):
+    client = _client(tmp_path)
+    result = {
+        "name": "minio",
+        "container_name": "oduflow-1-svc-minio",
+        "image": "minio/minio:latest",
+        "url": "https://minio.example.com",
+    }
+    with patch(
+        "oduflow.web_ui.service_ops.update_service", return_value=result
+    ) as update:
+        client.post("/api/services/minio/update", json={})
+        assert update.call_args.kwargs["command_override"] is None
+
+        client.post("/api/services/minio/update", json={"command": ""})
+        assert update.call_args.kwargs["command_override"] == []
+
+        client.post("/api/services/minio/update", json={"command": "server /data"})
+        assert update.call_args.kwargs["command_override"] == ["server", "/data"]

--- a/tests/test_stack_models.py
+++ b/tests/test_stack_models.py
@@ -192,6 +192,31 @@ def test_service_route_paths_are_canonicalized_before_duplicate_validation():
         )
 
 
+def test_service_command_accepts_argv_list_and_shell_string():
+    assert Service(
+        image="example/service:1", port=1, command=["server", "/data"]
+    ).command == [
+        "server",
+        "/data",
+    ]
+    # The string form is the one operators type; it is split with shell rules.
+    assert Service(
+        image="example/service:1", port=1, command='server "/data dir"'
+    ).command == ["server", "/data dir"]
+    assert Service(image="example/service:1", port=1).command == []
+
+
+def test_service_command_json_schema_accepts_argv_list_and_shell_string():
+    command_schema = StackManifest.model_json_schema(by_alias=True)["$defs"]["Service"][
+        "properties"
+    ]["command"]
+
+    assert {branch["type"] for branch in command_schema["anyOf"]} == {
+        "array",
+        "string",
+    }
+
+
 def test_shipped_json_schema_matches_models():
     schema_path = (
         Path(__file__).parents[1] / "src/oduflow/schemas/oduflow-stack-v1alpha1.json"

--- a/tests/test_stack_models.py
+++ b/tests/test_stack_models.py
@@ -206,6 +206,15 @@ def test_service_command_accepts_argv_list_and_shell_string():
     assert Service(image="example/service:1", port=1).command == []
 
 
+def test_service_command_preserves_argument_whitespace():
+    assert Service(
+        image="example/service:1", port=1, command=["printf", "  value  "]
+    ).command == ["printf", "  value  "]
+    assert Service(
+        image="example/service:1", port=1, command='printf "  value  "'
+    ).command == ["printf", "  value  "]
+
+
 def test_service_command_json_schema_accepts_argv_list_and_shell_string():
     command_schema = StackManifest.model_json_schema(by_alias=True)["$defs"]["Service"][
         "properties"

--- a/tests/test_stack_ops.py
+++ b/tests/test_stack_ops.py
@@ -490,6 +490,75 @@ def test_plan_ignores_service_image_environment_defaults(
     assert plan.actions == ()
 
 
+@patch("oduflow.extra_addons.list_extra_repos", return_value=[])
+@patch("oduflow.stack_ops.volume_ops.list_volumes", return_value=[])
+@patch("oduflow.stack_ops.env_ops.get_environment_info")
+@patch("oduflow.stack_ops.env_ops.list_environments")
+def test_plan_reports_service_command_drift(
+    envs, env_info, _volumes, _repos, stack_fixture
+):
+    settings, team, manifest, path = stack_fixture
+    manifest.spec.extra_repositories = {}
+    manifest.spec.volumes = {}
+    manifest.spec.files = []
+    manifest.spec.environment.modules.install = []
+    service = manifest.spec.services["fs"]
+    service.env = {}
+    service.volumes = []
+    service.command = ["server", "/data"]
+    envs.return_value = [
+        {
+            "env_name": "acme-dev",
+            "stack": "acme",
+            "stack_resource": "environment",
+            "repo_url": "https://github.com/acme/addons.git",
+            "git_branch": "main",
+            "template_name": "default",
+            "extra_addons": {},
+            "odoo_image": "odoo:18.0",
+            "stack_sanitize": "true",
+        }
+    ]
+    env_info.return_value = {"env_vars": {"LOG_LEVEL": "info"}}
+    actual_service = {
+        "name": "fs",
+        "image": "example/fs:1",
+        "port": 8080,
+        "hostname": None,
+        "env_vars": {},
+        "image_env_vars": {},
+        "host_mode": False,
+        "volumes": [],
+        "cap_add": [],
+        "privileged": False,
+        "command": [],
+        "routes": [],
+        "stack": "acme",
+        "stack_resource": "services.fs",
+        "stack_spec_hash": _resource_hash(service),
+    }
+
+    with patch(
+        "oduflow.stack_ops.service_ops.list_services", return_value=[actual_service]
+    ):
+        plan = build_plan(settings, team, manifest, path)
+
+    action = next(item for item in plan.actions if item.resource == "services.fs")
+    assert action.operation == "update"
+    assert "command" in action.detail
+
+    # An explicit desired command that happens to equal the image CMD is
+    # already converged. Docker inspect cannot distinguish those two sources,
+    # but their effective argv is identical.
+    actual_service["image_command"] = ["server", "/data"]
+    with patch(
+        "oduflow.stack_ops.service_ops.list_services", return_value=[actual_service]
+    ):
+        converged_plan = build_plan(settings, team, manifest, path)
+
+    assert converged_plan.actions == ()
+
+
 def test_stack_file_comparison_uses_manifest_size_limit(stack_fixture):
     settings, team, _manifest, _path = stack_fixture
     content = "x" * 200_000


### PR DESCRIPTION
## Summary
- add Docker CMD overrides across MCP, REST, dashboard, presets, and declarative stacks
- preserve tri-state update semantics and report effective/image commands
- fix stack convergence when an explicit command matches the image CMD
- align the generated JSON Schema and reject invalid REST command shapes
- document the feature and add regression coverage

## Validation
- ruff check src/oduflow tests
- ruff format --check src/oduflow tests
- mypy src/oduflow
- 2695 unit tests passed locally; 7 environment-dependent failures require Docker or rsync, neither available in the review container