### PR TITLE
Edit service environment variables from the dashboard

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2724,6 +2724,8 @@ oduflow call run_service_command redis "redis-cli ping"
 
 `update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `command`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
 
+In the dashboard, **Update** on a service card opens a dialog prefilled with the service's current environment variables (from its preset, or from the container for a service created before presets). Edit them and confirm to apply the change and pull the latest image in one go; leave the field untouched to just pull and recreate, or clear it to remove every variable. The other settings are changed over MCP or the CLI.
+
 If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `command`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
 
 ## Service Update Flow
@@ -3223,6 +3225,7 @@ Odoo.sh ingest endpoints accept the import token only in
 |---|---|---|
 | `GET` | `/api/services` | List services |
 | `POST` | `/api/services/create` | Create a service with either catch-all `port` or restricted Traefik `routes`, plus optional image/runtime settings. `command` accepts a shell-quoted string or an argv array and replaces the image `CMD` |
+| `GET` | `/api/services/{name}/env-vars` | Return the environment variables an update keeps — the saved preset, or the container's own environment for a service created before presets |
 | `POST` | `/api/services/{name}/update` | Pull/change settings and recreate safely; `env_vars`, `volumes`, and `routes` are full replacements when supplied. Omit `command` to keep it, send `""`/`[]` to fall back to the image `CMD` |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |

--- a/docs/services.md
+++ b/docs/services.md
@@ -190,6 +190,8 @@ oduflow call run_service_command redis "redis-cli ping"
 
 `update_service` is the preferred way to change **any** setting of a running service — image, env vars, port/routes, hostname, `host_mode`, `command`, `volumes`, `privileged`, or `net_admin`. It recreates the container automatically and preserves every setting you do not override, so you rarely need to delete and recreate a service by hand. Passing `routes` fully replaces the route list. To return to a single catch-all port, pass `routes=[]` and the replacement `port` in the same call.
 
+In the dashboard, **Update** on a service card opens a dialog prefilled with the service's current environment variables (from its preset, or from the container for a service created before presets). Edit them and confirm to apply the change and pull the latest image in one go; leave the field untouched to just pull and recreate, or clear it to remove every variable. The other settings are changed over MCP or the CLI.
+
 If you do recreate a service manually (e.g. to rename it), call `get_service_info` first and reuse its fields in the new `create_service` call. The returned dict carries the full configuration (`image`, `port` or `routes`, `hostname`, `env_vars`, `host_mode`, `command`, `volumes`, `cap_add`, `privileged`) so you do not lose anything that `list_services` truncates or that lived only inside the preset.
 
 ## Service Update Flow

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -112,6 +112,7 @@ Odoo.sh ingest endpoints accept the import token only in
 |---|---|---|
 | `GET` | `/api/services` | List services |
 | `POST` | `/api/services/create` | Create a service with either catch-all `port` or restricted Traefik `routes`, plus optional image/runtime settings. `command` accepts a shell-quoted string or an argv array and replaces the image `CMD` |
+| `GET` | `/api/services/{name}/env-vars` | Return the environment variables an update keeps — the saved preset, or the container's own environment for a service created before presets |
 | `POST` | `/api/services/{name}/update` | Pull/change settings and recreate safely; `env_vars`, `volumes`, and `routes` are full replacements when supplied. Omit `command` to keep it, send `""`/`[]` to fall back to the image `CMD` |
 | `POST` | `/api/services/{name}/restart` | Restart a service |
 | `POST` | `/api/services/{name}/delete` | Delete a service |

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -763,7 +763,10 @@ def get_service_env_vars(
     also what an edit dialog must prefill; the container's own environment
     additionally carries the image defaults, which are not part of the service
     configuration. Only legacy services created before presets existed fall
-    back to inspecting the container.
+    back to inspecting the container — a preset that exists but cannot be read
+    raises instead, because prefilling from the container in that case would
+    offer the image defaults for editing and bake them into the preset on the
+    first save.
     """
     client = get_client()
     container_name = get_service_container_name(name, settings.prefix, team.team_id)
@@ -779,15 +782,9 @@ def get_service_env_vars(
     try:
         preset = service_presets.get_preset(team, name)
     except NotFoundError:
-        preset = None
-    except Exception:
-        logger.warning("Failed to read preset for service %s", name, exc_info=True)
-        preset = None
+        return _container_env_vars(container)
 
-    if preset is not None:
-        return dict(preset.get("env_vars") or {})
-
-    return _container_env_vars(container)
+    return dict(preset.get("env_vars") or {})
 
 
 def update_service(

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -551,6 +551,17 @@ def _traefik_label_by_suffix(labels: dict[str, str], suffix: str) -> str:
     return ""
 
 
+def _container_env_vars(container: Any) -> dict[str, str]:
+    """Env of a service container without the keys every image sets anyway."""
+    env_vars: dict[str, str] = {}
+    for entry in container.attrs.get("Config", {}).get("Env", []) or []:
+        if "=" in entry:
+            key, value = entry.split("=", 1)
+            if key not in _SYSTEM_ENV_KEYS:
+                env_vars[key] = value
+    return env_vars
+
+
 def _describe_service_container(
     settings: Settings, team: TeamSettings, container: Any
 ) -> dict[str, Any]:
@@ -563,13 +574,7 @@ def _describe_service_container(
     image = container.image.tags[0] if container.image.tags else "unknown"
     status = container.status
 
-    raw_env = container.attrs.get("Config", {}).get("Env", [])
-    env_vars: dict[str, str] = {}
-    for entry in raw_env:
-        if "=" in entry:
-            key, value = entry.split("=", 1)
-            if key not in _SYSTEM_ENV_KEYS:
-                env_vars[key] = value
+    env_vars = _container_env_vars(container)
 
     image_env_vars: dict[str, str] = {}
     try:
@@ -749,6 +754,42 @@ def get_service_info(
     return info
 
 
+def get_service_env_vars(
+    settings: Settings, team: TeamSettings, name: str
+) -> dict[str, str]:
+    """Return the env vars ``update_service`` keeps when nothing overrides them.
+
+    The saved preset is authoritative and is what an update reuses, so it is
+    also what an edit dialog must prefill; the container's own environment
+    additionally carries the image defaults, which are not part of the service
+    configuration. Only legacy services created before presets existed fall
+    back to inspecting the container.
+    """
+    client = get_client()
+    container_name = get_service_container_name(name, settings.prefix, team.team_id)
+
+    try:
+        container = client.containers.get(container_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(f"Service '{name}' not found")
+
+    if not container.labels.get("oduflow.service"):
+        raise NotFoundError(f"Service '{name}' not found")
+
+    try:
+        preset = service_presets.get_preset(team, name)
+    except NotFoundError:
+        preset = None
+    except Exception:
+        logger.warning("Failed to read preset for service %s", name, exc_info=True)
+        preset = None
+
+    if preset is not None:
+        return dict(preset.get("env_vars") or {})
+
+    return _container_env_vars(container)
+
+
 def update_service(
     settings: Settings,
     team: TeamSettings,
@@ -815,13 +856,7 @@ def update_service(
         command = list(preset.get("command") or [])
     else:
         # Legacy fallback: extract from running container
-        raw_env = container.attrs.get("Config", {}).get("Env", [])
-        env_vars = {}
-        for entry in raw_env:
-            if "=" in entry:
-                key, value = entry.split("=", 1)
-                if key not in _SYSTEM_ENV_KEYS:
-                    env_vars[key] = value
+        env_vars = _container_env_vars(container)
 
         is_host_mode = container.labels.get("oduflow.host_mode") == "true"
         routes = _routes_from_labels(container.labels)

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -5394,10 +5394,13 @@ async function doUpdateService(name) {
       var vars = data.env_vars || {};
       _updateSvcInitial = Object.keys(vars).map(function(k) { return k + '=' + vars[k]; }).join('\n');
       ta.value = _updateSvcInitial;
-      // A line-per-assignment field cannot represent a multi-line value, so
-      // show it read-only rather than let an edit write back a mangled version.
-      if (Object.keys(vars).some(function(k) { return /[\r\n]/.test(vars[k]); })) {
-        showToast('A variable holds a multi-line value — edit it over MCP', true);
+      // parseEnvLines trims each line, and a line cannot hold a line break at
+      // all, so a value with either would come back mangled. Show the field
+      // read-only rather than let an edit rewrite a secret it cannot represent.
+      if (Object.keys(vars).some(function(k) {
+        return /[\r\n]/.test(vars[k]) || vars[k] !== vars[k].trim();
+      })) {
+        showToast('A variable value has line breaks or leading/trailing spaces — edit it over MCP', true);
       } else {
         ta.disabled = false;
       }

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1578,6 +1578,26 @@
     <div class="modal-body"><pre id="svc-info-content"></pre></div>
   </div>
 </div>
+<div class="modal-overlay" id="svc-update-modal" onclick="closeUpdateService(event)">
+  <div class="modal modal-sm">
+    <div class="modal-header">
+      <h2 id="svc-update-title">Update service</h2>
+      <button class="modal-close" onclick="closeUpdateService()" aria-label="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p class="modal-note">Pull the latest image for <strong id="svc-update-name"></strong> and re-create its container. Volumes are kept.</p>
+      <div class="form-group">
+        <label for="svc-update-env-vars">Environment variables</label>
+        <textarea id="svc-update-env-vars" rows="6" spellcheck="false" placeholder="MEILI_ENV=production&#10;MEILI_MASTER_KEY=..."></textarea>
+        <p class="modal-note">One KEY=VALUE per line. Clear the field to remove all variables; leave it untouched to keep them.</p>
+      </div>
+      <div class="form-actions">
+        <button class="btn" onclick="closeUpdateService()">Cancel</button>
+        <button class="btn-create" onclick="confirmUpdateService()">Update service</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="modal-overlay" id="create-database-modal" onclick="closeCreateDatabaseModal(event)">
   <div class="modal modal-md">
     <div class="modal-header">
@@ -5310,7 +5330,10 @@ function renderServices(services) {
       '</div>' +
       '<div class="svc-meta">' +
         '<span>Image: <strong>' + esc(svc.image) + '</strong></span>' +
-        '<span>Container: <strong>' + esc(svc.container_name) + '</strong>' + containerStatsHtml(svc.container_name) + '</span>' +
+        '<span>Container: <strong class="copy-db" role="button" tabindex="0" title="Copy container name" aria-label="Copy container name" ' +
+          'onclick="copyToClipboard(\'' + escAttr(svc.container_name) + '\')" ' +
+          'onkeydown="if (event.key === \'Enter\' || event.key === \' \') { event.preventDefault(); copyToClipboard(\'' + escAttr(svc.container_name) + '\'); }">' +
+          esc(svc.container_name) + '</strong>' + containerStatsHtml(svc.container_name) + '</span>' +
         (svc.port ? '<span>Port: <strong>' + svc.port + '</strong></span>' : '') +
         (svc.created_at ? '<span>Created: <strong>' + formatDate(svc.created_at) + '</strong></span>' : '') +
       '</div>' +
@@ -5346,22 +5369,78 @@ function closeServiceInfo(event) {
   hideModal('svc-info-modal');
 }
 
+var _updateSvc = '';
+var _updateSvcInitial = '';
+// Bumped on every open and every close — see _updateEnvSeq: a slow prefill
+// must not land in a dialog reopened for another service and get submitted
+// there.
+var _updateSvcSeq = 0;
+
 async function doUpdateService(name) {
-  if (!(await confirmDialog({
-    title: 'Update service',
-    message: 'Pull the latest image for "' + name + '" and recreate its container?',
-    confirmLabel: 'Update service'
-  }))) return;
+  var seq = ++_updateSvcSeq;
+  _updateSvc = name;
+  _updateSvcInitial = '';
+  document.getElementById('svc-update-title').textContent = 'Update service — ' + name;
+  document.getElementById('svc-update-name').textContent = name;
+  var ta = document.getElementById('svc-update-env-vars');
+  ta.value = '';
+  ta.disabled = true;
+  showModal('svc-update-modal');
+  try {
+    var r = await fetch(API_SERVICES + '/' + encodeURIComponent(name) + '/env-vars');
+    var data = await readResult(r);
+    if (seq !== _updateSvcSeq) return;
+    if (data.ok) {
+      var vars = data.env_vars || {};
+      _updateSvcInitial = Object.keys(vars).map(function(k) { return k + '=' + vars[k]; }).join('\n');
+      ta.value = _updateSvcInitial;
+      // A line-per-assignment field cannot represent a multi-line value, so
+      // show it read-only rather than let an edit write back a mangled version.
+      if (Object.keys(vars).some(function(k) { return /[\r\n]/.test(vars[k]); })) {
+        showToast('A variable holds a multi-line value — edit it over MCP', true);
+      } else {
+        ta.disabled = false;
+      }
+    } else {
+      // Keep the field disabled: an empty editable field would look like
+      // "no variables" and the first edit would replace the real ones.
+      showToast(data.error || 'Could not load the current environment variables', true);
+    }
+  } catch (e) {
+    showToast('Could not load the current environment variables', true);
+  }
+}
+
+function closeUpdateService(event) {
+  if (event && event.target !== event.currentTarget) return;
+  _updateSvcSeq++;
+  hideModal('svc-update-modal');
+}
+
+async function confirmUpdateService() {
+  var name = _updateSvc;
+  var raw = document.getElementById('svc-update-env-vars').value;
+  var payload = {};
+  // Send a mapping, not the raw blob: the server must not re-split values.
+  if (raw.trim() !== _updateSvcInitial.trim()) payload.env_vars = parseEnvLines(raw);
+  _updateSvcSeq++;
+  hideModal('svc-update-modal');
   var card = document.querySelector('[data-svc="' + name + '"]');
   if (card) card.querySelectorAll('button').forEach(function(b) { b.disabled = true; });
   try {
-    var r = await fetch(API_SERVICES + '/' + encodeURIComponent(name) + '/update', { method: 'POST' });
+    var r = await fetch(API_SERVICES + '/' + encodeURIComponent(name) + '/update', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    });
     var data = await readResult(r);
     if (data.ok) {
       var res = data.result || {};
       var digest = (res.new_digest || '').substring(0, 19);
       if (res.image_updated) {
         showToast('Service "' + name + '" updated — new image pulled (' + digest + ')');
+      } else if (res.config_updated) {
+        showToast('Service "' + name + '" re-created with the new configuration');
       } else {
         showToast('Service "' + name + '" is already up-to-date (' + digest + ')');
       }
@@ -6721,6 +6800,7 @@ var MODAL_CLOSERS = {
   'feedback-modal': closeFeedbackModal,
   'logs-modal': closeLogsModal,
   'svc-info-modal': closeServiceInfo,
+  'svc-update-modal': closeUpdateService,
   'create-database-modal': closeCreateDatabaseModal,
   'database-credentials-modal': closeDatabaseCredentials,
   'console-modal': closeConsole,

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -2808,8 +2808,13 @@ def _build_routes(
             except Exception:
                 body = {}
 
+            # "env_vars" present in the body is a full replacement (an empty
+            # value clears every variable); an absent key keeps the current
+            # ones — see api_update.
             env_override = (
-                _env_vars_from_body(body.get("env_vars")) or None if body else None
+                _env_vars_from_body(body.get("env_vars"))
+                if body and "env_vars" in body
+                else None
             )
 
             volumes_raw = (body.get("volumes") or "").strip() if body else ""
@@ -2870,6 +2875,20 @@ def _build_routes(
             )
         finally:
             locks.release_env(key)
+
+    def api_service_env_vars(request: Request) -> JSONResponse:
+        name = request.path_params["name"]
+        team = _get_ui_team(request)
+        try:
+            env_vars = service_ops.get_service_env_vars(get_settings(), team, name)
+            return JSONResponse({"ok": True, "env_vars": env_vars})
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in api_service_env_vars")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
 
     def api_service_restart(request: Request) -> JSONResponse:
         name = request.path_params["name"]
@@ -5425,6 +5444,7 @@ def _build_routes(
         Route("/api/services", api_services, methods=["GET"]),
         Route("/api/services/create", api_service_create, methods=["POST"]),
         Route("/api/services/{name}/update", api_service_update, methods=["POST"]),
+        Route("/api/services/{name}/env-vars", api_service_env_vars, methods=["GET"]),
         Route("/api/services/{name}/restart", api_service_restart, methods=["POST"]),
         Route("/api/services/{name}/delete", api_service_delete, methods=["POST"]),
         Route("/api/services/{name}/logs", api_service_logs, methods=["GET"]),

--- a/tests/test_service_env_vars_web.py
+++ b/tests/test_service_env_vars_web.py
@@ -1,0 +1,157 @@
+"""Env-var handling for services in the dashboard REST API.
+
+``api_service_env_vars`` prefills the update dialog with exactly the variables
+an update would otherwise keep, and ``api_service_update`` treats an
+``env_vars`` key present in the body as a full replacement — an empty mapping
+clears every variable, an absent key keeps the current ones.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import docker
+from oduflow.errors import NotFoundError
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+from oduflow.web_ui import mount_web_ui
+
+
+def _client(tmp_path):
+    team = TeamSettings(team_id="1", hostname="example.com", data_dir=str(tmp_path))
+    settings = Settings(
+        routing_mode="port",
+        base_data_dir=str(tmp_path),
+        teams={"1": team},
+    )
+    app = Starlette()
+    mount_web_ui(app, lambda: settings, LockManager())
+    return TestClient(app)
+
+
+def _settings(tmp_path):
+    team = TeamSettings(team_id="1", hostname="example.com", data_dir=str(tmp_path))
+    return Settings(
+        routing_mode="port", base_data_dir=str(tmp_path), teams={"1": team}
+    ), team
+
+
+def _container(env):
+    container = MagicMock()
+    container.labels = {"oduflow.service": "meili"}
+    container.attrs = {"Config": {"Env": env}}
+    return container
+
+
+def test_env_vars_prefers_the_preset(tmp_path):
+    """The preset is what an update reuses, so it is what the dialog shows."""
+    from oduflow.docker_ops import service_ops
+
+    settings, team = _settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.return_value = _container(
+        ["PATH=/usr/bin", "MEILI_ENV=production", "IMAGE_DEFAULT=1"]
+    )
+    with (
+        patch("oduflow.docker_ops.service_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            return_value={"name": "meili", "env_vars": {"MEILI_ENV": "production"}},
+        ),
+    ):
+        assert service_ops.get_service_env_vars(settings, team, "meili") == {
+            "MEILI_ENV": "production"
+        }
+
+
+def test_env_vars_falls_back_to_the_container(tmp_path):
+    """A legacy service without a preset is read off its container instead."""
+    from oduflow.docker_ops import service_ops
+
+    settings, team = _settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.return_value = _container(
+        ["PATH=/usr/bin", "HOME=/root", "MEILI_ENV=production", "OPTIONS=a,b"]
+    )
+    with (
+        patch("oduflow.docker_ops.service_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=NotFoundError("no preset"),
+        ),
+    ):
+        assert service_ops.get_service_env_vars(settings, team, "meili") == {
+            "MEILI_ENV": "production",
+            "OPTIONS": "a,b",
+        }
+
+
+def test_env_vars_missing_service(tmp_path):
+    from oduflow.docker_ops import service_ops
+
+    settings, team = _settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.side_effect = docker.errors.NotFound("missing")
+    with patch("oduflow.docker_ops.service_ops.get_client", return_value=client):
+        with pytest.raises(NotFoundError):
+            service_ops.get_service_env_vars(settings, team, "meili")
+
+
+def test_api_service_env_vars_returns_mapping(tmp_path):
+    client = _client(tmp_path)
+    with patch(
+        "oduflow.web_ui.service_ops.get_service_env_vars",
+        return_value={"MEILI_ENV": "production"},
+    ):
+        response = client.get("/api/services/meili/env-vars")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "env_vars": {"MEILI_ENV": "production"}}
+
+
+def test_api_service_env_vars_reports_missing_service(tmp_path):
+    client = _client(tmp_path)
+    with patch(
+        "oduflow.web_ui.service_ops.get_service_env_vars",
+        side_effect=NotFoundError("Service 'meili' not found"),
+    ):
+        response = client.get("/api/services/meili/env-vars")
+
+    assert response.status_code == 404
+    assert response.json()["ok"] is False
+
+
+def test_api_service_update_takes_a_mapping_verbatim(tmp_path):
+    """The dashboard sends a mapping so values are never re-split server side."""
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.service_ops.update_service", return_value={}) as update:
+        response = client.post(
+            "/api/services/meili/update",
+            json={"env_vars": {"OPTIONS": "a,b", " MEILI_ENV ": "production"}},
+        )
+
+    assert response.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {
+        "OPTIONS": "a,b",
+        "MEILI_ENV": "production",
+    }
+
+
+def test_api_service_update_empty_mapping_clears(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.service_ops.update_service", return_value={}) as update:
+        response = client.post("/api/services/meili/update", json={"env_vars": {}})
+
+    assert response.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] == {}
+
+
+def test_api_service_update_without_env_vars_keeps_them(tmp_path):
+    client = _client(tmp_path)
+    with patch("oduflow.web_ui.service_ops.update_service", return_value={}) as update:
+        response = client.post("/api/services/meili/update", json={})
+
+    assert response.json()["ok"] is True
+    assert update.call_args.kwargs["env_override"] is None

--- a/tests/test_service_env_vars_web.py
+++ b/tests/test_service_env_vars_web.py
@@ -88,6 +88,28 @@ def test_env_vars_falls_back_to_the_container(tmp_path):
         }
 
 
+def test_env_vars_propagates_an_unreadable_preset(tmp_path):
+    """A preset that exists but cannot be read must not fall back.
+
+    The container's environment carries the image defaults; offering those for
+    editing would bake them into the preset on the first save.
+    """
+    from oduflow.docker_ops import service_ops
+
+    settings, team = _settings(tmp_path)
+    client = MagicMock()
+    client.containers.get.return_value = _container(["MEILI_ENV=production"])
+    with (
+        patch("oduflow.docker_ops.service_ops.get_client", return_value=client),
+        patch(
+            "oduflow.docker_ops.service_ops.service_presets.get_preset",
+            side_effect=OSError("presets file is unreadable"),
+        ),
+    ):
+        with pytest.raises(OSError):
+            service_ops.get_service_env_vars(settings, team, "meili")
+
+
 def test_env_vars_missing_service(tmp_path):
     from oduflow.docker_ops import service_ops
 


### PR DESCRIPTION
## What

**Update** on a service card now opens a dialog prefilled with the service's current environment variables. Edit them and confirm to apply the change *and* pull the latest image in one go; leave the field untouched and it behaves exactly as before (pull + recreate); clear it to remove every variable.

Also: the container name in a service card copies on click, like the one in an environment card.

## Why

`update_service` has always accepted an env override — only the dashboard had no way to send one, so changing a variable meant dropping to MCP or the CLI.

## Notes

- The prefill comes from a new `GET /api/services/{name}/env-vars` rather than the existing services list: the list reports the container's whole environment, image defaults included, while an update reuses the saved preset. Prefilling from the list would have offered image defaults for editing and persisted them into the preset on the first save. The endpoint returns the preset, falling back to container inspection for services created before presets existed.
- `api_service_update` now treats `env_vars` as a full replacement by key presence, so an empty mapping clears every variable instead of collapsing into "keep" — this matches how the environment dialog has always read the same field.
- The dialog mirrors the environment one: the field stays disabled while the prefill is in flight, on a failed prefill, and when a value spans lines (a line-per-assignment field cannot round-trip those). A sequence counter keeps a slow prefill from landing in a dialog reopened for another service.
- No `CHAT_V` bump — `chat.js`/`acp-client.js` are untouched. No `specs/` record: this is a UI affordance over an existing capability.

## Testing

New `tests/test_service_env_vars_web.py` (preset prefill, container fallback, 404, mapping verbatim, `{}` clears, absent key keeps). `ruff`, `mypy` clean; full unit suite 2704 passed with only the sandbox's pre-existing failures (no Docker/rsync), verified identical against a pristine HEAD checkout.

Not exercised in a live browser — no Docker daemon in this sandbox to bring the dashboard up against real services. Inline dashboard scripts were syntax-checked with `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)