### PR TITLE
Configure registry tokens directly

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,10 +17,11 @@
   and publishing is a tag and push of that same image — nothing is rebuilt on
   the way out. The capability is gated on a `[team.X.image_registry]` TOML
   section whose `repository_prefix` is the authorization boundary; registry
-  credentials are request-scoped, resolved from `token_env` at publish time and
-  never persisted. Concurrency, context size, log size, and wall-clock limits
-  are enforced per team, and older staging images are pruned automatically
-  (the newest `keep_images` are kept). (#221)
+  credentials are read directly from `username` + `token` in that config and
+  passed request-scoped for each push, without persisting them in build jobs.
+  Concurrency, context size, log size, and wall-clock limits are enforced per
+  team, and older staging images are pruned automatically (the newest
+  `keep_images` are kept). (#221)
 
 - **Custom start command for auxiliary services** — `create_service` and
   `update_service` accept an optional `command` that replaces the image `CMD`,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -267,8 +267,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 # [team.1.image_registry]            # enables the image build/publish MCP tools for this team
 # repository_prefix = "acme"         # registry namespace all published images live under (required)
 # host = "docker.io"                 # plain registry hostname, optionally with :port
-# username = "acme-ci"               # optional; with token_env, request-scoped push credentials
-# token_env = "ODUFLOW_REGISTRY_TEAM_1_TOKEN"  # env var holding the registry token
+# username = "acme-ci"               # optional; with token, request-scoped push credentials
+# token = "<registry-token>"         # registry token/password stored in this config
 # build_timeout_seconds = 1800       # per-build wall clock limit
 # max_context_mb = 512               # sealed build context size cap
 # max_log_mb = 16                    # persisted log cap per build
@@ -379,7 +379,7 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `db_quota_gb` | `50` | Combined size cap for the team's environment and template PostgreSQL databases. `0` disables the check |
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
 | `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
-| `[team.X.image_registry]` | *(absent — image building disabled)* | Sub-table enabling the container image build/publish MCP tools for the team. `repository_prefix` (required) is the registry namespace agents may publish under — the authorization boundary; `host` (default `docker.io`) is a plain registry hostname; `username` + `token_env` (set together) name a push user and the environment variable holding its token for request-scoped authentication — omit both to use the host Docker daemon's own `docker login` credentials. Resource bounds are `build_timeout_seconds` (default `1800`, hard wall-clock deadline), `max_context_mb` (default `512`), `max_log_mb` (default `16`), and `max_concurrent_builds` (default `2`). `keep_images` (default `10`, `0` disables pruning) retains that many local staging builds; temporary publish tags are removed after push and older untagged image objects are deleted once unused. Use a least-privilege registry token restricted to the prefix |
+| `[team.X.image_registry]` | *(absent — image building disabled)* | Sub-table enabling the container image build/publish MCP tools for the team. `repository_prefix` (required) is the registry namespace agents may publish under — the authorization boundary; `host` (default `docker.io`) is a plain registry hostname; `username` + `token` (set together) provide request-scoped push credentials directly from the Oduflow config — omit both to use the host Docker daemon's own `docker login` credentials. Resource bounds are `build_timeout_seconds` (default `1800`, hard wall-clock deadline), `max_context_mb` (default `512`), `max_log_mb` (default `16`), and `max_concurrent_builds` (default `2`). `keep_images` (default `10`, `0` disables pruning) retains that many local staging builds; temporary publish tags are removed after push and older untagged image objects are deleted once unused. Protect the config file and use a least-privilege registry token restricted to the prefix |
 
 `environment_hostname_mode = "slots"` requires Traefik and a hostname with a
 distinct host prefix and parent domain, such as `dev.example.com`. A bare

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -828,8 +828,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 # [team.1.image_registry]            # enables the image build/publish MCP tools for this team
 # repository_prefix = "acme"         # registry namespace all published images live under (required)
 # host = "docker.io"                 # plain registry hostname, optionally with :port
-# username = "acme-ci"               # optional; with token_env, request-scoped push credentials
-# token_env = "ODUFLOW_REGISTRY_TEAM_1_TOKEN"  # env var holding the registry token
+# username = "acme-ci"               # optional; with token, request-scoped push credentials
+# token = "<registry-token>"         # registry token/password stored in this config
 # build_timeout_seconds = 1800       # per-build wall clock limit
 # max_context_mb = 512               # sealed build context size cap
 # max_log_mb = 16                    # persisted log cap per build
@@ -940,7 +940,7 @@ Each `[team.*]` section defines an isolated team with its own workspaces, templa
 | `db_quota_gb` | `50` | Combined size cap for the team's environment and template PostgreSQL databases. `0` disables the check |
 | `disk_quota_gb` | `0` | Kernel-enforced cap for team files and databases when the data filesystem supports XFS project quotas. `0` disables it |
 | `[team.X.agent_env]` | *(empty)* | Sub-table of environment variables injected into the team's agent container — provider credentials (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENCODE_API_KEY`, or any provider-specific OpenCode variable) and custom vars |
-| `[team.X.image_registry]` | *(absent — image building disabled)* | Sub-table enabling the container image build/publish MCP tools for the team. `repository_prefix` (required) is the registry namespace agents may publish under — the authorization boundary; `host` (default `docker.io`) is a plain registry hostname; `username` + `token_env` (set together) name a push user and the environment variable holding its token for request-scoped authentication — omit both to use the host Docker daemon's own `docker login` credentials. Resource bounds are `build_timeout_seconds` (default `1800`, hard wall-clock deadline), `max_context_mb` (default `512`), `max_log_mb` (default `16`), and `max_concurrent_builds` (default `2`). `keep_images` (default `10`, `0` disables pruning) retains that many local staging builds; temporary publish tags are removed after push and older untagged image objects are deleted once unused. Use a least-privilege registry token restricted to the prefix |
+| `[team.X.image_registry]` | *(absent — image building disabled)* | Sub-table enabling the container image build/publish MCP tools for the team. `repository_prefix` (required) is the registry namespace agents may publish under — the authorization boundary; `host` (default `docker.io`) is a plain registry hostname; `username` + `token` (set together) provide request-scoped push credentials directly from the Oduflow config — omit both to use the host Docker daemon's own `docker login` credentials. Resource bounds are `build_timeout_seconds` (default `1800`, hard wall-clock deadline), `max_context_mb` (default `512`), `max_log_mb` (default `16`), and `max_concurrent_builds` (default `2`). `keep_images` (default `10`, `0` disables pruning) retains that many local staging builds; temporary publish tags are removed after push and older untagged image objects are deleted once unused. Protect the config file and use a least-privilege registry token restricted to the prefix |
 
 `environment_hostname_mode = "slots"` requires Traefik and a hostname with a
 distinct host prefix and parent domain, such as `dev.example.com`. A bare

--- a/specs/0054-agent-container-image-build-and-publish.md
+++ b/specs/0054-agent-container-image-build-and-publish.md
@@ -61,10 +61,10 @@ a thin control plane over the host Docker daemon:
   `interrupted` on first access; succeeded builds remain publishable while
   their retained staging image exists. Retry is a new build, cheap via the
   layer cache.
-- **Credentials are request-scoped.** `username` + `token_env` (resolved from
-  the server environment at publish time) are passed per-push to the Docker
-  API; with neither set, the host's own `docker login` is used. No daemon-wide
-  login, nothing persisted.
+- **Credentials are request-scoped.** `username` + `token` are read from the
+  Oduflow config and passed per-push to the Docker API; with neither set, the
+  host's own `docker login` is used. There is no daemon-wide login, and the
+  credentials are not persisted in build jobs.
 
 ## Consequences
 
@@ -122,3 +122,6 @@ mutually untrusting tenants. Each pillar and why it was dropped:
 
 - 2026-09-01 — introduced (simplified from a 2026-08-31 design after review;
   that document's rationale is folded into this record).
+- 2026-09-02 — registry tokens moved from an environment-variable reference to
+  a direct config value, matching how Oduflow stores its other deployment
+  credentials while preserving request-scoped Docker authentication.

--- a/src/oduflow/docker_ops/build_ops.py
+++ b/src/oduflow/docker_ops/build_ops.py
@@ -513,14 +513,10 @@ def publish(
     )
     auth_config = None
     if registry_cfg.username:
-        token = os.environ.get(registry_cfg.token_env, "")
-        if not token:
-            raise PrerequisiteNotMetError(
-                f"Registry credentials are configured to come from the "
-                f"environment variable '{registry_cfg.token_env}', but it is "
-                "empty in the Oduflow server environment."
-            )
-        auth_config = {"username": registry_cfg.username, "password": token}
+        auth_config = {
+            "username": registry_cfg.username,
+            "password": registry_cfg.token,
+        }
 
     client = get_client()
     results: list[dict[str, Any]] = []

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -53,17 +53,17 @@ class ImageRegistrySettings:
     team; teams without it are refused with a clear prerequisite error. The
     agent can publish only below ``repository_prefix`` on ``host`` — that prefix
     is the authorization boundary. Credentials are optional: when ``username``
-    and ``token_env`` are set, pushes send request-scoped auth to the Docker
-    API; otherwise the host Docker daemon's ambient credentials (``docker
-    login``) are used.
+    and ``token`` are set, pushes send request-scoped auth to the Docker API;
+    otherwise the host Docker daemon's ambient credentials (``docker login``)
+    are used.
     """
 
     repository_prefix: str  # e.g. "acme" — namespace all published repos live under
     host: str = "docker.io"
     username: str = ""
-    # Name of the environment variable holding the registry token/password.
-    # Resolved at publish time; the value itself never lives in config or jobs.
-    token_env: str = ""
+    # Registry token/password from the Oduflow config. It is sent only as
+    # request-scoped Docker API auth and is never persisted in build jobs.
+    token: str = field(default="", repr=False)
     build_timeout_seconds: int = 1800
     max_context_mb: int = 512
     max_log_mb: int = 16
@@ -741,10 +741,10 @@ def _parse_image_registry_section(
             "registry hostname (optionally with :port), without scheme or path."
         )
     username = str(raw.get("username", "")).strip()
-    token_env = str(raw.get("token_env", "")).strip()
-    if bool(username) != bool(token_env):
+    token = str(raw.get("token", "")).strip()
+    if bool(username) != bool(token):
         raise ValueError(
-            f"Team '{team_id}': image_registry username and token_env must be "
+            f"Team '{team_id}': image_registry username and token must be "
             "set together (explicit credentials) or both omitted (use the host "
             "Docker daemon's own `docker login` credentials)."
         )
@@ -774,7 +774,7 @@ def _parse_image_registry_section(
         repository_prefix=prefix,
         host=host,
         username=username,
-        token_env=token_env,
+        token=token,
         build_timeout_seconds=timeout,
         max_context_mb=max_context_mb,
         max_log_mb=max_log_mb,

--- a/tests/test_image_builds.py
+++ b/tests/test_image_builds.py
@@ -253,7 +253,7 @@ def test_settings_parse_registry_section(tmp_path):
             [team.1.image_registry]
             repository_prefix = "acme/"
             username = "acme-ci"
-            token_env = "ODUFLOW_REGISTRY_TOKEN"
+            token = "registry-secret"
             build_timeout_seconds = 600
             """
         ),
@@ -263,7 +263,8 @@ def test_settings_parse_registry_section(tmp_path):
     assert registry.repository_prefix == "acme"  # trailing slash trimmed
     assert registry.host == "docker.io"
     assert registry.username == "acme-ci"
-    assert registry.token_env == "ODUFLOW_REGISTRY_TOKEN"
+    assert registry.token == "registry-secret"
+    assert "registry-secret" not in repr(registry)
     assert registry.build_timeout_seconds == 600
     assert registry.max_context_mb == 512
     assert registry.max_log_mb == 16
@@ -279,8 +280,9 @@ def test_settings_parse_registry_section(tmp_path):
         '[team.1.image_registry]\nrepository_prefix = "Acme"',
         # host must be a plain hostname
         '[team.1.image_registry]\nrepository_prefix = "acme"\nhost = "https://x.io"',
-        # username and token_env come together
+        # username and token come together
         '[team.1.image_registry]\nrepository_prefix = "acme"\nusername = "ci"',
+        '[team.1.image_registry]\nrepository_prefix = "acme"\ntoken = "secret"',
         # limits must be positive
         '[team.1.image_registry]\nrepository_prefix = "acme"\nmax_context_mb = 0',
         '[team.1.image_registry]\nrepository_prefix = "acme"\nmax_log_mb = 0',
@@ -289,6 +291,20 @@ def test_settings_parse_registry_section(tmp_path):
 )
 def test_settings_reject_bad_registry_sections(tmp_path, body):
     with pytest.raises(ValueError):
+        _load_settings(tmp_path, body)
+
+
+def test_settings_reject_legacy_registry_token_env(tmp_path):
+    body = textwrap.dedent(
+        """
+        [team.1.image_registry]
+        repository_prefix = "acme"
+        username = "ci"
+        token_env = "ODUFLOW_REGISTRY_TOKEN"
+        """
+    )
+
+    with pytest.raises(ValueError, match="username and token must be set together"):
         _load_settings(tmp_path, body)
 
 
@@ -516,11 +532,10 @@ def test_publish_cleans_tag_after_registry_error_and_uses_scoped_auth(tmp_path):
     client.api.push.return_value = [{"error": "registry rejected push"}]
     client.images.get.return_value = SimpleNamespace(tags=[job.local_tag])
     registry = ImageRegistrySettings(
-        repository_prefix="acme", username="ci", token_env="TEST_REGISTRY_TOKEN"
+        repository_prefix="acme", username="ci", token="secret"
     )
 
     with (
-        patch.dict(os.environ, {"TEST_REGISTRY_TOKEN": "secret"}),
         patch.object(build_ops, "store", local_store),
         patch.object(build_ops, "get_client", return_value=client),
     ):


### PR DESCRIPTION
## Summary

- replace `image_registry.token_env` with a direct `token` config value
- keep Docker registry authentication request-scoped and hide the token from settings repr
- update tests, installation docs, changelog, generated LLM docs, and ADR 0054

## Validation

- `python3 -m pytest tests/test_image_builds.py -q` — 55 passed
- `python3 -m ruff check src/oduflow tests` — passed
- `python3 -m mypy src/oduflow` — passed
- `python3 scripts/build_llms_full.py --check` — passed
- full non-integration/non-heavyweight suite — 2759 passed, 7 environment-only failures because this runner has neither `rsync` nor a Docker daemon