### PR TITLE
Add scoped single-environment dashboard sharing

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3131,8 +3131,8 @@ hooks, dashboard controls, and OCI distribution are intentionally deferred.
 HTTP mode serves the dashboard at `/`. It manages environments, templates,
 services, volumes, extra addons, credentials, licenses, usage/quotas, and—when
 enabled—coding agents and productions. Environment cards also expose logs,
-Odoo/SQL terminals, Connect As, notes, protection, scoped MCP access, and
-save-as-template actions.
+Odoo/SQL terminals, Connect As, notes, protection, scoped MCP access,
+single-environment share links, and save-as-template actions.
 
 The header's **Feedback** action opens a prefilled issue form on
 `github.com/oduist/oduflow`. Oduflow holds no GitHub credentials and files
@@ -3184,6 +3184,10 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/note` | Store the body `note` on the environment |
 | `POST` | `/api/environments/{branch}/storage/refresh` | Refresh cached DB/workspace sizes |
 | `GET` | `/api/environments/{branch}/mcp-access` | Return the scoped MCP URL and per-environment token |
+| `GET` | `/api/environments/{branch}/share` | Return the environment's share link status: `shared`, `url` (with its key) and `created_at` |
+| `POST` | `/api/environments/{branch}/share` | Start sharing the environment, or return the existing link |
+| `POST` | `/api/environments/{branch}/share/rotate` | Issue a new link; the previous one and every session opened with it stop working |
+| `POST` | `/api/environments/{branch}/share/revoke` | Stop sharing the environment |
 | `GET` | `/api/environments/{branch}/users` | List internal and portal users for Connect As |
 | `POST` | `/api/environments/{branch}/connect-as` | Mint an Odoo session for body `user` and return URL/cookie details |
 | `GET` | `/api/environments/{branch}/connect-open?user=` | Mint a session and redirect toward the environment login handoff |
@@ -3191,6 +3195,44 @@ than a JSON API. Production routes are registered only when
 
 Branch parameters use Starlette's `path` converter internally, so names that
 contain `/` are accepted and URL-decoded as one environment name.
+
+The four `share` routes are operator-only: a shared session cannot read, reissue
+or revoke the link it arrived on. See
+[Shared environment links](#shared-environment-links).
+
+## Shared environment links
+
+`/env/{name}` is the same dashboard reduced to a single environment. An operator
+opens **Share UI** on an environment card, which mints a link
+`https://<team-host>/env/<name>?key=<secret>` and hands it to a client. Opening
+it exchanges the key for an HTTP-only, SameSite=Strict cookie and redirects to
+the clean `/env/<name>`, so the key leaves the address bar and browser history.
+The link stays valid until it is regenerated or revoked from the same modal;
+both act immediately on sessions already opened with it.
+
+A shared session may only do the following, enforced server-side as a
+default-deny allowlist (`src/oduflow/ui_scope.py`) and re-checked on every
+request:
+
+- see that environment's card, status, storage and logs;
+- start, stop, restart and sync it, and install or upgrade modules;
+- open its Odoo shell and `psql` consoles, use Connect As, and read its scoped
+  MCP endpoint and Secret Key;
+- use **Agent Chat**.
+
+Everything else is refused with HTTP 403 (WebSockets close with 1008): the full
+dashboard, any other environment, every team-wide surface (templates, services,
+volumes, extra addons, credentials, productions, host statistics, license), the
+provisioning actions on the shared environment itself (create, delete, update,
+recreate, switch branch, protect, save as template), the share routes, and
+**Agent CLI**.
+
+Agent CLI is excluded because it is a terminal in the *per-team* agent
+container, whose workspace holds a checkout of every environment of the team.
+Agent Chat runs in that same container, so the scope of a shared link is a
+policy boundary on the dashboard — it is not the cryptographic confinement that
+the per-environment token gives on `/mcp/<env>`. Share links with people you
+would let work in the environment.
 
 ## Environment WebSockets
 
@@ -4311,6 +4353,50 @@ oduflow client get_environment_info
 Environments created before this feature carry no Secret Key (Docker labels can't
 be added to a live container); recreate the environment to issue one. Recreating
 an environment also rotates its token.
+
+## Shared single-environment dashboard (`/env/<name>`)
+
+The dashboard equivalent of `/mcp/<env>`: a link that opens the dashboard
+reduced to one environment, for a client or collaborator who has no team
+password.
+
+Open **More → Share UI** on an environment card and Oduflow mints
+
+```
+https://your-server.com/env/<env>?key=<share-secret>
+```
+
+Opening it trades the key for a signed, HTTP-only, SameSite=Strict cookie and
+redirects to the clean `/env/<env>`, so the key does not linger in the address
+bar or browser history. The same modal regenerates or revokes the link; both
+take effect immediately, including for sessions already opened with it, because
+the cookie carries a fingerprint of the secret it was minted from. Links have no
+expiry of their own; a session cookie lasts seven days and re-opening the link
+renews it.
+
+A shared session sees that environment's card, logs, storage and status; can
+start, stop, restart and sync it, install and upgrade modules, open its Odoo
+shell and `psql` consoles, use Connect As and its **Agent Chat**, and read its
+`/mcp/<env>` URL and Secret Key. Everything else is refused server-side by a
+default-deny allowlist re-checked on every request: the full dashboard, any
+other environment, all team-wide surfaces (templates, services, volumes, extra
+addons, credentials, productions, host statistics, license), the provisioning
+actions on the environment itself (create, delete, update, recreate, switch
+branch, protect, save as template), the share routes themselves, and **Agent
+CLI**.
+
+Agent CLI is deliberately excluded: it is a terminal in the *per-team* agent
+container, whose workspace holds a checkout of every environment of the team.
+Agent Chat runs in that same container — driven over ACP at this environment's
+checkout, with this environment's scoped MCP token — so the boundary a share
+link enforces is the dashboard surface, not the confinement that the
+per-environment Bearer token gives on `/mcp/<env>`. Share with people you would
+let work in the environment, and revoke when they are done.
+
+Share secrets live in the team's data directory (`shares.json`, mode 0600), not
+in a container label, so environments that already exist can be shared, and a
+link survives recreating the environment. Deleting an environment drops its
+share; renaming one carries it over.
 
 ## Web Dashboard Auth
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -154,6 +154,50 @@ Environments created before this feature carry no Secret Key (Docker labels can'
 be added to a live container); recreate the environment to issue one. Recreating
 an environment also rotates its token.
 
+## Shared single-environment dashboard (`/env/<name>`)
+
+The dashboard equivalent of `/mcp/<env>`: a link that opens the dashboard
+reduced to one environment, for a client or collaborator who has no team
+password.
+
+Open **More → Share UI** on an environment card and Oduflow mints
+
+```
+https://your-server.com/env/<env>?key=<share-secret>
+```
+
+Opening it trades the key for a signed, HTTP-only, SameSite=Strict cookie and
+redirects to the clean `/env/<env>`, so the key does not linger in the address
+bar or browser history. The same modal regenerates or revokes the link; both
+take effect immediately, including for sessions already opened with it, because
+the cookie carries a fingerprint of the secret it was minted from. Links have no
+expiry of their own; a session cookie lasts seven days and re-opening the link
+renews it.
+
+A shared session sees that environment's card, logs, storage and status; can
+start, stop, restart and sync it, install and upgrade modules, open its Odoo
+shell and `psql` consoles, use Connect As and its **Agent Chat**, and read its
+`/mcp/<env>` URL and Secret Key. Everything else is refused server-side by a
+default-deny allowlist re-checked on every request: the full dashboard, any
+other environment, all team-wide surfaces (templates, services, volumes, extra
+addons, credentials, productions, host statistics, license), the provisioning
+actions on the environment itself (create, delete, update, recreate, switch
+branch, protect, save as template), the share routes themselves, and **Agent
+CLI**.
+
+Agent CLI is deliberately excluded: it is a terminal in the *per-team* agent
+container, whose workspace holds a checkout of every environment of the team.
+Agent Chat runs in that same container — driven over ACP at this environment's
+checkout, with this environment's scoped MCP token — so the boundary a share
+link enforces is the dashboard surface, not the confinement that the
+per-environment Bearer token gives on `/mcp/<env>`. Share with people you would
+let work in the environment, and revoke when they are done.
+
+Share secrets live in the team's data directory (`shares.json`, mode 0600), not
+in a container label, so environments that already exist can be shared, and a
+link survives recreating the environment. Deleting an environment drops its
+share; renaming one carries it over.
+
 ## Web Dashboard Auth
 
 The browser login form creates a signed, seven-day HTTP-only session cookie.

--- a/docs/web-api.md
+++ b/docs/web-api.md
@@ -7,8 +7,8 @@
 HTTP mode serves the dashboard at `/`. It manages environments, templates,
 services, volumes, extra addons, credentials, licenses, usage/quotas, and—when
 enabled—coding agents and productions. Environment cards also expose logs,
-Odoo/SQL terminals, Connect As, notes, protection, scoped MCP access, and
-save-as-template actions.
+Odoo/SQL terminals, Connect As, notes, protection, scoped MCP access,
+single-environment share links, and save-as-template actions.
 
 The header's **Feedback** action opens a prefilled issue form on
 `github.com/oduist/oduflow`. Oduflow holds no GitHub credentials and files
@@ -60,6 +60,10 @@ than a JSON API. Production routes are registered only when
 | `POST` | `/api/environments/{branch}/note` | Store the body `note` on the environment |
 | `POST` | `/api/environments/{branch}/storage/refresh` | Refresh cached DB/workspace sizes |
 | `GET` | `/api/environments/{branch}/mcp-access` | Return the scoped MCP URL and per-environment token |
+| `GET` | `/api/environments/{branch}/share` | Return the environment's share link status: `shared`, `url` (with its key) and `created_at` |
+| `POST` | `/api/environments/{branch}/share` | Start sharing the environment, or return the existing link |
+| `POST` | `/api/environments/{branch}/share/rotate` | Issue a new link; the previous one and every session opened with it stop working |
+| `POST` | `/api/environments/{branch}/share/revoke` | Stop sharing the environment |
 | `GET` | `/api/environments/{branch}/users` | List internal and portal users for Connect As |
 | `POST` | `/api/environments/{branch}/connect-as` | Mint an Odoo session for body `user` and return URL/cookie details |
 | `GET` | `/api/environments/{branch}/connect-open?user=` | Mint a session and redirect toward the environment login handoff |
@@ -67,6 +71,44 @@ than a JSON API. Production routes are registered only when
 
 Branch parameters use Starlette's `path` converter internally, so names that
 contain `/` are accepted and URL-decoded as one environment name.
+
+The four `share` routes are operator-only: a shared session cannot read, reissue
+or revoke the link it arrived on. See
+[Shared environment links](#shared-environment-links).
+
+## Shared environment links
+
+`/env/{name}` is the same dashboard reduced to a single environment. An operator
+opens **Share UI** on an environment card, which mints a link
+`https://<team-host>/env/<name>?key=<secret>` and hands it to a client. Opening
+it exchanges the key for an HTTP-only, SameSite=Strict cookie and redirects to
+the clean `/env/<name>`, so the key leaves the address bar and browser history.
+The link stays valid until it is regenerated or revoked from the same modal;
+both act immediately on sessions already opened with it.
+
+A shared session may only do the following, enforced server-side as a
+default-deny allowlist (`src/oduflow/ui_scope.py`) and re-checked on every
+request:
+
+- see that environment's card, status, storage and logs;
+- start, stop, restart and sync it, and install or upgrade modules;
+- open its Odoo shell and `psql` consoles, use Connect As, and read its scoped
+  MCP endpoint and Secret Key;
+- use **Agent Chat**.
+
+Everything else is refused with HTTP 403 (WebSockets close with 1008): the full
+dashboard, any other environment, every team-wide surface (templates, services,
+volumes, extra addons, credentials, productions, host statistics, license), the
+provisioning actions on the shared environment itself (create, delete, update,
+recreate, switch branch, protect, save as template), the share routes, and
+**Agent CLI**.
+
+Agent CLI is excluded because it is a terminal in the *per-team* agent
+container, whose workspace holds a checkout of every environment of the team.
+Agent Chat runs in that same container, so the scope of a shared link is a
+policy boundary on the dashboard — it is not the cryptographic confinement that
+the per-environment token gives on `/mcp/<env>`. Share links with people you
+would let work in the environment.
 
 ## Environment WebSockets
 

--- a/specs/0055-scoped-environment-ui-sharing.md
+++ b/specs/0055-scoped-environment-ui-sharing.md
@@ -1,0 +1,104 @@
+# 0055 — Shared single-environment dashboard (`/env/<name>` + share links)
+
+**Status:** Adopted
+**Type:** Architecture / Web capability
+**First introduced:** 2026-09-02
+**Key code today:** `ui_scope.py` (default-deny allowlist, scoped cookie name), `env_share.py` (per-team `shares.json` secrets), `web_ui.py` (`scoped_env_page`, share cookie mint/verify, `BasicAuthMiddleware` scoped principal, `api_share_*`), `templates/dashboard.html` (`data-scoped-env`, Share modal, scoped card rendering)
+
+## Context
+
+[[0028-scoped-environment-mcp-access]] solved this problem for *agents*: an
+operator can hand out a `/mcp/<env>` URL plus a per-environment Bearer token and
+know the holder cannot reach anything else the team owns. The dashboard had no
+counterpart. Its authentication is per team and all-or-nothing: the
+`ui_password` opens every environment plus templates, services, volumes, extra
+repos, credentials, productions and host statistics.
+
+So a hosting customer who wanted to show a client their staging environment —
+or let them click around, watch the logs, or drive the coding agent in
+chat — had to give away the team password. In practice that meant either not
+sharing at all, or sharing far more than intended. The people this matters for
+are not agents and often not developers: they want a browser tab, not an MCP
+client.
+
+## Decision
+
+Serve the **same dashboard, scoped by URL**, at `/env/<name>`, and give each
+environment a **share secret** the operator can mint, regenerate and revoke from
+the environment card. Opening `https://<team-host>/env/<name>?key=<secret>` exchanges the
+key for a signed, host-only cookie and lands on the clean `/env/<name>`.
+
+- **One page, two faces.** The scoped view is `dashboard.html` rendered with a
+  `data-scoped-env` attribute, not a second template. Agent Chat, the consoles,
+  the logs viewer and the module dialogs are the ones operators already use, so
+  they cannot drift apart.
+- **The server is the boundary, not the rendering.** A default-deny allowlist
+  (`ui_scope.is_allowed`) runs in the auth middleware for every request a scoped
+  session makes — HTTP and WebSocket — and any env-addressed path must address
+  the cookie's own environment. Hiding buttons is presentation; this is the
+  policy.
+- **Agent Chat yes, Agent CLI no.** Chat is the point of sharing (a client grows
+  their Odoo by talking to the agent). The CLI is a PTY in the *per-team* agent
+  container, whose `/workspace` holds a checkout of every environment of the
+  team ([[0029-agent-console-and-chat]]), so it is not a single-environment
+  surface and is denied.
+- **Secrets in a registry, not a container label.** Unlike the MCP token, the
+  share secret lives in the team's `shares.json`. Labels cannot be added to a
+  live container, which would have made every pre-existing environment
+  unshareable — unacceptable for a feature whose whole purpose is to share the
+  environment you are looking at right now.
+
+The dev-loop actions (start/stop/restart/sync, install/upgrade modules,
+consoles, Connect As, and the `/mcp/<env>` credentials) are exposed
+deliberately: a share link is for someone who is meant to *work in* the
+environment, and the scoped MCP endpoint already grants equivalent in-environment
+power to anyone holding its token.
+
+## How it works (macro)
+
+- **Link → session.** `/env/<name>` is outside the team login and authenticates
+  itself. With `?key=`, the secret is verified against each team's share
+  registry (host-matched team first), traded for a cookie signed with the
+  server secret under its own salt, and dropped from the URL by a redirect, so
+  it does not persist in history or a `Referer`. The cookie embeds a
+  fingerprint of the secret, so regenerating or revoking the link invalidates
+  live sessions at once — the same mechanism that makes a password change
+  invalidate operator cookies.
+- **Cookie → principal.** The auth middleware, having found no team credential,
+  resolves the scoped cookie to *(team, environment)* and stores both on the
+  request. Handlers keep acting as the team; the environment is the restriction.
+- **Policy, default-deny.** Every scoped request is matched against the
+  allowlist before reaching a handler; a mismatch is a 403 (or a 1008 WebSocket
+  close). The environment list endpoint is allowed but filtered server-side to
+  the one environment, mirroring how the scoped MCP endpoint filters
+  `tools/list`.
+- **Operator UX.** The card's **Share UI** action shows the link masked, with
+  Copy, Regenerate and Revoke. The share routes are themselves outside the
+  allowlist, so a shared session cannot read, reissue or revoke the link it
+  arrived on.
+
+## Consequences
+
+- An environment can be handed to a **non-technical client in a browser** —
+  card, logs, consoles, Connect As, Agent Chat — with no team password and no
+  reach into any other environment or team-wide resource.
+- **Revocation is real and immediate**, per environment, and does not require
+  recreating anything (contrast the MCP token, which rotates only by recreating
+  the environment).
+- **Not a cryptographic confinement.** Agent Chat runs in the per-team agent
+  container, so the agent a shared visitor drives can read other environments'
+  checkouts and the team's git credentials. The link bounds the dashboard
+  surface; it does not sandbox the agent. Making it a hard boundary would need a
+  per-share agent container — deliberately out of scope here, and documented as
+  a caveat in `docs/security.md`.
+- **One scoped session per browser and host.** The cookie is single-valued, so
+  opening a second share link on the same host replaces the first. Reopening
+  either link restores it.
+- Sharing is **operator-controlled and audit-visible**: `shares.json` records
+  which environments are shared and since when.
+
+## History
+
+- 2026-09-02 — shared single-environment dashboard: `/env/<name>` page, per-env
+  share secrets with rotate/revoke, default-deny scoped allowlist in the auth
+  middleware, Share modal on the environment card.

--- a/specs/README.md
+++ b/specs/README.md
@@ -73,6 +73,7 @@ precursors).
 | [0052](0052-managed-postgresql-databases-for-auxiliary-services.md) | 2026-08-29 | Managed PostgreSQL databases for auxiliary services |
 | [0053](0053-explicit-start-commands-for-auxiliary-services.md) | 2026-08-31 | Explicit Docker CMD overrides for auxiliary services |
 | [0054](0054-agent-container-image-build-and-publish.md) | 2026-09-01 | Agent-driven container image build and publication |
+| [0055](0055-scoped-environment-ui-sharing.md) | 2026-09-02 | Shared single-environment dashboard (`/env/<name>` share links) |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import docker
 from docker import DockerClient
-from oduflow import activity, settings
+from oduflow import activity, env_share, settings
 from oduflow.docker_ops.client import chown_recursive, get_client, get_odoo_uid_gid
 from oduflow.docker_ops.stats import default_env_limits
 from oduflow.docker_ops.system_ops import (
@@ -3009,6 +3009,16 @@ def unprotect_environment(
     return {"env_name": env_name, "protected": False}
 
 
+def require_environment(settings: Settings, team: TeamSettings, env_name: str) -> None:
+    """Raise NotFoundError unless the team owns an environment by that name."""
+    client = get_client()
+    container_name = get_resource_name(env_name, "odoo", settings.prefix, team.team_id)
+    try:
+        client.containers.get(container_name)
+    except docker.errors.NotFound:
+        raise NotFoundError(f"Environment '{env_name}' does not exist.")
+
+
 def get_env_token(settings: Settings, team: TeamSettings, env_name: str) -> str | None:
     """Return the per-environment MCP access token from the container label.
 
@@ -3149,6 +3159,7 @@ def delete_environment(
         shutil.rmtree(workspace_path)
 
     activity.remove(team, env_name)
+    env_share.remove(team, env_name)
     invalidate_cache()
     logger.info("Environment deleted", extra={"env_name": env_name})
     return warnings
@@ -4669,6 +4680,7 @@ def _relocate_environment_state(
     if team.hostname_registry_path or team.data_dir:
         rename_hostname_env(_hostname_registry_path(team), old_name, new_name)
     activity.rename(team, old_name, new_name)
+    env_share.rename(team, old_name, new_name)
 
     from oduflow import agent_sessions
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -3062,7 +3062,11 @@ def set_note(
 
 
 def delete_environment(
-    settings: Settings, team: TeamSettings, env_name: str
+    settings: Settings,
+    team: TeamSettings,
+    env_name: str,
+    *,
+    preserve_share: bool = False,
 ) -> list[str]:
     if is_protected(settings, team, env_name):
         raise ProtectedError(
@@ -3159,7 +3163,8 @@ def delete_environment(
         shutil.rmtree(workspace_path)
 
     activity.remove(team, env_name)
-    env_share.remove(team, env_name)
+    if not preserve_share:
+        env_share.remove(team, env_name)
     invalidate_cache()
     logger.info("Environment deleted", extra={"env_name": env_name})
     return warnings

--- a/src/oduflow/env_share.py
+++ b/src/oduflow/env_share.py
@@ -1,0 +1,228 @@
+"""Per-environment dashboard share secrets.
+
+An operator can hand a client a link to *one* environment's dashboard —
+``https://<team-host>/env/<name>?key=<secret>`` — which opens the scoped UI
+described in ``oduflow.ui_scope``. This module owns the secret behind that
+link.
+
+The secret is deliberately NOT a Docker label (the model used by
+``env_tokens`` for the scoped MCP endpoint): labels cannot be added to a live
+container, so environments created before this feature would never be
+shareable. It lives instead in a per-team registry next to ``ports.json`` and
+``activity.json``:
+
+    {"<env>": {"secret": "...", "created_at": iso}}
+
+That keeps sharing available for existing environments, survives container
+recreation, and gives the operator per-environment revoke and rotate. The file
+holds credentials, so it is written 0600 (the sibling registries are 0644).
+
+Writes follow the same concurrency discipline as those registries: a per-path
+mutex for threads plus an flock for sibling processes, and a unique temp file
+per write.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hmac
+import json
+import logging
+import os
+import secrets
+import tempfile
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterator
+
+from oduflow.settings import TeamSettings
+
+logger = logging.getLogger("oduflow")
+
+_FILENAME = "shares.json"
+
+_locks_guard = threading.Lock()
+_path_locks: dict[str, threading.Lock] = {}
+
+
+def shares_path(team: TeamSettings) -> str:
+    return os.path.join(team.data_dir, _FILENAME)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def generate_secret() -> str:
+    """Generate a fresh share secret (the ``key`` in a share link)."""
+    return secrets.token_urlsafe(32)
+
+
+def _thread_lock(path: str) -> threading.Lock:
+    with _locks_guard:
+        lock = _path_locks.get(path)
+        if lock is None:
+            lock = threading.Lock()
+            _path_locks[path] = lock
+        return lock
+
+
+@contextmanager
+def _file_lock(path: str) -> Iterator[None]:
+    with _thread_lock(path):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        fd = os.open(path + ".lock", os.O_RDWR | os.O_CREAT, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)
+
+
+def _load(path: str) -> dict[str, dict[str, Any]]:
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            # Valid JSON of the wrong shape (a truncated write leaving `null`,
+            # a hand-edit). Treat as "no shares": every link then fails closed.
+            logger.warning("Ignoring malformed share registry %s", path)
+            return {}
+        return {k: dict(v) for k, v in data.items() if isinstance(v, dict)}
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        logger.warning("Could not load share registry %s: %s", path, e)
+        return {}
+
+
+def _save(path: str, records: dict[str, dict[str, Any]]) -> None:
+    dir_name = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(prefix="shares.", suffix=".tmp", dir=dir_name)
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(records, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _mutate(
+    team: TeamSettings, fn: Callable[[dict[str, dict[str, Any]]], bool]
+) -> None:
+    """Run ``fn(records)`` under the lock; save when it returns True.
+
+    Unlike activity tracking this is not best-effort: a failed write means the
+    operator would be shown a link that does not work, so OSError propagates.
+    """
+    if not team.data_dir:
+        raise ValueError("Team data_dir is required for environment sharing.")
+    path = shares_path(team)
+    with _file_lock(path):
+        records = _load(path)
+        if fn(records):
+            _save(path, records)
+
+
+def get(team: TeamSettings, env_name: str) -> dict[str, Any] | None:
+    """The share record for an environment, or None when it is not shared."""
+    if not team.data_dir:
+        return None
+    record = _load(shares_path(team)).get(env_name)
+    if not record or not isinstance(record.get("secret"), str):
+        return None
+    return record
+
+
+def create_or_get(team: TeamSettings, env_name: str) -> str:
+    """Return the environment's share secret, minting one on first use."""
+    existing = get(team, env_name)
+    if existing:
+        secret: str = existing["secret"]
+        return secret
+    fresh = generate_secret()
+
+    def fn(records: dict[str, dict[str, Any]]) -> bool:
+        # Re-check under the lock: two operators opening the Share modal at
+        # once must end up with the same link, not overwrite each other.
+        record = records.get(env_name)
+        if record and isinstance(record.get("secret"), str):
+            return False
+        records[env_name] = {"secret": fresh, "created_at": _now_iso()}
+        return True
+
+    _mutate(team, fn)
+    current = get(team, env_name)
+    return current["secret"] if current else fresh
+
+
+def rotate(team: TeamSettings, env_name: str) -> str:
+    """Replace the share secret, invalidating the old link and live sessions."""
+    fresh = generate_secret()
+
+    def fn(records: dict[str, dict[str, Any]]) -> bool:
+        records[env_name] = {"secret": fresh, "created_at": _now_iso()}
+        return True
+
+    _mutate(team, fn)
+    return fresh
+
+
+def revoke(team: TeamSettings, env_name: str) -> bool:
+    """Drop the share record. Returns whether the environment was shared."""
+    removed = False
+
+    def fn(records: dict[str, dict[str, Any]]) -> bool:
+        nonlocal removed
+        removed = records.pop(env_name, None) is not None
+        return removed
+
+    _mutate(team, fn)
+    return removed
+
+
+def verify(team: TeamSettings, env_name: str, key: str) -> bool:
+    """Whether ``key`` is the environment's current share secret."""
+    if not key:
+        return False
+    record = get(team, env_name)
+    if not record:
+        return False
+    return hmac.compare_digest(str(record["secret"]), key)
+
+
+def remove(team: TeamSettings, env_name: str) -> None:
+    """Drop the record of a deleted environment (best-effort cleanup)."""
+    try:
+        revoke(team, env_name)
+    except (OSError, ValueError) as e:
+        logger.warning("Could not drop share record for '%s': %s", env_name, e)
+
+
+def rename(team: TeamSettings, old_name: str, new_name: str) -> None:
+    """Carry a share over to a renamed environment: the link's path changes
+    with the name, but the secret the operator already handed out stays
+    valid."""
+
+    def fn(records: dict[str, dict[str, Any]]) -> bool:
+        record = records.pop(old_name, None)
+        if record is None:
+            return False
+        records[new_name] = record
+        return True
+
+    try:
+        _mutate(team, fn)
+    except (OSError, ValueError) as e:
+        logger.warning(
+            "Could not move share record '%s' -> '%s': %s", old_name, new_name, e
+        )

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -1257,6 +1257,29 @@
   .tpl-head-right { display: flex; align-items: center; gap: 8px; }
   .tpl-meta strong { font-family: var(--font-mono); font-size: var(--text-xs); color: var(--text); font-weight: 500; }
   .tag-plain { font-weight: 400 !important; text-transform: none !important; letter-spacing: normal !important; }
+  /* Shared single-environment view (/env/<name>): the same dashboard with
+     everything that is not this one environment taken away. The server-side
+     allowlist (oduflow/ui_scope.py) is the boundary — this only shapes the UI. */
+  body.scoped .tabs,
+  body.scoped #license-badge,
+  body.scoped #bulk-bar,
+  body.scoped header .btn-create,
+  body.scoped .env-card .select-box { display: none !important; }
+  /* Hide the host metrics but keep the bar: it docks minimized consoles. */
+  body.scoped .system-bar > span { display: none; }
+  .scoped-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    font-size: var(--text-xs);
+    color: var(--text-dim);
+  }
+  .scoped-chip strong { font-family: var(--font-mono); color: var(--text); font-weight: 500; }
+
   @media (max-width: 880px) {
     body { padding: 16px; padding-bottom: 96px; }
     header { flex-wrap: wrap; gap: 12px; }
@@ -1305,7 +1328,7 @@
   }
 </style>
 </head>
-<body>
+<body data-scoped-env="__SCOPED_ENV__">
 
 <header>
   <div class="brand-lockup">
@@ -1315,6 +1338,7 @@
       <div class="brand-byline">a product by <a href="https://oduist.com" target="_blank" rel="noopener">Oduist</a></div>
     </div>
   </div>
+  <span class="scoped-chip" id="scoped-chip" hidden></span>
   <button id="license-badge" class="license-badge" style="display:none"></button>
   <div class="actions">
     <a class="docs-link" href="https://docs.oduflow.dev" target="_blank" rel="noopener" title="Open the Oduflow documentation">Docs &#8599;</a>
@@ -2210,6 +2234,33 @@
     </div>
   </div>
 </div>
+<div class="modal-overlay" id="share-modal" onclick="closeShare(event)">
+  <div class="modal modal-sm">
+    <div class="modal-header">
+      <h2 id="share-title">Share environment</h2>
+      <button class="modal-close" onclick="closeShare()">&times;</button>
+    </div>
+    <div class="modal-body">
+      <p class="modal-note">A link to this environment alone. Whoever opens it gets this card, its logs, consoles, module install/upgrade, Connect As and Agent Chat &mdash; and nothing else of the team: no other environment, no templates, services, volumes, repositories or credentials, and no Agent CLI. The link carries its own key, so treat it as a credential.</p>
+      <div class="form-group" id="share-link-group">
+        <label for="share-url">Share link</label>
+        <div class="copy-row">
+          <input id="share-url" class="mono-input" type="password" readonly>
+          <button class="btn" type="button" id="share-reveal" onclick="toggleShareSecret()" aria-pressed="false">Show</button>
+          <button class="btn" type="button" onclick="copyMcpField('share-url', 'Share link copied')">Copy</button>
+        </div>
+      </div>
+      <p class="modal-note" id="share-created" style="display:none;"></p>
+      <p class="modal-note" id="share-none" style="display:none;">This environment is not shared yet.</p>
+      <div class="form-actions">
+        <button class="btn btn-create" type="button" id="share-create" onclick="shareCreate()">Create link</button>
+        <button class="btn" type="button" id="share-rotate" onclick="shareRotate()" title="Issue a new link and invalidate the old one, including sessions already opened with it">Regenerate</button>
+        <button class="btn btn-delete" type="button" id="share-revoke" onclick="shareRevoke()" title="Stop sharing: the link and any session opened with it stop working">Revoke</button>
+        <button class="btn" onclick="closeShare()">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 <div class="modal-overlay" id="mcp-access-modal" onclick="closeMcpAccess(event)">
   <div class="modal modal-sm">
     <div class="modal-header">
@@ -2333,17 +2384,43 @@
   </div>
 </div>
 <script>
-// Redirect to the login page whenever a request is rejected as unauthenticated
-// (e.g. the session cookie expired while the tab was open).
+// Shared single-environment view: set when the page was served at /env/<name>
+// from a share link (see specs/0055-scoped-environment-ui-sharing.md). The
+// server enforces the scope in oduflow/ui_scope.py; everything this flag does
+// on the page is presentation — hiding controls whose endpoints are denied.
+var SCOPED_ENV = document.body.getAttribute('data-scoped-env') || '';
+
+// Path of the scoped page itself. Environment names may contain slashes
+// (feature/x), which stay separators in the URL.
+function scopedPagePath() {
+  return '/env/' + SCOPED_ENV.split('/').map(encodeURIComponent).join('/');
+}
+
+// Redirect whenever a request is rejected as unauthenticated (e.g. the session
+// cookie expired while the tab was open). A share-link visitor has no team
+// password, so send them back to their own page, which asks for the link.
 (function () {
   const _fetch = window.fetch;
   window.fetch = function () {
     return _fetch.apply(this, arguments).then(function (resp) {
-      if (resp.status === 401) { window.location.href = '/login'; }
+      if (resp.status === 401) {
+        window.location.href = SCOPED_ENV ? scopedPagePath() : '/login';
+      }
       return resp;
     });
   };
 })();
+
+if (SCOPED_ENV) {
+  document.body.classList.add('scoped');
+  document.title = 'Oduflow — ' + SCOPED_ENV;
+  var _scopedChip = document.getElementById('scoped-chip');
+  _scopedChip.textContent = 'Shared environment ';
+  var _scopedName = document.createElement('strong');
+  _scopedName.textContent = SCOPED_ENV;
+  _scopedChip.appendChild(_scopedName);
+  _scopedChip.hidden = false;
+}
 
 function logout() {
   const form = document.createElement('form');
@@ -2761,6 +2838,11 @@ function renderEnvironments(envs, force) {
   const el = document.getElementById('env-list');
   if (!envs || envs.length === 0) {
     el._lastHtml = '';
+    if (SCOPED_ENV) {
+      el.innerHTML = '<div class="empty">This environment is not available.<br>' +
+        '<span class="empty-hint">It may have been deleted. Ask whoever shared the link.</span></div>';
+      return;
+    }
     el.innerHTML = '<div class="empty">No environments yet.<br>' +
       '<span class="empty-hint">Agents create them over MCP: <code>create_environment(env_name="feature/...")</code></span><br>' +
       'or use "+ Create" above.</div>';
@@ -2848,6 +2930,8 @@ function renderEnvironments(envs, force) {
           // itself the control that switches it. Live-mount has no managed clone.
           (env.local_path
             ? ''
+            : SCOPED_ENV
+            ? '<span class="git-branch">⎇ ' + esc(env.git_branch || env.branch) + '</span>'
             : '<span class="git-branch" role="button" tabindex="0" title="Switch this environment to another branch" ' +
                 'onclick="openSwitchBranch(\'' + escAttr(env.branch) + '\')" ' +
                 'onkeydown="if (event.key === \'Enter\' || event.key === \' \') { event.preventDefault(); openSwitchBranch(\'' + escAttr(env.branch) + '\'); }"' +
@@ -2886,30 +2970,39 @@ function renderEnvironments(envs, force) {
               '<button role="menuitem" title="Pick installed modules and upgrade them with odoo -u" onclick="openUpgradeModules(\'' + escAttr(env.branch) + '\')" ' + dis +
                 (allStopped ? 'disabled' : '') + '>Upgrade modules</button>' +
               '<button role="menuitem" title="Scoped MCP endpoint and Secret Key for this environment only" onclick="openMcpAccess(\'' + escAttr(env.branch) + '\')">MCP Access</button>' +
-              (showAgent
+              (SCOPED_ENV
+                ? ''
+                : '<button role="menuitem" title="Share a link to this environment only: its dashboard, consoles and Agent Chat, nothing else" onclick="openShare(\'' + escAttr(env.branch) + '\')">Share UI</button>') +
+              (showAgent && !SCOPED_ENV
                 ? '<button role="menuitem" title="Terminal session with the coding agent for this environment" onclick="openAgentConsole(\'' + escAttr(env.branch) + '\')">Agent CLI</button>'
                 : '') +
-              '<button role="menuitem" title="' + (env.note ? 'Edit the note on this environment' : 'Add a note to this environment') + '" onclick="editNote(\'' + escAttr(env.branch) + '\')">' +
-                (env.note ? 'Edit note' : 'Add note') + '</button>' +
-              '<button role="menuitem" title="' + (env.protected ? 'Allow Stop, Update, Recreate and Delete again' : 'Disable Stop, Update, Recreate and Delete') + '" onclick="doProtect(\'' + escAttr(env.branch) + '\',' + (env.protected ? 'true' : 'false') + ')" ' + dis + '>' +
-                (env.protected ? 'Unprotect' : 'Protect') + '</button>' +
-              (env.local_path
-                ? ''
-                : '<button role="menuitem" onclick="openSwitchBranch(\'' + escAttr(env.branch) + '\')" ' + dis +
-                    'title="Reuse this environment for another branch, keeping its database and URL">Switch branch</button>') +
-              '<button role="menuitem" onclick="doUpdate(\'' + escAttr(env.branch) + '\')" ' + dis +
-                (env.protected ? 'disabled title="Environment is protected"' : 'title="Recreate the container, keep the database and filestore"') + '>Update</button>' +
-              '<button role="menuitem" onclick="doRecreate(\'' + escAttr(env.branch) + '\')" ' + dis +
-                (env.protected ? 'disabled title="Environment is protected"' : 'title="Delete and rebuild from template: replaces the current database"') + '>Recreate</button>' +
-              '<button role="menuitem" onclick="doNewTemplate(\'' + escAttr(env.branch) + '\')" ' + dis +
-                'title="Save this environment (DB + filestore) as a new template">New Template</button>' +
-              '<button role="menuitem" class="danger" onclick="doDelete(\'' + escAttr(env.branch) + '\')" ' + dis +
-                (env.protected ? 'disabled title="Environment is protected"' : '') + '>Delete</button>' +
+              (SCOPED_ENV ? '' :
+                '<button role="menuitem" title="' + (env.note ? 'Edit the note on this environment' : 'Add a note to this environment') + '" onclick="editNote(\'' + escAttr(env.branch) + '\')">' +
+                  (env.note ? 'Edit note' : 'Add note') + '</button>' +
+                '<button role="menuitem" title="' + (env.protected ? 'Allow Stop, Update, Recreate and Delete again' : 'Disable Stop, Update, Recreate and Delete') + '" onclick="doProtect(\'' + escAttr(env.branch) + '\',' + (env.protected ? 'true' : 'false') + ')" ' + dis + '>' +
+                  (env.protected ? 'Unprotect' : 'Protect') + '</button>' +
+                (env.local_path
+                  ? ''
+                  : '<button role="menuitem" onclick="openSwitchBranch(\'' + escAttr(env.branch) + '\')" ' + dis +
+                      'title="Reuse this environment for another branch, keeping its database and URL">Switch branch</button>') +
+                '<button role="menuitem" onclick="doUpdate(\'' + escAttr(env.branch) + '\')" ' + dis +
+                  (env.protected ? 'disabled title="Environment is protected"' : 'title="Recreate the container, keep the database and filestore"') + '>Update</button>' +
+                '<button role="menuitem" onclick="doRecreate(\'' + escAttr(env.branch) + '\')" ' + dis +
+                  (env.protected ? 'disabled title="Environment is protected"' : 'title="Delete and rebuild from template: replaces the current database"') + '>Recreate</button>' +
+                '<button role="menuitem" onclick="doNewTemplate(\'' + escAttr(env.branch) + '\')" ' + dis +
+                  'title="Save this environment (DB + filestore) as a new template">New Template</button>' +
+                '<button role="menuitem" class="danger" onclick="doDelete(\'' + escAttr(env.branch) + '\')" ' + dis +
+                  (env.protected ? 'disabled title="Environment is protected"' : '') + '>Delete</button>') +
             '</div>' +
           '</div>' +
         '</div>' +
       '</div>' +
-      (env.note
+      (env.note && SCOPED_ENV
+        ? '<div class="env-note env-note-set">' +
+            '<span class="note-label" aria-hidden="true">Note</span>' + esc(env.note) +
+          '</div>'
+        : '') +
+      (env.note && !SCOPED_ENV
         ? '<div class="env-note env-note-set" role="button" tabindex="0" aria-label="Edit note" ' +
             'onclick="editNote(\'' + escAttr(env.branch) + '\')" title="Click to edit note">' +
             '<span class="note-label" aria-hidden="true">Note</span>' + esc(env.note) +
@@ -3234,6 +3327,102 @@ async function openMcpAccess(branch) {
   } catch (e) {
     showToast('Connection error: ' + e.message, true);
   }
+}
+
+var _shareBranch = '';
+
+async function openShare(branch) {
+  _shareBranch = branch;
+  document.getElementById('share-title').textContent = 'Share environment — ' + branch;
+  var urlEl = document.getElementById('share-url');
+  // Reset to the masked state every time: the link is a credential.
+  urlEl.type = 'password';
+  urlEl.value = '';
+  var reveal = document.getElementById('share-reveal');
+  reveal.textContent = 'Show';
+  reveal.setAttribute('aria-pressed', 'false');
+  showModal('share-modal');
+  await loadShare();
+}
+
+function renderShare(result) {
+  var shared = !!(result && result.shared);
+  document.getElementById('share-url').value = shared ? (result.url || '') : '';
+  document.getElementById('share-link-group').style.display = shared ? '' : 'none';
+  document.getElementById('share-none').style.display = shared ? 'none' : '';
+  var created = document.getElementById('share-created');
+  if (shared && result.created_at) {
+    // formatDate returns markup (a <span> carrying the absolute time as a
+    // tooltip), built from our own escaped timestamp.
+    created.innerHTML = 'Link created ' + formatDate(result.created_at) + '.';
+    created.style.display = '';
+  } else {
+    created.style.display = 'none';
+  }
+  document.getElementById('share-create').style.display = shared ? 'none' : '';
+  document.getElementById('share-rotate').style.display = shared ? '' : 'none';
+  document.getElementById('share-revoke').style.display = shared ? '' : 'none';
+}
+
+async function _shareRequest(path, method, okMessage) {
+  try {
+    var r = await fetch(API + '/' + encodeURIComponent(_shareBranch) + path,
+      { method: method });
+    var data = await readResult(r);
+    if (!data.ok) { showToast(data.error || 'Share request failed', true); return; }
+    renderShare(data.result);
+    if (okMessage) showToast(okMessage);
+  } catch (e) {
+    showToast('Connection error: ' + e.message, true);
+  }
+}
+
+function loadShare() { return _shareRequest('/share', 'GET', ''); }
+function shareCreate() { return _shareRequest('/share', 'POST', 'Share link created'); }
+
+// The confirm dialog is its own overlay, so step out of the share modal for it
+// and come back afterwards rather than stacking two modals.
+async function _shareConfirm(opts) {
+  hideModal('share-modal');
+  var ok = await confirmDialog(opts);
+  showModal('share-modal');
+  return ok;
+}
+
+async function shareRotate() {
+  if (!(await _shareConfirm({
+    title: 'Regenerate share link',
+    message: 'Issue a new link for "' + _shareBranch + '"? The current link, and ' +
+      'anyone already using it, stop working.',
+    confirmLabel: 'Regenerate link',
+    danger: true
+  }))) return;
+  await _shareRequest('/share/rotate', 'POST', 'New share link issued');
+}
+
+async function shareRevoke() {
+  if (!(await _shareConfirm({
+    title: 'Revoke sharing',
+    message: 'Stop sharing "' + _shareBranch + '"? The link, and anyone already ' +
+      'using it, stop working.',
+    confirmLabel: 'Revoke link',
+    danger: true
+  }))) return;
+  await _shareRequest('/share/revoke', 'POST', 'Sharing revoked');
+}
+
+function closeShare(event) {
+  if (event && event.target !== event.currentTarget) return;
+  hideModal('share-modal');
+}
+
+function toggleShareSecret() {
+  var el = document.getElementById('share-url');
+  var btn = document.getElementById('share-reveal');
+  var show = el.type === 'password';
+  el.type = show ? 'text' : 'password';
+  btn.textContent = show ? 'Hide' : 'Show';
+  btn.setAttribute('aria-pressed', show ? 'true' : 'false');
 }
 
 function closeMcpAccess(event) {
@@ -5030,6 +5219,7 @@ function resetTimers() {
   var ms = refreshInterval * 1000;
   refreshTimer = setInterval(function() {
     loadEnvironments();
+    if (SCOPED_ENV) return;
     loadStats();
     loadHealth();
     var prodTab = document.getElementById('tab-production');
@@ -6820,6 +7010,7 @@ var MODAL_CLOSERS = {
   'import-odoo-modal': closeImportOdooModal,
   'template-settings-modal': closeTemplateSettingsModal,
   'confirm-modal': cancelConfirm,
+  'share-modal': closeShare,
   'note-modal': closeNoteModal,
   'install-modules-modal': closeInstallModules,
   'upgrade-modules-modal': closeUpgradeModules
@@ -7298,11 +7489,13 @@ async function loadHealth() {
   } catch (e) { /* health chips are best-effort */ }
 }
 
-loadLicense();
+if (!SCOPED_ENV) {
+  loadLicense();
+  loadStats();
+  loadHealth();
+  loadServicePresets();
+}
 loadEnvironments();
-loadStats();
-loadHealth();
-loadServicePresets();
 refreshAgentInfo();
 resetTimers();
 </script>

--- a/src/oduflow/templates/dashboard.html
+++ b/src/oduflow/templates/dashboard.html
@@ -2241,7 +2241,7 @@
       <button class="modal-close" onclick="closeShare()">&times;</button>
     </div>
     <div class="modal-body">
-      <p class="modal-note">A link to this environment alone. Whoever opens it gets this card, its logs, consoles, module install/upgrade, Connect As and Agent Chat &mdash; and nothing else of the team: no other environment, no templates, services, volumes, repositories or credentials, and no Agent CLI. The link carries its own key, so treat it as a credential.</p>
+      <p class="modal-note">The dashboard link is scoped to this environment: its card, logs, consoles, module install/upgrade, Connect As and Agent Chat. Other team environments and team-wide pages are unavailable, as is Agent CLI. Important: Agent Chat runs in the team's shared coder container, so the agent may read other team checkouts and Git credentials available there. Share only with someone trusted for that access. The link carries its own key, so treat it as a credential.</p>
       <div class="form-group" id="share-link-group">
         <label for="share-url">Share link</label>
         <div class="copy-row">
@@ -2250,9 +2250,12 @@
           <button class="btn" type="button" onclick="copyMcpField('share-url', 'Share link copied')">Copy</button>
         </div>
       </div>
+      <p class="modal-note" id="share-loading" role="status" aria-live="polite" style="display:none;"></p>
+      <div class="form-error" id="share-error" style="display:none;"></div>
       <p class="modal-note" id="share-created" style="display:none;"></p>
       <p class="modal-note" id="share-none" style="display:none;">This environment is not shared yet.</p>
       <div class="form-actions">
+        <button class="btn" type="button" id="share-retry" onclick="loadShare()" style="display:none;">Retry</button>
         <button class="btn btn-create" type="button" id="share-create" onclick="shareCreate()">Create link</button>
         <button class="btn" type="button" id="share-rotate" onclick="shareRotate()" title="Issue a new link and invalidate the old one, including sessions already opened with it">Regenerate</button>
         <button class="btn btn-delete" type="button" id="share-revoke" onclick="shareRevoke()" title="Stop sharing: the link and any session opened with it stop working">Revoke</button>
@@ -3330,9 +3333,57 @@ async function openMcpAccess(branch) {
 }
 
 var _shareBranch = '';
+var _shareRequestGeneration = 0;
+var _shareBusy = false;
+var _shareResult = null;
+
+function _setShareActions(shared, disabled) {
+  var create = document.getElementById('share-create');
+  var rotate = document.getElementById('share-rotate');
+  var revoke = document.getElementById('share-revoke');
+  create.style.display = shared ? 'none' : '';
+  rotate.style.display = shared ? '' : 'none';
+  revoke.style.display = shared ? '' : 'none';
+  create.disabled = disabled;
+  rotate.disabled = disabled;
+  revoke.disabled = disabled;
+}
+
+function _renderSharePending(message, clearState) {
+  _shareBusy = true;
+  var loading = document.getElementById('share-loading');
+  loading.textContent = message;
+  loading.style.display = '';
+  document.getElementById('share-error').style.display = 'none';
+  document.getElementById('share-retry').style.display = 'none';
+  if (clearState) {
+    document.getElementById('share-url').value = '';
+    document.getElementById('share-link-group').style.display = 'none';
+    document.getElementById('share-created').style.display = 'none';
+    document.getElementById('share-none').style.display = 'none';
+    document.getElementById('share-create').style.display = 'none';
+    document.getElementById('share-rotate').style.display = 'none';
+    document.getElementById('share-revoke').style.display = 'none';
+  } else {
+    _setShareActions(!!(_shareResult && _shareResult.shared), true);
+  }
+}
+
+function _renderShareError(message) {
+  _shareBusy = false;
+  document.getElementById('share-loading').style.display = 'none';
+  var error = document.getElementById('share-error');
+  error.textContent = message;
+  error.style.display = 'block';
+  document.getElementById('share-retry').style.display = '';
+}
 
 async function openShare(branch) {
+  // Invalidate an older request before changing the modal's environment.
+  _shareRequestGeneration += 1;
   _shareBranch = branch;
+  _shareResult = null;
+  _shareBusy = false;
   document.getElementById('share-title').textContent = 'Share environment — ' + branch;
   var urlEl = document.getElementById('share-url');
   // Reset to the masked state every time: the link is a credential.
@@ -3346,6 +3397,11 @@ async function openShare(branch) {
 }
 
 function renderShare(result) {
+  _shareBusy = false;
+  _shareResult = result;
+  document.getElementById('share-loading').style.display = 'none';
+  document.getElementById('share-error').style.display = 'none';
+  document.getElementById('share-retry').style.display = 'none';
   var shared = !!(result && result.shared);
   document.getElementById('share-url').value = shared ? (result.url || '') : '';
   document.getElementById('share-link-group').style.display = shared ? '' : 'none';
@@ -3359,26 +3415,44 @@ function renderShare(result) {
   } else {
     created.style.display = 'none';
   }
-  document.getElementById('share-create').style.display = shared ? 'none' : '';
-  document.getElementById('share-rotate').style.display = shared ? '' : 'none';
-  document.getElementById('share-revoke').style.display = shared ? '' : 'none';
+  _setShareActions(shared, false);
 }
 
-async function _shareRequest(path, method, okMessage) {
+async function _shareRequest(path, method, okMessage, pendingMessage) {
+  if (_shareBusy) return;
+  var branch = _shareBranch;
+  var generation = ++_shareRequestGeneration;
+  var previous = _shareResult;
+  _renderSharePending(pendingMessage, method === 'GET');
   try {
-    var r = await fetch(API + '/' + encodeURIComponent(_shareBranch) + path,
+    var r = await fetch(API + '/' + encodeURIComponent(branch) + path,
       { method: method });
     var data = await readResult(r);
-    if (!data.ok) { showToast(data.error || 'Share request failed', true); return; }
+    if (generation !== _shareRequestGeneration || branch !== _shareBranch) return;
+    if (!data.ok) {
+      var error = data.error || 'Share request failed';
+      if (previous) renderShare(previous); else _renderShareError(error);
+      showToast(error, true);
+      return;
+    }
     renderShare(data.result);
     if (okMessage) showToast(okMessage);
   } catch (e) {
-    showToast('Connection error: ' + e.message, true);
+    if (generation !== _shareRequestGeneration || branch !== _shareBranch) return;
+    var error = 'Connection error: ' + e.message;
+    if (previous) renderShare(previous); else _renderShareError(error);
+    showToast(error, true);
   }
 }
 
-function loadShare() { return _shareRequest('/share', 'GET', ''); }
-function shareCreate() { return _shareRequest('/share', 'POST', 'Share link created'); }
+function loadShare() {
+  return _shareRequest('/share', 'GET', '', 'Loading share status…');
+}
+
+function shareCreate() {
+  if (_shareBusy || !_shareResult || _shareResult.shared) return;
+  return _shareRequest('/share', 'POST', 'Share link created', 'Creating share link…');
+}
 
 // The confirm dialog is its own overlay, so step out of the share modal for it
 // and come back afterwards rather than stacking two modals.
@@ -3390,29 +3464,43 @@ async function _shareConfirm(opts) {
 }
 
 async function shareRotate() {
+  if (_shareBusy || !_shareResult || !_shareResult.shared) return;
+  var branch = _shareBranch;
+  var generation = _shareRequestGeneration;
   if (!(await _shareConfirm({
     title: 'Regenerate share link',
-    message: 'Issue a new link for "' + _shareBranch + '"? The current link, and ' +
+    message: 'Issue a new link for "' + branch + '"? The current link, and ' +
       'anyone already using it, stop working.',
     confirmLabel: 'Regenerate link',
     danger: true
   }))) return;
-  await _shareRequest('/share/rotate', 'POST', 'New share link issued');
+  if (generation !== _shareRequestGeneration || branch !== _shareBranch) return;
+  await _shareRequest(
+    '/share/rotate', 'POST', 'New share link issued', 'Regenerating share link…'
+  );
 }
 
 async function shareRevoke() {
+  if (_shareBusy || !_shareResult || !_shareResult.shared) return;
+  var branch = _shareBranch;
+  var generation = _shareRequestGeneration;
   if (!(await _shareConfirm({
     title: 'Revoke sharing',
-    message: 'Stop sharing "' + _shareBranch + '"? The link, and anyone already ' +
+    message: 'Stop sharing "' + branch + '"? The link, and anyone already ' +
       'using it, stop working.',
     confirmLabel: 'Revoke link',
     danger: true
   }))) return;
-  await _shareRequest('/share/revoke', 'POST', 'Sharing revoked');
+  if (generation !== _shareRequestGeneration || branch !== _shareBranch) return;
+  await _shareRequest(
+    '/share/revoke', 'POST', 'Sharing revoked', 'Revoking share link…'
+  );
 }
 
 function closeShare(event) {
   if (event && event.target !== event.currentTarget) return;
+  _shareRequestGeneration += 1;
+  _shareBusy = false;
   hideModal('share-modal');
 }
 
@@ -3534,7 +3622,10 @@ async function loadEnvironments(force) {
     const r = await fetch(API);
     const data = await readResult(r);
     if (data.ok) {
-      cachedEnvs = data.environments || [];
+      var environments = data.environments || [];
+      cachedEnvs = SCOPED_ENV
+        ? environments.filter(function (env) { return env.env_name === SCOPED_ENV; })
+        : environments;
       renderEnvironments(cachedEnvs, force);
     } else {
       showToast(data.error || 'Failed to load', true);

--- a/src/oduflow/ui_scope.py
+++ b/src/oduflow/ui_scope.py
@@ -1,0 +1,139 @@
+"""Scoped single-environment dashboard access (``/env/<name>``).
+
+The UI counterpart of the scoped MCP endpoint (see ``oduflow.scoped_access``
+and ``specs/0028-scoped-environment-mcp-access.md``): an operator shares one
+environment with a client, who gets the normal dashboard reduced to that
+environment — its card, logs, dev-loop actions, consoles and Agent Chat — and
+nothing else of the team.
+
+Two pieces cooperate, both in ``web_ui``:
+
+- the ``/env/<name>`` route exchanges a share link's ``?key=`` (verified
+  against ``oduflow.env_share``) for a signed, host-only cookie and renders the
+  dashboard in scoped mode;
+- ``BasicAuthMiddleware`` resolves that cookie to a *scoped principal* — the
+  owning team plus one environment name — and runs every subsequent request
+  through :func:`is_allowed` here.
+
+The policy is **default-deny**: a request is refused unless it matches this
+table, and any env-addressed request must address the cookie's own
+environment. So a scoped visitor cannot reach another environment, another
+team's resources, or the team-wide surfaces (templates, services, volumes,
+extra repos, credentials, productions, host stats) even by typing the URL.
+
+Deliberately denied although the environment is theirs to work in:
+
+- ``WS .../agent`` — **Agent CLI**. It is a PTY in the *per-team* agent
+  container, whose ``/workspace`` holds a checkout of every environment of the
+  team; a shell there is not confined to one environment. Agent Chat
+  (``.../agent-acp``) is exposed instead: same agent, but driven over ACP at
+  this environment's checkout with its scoped MCP token.
+- everything that creates, destroys or re-provisions: create, delete, update,
+  recreate, switch-branch, protect/unprotect, save-as-template.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Cookie holding the scoped session (signed team + env + share-secret
+# fingerprint). Host-only and SameSite=Strict, like the operator's own session
+# cookie. One scoped session per browser and host at a time: opening a second
+# share link on the same host replaces the first.
+SHARE_COOKIE = "oduflow_env_auth"
+
+# Prefix of the scoped dashboard page.
+PAGE_PREFIX = "/env/"
+
+_ENV_API_PREFIX = "/api/environments/"
+
+# Team-wide paths a scoped session may still reach. `/api/agent` reports only
+# whether the team's coding agent is enabled and its default type — no secrets
+# — and the dashboard needs it to decide whether to offer Agent Chat.
+_GLOBAL_ALLOWED: dict[str, frozenset[str]] = {
+    "GET": frozenset({"/api/agent"}),
+    # Ends the scoped session by clearing the cookie; the visitor gets back in
+    # with the share link they were sent.
+    "POST": frozenset({"/logout"}),
+}
+
+# Per-environment paths, keyed by method, matched against the part of the path
+# that follows `/api/environments/<env>/`.
+_ENV_ALLOWED: dict[str, frozenset[str]] = {
+    "GET": frozenset(
+        {
+            "logs",
+            "modules",
+            "users",
+            "connect-open",
+            "mcp-access",
+            "agent-acp/info",
+        }
+    ),
+    "POST": frozenset(
+        {
+            "start",
+            "stop",
+            "restart",
+            "sync",
+            "modules",
+            "storage/refresh",
+            "connect-as",
+            "agent-acp/session",
+            "agent-acp/attachments",
+        }
+    ),
+    "WEBSOCKET": frozenset({"terminal", "sql", "agent-acp"}),
+}
+
+# Agent Chat attachment removal: the id is generated per upload.
+_ENV_ALLOWED_PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    "DELETE": (re.compile(r"^agent-acp/attachments/[^/]+$"),),
+}
+
+# The environment list: allowed because the scoped dashboard polls it for its
+# one card. `api_list` filters the response down to the scoped environment.
+_ENV_LIST_PATH = "/api/environments"
+
+
+def _normalize(path: str) -> str:
+    """Drop a single trailing slash so `/env/x/` and `/env/x` behave alike."""
+    if len(path) > 1 and path.endswith("/"):
+        return path[:-1]
+    return path
+
+
+def is_scoped_page(path: str, env: str) -> bool:
+    """Whether ``path`` is the scoped dashboard page of ``env``."""
+    return _normalize(path) == PAGE_PREFIX + env
+
+
+def is_allowed(method: str, path: str, env: str) -> bool:
+    """Whether a scoped session for ``env`` may make this request.
+
+    ``method`` is the HTTP method, or ``"WEBSOCKET"`` for a WebSocket
+    handshake. Default-deny: anything not matched here is refused.
+    """
+    if not env:
+        return False
+    method = method.upper()
+    path = _normalize(path)
+
+    if is_scoped_page(path, env):
+        return method == "GET"
+    if path in _GLOBAL_ALLOWED.get(method, frozenset()):
+        return True
+    if path == _ENV_LIST_PATH:
+        return method == "GET"
+    if not path.startswith(_ENV_API_PREFIX):
+        return False
+
+    # `<env>/<suffix>`: environment names may contain slashes (feature/x), so
+    # match the name explicitly rather than splitting on the next separator.
+    rest = path[len(_ENV_API_PREFIX) :]
+    if not rest.startswith(env + "/"):
+        return False
+    suffix = rest[len(env) + 1 :]
+    if suffix in _ENV_ALLOWED.get(method, frozenset()):
+        return True
+    return any(p.match(suffix) for p in _ENV_ALLOWED_PATTERNS.get(method, ()))

--- a/src/oduflow/ui_scope.py
+++ b/src/oduflow/ui_scope.py
@@ -49,12 +49,13 @@ _ENV_API_PREFIX = "/api/environments/"
 
 # Team-wide paths a scoped session may still reach. `/api/agent` reports only
 # whether the team's coding agent is enabled and its default type — no secrets
-# — and the dashboard needs it to decide whether to offer Agent Chat.
+# — and the dashboard needs it to decide whether to offer Agent Chat. Feedback
+# returns only a prefilled public GitHub issue URL.
 _GLOBAL_ALLOWED: dict[str, frozenset[str]] = {
     "GET": frozenset({"/api/agent"}),
     # Ends the scoped session by clearing the cookie; the visitor gets back in
     # with the share link they were sent.
-    "POST": frozenset({"/logout"}),
+    "POST": frozenset({"/logout", "/api/feedback/link"}),
 }
 
 # Per-environment paths, keyed by method, matched against the part of the path

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -342,20 +342,23 @@ class BasicAuthMiddleware:
             return
 
         conn = HTTPConnection(scope)
-        team = self._check_credentials(conn.headers.get("authorization", ""))
+        # A valid share cookie deliberately wins over full credentials. This
+        # keeps a share link scoped even when an operator previews it in a
+        # browser that already has a team session.
+        share = _check_share_token(
+            conn.cookies.get(ui_scope.SHARE_COOKIE, ""), self._get_settings()
+        )
+        team: TeamSettings | None = None
         scoped_env: str | None = None
+        if share:
+            team = share[0]
+            scoped_env = share[1]
+        else:
+            team = self._check_credentials(conn.headers.get("authorization", ""))
         if not team:
             token = conn.cookies.get(_AUTH_COOKIE)
             if token:
                 team = _check_cookie_token(token, self._get_settings())
-        if not team:
-            # A share link's scoped session: full team rights are absent, the
-            # principal is one environment of that team (see oduflow.ui_scope).
-            share = _check_share_token(
-                conn.cookies.get(ui_scope.SHARE_COOKIE, ""), self._get_settings()
-            )
-            if share:
-                team, scoped_env = share
         if team:
             # CSRF: browsers authenticate with an ambient cookie, so reject
             # cross-site state-changing requests (unsafe HTTP methods and every
@@ -1032,14 +1035,27 @@ def _build_routes(
 
     def logout(request: Request) -> RedirectResponse:
         # /logout is public, so the scoped session is read from its cookie
-        # rather than request.state: a share-link visitor is sent back to their
-        # own environment page (which then asks for the link), not to a team
-        # login form they have no password for.
-        share = _check_share_token(
-            request.cookies.get(ui_scope.SHARE_COOKIE, ""), get_settings()
-        )
-        target = ui_scope.PAGE_PREFIX + quote(share[1], safe="/") if share else "/login"
-        response = RedirectResponse(target, status_code=303)
+        # rather than request.state. When an operator opened a share link in an
+        # already authenticated browser, leaving scoped mode restores that
+        # operator session instead of signing it out too.
+        settings = get_settings()
+        share_token = request.cookies.get(ui_scope.SHARE_COOKIE, "")
+        share = _check_share_token(share_token, settings)
+        session = request.cookies.get(_AUTH_COOKIE, "")
+        operator = _check_cookie_token(session, settings) if session else None
+        if share_token and operator is not None:
+            response = RedirectResponse("/", status_code=303)
+            response.delete_cookie(ui_scope.SHARE_COOKIE, path="/", samesite="strict")
+            return response
+        if share:
+            target = ui_scope.PAGE_PREFIX + quote(share[1], safe="/")
+            response = RedirectResponse(target, status_code=303)
+            response.delete_cookie(ui_scope.SHARE_COOKIE, path="/", samesite="strict")
+            return response
+
+        # A normal operator logout clears the full session. Also remove any
+        # stale scoped cookie that failed validation.
+        response = RedirectResponse("/login", status_code=303)
         response.delete_cookie(_AUTH_COOKIE, path="/", samesite="strict")
         response.delete_cookie(ui_scope.SHARE_COOKIE, path="/", samesite="strict")
         return response
@@ -1549,7 +1565,7 @@ def _build_routes(
                 env_name=branch,
             )
 
-            env_ops.delete_environment(settings, team, branch)
+            env_ops.delete_environment(settings, team, branch, preserve_share=True)
             result = env_ops.create_environment(
                 settings,
                 team,

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -41,10 +41,12 @@ from oduflow import (
     agent_uploads,
     artifact_tokens,
     connect_tokens,
+    env_share,
     feedback,
     git_ops,
     import_tokens,
     production_registry,
+    ui_scope,
 )
 from oduflow.docker_ops import (
     env_ops,
@@ -133,14 +135,22 @@ _PUBLIC_PATHS = frozenset(
         "/oduflow-artifact",
     }
 )
-_PUBLIC_PREFIXES = ("/static/",)
+# /env/<name> is the scoped single-environment dashboard reached from a share
+# link. It bypasses the team login because it authenticates itself: the link's
+# ?key= (verified against the team's share registry) or the scoped cookie it
+# exchanges that key for. Only the page lives under this prefix — every API
+# call it makes goes to the normal /api/... routes, where the middleware
+# resolves the scoped cookie and applies the ui_scope allowlist.
+_PUBLIC_PREFIXES = ("/static/", ui_scope.PAGE_PREFIX)
 _SESSION_SALT = "oduflow.ui-auth.v1"
+_SHARE_SALT = "oduflow.env-share.v1"
 _SESSION_MAX_AGE = 7 * 24 * 3600  # 7 days
 _SECRET_FILENAME = ".ui_session_secret"
 
 # Cached per data dir (process-wide; the server runs against a single one).
 _secrets_cache: dict[str, str] = {}
 _signers: dict[str, URLSafeTimedSerializer] = {}
+_share_signers: dict[str, URLSafeTimedSerializer] = {}
 
 
 def _load_or_create_secret(data_dir: str) -> str:
@@ -234,6 +244,67 @@ def _check_cookie_token(token: str, settings: Settings) -> "TeamSettings | None"
     return team
 
 
+def _get_share_signer(settings: Settings) -> URLSafeTimedSerializer:
+    """Signer for scoped-environment share cookies.
+
+    Same server secret as the operator session signer but a different salt, so
+    a scoped cookie can never be replayed as a full team session (or the other
+    way round) even if the payload shapes ever converge.
+    """
+    key = settings.base_data_dir or ""
+    signer = _share_signers.get(key)
+    if signer is None:
+        signer = URLSafeTimedSerializer(_get_secret(settings), salt=_SHARE_SALT)
+        _share_signers[key] = signer
+    return signer
+
+
+def _share_fingerprint(secret: str, share_secret: str) -> str:
+    """A fingerprint of an environment's share secret, keyed by the server
+    secret. Embedded in the scoped cookie so that rotating or revoking the
+    share link invalidates every session opened with the old link."""
+    return hmac.new(
+        secret.encode("utf-8"), share_secret.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def _make_share_token(
+    settings: Settings, team: "TeamSettings", env_name: str, share_secret: str
+) -> str:
+    """Signed, timestamped scoped session token for one environment."""
+    fingerprint = _share_fingerprint(_get_secret(settings), share_secret)
+    return _get_share_signer(settings).dumps([team.team_id, env_name, fingerprint])
+
+
+def _check_share_token(
+    token: str, settings: Settings
+) -> "tuple[TeamSettings, str] | None":
+    """Validate a scoped cookie from `_make_share_token` and return its
+    ``(team, env_name)``, or None when it is invalid, expired, or its share
+    link has since been rotated or revoked."""
+    if not token:
+        return None
+    try:
+        data = _get_share_signer(settings).loads(token, max_age=_SESSION_MAX_AGE)
+    except BadData:
+        return None
+    if not (isinstance(data, list) and len(data) == 3):
+        return None
+    team_id, env_name, fingerprint = data
+    if not all(isinstance(v, str) for v in (team_id, env_name, fingerprint)):
+        return None
+    team = settings.teams.get(team_id)
+    if not team:
+        return None
+    record = env_share.get(team, env_name)
+    if not record:
+        return None
+    expected = _share_fingerprint(_get_secret(settings), str(record["secret"]))
+    if not hmac.compare_digest(fingerprint, expected):
+        return None
+    return (team, env_name)
+
+
 def _is_cross_origin(headers: Headers) -> bool:
     """Whether Origin/Referer mark this as a cross-site request (CSRF).
 
@@ -272,10 +343,19 @@ class BasicAuthMiddleware:
 
         conn = HTTPConnection(scope)
         team = self._check_credentials(conn.headers.get("authorization", ""))
+        scoped_env: str | None = None
         if not team:
             token = conn.cookies.get(_AUTH_COOKIE)
             if token:
                 team = _check_cookie_token(token, self._get_settings())
+        if not team:
+            # A share link's scoped session: full team rights are absent, the
+            # principal is one environment of that team (see oduflow.ui_scope).
+            share = _check_share_token(
+                conn.cookies.get(ui_scope.SHARE_COOKIE, ""), self._get_settings()
+            )
+            if share:
+                team, scoped_env = share
         if team:
             # CSRF: browsers authenticate with an ambient cookie, so reject
             # cross-site state-changing requests (unsafe HTTP methods and every
@@ -300,7 +380,24 @@ class BasicAuthMiddleware:
                     )
                     await forbidden(scope, receive, send)
                 return
+            # Scoped sessions are default-deny: only the single-environment
+            # surface of ui_scope, and only for their own environment.
+            if scoped_env is not None and not ui_scope.is_allowed(
+                "WEBSOCKET" if scope["type"] == "websocket" else method,
+                path,
+                scoped_env,
+            ):
+                if scope["type"] == "websocket":
+                    await WebSocket(scope, receive, send).close(code=1008)
+                else:
+                    denied: Response = JSONResponse(
+                        {"ok": False, "error": "Not available for a shared link."},
+                        status_code=403,
+                    )
+                    await denied(scope, receive, send)
+                return
             scope.setdefault("state", {})["team"] = team
+            scope["state"]["scoped_env"] = scoped_env
             await self._app(scope, receive, send)
             return
 
@@ -794,14 +891,17 @@ def _build_routes(
             path="/",
         )
 
-    def dashboard(request: Request) -> HTMLResponse:
+    def _render_dashboard(settings: Settings, scoped_env: str = "") -> str:
+        """Render the dashboard page. With ``scoped_env`` set it renders in
+        shared single-environment mode (see oduflow.ui_scope): the client-side
+        surface collapses to that one environment's card. The server-side
+        allowlist, not this rendering, is the boundary."""
         html_path = _TEMPLATE_DIR / "dashboard.html"
-        settings = get_settings()
-        page = (
+        return (
             html_path.read_text(encoding="utf-8")
             .replace(
                 "__PRODUCTION_TAB_HIDDEN__",
-                "" if settings.prod_enabled else "hidden",
+                "" if settings.prod_enabled and not scoped_env else "hidden",
             )
             .replace("__ODUFLOW_VERSION__", html.escape(feedback.oduflow_version()))
             .replace(
@@ -810,12 +910,98 @@ def _build_routes(
                     feedback.format_diagnostics(feedback.diagnostics(settings))
                 ),
             )
+            # Read back from a body data attribute, never inlined into a script
+            # literal: environment names are git branch names and may carry
+            # quotes. Attribute escaping is exactly the right encoding there.
+            .replace("__SCOPED_ENV__", html.escape(scoped_env, quote=True))
         )
+
+    def dashboard(request: Request) -> HTMLResponse:
+        settings = get_settings()
+        page = _render_dashboard(settings)
         response = HTMLResponse(page)
         team = getattr(request.state, "team", None)
         if team is not None and team.ui_password:
             _set_session_cookie(response, team, request)
         return response
+
+    def _team_for_share(
+        settings: Settings, env_name: str, key: str, host: str
+    ) -> TeamSettings | None:
+        """The team whose environment ``env_name`` is shared under ``key``.
+
+        The share secret is the only credential a link carries, so the team is
+        resolved from it. In traefik mode the request host names the team, so
+        try that one first; the scan is the fallback for port mode (one host,
+        many teams)."""
+        by_host = settings.get_team_by_hostname(host) if host else None
+        candidates = [by_host] if by_host else []
+        candidates += [t for t in settings.teams.values() if t is not by_host]
+        for team in candidates:
+            if team is not None and env_share.verify(team, env_name, key):
+                return team
+        return None
+
+    def _share_link_error(message: str, status_code: int) -> Response:
+        return Response(message, status_code=status_code, media_type="text/plain")
+
+    def scoped_env_page(request: Request) -> Response:
+        """The shared single-environment dashboard at ``/env/<name>``.
+
+        This route authenticates itself (it is outside the team login): either
+        the share link's ``?key=``, which is exchanged for a scoped cookie and
+        dropped from the URL, or that cookie on later visits. An operator with
+        a full session can also open it to preview what the client sees.
+        """
+        env_name = request.path_params["name"]
+        settings = get_settings()
+        key = request.query_params.get("key") or ""
+        if key:
+            client_ip = request.client.host if request.client else "unknown"
+            if login_limiter.is_limited(client_ip):
+                return _share_link_error(
+                    "Too many failed attempts. Try again later.", 429
+                )
+            team = _team_for_share(settings, env_name, key, request.url.hostname or "")
+            if team is None:
+                login_limiter.record_failure(client_ip)
+                return _share_link_error(
+                    "This share link is invalid or has been revoked. "
+                    "Ask for a new one.",
+                    403,
+                )
+            login_limiter.clear(client_ip)
+            # Land on the clean URL so the key leaves the address bar, browser
+            # history, and any Referer sent by the page's own requests.
+            target = ui_scope.PAGE_PREFIX + quote(env_name, safe="/")
+            response: Response = RedirectResponse(target, status_code=303)
+            response.set_cookie(
+                ui_scope.SHARE_COOKIE,
+                _make_share_token(settings, team, env_name, key),
+                max_age=_SESSION_MAX_AGE,
+                httponly=True,
+                samesite="strict",
+                secure=_is_secure_request(request),
+                path="/",
+            )
+            return response
+
+        share = _check_share_token(
+            request.cookies.get(ui_scope.SHARE_COOKIE, ""), settings
+        )
+        if share and share[1] == env_name:
+            return HTMLResponse(_render_dashboard(settings, scoped_env=env_name))
+
+        auth_enabled = any(t.ui_password for t in settings.teams.values())
+        session = request.cookies.get(_AUTH_COOKIE, "")
+        operator = _check_cookie_token(session, settings) if session else None
+        if operator is not None or not auth_enabled:
+            return HTMLResponse(_render_dashboard(settings, scoped_env=env_name))
+        return _share_link_error(
+            "This link is missing its key. Open the full share link you were "
+            "sent (it ends with ?key=...).",
+            401,
+        )
 
     async def login(request: Request) -> Response:
         settings = get_settings()
@@ -845,8 +1031,17 @@ def _build_routes(
         return HTMLResponse(_render_login())
 
     def logout(request: Request) -> RedirectResponse:
-        response = RedirectResponse("/login", status_code=303)
+        # /logout is public, so the scoped session is read from its cookie
+        # rather than request.state: a share-link visitor is sent back to their
+        # own environment page (which then asks for the link), not to a team
+        # login form they have no password for.
+        share = _check_share_token(
+            request.cookies.get(ui_scope.SHARE_COOKIE, ""), get_settings()
+        )
+        target = ui_scope.PAGE_PREFIX + quote(share[1], safe="/") if share else "/login"
+        response = RedirectResponse(target, status_code=303)
         response.delete_cookie(_AUTH_COOKIE, path="/", samesite="strict")
+        response.delete_cookie(ui_scope.SHARE_COOKIE, path="/", samesite="strict")
         return response
 
     def favicon(request: Request) -> Response:
@@ -907,6 +1102,11 @@ def _build_routes(
             settings = get_settings()
             team = _get_ui_team(request)
             envs = env_ops.list_environments(settings, team)
+            # A share link sees exactly its own environment: the scoped
+            # dashboard polls this route for its single card.
+            scoped_env = getattr(request.state, "scoped_env", None)
+            if scoped_env:
+                envs = [e for e in envs if e.get("env_name") == scoped_env]
             return JSONResponse({"ok": True, "environments": envs})
         except FlowError as e:
             return _error_response(e)
@@ -3765,6 +3965,92 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
 
+    def _share_base_url(
+        request: Request, settings: Settings, team: TeamSettings
+    ) -> str:
+        """Origin a share link should be opened on. In traefik mode that is the
+        team's own TLS-terminated hostname (the env pages are served there);
+        port mode keeps the configured base or the request's own."""
+        if settings.routing_mode == "traefik":
+            return f"https://{team.hostname}"
+        return (settings.oauth_base_url or str(request.base_url)).rstrip("/")
+
+    def _share_payload(
+        request: Request,
+        settings: Settings,
+        team: TeamSettings,
+        branch: str,
+        record: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if not record:
+            return {"shared": False, "url": None, "created_at": None}
+        page = ui_scope.PAGE_PREFIX + quote(branch, safe="/")
+        key = quote(str(record["secret"]), safe="")
+        return {
+            "shared": True,
+            "url": f"{_share_base_url(request, settings, team)}{page}?key={key}",
+            "created_at": record.get("created_at"),
+        }
+
+    def _share_endpoint(
+        request: Request, action: Callable[[TeamSettings, str], dict[str, Any] | None]
+    ) -> JSONResponse:
+        """Shared plumbing for the four share routes. Sharing is an operator
+        action: a scoped session must not be able to read, mint or revoke the
+        link it came in on (the ui_scope allowlist denies these paths too)."""
+        branch = request.path_params["branch"]
+        try:
+            if getattr(request.state, "scoped_env", None):
+                return JSONResponse(
+                    {"ok": False, "error": "Not available for a shared link."},
+                    status_code=403,
+                )
+            settings = get_settings()
+            team = _get_ui_team(request)
+            record = action(team, branch)
+            return JSONResponse(
+                {
+                    "ok": True,
+                    "result": _share_payload(request, settings, team, branch, record),
+                },
+                headers={"Cache-Control": "no-store"},
+            )
+        except FlowError as e:
+            return _error_response(e)
+        except Exception:
+            logger.exception("Unexpected error in share endpoint")
+            return JSONResponse(
+                {"ok": False, "error": "Internal server error."}, status_code=500
+            )
+
+    def api_share_get(request: Request) -> JSONResponse:
+        return _share_endpoint(
+            request, lambda team, branch: env_share.get(team, branch)
+        )
+
+    def api_share_create(request: Request) -> JSONResponse:
+        def action(team: TeamSettings, branch: str) -> dict[str, Any] | None:
+            env_ops.require_environment(get_settings(), team, branch)
+            env_share.create_or_get(team, branch)
+            return env_share.get(team, branch)
+
+        return _share_endpoint(request, action)
+
+    def api_share_rotate(request: Request) -> JSONResponse:
+        def action(team: TeamSettings, branch: str) -> dict[str, Any] | None:
+            env_ops.require_environment(get_settings(), team, branch)
+            env_share.rotate(team, branch)
+            return env_share.get(team, branch)
+
+        return _share_endpoint(request, action)
+
+    def api_share_revoke(request: Request) -> JSONResponse:
+        def action(team: TeamSettings, branch: str) -> dict[str, Any] | None:
+            env_share.revoke(team, branch)
+            return None
+
+        return _share_endpoint(request, action)
+
     def api_env_users(request: Request) -> JSONResponse:
         branch = request.path_params["branch"]
         try:
@@ -5284,6 +5570,9 @@ def _build_routes(
 
     return [
         Route("/", dashboard, methods=["GET"]),
+        # Shared single-environment dashboard; authenticates itself with the
+        # share link's ?key= or the scoped cookie (see oduflow.ui_scope).
+        Route(ui_scope.PAGE_PREFIX + "{name:path}", scoped_env_page, methods=["GET"]),
         Route("/login", login, methods=["GET", "POST"]),
         Route("/logout", logout, methods=["POST"]),
         Route("/favicon.ico", favicon, methods=["GET"]),
@@ -5384,6 +5673,26 @@ def _build_routes(
             "/api/environments/{branch:path}/mcp-access",
             api_mcp_access,
             methods=["GET"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/share",
+            api_share_get,
+            methods=["GET"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/share",
+            api_share_create,
+            methods=["POST"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/share/rotate",
+            api_share_rotate,
+            methods=["POST"],
+        ),
+        Route(
+            "/api/environments/{branch:path}/share/revoke",
+            api_share_revoke,
+            methods=["POST"],
         ),
         Route(
             "/api/environments/{branch:path}/users",

--- a/tests/test_env_share.py
+++ b/tests/test_env_share.py
@@ -1,0 +1,97 @@
+"""Per-environment share secrets (the credential inside a /env/<name> link)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from oduflow import env_share
+from oduflow.settings import TeamSettings
+
+
+def _team(tmp_path) -> TeamSettings:
+    return TeamSettings(team_id="1", data_dir=str(tmp_path))
+
+
+def test_not_shared_by_default(tmp_path):
+    team = _team(tmp_path)
+    assert env_share.get(team, "feature/x") is None
+    assert not env_share.verify(team, "feature/x", "anything")
+
+
+def test_create_is_idempotent_and_verifies(tmp_path):
+    team = _team(tmp_path)
+    secret = env_share.create_or_get(team, "feature/x")
+    assert secret
+    assert env_share.create_or_get(team, "feature/x") == secret
+    assert env_share.verify(team, "feature/x", secret)
+    assert not env_share.verify(team, "feature/x", secret + "x")
+    assert not env_share.verify(team, "feature/x", "")
+    # Sharing one environment shares only that one.
+    assert not env_share.verify(team, "other", secret)
+
+
+def test_rotate_replaces_the_secret(tmp_path):
+    team = _team(tmp_path)
+    old = env_share.create_or_get(team, "feature/x")
+    new = env_share.rotate(team, "feature/x")
+    assert new != old
+    assert env_share.verify(team, "feature/x", new)
+    assert not env_share.verify(team, "feature/x", old)
+
+
+def test_revoke_removes_the_share(tmp_path):
+    team = _team(tmp_path)
+    secret = env_share.create_or_get(team, "feature/x")
+    assert env_share.revoke(team, "feature/x") is True
+    assert env_share.get(team, "feature/x") is None
+    assert not env_share.verify(team, "feature/x", secret)
+    # Revoking again is a no-op, not an error.
+    assert env_share.revoke(team, "feature/x") is False
+
+
+def test_rename_carries_the_share_over(tmp_path):
+    team = _team(tmp_path)
+    secret = env_share.create_or_get(team, "old")
+    env_share.rename(team, "old", "new")
+    assert env_share.verify(team, "new", secret)
+    assert env_share.get(team, "old") is None
+
+
+def test_shares_of_different_environments_are_independent(tmp_path):
+    team = _team(tmp_path)
+    a = env_share.create_or_get(team, "a")
+    b = env_share.create_or_get(team, "b")
+    assert a != b
+    env_share.revoke(team, "a")
+    assert env_share.verify(team, "b", b)
+
+
+def test_registry_file_is_not_world_readable(tmp_path):
+    team = _team(tmp_path)
+    env_share.create_or_get(team, "feature/x")
+    mode = stat.S_IMODE(os.stat(env_share.shares_path(team)).st_mode)
+    assert mode == 0o600
+    with open(env_share.shares_path(team)) as f:
+        assert "feature/x" in json.load(f)
+
+
+def test_malformed_registry_fails_closed(tmp_path):
+    team = _team(tmp_path)
+    with open(env_share.shares_path(team), "w") as f:
+        f.write("null")
+    assert env_share.get(team, "feature/x") is None
+    assert not env_share.verify(team, "feature/x", "anything")
+    # And can still be written over.
+    secret = env_share.create_or_get(team, "feature/x")
+    assert env_share.verify(team, "feature/x", secret)
+
+
+def test_sharing_requires_a_data_dir():
+    team = TeamSettings(team_id="1", data_dir="")
+    with pytest.raises(ValueError):
+        env_share.create_or_get(team, "feature/x")
+    assert env_share.get(team, "feature/x") is None

--- a/tests/test_odoo_manager.py
+++ b/tests/test_odoo_manager.py
@@ -2112,7 +2112,8 @@ class TestDeleteEnvironment:
         container.labels = {"oduflow.team": "1"}
         mock_docker_client.containers.get.return_value = container
 
-        env_ops.delete_environment(TEST_SETTINGS, TEST_TEAM, "feature/payments")
+        with patch("oduflow.docker_ops.env_ops.env_share.remove") as remove_share:
+            env_ops.delete_environment(TEST_SETTINGS, TEST_TEAM, "feature/payments")
 
         container.stop.assert_called_once()
         container.remove.assert_called_once()
@@ -2124,6 +2125,7 @@ class TestDeleteEnvironment:
         mock_release.assert_called_once_with(
             TEST_TEAM.port_registry_path, "feature/payments"
         )
+        remove_share.assert_called_once_with(TEST_TEAM, "feature/payments")
 
     @patch("oduflow.docker_ops.env_ops.release_port")
     @patch("oduflow.docker_ops.env_ops._exec_sql")

--- a/tests/test_ui_scope.py
+++ b/tests/test_ui_scope.py
@@ -1,0 +1,133 @@
+"""The default-deny policy behind a shared single-environment dashboard.
+
+``ui_scope.is_allowed`` is the boundary a share link runs against: it decides
+what a visitor holding only the scoped cookie may reach. The table below is
+the contract — anything not listed must be refused, and every env-addressed
+request must address the visitor's own environment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from oduflow import ui_scope
+
+ENV = "feature/scope"
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("GET", f"/env/{ENV}"),
+        ("GET", f"/env/{ENV}/"),
+        ("GET", "/api/environments"),
+        ("GET", "/api/agent"),
+        ("POST", "/logout"),
+        ("GET", f"/api/environments/{ENV}/logs"),
+        ("GET", f"/api/environments/{ENV}/modules"),
+        ("GET", f"/api/environments/{ENV}/users"),
+        ("GET", f"/api/environments/{ENV}/connect-open"),
+        ("GET", f"/api/environments/{ENV}/mcp-access"),
+        ("GET", f"/api/environments/{ENV}/agent-acp/info"),
+        ("POST", f"/api/environments/{ENV}/start"),
+        ("POST", f"/api/environments/{ENV}/stop"),
+        ("POST", f"/api/environments/{ENV}/restart"),
+        ("POST", f"/api/environments/{ENV}/sync"),
+        ("POST", f"/api/environments/{ENV}/modules"),
+        ("POST", f"/api/environments/{ENV}/storage/refresh"),
+        ("POST", f"/api/environments/{ENV}/connect-as"),
+        ("POST", f"/api/environments/{ENV}/agent-acp/session"),
+        ("POST", f"/api/environments/{ENV}/agent-acp/attachments"),
+        ("DELETE", f"/api/environments/{ENV}/agent-acp/attachments/abc123"),
+        ("WEBSOCKET", f"/api/environments/{ENV}/terminal"),
+        ("WEBSOCKET", f"/api/environments/{ENV}/sql"),
+        ("WEBSOCKET", f"/api/environments/{ENV}/agent-acp"),
+    ],
+)
+def test_single_environment_surface_is_allowed(method, path):
+    assert ui_scope.is_allowed(method, path, ENV)
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        # The full dashboard and everything team-wide.
+        ("GET", "/"),
+        ("GET", "/api/templates"),
+        ("GET", "/api/services"),
+        ("GET", "/api/volumes"),
+        ("GET", "/api/extra-repos"),
+        ("GET", "/api/credentials"),
+        ("GET", "/api/productions"),
+        ("GET", "/api/stats"),
+        ("GET", "/api/usage"),
+        ("GET", "/api/license"),
+        ("POST", "/api/environments/create"),
+        # Provisioning and protection of the shared environment itself.
+        ("POST", f"/api/environments/{ENV}/delete"),
+        ("POST", f"/api/environments/{ENV}/update"),
+        ("POST", f"/api/environments/{ENV}/recreate"),
+        ("POST", f"/api/environments/{ENV}/switch-branch"),
+        ("POST", f"/api/environments/{ENV}/protect"),
+        ("POST", f"/api/environments/{ENV}/unprotect"),
+        ("POST", f"/api/environments/{ENV}/save-as-template"),
+        ("POST", f"/api/environments/{ENV}/note"),
+        ("GET", f"/api/environments/{ENV}/env-vars"),
+        # Sharing is an operator action: a share link cannot read, reissue or
+        # revoke itself.
+        ("GET", f"/api/environments/{ENV}/share"),
+        ("POST", f"/api/environments/{ENV}/share"),
+        ("POST", f"/api/environments/{ENV}/share/rotate"),
+        ("POST", f"/api/environments/{ENV}/share/revoke"),
+    ],
+)
+def test_everything_else_is_denied(method, path):
+    assert not ui_scope.is_allowed(method, path, ENV)
+
+
+def test_agent_cli_is_denied_while_agent_chat_is_allowed():
+    """The CLI is a PTY in the per-team agent container, whose workspace holds
+    a checkout of every environment of the team."""
+    assert not ui_scope.is_allowed("WEBSOCKET", f"/api/environments/{ENV}/agent", ENV)
+    assert ui_scope.is_allowed("WEBSOCKET", f"/api/environments/{ENV}/agent-acp", ENV)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/environments/other/logs",
+        "/api/environments/feature/other/logs",
+        f"/api/environments/{ENV}-2/logs",
+        f"/api/environments/prefix{ENV}/logs",
+    ],
+)
+def test_other_environments_are_denied(path):
+    assert not ui_scope.is_allowed("GET", path, ENV)
+
+
+def test_other_environment_page_is_denied():
+    assert not ui_scope.is_allowed("GET", "/env/other", ENV)
+    assert ui_scope.is_scoped_page(f"/env/{ENV}", ENV)
+    assert not ui_scope.is_scoped_page("/env/other", ENV)
+
+
+def test_method_must_match():
+    assert not ui_scope.is_allowed("POST", f"/api/environments/{ENV}/logs", ENV)
+    assert not ui_scope.is_allowed("DELETE", f"/api/environments/{ENV}/modules", ENV)
+    assert not ui_scope.is_allowed("POST", "/api/environments", ENV)
+    assert not ui_scope.is_allowed("GET", "/logout", ENV)
+
+
+def test_attachment_pattern_does_not_widen_the_surface():
+    ok = f"/api/environments/{ENV}/agent-acp/attachments/abc"
+    assert ui_scope.is_allowed("DELETE", ok, ENV)
+    # Nothing deeper, and only the DELETE method.
+    assert not ui_scope.is_allowed("DELETE", ok + "/more", ENV)
+    assert not ui_scope.is_allowed("GET", ok, ENV)
+
+
+def test_traversal_and_empty_scope_are_denied():
+    assert not ui_scope.is_allowed(
+        "POST", f"/api/environments/{ENV}/../other/delete", ENV
+    )
+    assert not ui_scope.is_allowed("GET", f"/api/environments/{ENV}/logs", "")

--- a/tests/test_ui_scope.py
+++ b/tests/test_ui_scope.py
@@ -22,6 +22,7 @@ ENV = "feature/scope"
         ("GET", f"/env/{ENV}/"),
         ("GET", "/api/environments"),
         ("GET", "/api/agent"),
+        ("POST", "/api/feedback/link"),
         ("POST", "/logout"),
         ("GET", f"/api/environments/{ENV}/logs"),
         ("GET", f"/api/environments/{ENV}/modules"),
@@ -116,6 +117,7 @@ def test_method_must_match():
     assert not ui_scope.is_allowed("DELETE", f"/api/environments/{ENV}/modules", ENV)
     assert not ui_scope.is_allowed("POST", "/api/environments", ENV)
     assert not ui_scope.is_allowed("GET", "/logout", ENV)
+    assert not ui_scope.is_allowed("GET", "/api/feedback/link", ENV)
 
 
 def test_attachment_pattern_does_not_widen_the_surface():

--- a/tests/test_web_ui_create_lock.py
+++ b/tests/test_web_ui_create_lock.py
@@ -185,7 +185,7 @@ def test_api_recreate_uses_recorded_git_branch(tmp_path):
         patch("oduflow.docker_ops.client.get_client") as mock_client,
         patch("oduflow.docker_ops.system_ops.check_disk_space"),
         patch("oduflow.docker_ops.system_ops.estimate_new_db_bytes", return_value=0),
-        patch("oduflow.docker_ops.env_ops.delete_environment"),
+        patch("oduflow.docker_ops.env_ops.delete_environment") as delete,
         patch(
             "oduflow.docker_ops.env_ops.create_environment",
             return_value={"url": "http://localhost:50000"},
@@ -195,6 +195,7 @@ def test_api_recreate_uses_recorded_git_branch(tmp_path):
         resp = client.post("/api/environments/oldstaging/recreate")
 
     assert resp.status_code == 200
+    assert delete.call_args.kwargs["preserve_share"] is True
     assert create.call_args.args[2] == "staging"
     assert create.call_args.kwargs["env_name"] == "oldstaging"
 
@@ -239,7 +240,7 @@ def test_api_recreate_restores_legacy_slot_to_branch_hostname(tmp_path):
         patch("oduflow.docker_ops.client.get_client") as mock_client,
         patch("oduflow.docker_ops.system_ops.check_disk_space"),
         patch("oduflow.docker_ops.system_ops.estimate_new_db_bytes", return_value=0),
-        patch("oduflow.docker_ops.env_ops.delete_environment"),
+        patch("oduflow.docker_ops.env_ops.delete_environment") as delete,
         patch(
             "oduflow.docker_ops.env_ops.create_environment",
             return_value={"url": "https://feature-a.dev.example.com"},
@@ -249,6 +250,7 @@ def test_api_recreate_restores_legacy_slot_to_branch_hostname(tmp_path):
         resp = client.post("/api/environments/feature-a/recreate")
 
     assert resp.status_code == 200
+    assert delete.call_args.kwargs["preserve_share"] is True
     assert create.call_args.kwargs["hostname"] == ""
     assert create.call_args.kwargs["hostname_source"] == ""
 

--- a/tests/test_web_ui_share.py
+++ b/tests/test_web_ui_share.py
@@ -154,6 +154,17 @@ def test_operator_can_preview_the_shared_view(app):
     resp = client.get(f"/env/{_ENV}")
     assert resp.status_code == 200
     assert f'data-scoped-env="{_ENV}"' in resp.text
+    assert "environments.filter(function (env)" in resp.text
+
+
+def test_share_cookie_scopes_an_existing_operator_session(app):
+    client = _operator(app)
+    result = client.post(f"/api/environments/{_ENV}/share").json()["result"]
+    path = str(result["url"]).split("/", 3)[3]
+
+    assert client.get("/" + path, follow_redirects=False).status_code == 303
+    envs = client.get("/api/environments").json()["environments"]
+    assert [e["env_name"] for e in envs] == [_ENV]
 
 
 # --- what the scoped session may do --------------------------------------
@@ -203,6 +214,18 @@ def test_agent_cli_websocket_is_refused_for_a_share_link(app):
     assert excinfo.value.code == 1008
 
 
+def test_feedback_is_available_from_a_shared_view(app):
+    client = _visitor(app, _share_url(app))
+    resp = client.post(
+        "/api/feedback/link",
+        json={"kind": "feedback", "details": "Feedback from a shared view"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert resp.json()["url"].startswith("https://github.com/")
+
+
 # --- ending access -------------------------------------------------------
 
 
@@ -227,6 +250,36 @@ def test_logout_clears_the_scoped_session(app):
     # Back to their own page (they have no team password to log in with).
     assert resp.headers["location"] == f"/env/{_ENV}"
     assert client.get("/api/environments").status_code == 401
+
+
+def test_scoped_logout_restores_an_existing_operator_session(app):
+    client = _operator(app)
+    result = client.post(f"/api/environments/{_ENV}/share").json()["result"]
+    path = str(result["url"]).split("/", 3)[3]
+    assert client.get("/" + path, follow_redirects=False).status_code == 303
+    assert len(client.get("/api/environments").json()["environments"]) == 1
+
+    resp = client.post("/logout", follow_redirects=False)
+
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+    envs = client.get("/api/environments").json()["environments"]
+    assert [e["env_name"] for e in envs] == [_ENV, "other"]
+
+
+def test_scoped_logout_restores_operator_after_share_is_revoked(app):
+    client = _operator(app)
+    result = client.post(f"/api/environments/{_ENV}/share").json()["result"]
+    path = str(result["url"]).split("/", 3)[3]
+    assert client.get("/" + path, follow_redirects=False).status_code == 303
+    _operator(app).post(f"/api/environments/{_ENV}/share/revoke")
+
+    resp = client.post("/logout", follow_redirects=False)
+
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+    envs = client.get("/api/environments").json()["environments"]
+    assert [e["env_name"] for e in envs] == [_ENV, "other"]
 
 
 def test_deleting_the_environment_drops_its_share(app, settings, monkeypatch):

--- a/tests/test_web_ui_share.py
+++ b/tests/test_web_ui_share.py
@@ -1,0 +1,237 @@
+"""Sharing one environment's dashboard: /env/<name> and the scoped session.
+
+The operator mints a link from the environment card; whoever opens it trades
+its ``?key=`` for a scoped cookie and gets the dashboard reduced to that one
+environment. The server-side allowlist (``oduflow.ui_scope``), not the page
+rendering, is the boundary — these tests exercise it through the real app.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from oduflow import env_share, ui_scope, web_ui
+from oduflow.locking import LockManager
+from oduflow.settings import Settings, TeamSettings
+
+_PW = "s3cret"
+_ENV = "feature/x"
+_DATA_DIR = tempfile.mkdtemp(prefix="oduflow-share-test-")
+
+
+@pytest.fixture
+def settings(tmp_path) -> Settings:
+    return Settings(
+        routing_mode="port",
+        base_data_dir=_DATA_DIR,
+        teams={
+            "1": TeamSettings(
+                team_id="1", ui_password=_PW, data_dir=str(tmp_path / "team1")
+            )
+        },
+    )
+
+
+@pytest.fixture
+def app(settings, monkeypatch) -> Starlette:
+    # Every route under test is either pure web plumbing or stubbed here; no
+    # Docker daemon is involved.
+    monkeypatch.setattr(
+        web_ui.env_ops,
+        "list_environments",
+        lambda s, team: [
+            {"env_name": _ENV, "branch": _ENV, "containers": []},
+            {"env_name": "other", "branch": "other", "containers": []},
+        ],
+    )
+    monkeypatch.setattr(
+        web_ui.env_ops, "require_environment", lambda s, team, env_name: None
+    )
+    application = Starlette()
+    web_ui.mount_web_ui(application, lambda: settings, LockManager())
+    return application
+
+
+def _operator(app) -> TestClient:
+    client = TestClient(app)
+    resp = client.post("/login", data={"password": _PW}, follow_redirects=False)
+    assert resp.status_code == 303
+    return client
+
+
+def _share_url(app) -> str:
+    client = _operator(app)
+    resp = client.post(f"/api/environments/{_ENV}/share")
+    assert resp.status_code == 200, resp.text
+    result = resp.json()["result"]
+    assert result["shared"] is True
+    return str(result["url"])
+
+
+def _visitor(app, url: str) -> TestClient:
+    """A browser that follows a share link and keeps its cookie."""
+    client = TestClient(app)
+    path = url.split("/", 3)[3]
+    resp = client.get("/" + path, follow_redirects=False)
+    assert resp.status_code == 303, resp.text
+    assert ui_scope.SHARE_COOKIE in client.cookies
+    return client
+
+
+# --- minting the link ----------------------------------------------------
+
+
+def test_share_link_points_at_the_scoped_page(app, settings):
+    url = _share_url(app)
+    assert f"/env/{_ENV}?key=" in url
+    key = url.split("key=", 1)[1]
+    assert env_share.verify(settings.teams["1"], _ENV, key)
+
+
+def test_share_status_round_trip(app):
+    client = _operator(app)
+    assert client.get(f"/api/environments/{_ENV}/share").json()["result"] == {
+        "shared": False,
+        "url": None,
+        "created_at": None,
+    }
+    client.post(f"/api/environments/{_ENV}/share")
+    result = client.get(f"/api/environments/{_ENV}/share").json()["result"]
+    assert result["shared"] is True and result["created_at"]
+    client.post(f"/api/environments/{_ENV}/share/revoke")
+    assert client.get(f"/api/environments/{_ENV}/share").json()["result"]["shared"] is (
+        False
+    )
+
+
+def test_sharing_requires_the_operator_session(app):
+    client = TestClient(app)
+    assert client.post(f"/api/environments/{_ENV}/share").status_code == 401
+
+
+# --- opening the link ----------------------------------------------------
+
+
+def test_key_is_exchanged_for_a_cookie_and_dropped_from_the_url(app):
+    url = _share_url(app)
+    client = TestClient(app)
+    resp = client.get("/" + url.split("/", 3)[3], follow_redirects=False)
+    assert resp.status_code == 303
+    # Landing URL carries no key: it must not sit in history or a Referer.
+    assert resp.headers["location"] == f"/env/{_ENV}"
+    assert "key=" not in resp.headers["location"]
+    cookie = resp.headers["set-cookie"]
+    assert cookie.startswith(f"{ui_scope.SHARE_COOKIE}=")
+    assert "HttpOnly" in cookie and "strict" in cookie.lower()
+
+
+def test_scoped_page_renders_for_the_cookie_holder(app):
+    client = _visitor(app, _share_url(app))
+    resp = client.get(f"/env/{_ENV}")
+    assert resp.status_code == 200
+    assert f'data-scoped-env="{_ENV}"' in resp.text
+
+
+def test_page_without_a_key_or_cookie_is_refused(app):
+    client = TestClient(app)
+    assert client.get(f"/env/{_ENV}").status_code == 401
+
+
+def test_wrong_and_revoked_keys_are_refused(app):
+    url = _share_url(app)
+    assert TestClient(app).get(f"/env/{_ENV}?key=nope").status_code == 403
+    _operator(app).post(f"/api/environments/{_ENV}/share/revoke")
+    assert TestClient(app).get("/" + url.split("/", 3)[3]).status_code == 403
+
+
+def test_operator_can_preview_the_shared_view(app):
+    client = _operator(app)
+    resp = client.get(f"/env/{_ENV}")
+    assert resp.status_code == 200
+    assert f'data-scoped-env="{_ENV}"' in resp.text
+
+
+# --- what the scoped session may do --------------------------------------
+
+
+def test_environment_list_is_filtered_to_the_shared_environment(app):
+    client = _visitor(app, _share_url(app))
+    envs = client.get("/api/environments").json()["environments"]
+    assert [e["env_name"] for e in envs] == [_ENV]
+
+
+def test_full_dashboard_and_team_surfaces_are_denied(app):
+    client = _visitor(app, _share_url(app))
+    assert client.get("/").status_code == 403
+    for path in ("/api/templates", "/api/services", "/api/volumes", "/api/stats"):
+        assert client.get(path).status_code == 403, path
+    assert client.post("/api/environments/create", json={}).status_code == 403
+
+
+def test_destructive_actions_on_the_shared_environment_are_denied(app):
+    client = _visitor(app, _share_url(app))
+    for action in ("delete", "recreate", "update", "protect", "save-as-template"):
+        resp = client.post(f"/api/environments/{_ENV}/{action}")
+        assert resp.status_code == 403, action
+
+
+def test_other_environments_are_denied(app):
+    client = _visitor(app, _share_url(app))
+    assert client.get("/api/environments/other/logs").status_code == 403
+    assert client.post("/api/environments/other/restart").status_code == 403
+
+
+def test_a_share_link_cannot_manage_its_own_sharing(app):
+    client = _visitor(app, _share_url(app))
+    assert client.get(f"/api/environments/{_ENV}/share").status_code == 403
+    assert client.post(f"/api/environments/{_ENV}/share/rotate").status_code == 403
+    assert client.post(f"/api/environments/{_ENV}/share/revoke").status_code == 403
+
+
+def test_agent_cli_websocket_is_refused_for_a_share_link(app):
+    client = _visitor(app, _share_url(app))
+    with pytest.raises(WebSocketDisconnect) as excinfo:
+        with client.websocket_connect(f"/api/environments/{_ENV}/agent"):
+            pass
+    # 1008 (policy violation) is the middleware's refusal, not a handler error:
+    # the request never reaches the agent container.
+    assert excinfo.value.code == 1008
+
+
+# --- ending access -------------------------------------------------------
+
+
+def test_rotating_the_link_invalidates_live_sessions(app):
+    client = _visitor(app, _share_url(app))
+    assert client.get("/api/environments").status_code == 200
+    _operator(app).post(f"/api/environments/{_ENV}/share/rotate")
+    # The cookie carries a fingerprint of the secret it was minted from.
+    assert client.get("/api/environments").status_code == 401
+
+
+def test_revoking_the_link_invalidates_live_sessions(app):
+    client = _visitor(app, _share_url(app))
+    _operator(app).post(f"/api/environments/{_ENV}/share/revoke")
+    assert client.get("/api/environments").status_code == 401
+
+
+def test_logout_clears_the_scoped_session(app):
+    client = _visitor(app, _share_url(app))
+    resp = client.post("/logout", follow_redirects=False)
+    assert resp.status_code == 303
+    # Back to their own page (they have no team password to log in with).
+    assert resp.headers["location"] == f"/env/{_ENV}"
+    assert client.get("/api/environments").status_code == 401
+
+
+def test_deleting_the_environment_drops_its_share(app, settings, monkeypatch):
+    team = settings.teams["1"]
+    secret = env_share.create_or_get(team, _ENV)
+    assert env_share.verify(team, _ENV, secret)
+    env_share.remove(team, _ENV)
+    assert env_share.get(team, _ENV) is None

--- a/tests/test_web_ui_static.py
+++ b/tests/test_web_ui_static.py
@@ -152,6 +152,149 @@ def test_feedback_modal_is_registered_for_escape_key(tmp_path):
     assert re.search(r"'feedback-modal':\s*closeFeedbackModal", dashboard.text)
 
 
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_scoped_preview_filters_environment_data_in_the_browser():
+    source = _DASHBOARD.read_text(encoding="utf-8")
+    function = _js_function(source, "loadEnvironments")
+    result = _run_node(
+        f"""
+        var API = '/api/environments';
+        var SCOPED_ENV = 'feature/x';
+        var cachedEnvs = [];
+        var rendered = [];
+        async function fetch() {{ return {{}}; }}
+        async function readResult() {{
+          return {{ok: true, environments: [
+            {{env_name: 'feature/x'}}, {{env_name: 'other'}}
+          ]}};
+        }}
+        function renderEnvironments(envs) {{ rendered = envs; }}
+        function showToast() {{}}
+        {function}
+        loadEnvironments().then(function () {{
+          console.log(JSON.stringify({{
+            cached: cachedEnvs.map(function (env) {{ return env.env_name; }}),
+            rendered: rendered.map(function (env) {{ return env.env_name; }})
+          }}));
+        }});
+        """
+    )
+
+    assert result == {"cached": ["feature/x"], "rendered": ["feature/x"]}
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is not installed")
+def test_share_modal_ignores_stale_loads_and_blocks_unsafe_actions():
+    source = _DASHBOARD.read_text(encoding="utf-8")
+    names = (
+        "_setShareActions",
+        "_renderSharePending",
+        "_renderShareError",
+        "openShare",
+        "renderShare",
+        "_shareRequest",
+        "loadShare",
+        "shareCreate",
+        "shareRotate",
+    )
+    functions = "\n".join(_js_function(source, name) for name in names)
+    result = _run_node(
+        f"""
+        var elements = {{}};
+        function element(id) {{
+          if (!elements[id]) elements[id] = {{
+            id: id, style: {{display: ''}}, disabled: false, value: 'stale',
+            type: 'text', textContent: '', attributes: {{}},
+            setAttribute: function (key, value) {{ this.attributes[key] = value; }}
+          }};
+          return elements[id];
+        }}
+        var document = {{getElementById: element}};
+        var API = '/api/environments';
+        var _shareBranch = '';
+        var _shareRequestGeneration = 0;
+        var _shareBusy = false;
+        var _shareResult = null;
+        var pending = [];
+        function fetch(url) {{
+          return new Promise(function (resolve) {{ pending.push({{url: url, resolve: resolve}}); }});
+        }}
+        async function readResult(response) {{ return response; }}
+        function showModal() {{}}
+        function showToast() {{}}
+        function formatDate(value) {{ return value; }}
+        {functions}
+
+        (async function () {{
+          var first = openShare('first');
+          var loading = {{
+            status: element('share-loading').style.display,
+            create: element('share-create').style.display,
+            rotate: element('share-rotate').style.display,
+            revoke: element('share-revoke').style.display
+          }};
+          var second = openShare('second');
+          pending[1].resolve({{ok: true, result: {{shared: false, url: null}}}});
+          await second;
+          pending[0].resolve({{
+            ok: true,
+            result: {{shared: true, url: 'https://stale.invalid', created_at: 'old'}}
+          }});
+          await first;
+
+          var beforeCreateRequests = pending.length;
+          var create = shareCreate();
+          var duplicate = shareCreate();
+          var mutation = {{
+            disabled: element('share-create').disabled,
+            requestCount: pending.length - beforeCreateRequests,
+            duplicateIgnored: duplicate === undefined
+          }};
+          pending[2].resolve({{ok: false, error: 'failed'}});
+          await create;
+          await shareRotate();
+
+          console.log(JSON.stringify({{
+            loading: loading,
+            branch: _shareBranch,
+            url: element('share-url').value,
+            createDisplay: element('share-create').style.display,
+            createDisabledAfterError: element('share-create').disabled,
+            rotateDisplay: element('share-rotate').style.display,
+            requestCountAfterInvalidRotate: pending.length,
+            mutation: mutation
+          }}));
+        }})();
+        """
+    )
+
+    assert result["loading"] == {
+        "status": "",
+        "create": "none",
+        "rotate": "none",
+        "revoke": "none",
+    }
+    assert result["branch"] == "second"
+    assert result["url"] == ""
+    assert result["createDisplay"] == ""
+    assert result["createDisabledAfterError"] is False
+    assert result["rotateDisplay"] == "none"
+    assert result["requestCountAfterInvalidRotate"] == 3
+    assert result["mutation"] == {
+        "disabled": True,
+        "requestCount": 1,
+        "duplicateIgnored": True,
+    }
+
+
+def test_share_modal_discloses_agent_chat_workspace_access(tmp_path):
+    dashboard = _client(tmp_path).get("/")
+
+    assert dashboard.status_code == 200
+    assert "Agent Chat runs in the team's shared coder container" in dashboard.text
+    assert "may read other team checkouts and Git credentials" in dashboard.text
+
+
 def test_dashboard_accepts_opencode_default_and_labels_it(tmp_path):
     dashboard = _client(tmp_path).get("/")
 


### PR DESCRIPTION
## Overview

- add revocable share links for a dashboard scoped to one environment
- enforce a default-deny server-side policy for shared sessions while retaining logs, consoles, module actions, Connect As, and Agent Chat
- preserve share links across recreation and revoke them on normal deletion
- harden operator preview/logout behavior and share-modal loading, mutation, and stale-response handling
- document the shared coder-container access boundary and allow scoped visitors to open Feedback

## Validation

- `ruff check src/oduflow tests`
- `mypy src/oduflow`
- 110 focused tests passed
- 2,857 non-integration/non-heavyweight tests passed with the pre-existing macOS-only stale-overlay test deselected
