### PR TITLE
Add [routing] public_scheme for plain-HTTP deployments

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -180,6 +180,8 @@ allow_local_path = true     # trusted single-user local development; disable on 
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik" and tls = true
 # tls = true                # traefik only. false = plain HTTP on :80, no ACME (behind a Cloudflare tunnel / TLS proxy)
+# public_scheme = "https"   # scheme of the URLs Oduflow hands out. Default: https (traefik) / http (port).
+                            # Set "http" with tls = false when nothing terminates TLS in front
 # hostname = "localhost"    # port mode only: default host for teams without their own
                             # (traefik requires each team to set its own hostname)
 
@@ -293,7 +295,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
 | `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` and `tls = true` |
-| `[routing].tls` | `true` | Traefik only. `true`: Traefik terminates TLS (:443, HTTP→HTTPS redirect, Let's Encrypt). `false`: plain HTTP on :80 only, no redirect/ACME — for a TLS-terminating upstream (e.g. a Cloudflare tunnel). Public URLs stay `https://` either way |
+| `[routing].tls` | `true` | Traefik only. `true`: Traefik terminates TLS (:443, HTTP→HTTPS redirect, Let's Encrypt). `false`: plain HTTP on :80 only, no redirect/ACME — for a TLS-terminating upstream (e.g. a Cloudflare tunnel). Public URLs stay `https://` either way unless `public_scheme` says otherwise |
+| `[routing].public_scheme` | *(derived)* | Scheme of every URL Oduflow hands out (dashboard links, MCP endpoints, share links, reported environment/service URLs). Derived by default: `https` in traefik mode, `http` in port mode. Set to `http` alongside `tls = false` when **nothing** terminates TLS in front — this also stops Traefik trusting inbound `X-Forwarded-*` on :80 |
 | `[routing].hostname` | `localhost` | Default hostname for teams that don't set their own `hostname` |
 
 ### OAuth settings

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -741,6 +741,8 @@ allow_local_path = true     # trusted single-user local development; disable on 
 mode = "port"               # "port" (direct host port) | "traefik" (reverse proxy with auto-HTTPS)
 # acme_email = "admin@example.com"  # required when mode = "traefik" and tls = true
 # tls = true                # traefik only. false = plain HTTP on :80, no ACME (behind a Cloudflare tunnel / TLS proxy)
+# public_scheme = "https"   # scheme of the URLs Oduflow hands out. Default: https (traefik) / http (port).
+                            # Set "http" with tls = false when nothing terminates TLS in front
 # hostname = "localhost"    # port mode only: default host for teams without their own
                             # (traefik requires each team to set its own hostname)
 
@@ -854,7 +856,8 @@ port_range = [50000, 50100]          # port range for Odoo containers [start, en
 |---|---|---|
 | `[routing].mode` | `port` | `port` — direct host port mapping; `traefik` — reverse proxy with auto-HTTPS |
 | `[routing].acme_email` | *(empty)* | Let's Encrypt email for TLS certificates. Required when `mode = "traefik"` and `tls = true` |
-| `[routing].tls` | `true` | Traefik only. `true`: Traefik terminates TLS (:443, HTTP→HTTPS redirect, Let's Encrypt). `false`: plain HTTP on :80 only, no redirect/ACME — for a TLS-terminating upstream (e.g. a Cloudflare tunnel). Public URLs stay `https://` either way |
+| `[routing].tls` | `true` | Traefik only. `true`: Traefik terminates TLS (:443, HTTP→HTTPS redirect, Let's Encrypt). `false`: plain HTTP on :80 only, no redirect/ACME — for a TLS-terminating upstream (e.g. a Cloudflare tunnel). Public URLs stay `https://` either way unless `public_scheme` says otherwise |
+| `[routing].public_scheme` | *(derived)* | Scheme of every URL Oduflow hands out (dashboard links, MCP endpoints, share links, reported environment/service URLs). Derived by default: `https` in traefik mode, `http` in port mode. Set to `http` alongside `tls = false` when **nothing** terminates TLS in front — this also stops Traefik trusting inbound `X-Forwarded-*` on :80 |
 | `[routing].hostname` | `localhost` | Default hostname for teams that don't set their own `hostname` |
 
 ### OAuth settings
@@ -4064,6 +4067,40 @@ With `tls = false` Traefik:
 Point the tunnel at the server's port 80 and route the wildcard hostname to it (e.g. `*.dev.example.com → http://localhost:80`). Cloudflare provides the certificate and forwards requests over HTTP; the tunnel sets `X-Forwarded-Proto: https`. On the `web` entrypoint Oduflow enables `forwardedHeaders.insecure` so Traefik passes those headers through (by default Traefik would overwrite `X-Forwarded-Proto` with the plain-HTTP connection scheme), letting Oduflow see the request as secure — the dashboard's session cookie stays `Secure` and every environment/service URL Oduflow reports is still `https://…`. Because this entrypoint trusts all forwarded headers, expose port 80 **only** to the tunnel, not to the public internet.
 
 > **Changing `tls` on a running deployment recreates Traefik but not your environments.** Each environment and service bakes its Traefik routing labels in at creation time — `entrypoints=websecure` (with Let's Encrypt) when `tls = true`, `entrypoints=web` when `tls = false`. Restarting Oduflow recreates the Traefik container in the new mode, but pre-existing environments and services keep their old labels: after the switch their routers point at an entrypoint that no longer matches, so they become unreachable until **recreated** (or, going `false → true`, get caught by the HTTP→HTTPS redirect). Treat `tls` as a deploy-time choice; if you must flip it on a live server, recreate the existing environments and services afterwards. The default is `tls = true` (Traefik terminates TLS with Let's Encrypt, as described above).
+
+## Plain HTTP, with nothing terminating TLS
+
+`tls = false` on its own means "**someone else** terminates TLS", so the links
+Oduflow hands out — environment and service URLs, dashboard share links, MCP
+endpoints — stay `https://`. If there is no such upstream (a LAN box, an
+internal staging server, a local demo), those links point at an endpoint nobody
+serves. Say so explicitly with `public_scheme`:
+
+```toml
+[routing]
+mode = "traefik"
+tls = false
+public_scheme = "http"   # no TLS anywhere: hand out http:// links
+
+[team.1]
+hostname = "dev.example.com"
+```
+
+`public_scheme` sets the scheme of every URL Oduflow reports; it defaults to
+`https` in traefik mode and `http` in port mode, and is independent of `tls`
+(which only decides whether *Traefik* terminates TLS). It also switches off
+`forwardedHeaders.insecure` on the `web` entrypoint: with no trusted terminator
+in front, that entrypoint is directly reachable and must not believe a
+client-supplied `X-Forwarded-Proto`.
+
+Changing `public_scheme` recreates the Traefik container (the forwarded-headers
+argument changes) but not your environments — only the reported URLs change, so
+no environment or service needs recreating.
+
+!!! warning "Plain HTTP is unencrypted"
+    Odoo logins, session cookies, the dashboard password and MCP bearer tokens
+    all travel in cleartext. Use this only on a trusted network, never on a
+    public-facing server.
 
 ---
 

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -179,3 +179,37 @@ With `tls = false` Traefik:
 Point the tunnel at the server's port 80 and route the wildcard hostname to it (e.g. `*.dev.example.com → http://localhost:80`). Cloudflare provides the certificate and forwards requests over HTTP; the tunnel sets `X-Forwarded-Proto: https`. On the `web` entrypoint Oduflow enables `forwardedHeaders.insecure` so Traefik passes those headers through (by default Traefik would overwrite `X-Forwarded-Proto` with the plain-HTTP connection scheme), letting Oduflow see the request as secure — the dashboard's session cookie stays `Secure` and every environment/service URL Oduflow reports is still `https://…`. Because this entrypoint trusts all forwarded headers, expose port 80 **only** to the tunnel, not to the public internet.
 
 > **Changing `tls` on a running deployment recreates Traefik but not your environments.** Each environment and service bakes its Traefik routing labels in at creation time — `entrypoints=websecure` (with Let's Encrypt) when `tls = true`, `entrypoints=web` when `tls = false`. Restarting Oduflow recreates the Traefik container in the new mode, but pre-existing environments and services keep their old labels: after the switch their routers point at an entrypoint that no longer matches, so they become unreachable until **recreated** (or, going `false → true`, get caught by the HTTP→HTTPS redirect). Treat `tls` as a deploy-time choice; if you must flip it on a live server, recreate the existing environments and services afterwards. The default is `tls = true` (Traefik terminates TLS with Let's Encrypt, as described above).
+
+## Plain HTTP, with nothing terminating TLS
+
+`tls = false` on its own means "**someone else** terminates TLS", so the links
+Oduflow hands out — environment and service URLs, dashboard share links, MCP
+endpoints — stay `https://`. If there is no such upstream (a LAN box, an
+internal staging server, a local demo), those links point at an endpoint nobody
+serves. Say so explicitly with `public_scheme`:
+
+```toml
+[routing]
+mode = "traefik"
+tls = false
+public_scheme = "http"   # no TLS anywhere: hand out http:// links
+
+[team.1]
+hostname = "dev.example.com"
+```
+
+`public_scheme` sets the scheme of every URL Oduflow reports; it defaults to
+`https` in traefik mode and `http` in port mode, and is independent of `tls`
+(which only decides whether *Traefik* terminates TLS). It also switches off
+`forwardedHeaders.insecure` on the `web` entrypoint: with no trusted terminator
+in front, that entrypoint is directly reachable and must not believe a
+client-supplied `X-Forwarded-Proto`.
+
+Changing `public_scheme` recreates the Traefik container (the forwarded-headers
+argument changes) but not your environments — only the reported URLs change, so
+no environment or service needs recreating.
+
+!!! warning "Plain HTTP is unencrypted"
+    Odoo logins, session cookies, the dashboard password and MCP bearer tokens
+    all travel in cleartext. Use this only on a trusted network, never on a
+    public-facing server.

--- a/specs/0056-public-url-scheme.md
+++ b/specs/0056-public-url-scheme.md
@@ -1,0 +1,79 @@
+# 0056 — Public URL scheme (`[routing] public_scheme`)
+
+**Status:** Adopted (still in force)
+**Type:** Architecture / Routing / Security
+**First introduced:** `litnimax/lethal-bullfrog` branch (2026-09-04)
+**Key code today:** `settings.py` (`public_scheme_setting` field, `public_scheme` property, `validate()` cross-checks), `docker_ops/system_ops.py` (`_trusts_upstream_headers`, `_ensure_traefik` drift control), URL construction sites in `docker_ops/env_ops.py`, `docker_ops/service_ops.py`, `docker_ops/production_ops.py` (`prod_url`), `server.py`, `web_ui.py`
+
+## Context
+
+Every URL Oduflow hands out — environment/service/production URLs, dashboard
+share links, MCP endpoints, artifact links — hardcoded its scheme: `https://`
+in traefik mode, `http://` in port mode. That baked in an assumption: a
+`tls = false` traefik deployment is always fronted by an upstream TLS
+terminator (a Cloudflare tunnel), so links stay `https://` and Traefik's `web`
+entrypoint unconditionally trusts inbound `X-Forwarded-*` headers
+([[0034]] introduced that entrypoint shape).
+
+Two deployment realities broke the assumption. First, plain-HTTP-end-to-end
+setups exist (LAN boxes, internal staging, local demos): with nothing
+terminating TLS, every handed-out `https://` link pointed at an endpoint
+nobody served. Second, the unconditional `forwardedHeaders.insecure` trust is
+a hole when :80 is directly exposed — any client could forge
+`X-Forwarded-Proto: https` (flipping request-security detection) or
+`X-Forwarded-For` (evading the login rate limiter), since uvicorn trusts
+Traefik's address.
+
+## Decision
+
+Add one setting, `[routing] public_scheme` (`"http"` | `"https"`), that names
+the scheme of every URL Oduflow hands out. Unset, it derives the historical
+default: `https` in traefik mode, `http` in port mode — so existing
+deployments (including `tls = false` behind a tunnel) are untouched.
+
+The same setting drives Traefik's forwarded-header trust: the `web`
+entrypoint gets `forwardedHeaders.insecure=true` only for the
+"upstream terminates TLS" shape (`tls = false` **and** effective scheme
+`https`). Declaring `public_scheme = "http"` therefore both fixes the links
+and closes the header-forgery hole, because "plain HTTP end to end" and "no
+trusted terminator in front" are the same statement about the topology.
+
+`validate()` rejects the combinations that contradict what actually answers on
+the wire: `public_scheme = "http"` with traefik `tls = true` (the :80→:443
+redirect would bounce every link and leak tokens on the plaintext first hop)
+and `public_scheme = "https"` in port mode (published per-environment ports
+serve plain HTTP; internal probes built from the same base URL would fail the
+TLS handshake). The only meaningful override is thus traefik + `tls = false` +
+`http`.
+
+## How it works (macro)
+
+`Settings` keeps the raw TOML value in `public_scheme_setting` and resolves it
+through the `public_scheme` property (the raw field stays empty by default so
+the derived default can depend on `routing_mode`). All URL construction sites
+interpolate `settings.public_scheme`; `prod_url` gained a `settings`
+parameter for the same reason.
+
+`_ensure_traefik`'s drift control ([[0034]]) compares the running container's
+`forwardedHeaders.insecure` arg against `_trusts_upstream_headers(settings)`
+and recreates the container on mismatch — so flipping `public_scheme` takes
+effect on the next server start. Environments and services need no
+recreation: their routing labels do not encode the scheme.
+
+## Consequences
+
+- Plain-HTTP deployments hand out reachable links, and their :80 entrypoint
+  no longer believes client-supplied forwarded headers.
+- Cookie `Secure` flags and request-security checks stay derived from the live
+  request (`X-Forwarded-Proto`), never from `public_scheme`; with trust off,
+  Traefik sanitizes those headers, keeping the two views consistent.
+- `public_scheme = "http"` implies remote OAuth-based MCP clients (which
+  require https issuers) cannot connect — inherent to plain HTTP and
+  documented in `docs/traefik.md`, along with the cleartext warning.
+- The default `tls = false` shape still trusts forwarded headers (it must, for
+  tunnels); an exposed-:80-without-terminator misconfiguration only becomes
+  safe once the operator declares `public_scheme = "http"`.
+
+## History
+
+- Introduced on the `litnimax/lethal-bullfrog` branch (2026-09-04).

--- a/specs/README.md
+++ b/specs/README.md
@@ -74,6 +74,7 @@ precursors).
 | [0053](0053-explicit-start-commands-for-auxiliary-services.md) | 2026-08-31 | Explicit Docker CMD overrides for auxiliary services |
 | [0054](0054-agent-container-image-build-and-publish.md) | 2026-09-01 | Agent-driven container image build and publication |
 | [0055](0055-scoped-environment-ui-sharing.md) | 2026-09-02 | Shared single-environment dashboard (`/env/<name>` share links) |
+| [0056](0056-public-url-scheme.md) | 2026-09-04 | Public URL scheme (`[routing] public_scheme`) and conditional forwarded-header trust |
 
 ## Design docs
 

--- a/src/oduflow/docker_ops/env_ops.py
+++ b/src/oduflow/docker_ops/env_ops.py
@@ -1707,7 +1707,9 @@ def build_env_traefik_labels(
         labels[f"traefik.http.routers.{router}.tls.certresolver"] = "letsencrypt"
     else:
         # Upstream (e.g. Cloudflare tunnel) terminates TLS; Traefik routes plain
-        # HTTP on the web entrypoint. Public URL stays https://.
+        # HTTP on the web entrypoint. Public URLs use settings.public_scheme
+        # (the upstream's scheme, https unless overridden), not this
+        # entrypoint's.
         labels[f"traefik.http.routers.{router}.entrypoints"] = "web"
     return labels
 
@@ -1763,10 +1765,14 @@ def adopt_existing_environment(
         container.reload()
 
     if settings.routing_mode == "traefik":
-        url = f"https://{get_env_hostname(env_name, team.hostname, labels.get(ENV_HOSTNAME_LABEL, ''))}"
+        url = f"{settings.public_scheme}://{get_env_hostname(env_name, team.hostname, labels.get(ENV_HOSTNAME_LABEL, ''))}"
     else:
         ports = container.ports.get("8069/tcp")
-        url = f"http://{team.hostname}:{ports[0]['HostPort']}" if ports else ""
+        url = (
+            f"{settings.public_scheme}://{team.hostname}:{ports[0]['HostPort']}"
+            if ports
+            else ""
+        )
 
     return {
         "env_name": env_name,
@@ -1978,11 +1984,11 @@ def _create_environment_impl(
         if existing.status == "running":
             existing.reload()
             if settings.routing_mode == "traefik":
-                url = f"https://{get_env_hostname(env_name, team.hostname, existing.labels.get(ENV_HOSTNAME_LABEL, ''))}"
+                url = f"{settings.public_scheme}://{get_env_hostname(env_name, team.hostname, existing.labels.get(ENV_HOSTNAME_LABEL, ''))}"
             else:
                 ports = existing.ports.get("8069/tcp")
                 existing_port = ports[0]["HostPort"] if ports else "?"
-                url = f"http://{team.hostname}:{existing_port}"
+                url = f"{settings.public_scheme}://{team.hostname}:{existing_port}"
             raise ConflictError(
                 f"Environment '{env_name}' already exists and is running at {url}."
             )
@@ -2353,9 +2359,9 @@ def _create_environment_impl(
         raise
 
     if settings.routing_mode == "traefik":
-        url = f"https://{get_env_hostname(env_name, team.hostname, hostname)}"
+        url = f"{settings.public_scheme}://{get_env_hostname(env_name, team.hostname, hostname)}"
     else:
-        url = f"http://{team.hostname}:{host_port}"
+        url = f"{settings.public_scheme}://{team.hostname}:{host_port}"
     logger.info(
         "Environment created",
         extra={"env_name": env_name, "url": url, "container": odoo_container_name},
@@ -2470,7 +2476,7 @@ def get_agent_mcp_url(settings: Settings, team: TeamSettings, env_name: str) -> 
     from urllib.parse import quote
 
     if settings.routing_mode == "traefik":
-        base = f"https://{team.hostname}"
+        base = f"{settings.public_scheme}://{team.hostname}"
     elif settings.oauth_base_url:
         base = settings.oauth_base_url.rstrip("/")
     else:
@@ -3244,7 +3250,7 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
         if "-odoo" in container.name:
             if settings.routing_mode == "traefik":
                 envs[env_name]["url"] = (
-                    f"https://{get_env_hostname(env_name, team.hostname, container.labels.get(ENV_HOSTNAME_LABEL, ''))}/web?debug=1"
+                    f"{settings.public_scheme}://{get_env_hostname(env_name, team.hostname, container.labels.get(ENV_HOSTNAME_LABEL, ''))}/web?debug=1"
                 )
             else:
                 ports = container.attrs.get("NetworkSettings", {}).get("Ports", {})
@@ -3254,7 +3260,8 @@ def list_environments(settings: Settings, team: TeamSettings) -> list[dict[str, 
                         host_port = mappings[0].get("HostPort")
                         if host_port:
                             envs[env_name]["url"] = (
-                                f"http://{team.hostname}:{host_port}/web?debug=1"
+                                f"{settings.public_scheme}://{team.hostname}"
+                                f":{host_port}/web?debug=1"
                             )
 
         envs[env_name]["containers"].append(container_info)
@@ -3461,7 +3468,7 @@ def get_env_base_url(
         host = get_env_hostname(
             env_name, team.hostname, container.labels.get(ENV_HOSTNAME_LABEL, "")
         )
-        return f"https://{host}", host
+        return f"{settings.public_scheme}://{host}", host
 
     # Port routing: read the container's published 8069 port. Cookies are not
     # port-scoped, so the domain is just the host.
@@ -3483,7 +3490,7 @@ def get_env_base_url(
             f"Environment '{env_name}' has no published HTTP port; "
             "is the environment running?"
         )
-    return f"http://{team.hostname}:{host_port}", team.hostname
+    return f"{settings.public_scheme}://{team.hostname}:{host_port}", team.hostname
 
 
 def get_environment_info(
@@ -3543,7 +3550,7 @@ def get_environment_info(
 
         if settings.routing_mode == "traefik":
             result["url"] = (
-                f"https://{get_env_hostname(env_name, team.hostname, labels.get(ENV_HOSTNAME_LABEL, ''))}/web?debug=1"
+                f"{settings.public_scheme}://{get_env_hostname(env_name, team.hostname, labels.get(ENV_HOSTNAME_LABEL, ''))}/web?debug=1"
             )
         else:
             ports = odoo_container.attrs.get("NetworkSettings", {}).get("Ports", {})
@@ -3553,7 +3560,8 @@ def get_environment_info(
                     host_port = mappings[0].get("HostPort")
                     if host_port:
                         result["url"] = (
-                            f"http://{team.hostname}:{host_port}/web?debug=1"
+                            f"{settings.public_scheme}://{team.hostname}"
+                            f":{host_port}/web?debug=1"
                         )
 
         stats = _get_one_container_stats(odoo_container)
@@ -5141,9 +5149,9 @@ def update_environment(
     # 6. Build URL and return result
     # ------------------------------------------------------------------
     if settings.routing_mode == "traefik":
-        url = f"https://{get_env_hostname(env_name, team.hostname, route_hostname)}"
+        url = f"{settings.public_scheme}://{get_env_hostname(env_name, team.hostname, route_hostname)}"
     else:
-        url = f"http://{team.hostname}:{host_port}"
+        url = f"{settings.public_scheme}://{team.hostname}:{host_port}"
 
     env_db = get_db_name(env_name, team.team_id)
     workspace = get_workspace_path(env_name, team.workspaces_dir)

--- a/src/oduflow/docker_ops/production_ops.py
+++ b/src/oduflow/docker_ops/production_ops.py
@@ -86,8 +86,8 @@ _DEPLOYS_CAP = 100
 pre_update_hooks: list[Callable[[Settings, TeamSettings, str], None]] = []
 
 
-def prod_url(record: dict[str, Any]) -> str:
-    return f"https://{record['domain']}"
+def prod_url(settings: Settings, record: dict[str, Any]) -> str:
+    return f"{settings.public_scheme}://{record['domain']}"
 
 
 def _odoo_container_name(settings: Settings, team: TeamSettings, name: str) -> str:
@@ -740,7 +740,7 @@ def create_production(
     )
     return {
         "name": name,
-        "url": prod_url(record),
+        "url": prod_url(settings, record),
         "domain": domain,
         "odoo_container": container_name,
         "database": env_db,
@@ -1267,7 +1267,7 @@ def list_productions(settings: Settings, team: TeamSettings) -> list[dict[str, A
             {
                 "name": name,
                 "domain": record.get("domain", ""),
-                "url": prod_url(record),
+                "url": prod_url(settings, record),
                 "status": _runtime_status(container, record),
                 "repo_url": record.get("repo_url", ""),
                 "branch": record.get("branch", ""),
@@ -1315,7 +1315,7 @@ def get_production_info(
     return {
         "name": name,
         "domain": record.get("domain", ""),
-        "url": prod_url(record),
+        "url": prod_url(settings, record),
         "status": _runtime_status(container, record),
         "healthy": healthy,
         "repo_url": record.get("repo_url", ""),

--- a/src/oduflow/docker_ops/service_ops.py
+++ b/src/oduflow/docker_ops/service_ops.py
@@ -211,7 +211,7 @@ def _routes_from_labels(labels: dict[str, str]) -> list[dict[str, object]] | Non
 
 
 def _routes_with_urls(
-    routes: list[dict[str, object]] | None, hostname: str | None
+    routes: list[dict[str, object]] | None, hostname: str | None, scheme: str
 ) -> list[dict[str, object]]:
     if not routes:
         return []
@@ -219,7 +219,7 @@ def _routes_with_urls(
     for route in routes:
         item = dict(route)
         if hostname:
-            item["url"] = f"https://{hostname}{route['path']}"
+            item["url"] = f"{scheme}://{hostname}{route['path']}"
         result.append(item)
     return result
 
@@ -455,7 +455,8 @@ def create_service(
                 )
             else:
                 # Upstream terminates TLS (e.g. Cloudflare tunnel): plain HTTP on
-                # the web entrypoint. Public URL stays https:// below.
+                # the web entrypoint. The public URL below keeps the upstream's
+                # scheme (settings.public_scheme), not this entrypoint's.
                 labels[f"traefik.http.routers.{container_name}.entrypoints"] = "web"
             if host_mode:
                 labels[
@@ -466,11 +467,11 @@ def create_service(
                     f"traefik.http.services.{container_name}.loadbalancer.server.port"
                 ] = str(port)
                 labels["traefik.docker.network"] = team_network
-        url = f"https://{hostname}"
+        url = f"{settings.public_scheme}://{hostname}"
     else:
         if not host_mode:
             run_kwargs["ports"] = {f"{port}/tcp": port}
-        url = f"http://{team.hostname}:{port}"
+        url = f"{settings.public_scheme}://{team.hostname}:{port}"
 
     if env_vars:
         run_kwargs["environment"] = env_vars
@@ -544,7 +545,7 @@ def create_service(
         "url": url,
         "host_mode": host_mode,
         "command": list(command or []),
-        "routes": _routes_with_urls(routes, hostname),
+        "routes": _routes_with_urls(routes, hostname, settings.public_scheme),
     }
 
 
@@ -685,7 +686,7 @@ def _describe_service_container(
         match = re.search(r"Host\(`([^`]+)`\)", rule_value)
         if match:
             hostname = match.group(1)
-            url = f"https://{hostname}"
+            url = f"{settings.public_scheme}://{hostname}"
 
         if routes:
             port_num = None
@@ -712,7 +713,7 @@ def _describe_service_container(
             except Exception:
                 pass
             if port_num:
-                url = f"http://{team.hostname}:{port_num}"
+                url = f"{settings.public_scheme}://{team.hostname}:{port_num}"
         else:
             ports_dict = container.attrs.get("NetworkSettings", {}).get("Ports", {})
             if ports_dict:
@@ -724,7 +725,7 @@ def _describe_service_container(
                         for mapping in mappings:
                             host_port = mapping.get("HostPort")
                             if host_port:
-                                url = f"http://{team.hostname}:{host_port}"
+                                url = f"{settings.public_scheme}://{team.hostname}:{host_port}"
                                 break
                     break  # only process first port entry
 
@@ -761,7 +762,7 @@ def _describe_service_container(
         "port": port_num,
         "hostname": hostname,
         "url": url,
-        "routes": _routes_with_urls(routes, hostname),
+        "routes": _routes_with_urls(routes, hostname, settings.public_scheme),
         "env_vars": env_vars,
         "image_env_vars": image_env_vars,
         "host_mode": is_host_mode,
@@ -1108,9 +1109,9 @@ def update_service(
             h = hostname or f"{name}.{team.hostname}"
             if "." not in h:
                 h = f"{h}.{team.hostname}"
-            url = f"https://{h}"
+            url = f"{settings.public_scheme}://{h}"
         else:
-            url = f"http://{team.hostname}:{port}"
+            url = f"{settings.public_scheme}://{team.hostname}:{port}"
         return {
             "name": name,
             "container_name": container_name,
@@ -1123,7 +1124,9 @@ def update_service(
             "old_digest": old_digest,
             "new_digest": new_digest,
             "routes": _routes_with_urls(
-                routes, h if settings.routing_mode == "traefik" else None
+                routes,
+                h if settings.routing_mode == "traefik" else None,
+                settings.public_scheme,
             ),
         }
 

--- a/src/oduflow/docker_ops/system_ops.py
+++ b/src/oduflow/docker_ops/system_ops.py
@@ -447,6 +447,18 @@ def _resolve_instance_conf(name: str, data_dir: str) -> pathlib.Path:
     return _PACKAGE_ROOT / "templates" / name
 
 
+def _trusts_upstream_headers(settings: Settings) -> bool:
+    """Whether Traefik's ``web`` entrypoint should trust incoming X-Forwarded-*.
+
+    Only true for the "upstream terminates TLS" shape: ``tls = false`` plus a
+    public scheme of https, i.e. a Cloudflare-tunnel-style terminator in front
+    that must be able to tell us the browser spoke HTTPS. When the deployment is
+    plain HTTP end to end (``public_scheme = "http"``) there is no trusted hop,
+    so the headers stay untrusted and any client-supplied ones are overwritten.
+    """
+    return not settings.routing_tls and settings.public_scheme == "https"
+
+
 def _route_entrypoint(settings: Settings) -> dict[str, Any]:
     """Entrypoint/TLS fragment shared by team and extra-route routers.
 
@@ -578,6 +590,9 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
         # Recreate on either drift:
         #   - routing tls: the HTTP->HTTPS redirect arg is present only in TLS
         #     mode, so its presence must match routing_tls.
+        #   - forwarded headers: trusted only in front of an upstream TLS
+        #     terminator, so its presence must match _trusts_upstream_headers
+        #     (which public_scheme can flip without touching tls).
         #   - file provider: older containers watch a single file
         #     (--providers.file.filename); we now watch the dynamic directory
         #     (--providers.file.directory), which is what lets operator drop-in
@@ -587,14 +602,24 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
         #     while the server ran in port mode.
         cmd = t.attrs.get("Config", {}).get("Cmd") or []
         has_redirect = any("redirections" in str(arg) for arg in cmd)
+        has_forwarded = any("forwardedHeaders.insecure" in str(arg) for arg in cmd)
+        wants_forwarded = _trusts_upstream_headers(settings)
         on_dir_provider = any(
             str(arg).startswith("--providers.file.directory=") for arg in cmd
         )
-        if has_redirect != settings.routing_tls or not on_dir_provider:
+        if (
+            has_redirect != settings.routing_tls
+            or has_forwarded != wants_forwarded
+            or not on_dir_provider
+        ):
             logger.info(
-                "Recreating %s: config drift (tls now=%s, on_dir_provider=%s)",
+                "Recreating %s: config drift (tls container=%s wanted=%s, "
+                "forwarded_headers container=%s wanted=%s, on_dir_provider=%s)",
                 settings.traefik_container,
+                has_redirect,
                 settings.routing_tls,
+                has_forwarded,
+                wants_forwarded,
                 on_dir_provider,
             )
             t.stop()
@@ -630,17 +655,21 @@ def _ensure_traefik(client: DockerClient, settings: Settings) -> None:
             "--certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json",
         ]
     else:
-        # Plain HTTP on :80 only — an upstream (e.g. Cloudflare tunnel)
-        # terminates TLS and forwards here over HTTP.
+        # Plain HTTP on :80 only — either an upstream (e.g. Cloudflare tunnel)
+        # terminates TLS and forwards here over HTTP, or the deployment really
+        # is plain HTTP end to end (public_scheme = "http").
         ports = {"80/tcp": 80}
-        # Trust the upstream's X-Forwarded-* headers. Without this Traefik
-        # overwrites X-Forwarded-Proto with the actual connection scheme (http
-        # on this entrypoint), so the tunnel's `X-Forwarded-Proto: https` would
-        # be lost and Oduflow would treat the request as insecure (dropping the
-        # cookie Secure flag and generating http:// links). This entrypoint is
-        # only meant to receive traffic from the trusted TLS terminator, so
-        # trusting all forwarded headers here is intended.
-        command.append("--entrypoints.web.forwardedHeaders.insecure=true")
+        if _trusts_upstream_headers(settings):
+            # Trust the upstream's X-Forwarded-* headers. Without this Traefik
+            # overwrites X-Forwarded-Proto with the actual connection scheme
+            # (http on this entrypoint), so the tunnel's `X-Forwarded-Proto:
+            # https` would be lost and Oduflow would treat the request as
+            # insecure (dropping the cookie Secure flag and generating http://
+            # links). This entrypoint is only meant to receive traffic from the
+            # trusted TLS terminator, so trusting all forwarded headers here is
+            # intended. Without such a terminator the entrypoint is directly
+            # exposed and anyone could forge the header, so it stays off.
+            command.append("--entrypoints.web.forwardedHeaders.insecure=true")
 
     client.containers.run(
         "traefik:v3",

--- a/src/oduflow/server.py
+++ b/src/oduflow/server.py
@@ -273,7 +273,7 @@ def _artifact_url(settings: Settings, team: TeamSettings, token: str) -> str | N
     if settings.oauth_base_url:
         base = settings.oauth_base_url.rstrip("/")
     elif settings.routing_mode == "traefik":
-        base = f"https://{team.hostname}"
+        base = f"{settings.public_scheme}://{team.hostname}"
     else:
         bind_host, port = _web_bind
         # The bind address controls where the listener accepts connections; it
@@ -282,7 +282,7 @@ def _artifact_url(settings: Settings, team: TeamSettings, token: str) -> str | N
         host = team.hostname or (
             "localhost" if bind_host in ("0.0.0.0", "::") else bind_host
         )
-        base = f"http://{host}:{port}"
+        base = f"{settings.public_scheme}://{host}:{port}"
     return f"{base}/oduflow-artifact?token={token}"
 
 
@@ -7196,9 +7196,9 @@ def _start_http() -> None:
 
     for tid, team in settings.teams.items():
         if settings.routing_mode == "traefik":
-            url = f"https://{team.hostname}/"
+            url = f"{settings.public_scheme}://{team.hostname}/"
         else:
-            url = f"http://{host}:{port}/"
+            url = f"{settings.public_scheme}://{host}:{port}/"
         mcp_status = "MCP token ON" if team.auth_token else "MCP token OFF"
         oauth_status = (
             "OAuth ON (self-hosted)" if settings.oauth_enabled else "OAuth OFF"

--- a/src/oduflow/settings.py
+++ b/src/oduflow/settings.py
@@ -250,8 +250,16 @@ class Settings:
     # Traefik listens on plain HTTP :80 only, no redirect and no ACME — for
     # running behind a TLS-terminating upstream (e.g. a Cloudflare tunnel) that
     # already serves HTTPS. Public URLs stay https:// (the upstream provides the
-    # certificate). Ignored in port mode.
+    # certificate) unless ``public_scheme`` says otherwise. Ignored in port mode.
     routing_tls: bool = True
+    # Raw ``[routing] public_scheme`` value; read the resolved
+    # :attr:`public_scheme` property instead of this field. Empty (default)
+    # derives the scheme from the routing mode: ``https`` in traefik mode
+    # (Traefik terminates TLS itself, or an upstream does when ``tls = false``)
+    # and ``http`` in port mode. Set it explicitly to ``"http"`` when nothing
+    # terminates TLS in front of a ``tls = false`` deployment — otherwise every
+    # URL Oduflow hands out points at an https:// endpoint nobody serves.
+    public_scheme_setting: str = ""
     # Static extra routes (traefik mode): each forwards an external hostname to
     # an arbitrary upstream URL for a service Oduflow does not manage. Parsed
     # from ``[route.*]`` TOML sections. For anything more complex than
@@ -359,6 +367,22 @@ class Settings:
         return None
 
     @property
+    def public_scheme(self) -> str:
+        """URL scheme ("http"/"https") for the public URLs Oduflow hands out.
+
+        Every dashboard link, MCP endpoint, share link and reported environment
+        URL is built with this scheme. It is deliberately independent of
+        ``routing_tls``: that flag only says whether *Traefik* terminates TLS,
+        and a ``tls = false`` deployment is normally fronted by an upstream
+        terminator (e.g. a Cloudflare tunnel) that still serves https. An
+        operator who runs plain HTTP end to end sets ``[routing]
+        public_scheme = "http"`` to override the derived default.
+        """
+        if self.public_scheme_setting:
+            return self.public_scheme_setting
+        return "https" if self.routing_mode == "traefik" else "http"
+
+    @property
     def oauth_enabled(self) -> bool:
         # Self-hosted OAuth is served whenever an explicit issuer is configured
         # (oauth_base_url) or we run behind Traefik, where each team's own
@@ -389,6 +413,30 @@ class Settings:
 
         if self.routing_mode not in ("port", "traefik"):
             raise ValueError("routing_mode must be 'port' or 'traefik'")
+
+        if self.public_scheme_setting not in ("", "http", "https"):
+            raise ValueError("public_scheme must be 'http' or 'https'")
+
+        # public_scheme must match what actually answers on the wire: with
+        # Traefik terminating TLS, :80 redirects to :443, so http:// links would
+        # bounce (POSTs drop body/Authorization) and leak tokens on the first
+        # plaintext hop; in port mode nothing can terminate TLS on the published
+        # per-environment ports, so https:// links (and the internal probes
+        # built from them) would fail the handshake outright.
+        if (
+            self.public_scheme_setting == "http"
+            and self.routing_mode == "traefik"
+            and self.routing_tls
+        ):
+            raise ValueError(
+                "public_scheme = 'http' requires tls = false: with tls = true "
+                "Traefik redirects :80 to :443, so http:// links would not work"
+            )
+        if self.public_scheme_setting == "https" and self.routing_mode == "port":
+            raise ValueError(
+                "public_scheme = 'https' is not supported in port mode: "
+                "published environment ports serve plain HTTP"
+            )
 
         if self.routing_mode == "traefik" and self.routing_tls:
             if not self.acme_email:
@@ -687,6 +735,7 @@ class Settings:
             routing_mode=routing_mode,
             acme_email=str(routing.get("acme_email", "")).strip(),
             routing_tls=bool(routing.get("tls", True)),
+            public_scheme_setting=str(routing.get("public_scheme", "")).strip().lower(),
             extra_routes=tuple(extra_routes),
             db_user=str(database.get("user", "odoo")),
             db_password=str(database.get("password", "odoo")),

--- a/src/oduflow/templates/oduflow.toml
+++ b/src/oduflow/templates/oduflow.toml
@@ -20,6 +20,12 @@ mode = "port"                   # "port" | "traefik"
 #                                  # Deploy-time choice: flipping it on a live server
 #                                  # requires recreating existing environments/services
 #                                  # (their routing labels are fixed at creation).
+# public_scheme = "https"          # scheme of every URL Oduflow hands out (dashboard
+#                                  # links, MCP endpoints, share links). Default:
+#                                  # https in traefik mode, http in port mode. Set
+#                                  # "http" with tls = false when NOTHING terminates
+#                                  # TLS in front, so the links are reachable (this
+#                                  # also stops Traefik trusting X-Forwarded-* on :80).
 
 # ── Extra routes (traefik only) ───────────────────────
 # Forward an external hostname to an arbitrary upstream URL for a service that

--- a/src/oduflow/web_ui.py
+++ b/src/oduflow/web_ui.py
@@ -3978,14 +3978,10 @@ def _build_routes(
             settings = get_settings()
             team = _get_ui_team(request)
             token = env_ops.get_env_token(settings, team, branch)
-            # In traefik mode the MCP endpoint is served on the team's own
-            # (TLS-terminated) hostname, which is also the per-request OAuth
-            # issuer — so advertise that, not a central oauth_base_url or the
-            # internal request host. Port mode keeps the explicit issuer/base.
-            if settings.routing_mode == "traefik":
-                base = f"https://{team.hostname}"
-            else:
-                base = (settings.oauth_base_url or str(request.base_url)).rstrip("/")
+            # The MCP endpoint is advertised on the same public origin as share
+            # links: the team's own hostname in traefik mode (also the
+            # per-request OAuth issuer), the explicit issuer/base in port mode.
+            base = _public_base_url(request, settings, team)
             url = f"{base}/mcp/{quote(branch, safe='/')}"
             return JSONResponse(
                 {"ok": True, "result": {"url": url, "token": token}},
@@ -3999,14 +3995,14 @@ def _build_routes(
                 {"ok": False, "error": "Internal server error."}, status_code=500
             )
 
-    def _share_base_url(
+    def _public_base_url(
         request: Request, settings: Settings, team: TeamSettings
     ) -> str:
-        """Origin a share link should be opened on. In traefik mode that is the
-        team's own TLS-terminated hostname (the env pages are served there);
+        """Origin share links and MCP endpoints should be opened on. In traefik
+        mode that is the team's own hostname (the env pages are served there);
         port mode keeps the configured base or the request's own."""
         if settings.routing_mode == "traefik":
-            return f"https://{team.hostname}"
+            return f"{settings.public_scheme}://{team.hostname}"
         return (settings.oauth_base_url or str(request.base_url)).rstrip("/")
 
     def _share_payload(
@@ -4022,7 +4018,7 @@ def _build_routes(
         key = quote(str(record["secret"]), safe="")
         return {
             "shared": True,
-            "url": f"{_share_base_url(request, settings, team)}{page}?key={key}",
+            "url": f"{_public_base_url(request, settings, team)}{page}?key={key}",
             "created_at": record.get("created_at"),
         }
 
@@ -4181,7 +4177,10 @@ def _build_routes(
             if settings.routing_mode == "traefik":
                 env_host = result["cookie_domain"]
                 token = connect_tokens.issue(env_host, result["sid"])
-                landing = f"https://{env_host}/oduflow-connect?token={token}"
+                landing = (
+                    f"{settings.public_scheme}://{env_host}"
+                    f"/oduflow-connect?token={token}"
+                )
                 return RedirectResponse(landing, status_code=303)
             response: Response = RedirectResponse(result["url"], status_code=303)
             # Host-only cookie (no domain): scoped to the dashboard's host and,
@@ -4231,7 +4230,7 @@ def _build_routes(
                 media_type="text/plain",
             )
         response: Response = RedirectResponse(
-            f"https://{env_host}/web", status_code=303
+            f"{get_settings().public_scheme}://{env_host}/web", status_code=303
         )
         response.set_cookie(
             "session_id",

--- a/tests/test_production_ops.py
+++ b/tests/test_production_ops.py
@@ -27,6 +27,29 @@ def settings(team, tmp_path):
     )
 
 
+class TestProdUrl:
+    def test_defaults_to_https(self, settings):
+        assert (
+            production_ops.prod_url(settings, {"domain": "erp.example.com"})
+            == "https://erp.example.com"
+        )
+
+    def test_follows_public_scheme(self, team, tmp_path):
+        # tls = false with no upstream terminator: the link must be reachable.
+        settings = Settings(
+            routing_mode="traefik",
+            routing_tls=False,
+            base_data_dir=str(tmp_path),
+            etc_dir=str(tmp_path / "etc"),
+            public_scheme_setting="http",
+            teams={"1": team},
+        )
+        assert (
+            production_ops.prod_url(settings, {"domain": "erp.example.com"})
+            == "http://erp.example.com"
+        )
+
+
 def _mock_client():
     client = MagicMock()
     client.containers.get.side_effect = docker.errors.NotFound("nf")

--- a/tests/test_service_ops.py
+++ b/tests/test_service_ops.py
@@ -28,6 +28,21 @@ TEST_SETTINGS = Settings(
 )
 
 
+class TestRoutesWithUrls:
+    ROUTES = [{"path": "/api", "port": 3000}]
+
+    def _url(self, scheme):
+        routes = service_ops._routes_with_urls(self.ROUTES, "svc.example.com", scheme)
+        return routes[0]["url"]
+
+    def test_uses_given_scheme(self):
+        assert self._url("https") == "https://svc.example.com/api"
+        assert self._url("http") == "http://svc.example.com/api"
+
+    def test_no_hostname_means_no_url(self):
+        assert "url" not in service_ops._routes_with_urls(self.ROUTES, None, "https")[0]
+
+
 @pytest.fixture(autouse=True)
 def _fake_team_network(monkeypatch):
     # Network provisioning is covered by tests/test_team_networks.py; here it

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -282,6 +282,79 @@ class TestSettings:
         s.validate()
 
 
+class TestPublicScheme:
+    """[routing] public_scheme: the scheme of every URL Oduflow hands out."""
+
+    def _settings(self, routing_mode="traefik", tls=True, scheme=""):
+        team = TeamSettings(team_id="1", hostname="dev.example.com")
+        return Settings(
+            routing_mode=routing_mode,
+            routing_tls=tls,
+            acme_email="admin@example.com",
+            public_scheme_setting=scheme,
+            teams={"1": team},
+        )
+
+    def test_traefik_defaults_to_https(self):
+        assert self._settings().public_scheme == "https"
+
+    def test_traefik_without_tls_still_defaults_to_https(self):
+        # tls = false means "an upstream terminates TLS" (Cloudflare tunnel),
+        # not "plain HTTP" — the public URL keeps the upstream's scheme.
+        assert self._settings(tls=False).public_scheme == "https"
+
+    def test_port_mode_defaults_to_http(self):
+        assert self._settings(routing_mode="port").public_scheme == "http"
+
+    def test_explicit_http_overrides_traefik_default(self):
+        # The whole point of the option: a tls = false deployment with nothing
+        # terminating TLS in front must hand out reachable http:// links.
+        assert self._settings(tls=False, scheme="http").public_scheme == "http"
+
+    def test_validate_rejects_https_in_port_mode(self):
+        # Published per-environment ports serve plain HTTP; https:// links (and
+        # the internal probes built from get_env_base_url) could never work.
+        with pytest.raises(ValueError, match="port mode"):
+            self._settings(routing_mode="port", scheme="https").validate()
+
+    def test_validate_rejects_http_with_traefik_tls(self):
+        # tls = true keeps the :80->:443 redirect, so http:// links would
+        # bounce and leak tokens on the first plaintext hop.
+        with pytest.raises(ValueError, match="tls = false"):
+            self._settings(tls=True, scheme="http").validate()
+
+    def test_from_toml(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[routing]\nmode = "traefik"\ntls = false\npublic_scheme = "HTTP"\n'
+            '[team.1]\nhostname = "dev.example.com"\n'
+        )
+        s = Settings.from_toml(str(toml))
+        # Case-insensitive, and it does not touch routing_tls.
+        assert s.public_scheme == "http"
+        assert s.routing_tls is False
+
+    def test_from_toml_default_is_empty(self, tmp_path):
+        toml = tmp_path / "oduflow.toml"
+        toml.write_text(
+            '[routing]\nmode = "traefik"\n[team.1]\nhostname = "dev.example.com"\n'
+        )
+        s = Settings.from_toml(str(toml))
+        assert s.public_scheme_setting == ""
+        assert s.public_scheme == "https"
+
+    def test_validate_rejects_other_schemes(self):
+        with pytest.raises(ValueError, match="public_scheme"):
+            self._settings(scheme="ftp").validate()
+
+    def test_validate_accepts_supported_schemes(self):
+        # Every combination that matches what actually answers on the wire.
+        self._settings(scheme="").validate()
+        self._settings(scheme="https").validate()
+        self._settings(tls=False, scheme="http").validate()
+        self._settings(routing_mode="port", scheme="http").validate()
+
+
 class TestOAuthSettings:
     def _team(self, **kw):
         defaults = {"team_id": "1", "port_range_start": 50000, "port_range_end": 50100}

--- a/tests/test_traefik_tls.py
+++ b/tests/test_traefik_tls.py
@@ -7,7 +7,7 @@ from oduflow.docker_ops.env_ops import build_env_traefik_labels
 from oduflow.settings import ExtraRoute, Settings, TeamSettings
 
 
-def _traefik_settings(tmp_path, tls, extra_routes=()):
+def _traefik_settings(tmp_path, tls, extra_routes=(), public_scheme=""):
     team = TeamSettings(team_id="1", hostname="dev.example.com")
     return Settings(
         routing_mode="traefik",
@@ -16,6 +16,7 @@ def _traefik_settings(tmp_path, tls, extra_routes=()):
         etc_dir=str(tmp_path),
         teams={"1": team},
         extra_routes=tuple(extra_routes),
+        public_scheme_setting=public_scheme,
     )
 
 
@@ -208,13 +209,14 @@ class TestEnsureTraefik:
         client.containers.run.assert_called_once()
 
     def test_no_drift_when_mode_matches(self, tmp_path):
-        # Existing container already in the desired (no-TLS, directory) mode:
-        # reuse it.
+        # Existing container already in the desired (no-TLS, upstream-trusting,
+        # directory) mode: reuse it.
         existing = MagicMock()
         existing.attrs = {
             "Config": {
                 "Cmd": [
                     "--entrypoints.web.address=:80",
+                    "--entrypoints.web.forwardedHeaders.insecure=true",
                     "--providers.file.directory=/etc/traefik/dynamic",
                 ]
             }
@@ -225,6 +227,42 @@ class TestEnsureTraefik:
         system_ops._ensure_traefik(client, _traefik_settings(tmp_path, False))
         existing.remove.assert_not_called()
         client.containers.run.assert_not_called()
+
+    def test_plain_http_mode_does_not_trust_forwarded_headers(self, tmp_path):
+        # public_scheme = "http": nothing terminates TLS in front, so the :80
+        # entrypoint is directly exposed and must not believe a client-supplied
+        # X-Forwarded-Proto (which would forge a "secure" request).
+        client = self._client_no_container()
+        system_ops._ensure_traefik(
+            client, _traefik_settings(tmp_path, False, public_scheme="http")
+        )
+        cmd = client.containers.run.call_args[1]["command"]
+        assert client.containers.run.call_args[1]["ports"] == {"80/tcp": 80}
+        assert not any("forwardedHeaders" in a for a in cmd)
+
+    def test_drift_recreates_when_public_scheme_drops_tls(self, tmp_path):
+        # Container was built for an upstream terminator (forwarded headers
+        # trusted); the operator has since set public_scheme = "http".
+        existing = MagicMock()
+        existing.attrs = {
+            "Config": {
+                "Cmd": [
+                    "--entrypoints.web.address=:80",
+                    "--entrypoints.web.forwardedHeaders.insecure=true",
+                    "--providers.file.directory=/etc/traefik/dynamic",
+                ]
+            }
+        }
+        existing.status = "running"
+        client = MagicMock()
+        client.containers.get.return_value = existing
+        system_ops._ensure_traefik(
+            client, _traefik_settings(tmp_path, False, public_scheme="http")
+        )
+        existing.stop.assert_called_once()
+        existing.remove.assert_called_once()
+        cmd = client.containers.run.call_args[1]["command"]
+        assert not any("forwardedHeaders" in a for a in cmd)
 
 
 def _env_settings(routing_mode, tls):


### PR DESCRIPTION
## Summary

- New `[routing] public_scheme` setting: the scheme (`http`/`https`) of every URL Oduflow hands out (environment/service/production URLs, dashboard share links, MCP endpoints, artifact links). Unset, it derives the historical default — `https` in traefik mode, `http` in port mode — so existing deployments (including `tls = false` behind a Cloudflare tunnel) are untouched.
- `public_scheme = "http"` (plain HTTP end to end, nothing terminating TLS) also switches off `forwardedHeaders.insecure` on Traefik's `web` entrypoint: with no trusted terminator in front, a client-supplied `X-Forwarded-Proto` must not be believed. The Traefik drift check recreates the container when the trust flag no longer matches; environments/services need no recreation (labels don't encode the scheme).
- `validate()` rejects contradictory combos: `public_scheme = "http"` with traefik `tls = true` (the :80→:443 redirect would bounce every link and leak tokens on the plaintext first hop) and `public_scheme = "https"` in port mode (published ports serve plain HTTP; internal probes built from `get_env_base_url` would fail the TLS handshake).
- Docs: new "Plain HTTP, with nothing terminating TLS" section in `docs/traefik.md`, `docs/installation.md` reference row, `oduflow.toml` template comment.
- Decision record [0056](specs/0056-public-url-scheme.md) added per AGENTS.md.

## Test plan

- New unit tests: `TestPublicScheme` (defaults, overrides, TOML parsing, validation cross-checks), `TestProdUrl`, `TestRoutesWithUrls`, Traefik drift/forwarded-headers tests in `test_traefik_tls.py`.
- `ruff check`, `ruff format --check`, `mypy` clean; `pytest -m "not integration and not heavyweight"`: 2903 passed (4 failures are pre-existing on `main` — no Docker daemon in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)